### PR TITLE
Shopware\Models\Customer\Billing does not expose underlying relationship to doctrine

### DIFF
--- a/engine/Shopware/Models/Customer/Billing.php
+++ b/engine/Shopware/Models/Customer/Billing.php
@@ -32,7 +32,8 @@
 
 namespace   Shopware\Models\Customer;
 use         Shopware\Components\Model\ModelEntity,
-            Doctrine\ORM\Mapping AS ORM;
+            Doctrine\ORM\Mapping AS ORM,
+            Shopware\Models\Country\Country;
 
 /**
  * Shopware customer billing model represents a single billing address of a customer.
@@ -81,6 +82,14 @@ class Billing extends ModelEntity
      * @ORM\Column(name="countryID", type="integer", nullable=false)
      */
     protected $countryId = 0;
+        
+    /**
+     * @var Country
+     *
+     * @ORM\OneToOne(targetEntity="Shopware\Models\Country\Country")
+     * @ORM\JoinColumn(name="countryId", referencedColumnName="id")
+     */
+    protected $country;
 
     /**
      * Contains the id of the state. Used for billing - state association.
@@ -499,6 +508,28 @@ class Billing extends ModelEntity
     public function getCountryId()
     {
         return $this->countryId;
+    }
+    
+    /**
+     * Getter function for the country instance.
+     * 
+     * @return Country
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+    /**
+     * Setter function for the country instance. 
+     * 
+     * @param Country $country
+     * @return Billing
+     */
+    public function setCountry(Country $country)
+    {
+        $this->country = $country;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
The billing class has an imprecise doctrine annotation mapping that hides the underlying relationship of the data structure from doctrine; namely, access to the `countryId` is of no (or little) use for the ORM Framework. 

The attached pull request fixes that. I'd recommend to flag the `countryId` and it's getter/setter methods as deprecated as well.

_Example usecase_

Adding the country to the customer listing in the backend requires manipulating the query builder and bypassing the doctrine infrastructure would lead to nasty and overcomplicated workarounds.

With the attached fix it would be as easy as:

``` php
public function afterGetListQueryBuilder(Enlight_Hook_HookArgs $arguments)
{
    /** @var \Shopware\Components\Model\QueryBuilder $builder */
    $builder = $arguments->getReturn();
    $builder->leftJoin('billing.country', 'country');
    $builder->addSelect('country.name as countryname');
    $arguments->setReturn($builder);
}
```
