### PR TITLE
Das Installationsscript prüfte nur auf PHP 5.3, das System an sich dann ...

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -44,12 +44,12 @@ if ($directory_not_empty) {
 }
 
 // Check the minimum required php version
-if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+if (version_compare(PHP_VERSION, '5.3.2', '<')) {
     header('Content-type: text/html; charset=utf-8', true, 503);
     echo '<h2>Fehler</h2>';
-    echo 'Auf Ihrem Server läuft PHP version ' . PHP_VERSION . ', Shopware 4 benötigt mindestens PHP 5.3';
+    echo 'Auf Ihrem Server läuft PHP version ' . PHP_VERSION . ', Shopware 4 benötigt mindestens PHP 5.3.2';
     echo '<h2>Error</h2>';
-    echo 'Your server is running PHP version ' . PHP_VERSION . ' but Shopware 4 requires at least PHP 5.3';
+    echo 'Your server is running PHP version ' . PHP_VERSION . ' but Shopware 4 requires at least PHP 5.3.2';
     return;
 }
 


### PR DESCRIPTION
...allerdings auf PHP 5.3.2, so würde z.B. eine Installation funktionieren, der Rest aber nicht wenn man z.B. PHP 5.3.1 laufen hat.
