### PR TITLE
Fixed wrong lable element attribute for DOUBLEEMAILVALIDATION at register form

### DIFF
--- a/templates/_default/frontend/register/personal_fieldset.tpl
+++ b/templates/_default/frontend/register/personal_fieldset.tpl
@@ -67,7 +67,7 @@
 		
 			{if {config name=DOUBLEEMAILVALIDATION}}
 			    <div>
-			        <label title="{s name='RegisterPersonalRequiredText'}{/s}">
+			        <label for="register_personal_emailConfirmation">
 			        	{se name='RegisterLabelMailConfirmation'}{/se}
 			        </label>
 			        <input name="register[personal][emailConfirmation]" type="text" id="register_personal_emailConfirmation" value="{$form_data.emailConfirmation|escape}" class="text emailConfirmation required {if $error_flags.emailConfirmation}instyle_error{/if}" />


### PR DESCRIPTION
Changed attribute from 'title' to 'for' and corrected value to input id.
