### PR TITLE
Fixed configuration form description translation issue

### DIFF
--- a/engine/Shopware/Controllers/Backend/Config.php
+++ b/engine/Shopware/Controllers/Backend/Config.php
@@ -149,6 +149,9 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
                 if($array['label'] !== null) {
                     $data['elements'][$elementsKey]['label'] = $array['label'];
                 }
+                if($array['description'] !== null) {
+                    $data['elements'][$elementsKey]['description'] = $array['description'];
+                }
             }
         }
 


### PR DESCRIPTION
The correct translation for backend config form elements now is used instead of the original description of the form element.
