### PR TITLE
Fixes different problems with the mobile slider component

### DIFF
--- a/templates/_emotion/frontend/_resources/styles/emotion.css
+++ b/templates/_emotion/frontend/_resources/styles/emotion.css
@@ -3393,6 +3393,8 @@ and (max-device-width : 1024px) {
 		margin-right: 5px;
 		position: relative; top: -3px;
 	}
+	
+	.my_options .service { background-position: right 5px }
 }
 
 /*	iPad related styles (portrait orientation only)	


### PR DESCRIPTION
Hey,

here is an pull request which fixes different problems with the touch enabled slider component in shopware. The pull request contains fixes for the following points:
- Each slider now creates a new instance of the `$.ajaxSlider` object
- Add support for links inside a touch enabled slider
- Globally deactivate event binding using delegation on sliders
- Fixes a small background positioning problem in the help/service menu

Kind regards,
klarstil
