### PR TITLE
Move referer and user agent retrieval to if-statement header

### DIFF
--- a/engine/Shopware/Plugins/Default/Backend/Auth/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Backend/Auth/Bootstrap.php
@@ -409,8 +409,7 @@ class Shopware_Plugins_Backend_Auth_Bootstrap extends Shopware_Components_Plugin
 
         Enlight_Components_Session::start($options);
 
-        $referer = $this->request->getHeader('referer');
-        if($refererCheck && $referer !== null
+        if($refererCheck && ($referer = $this->request->getHeader('referer')) !== null
           && strpos($referer, 'http') === 0) {
             $referer = substr($referer, 0, strpos($referer, '/backend/'));
             $referer .= '/backend/';
@@ -421,8 +420,7 @@ class Shopware_Plugins_Backend_Auth_Bootstrap extends Shopware_Components_Plugin
                 throw new Exception('Referer check for backend session failed');
             }
         }
-        $client = $this->request->getHeader('userAgent');
-        if($clientCheck && $client !== null) {
+        if($clientCheck && ($client = $this->request->getHeader('userAgent')) !== null) {
             if(!isset($_SESSION['__SW_CLIENT'])) {
                 $_SESSION['__SW_CLIENT'] = $client;
             } elseif ($client !==  $_SESSION['__SW_CLIENT']) {


### PR DESCRIPTION
Currently it is not possible to access the default Auth Component using `Shopware()->Auth()` before the `onPreDispatchBackend` of the Auth-Plugin has been executed. The instantiation of the Auth Component using `onInitResourceAuth` and `onInitResourceBackendSession` requires the `$request` property to be set, which happens in the `onPreDispatchBackend` method. 

This patch allows to use the Auth Component, at least when the referer and client checks are not executed, by retrieving the referer and user agent from the request only when the checks are enabled. 

The reason for this requirement is that we need to execute our own custom `onPreDispatchBackend` method before the default handlers `onPreDispatchBackend` method has been executed, because we adapted the backend login process to support preemptive HTTP Basic Authentication.

Maybe there's a better solution for this specific problem, but at least this pull request increases the performance a little bit by avoiding unnecessary variable instantiation. 
