### PR TITLE
Small fix in emotion template

### DIFF
--- a/templates/_emotion/frontend/index/left.tpl
+++ b/templates/_emotion/frontend/index/left.tpl
@@ -15,9 +15,11 @@
 {block name='frontend_index_left_last_articles'}{/block}
 
 {* Static sites *}
-{block name='frontend_index_left_menu'}{/block}
-	
+{block name='frontend_index_left_menu'}
+    {include file='frontend/index/menu_left.tpl'}
+{/block}
+
+{* Campaign left bottom *}
 {block name='frontend_index_left_campaigns_bottom'}
-	{include file='frontend/index/menu_left.tpl'}
     {include file="frontend/campaign/box.tpl" campaignsData=$campaigns.leftBottom}
 {/block}


### PR DESCRIPTION
The inclusion directive of the menu for static sites was in the wrong place.
