### PR TITLE
Check blogIds to prevent sql errors and broken sitemap.xml

### DIFF
--- a/engine/Shopware/Controllers/Frontend/SitemapXml.php
+++ b/engine/Shopware/Controllers/Frontend/SitemapXml.php
@@ -188,6 +188,10 @@ class Shopware_Controllers_Frontend_SitemapXml extends Enlight_Controller_Action
 		}
 		$blogIds = Shopware()->Db()->quote($blogIds);
 
+		if( empty($blogIds) ) {
+			return;
+		}
+
 		$sql = "
 			SELECT id, category_id, DATE(display_date) as changed
 			FROM s_blog


### PR DESCRIPTION
Return from function if blog ids are not set. Otherwise an incorrect
sql statement will break the script and the closing </urlset> tag is
missing.
