### PR TITLE
fixed host validation issue when site run under custom port

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
@@ -96,6 +96,10 @@ class Shopware_Plugins_Frontend_InputFilter_Bootstrap extends Shopware_Component
                 $shop->getSecureHost()
             );
             $host = parse_url($referer, PHP_URL_HOST);
+            $port = parse_url($referer, PHP_URL_PORT);
+            if (!is_null($port) && $port != 80 && $port != 443) {
+              $host = $host . ':' . $port;
+            }
             if (!in_array($host, $validHosts)) {
                 $response->setException(
                     new Exception('Referer check for frontend session failed')


### PR DESCRIPTION
Issue happened when I've installed site under MAMP on 8888 port. I was trying to login (front-end) but it shows me exception and stop execution. Ajax login form also not worked properly. I've checked how current validation works and seems it not checking url port so I've added fix which works for me (also works if site installed on default 80 port). 

Please review and let me know if I can explain more. 
