### PR TITLE
Fixed RatingStars calculation in box_article

### DIFF
--- a/templates/_default/frontend/listing/box_article.tpl
+++ b/templates/_default/frontend/listing/box_article.tpl
@@ -25,7 +25,7 @@
 		{* Article rating *}
         {block name='frontend_listing_box_article_rating'}
         	{if $sArticle.sVoteAverange.averange}
-	        <div class="star star{$sArticle.sVoteAverange.averange*2|round}"></div>
+	        <div class="star star{($sArticle.sVoteAverange.averange*2)|round}"></div>
 	        {/if}
 	    {/block}
         


### PR DESCRIPTION
In some cases the result of the used smarty statement was 9.5 or similar; resulting in showing "empty" stars on the listing page.
