### PR TITLE
Update Bootstrap.php, Funktion uninstall()

### DIFF
--- a/engine/Shopware/Components/Plugin/Bootstrap.php
+++ b/engine/Shopware/Components/Plugin/Bootstrap.php
@@ -146,7 +146,7 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
      */
     public function uninstall()
     {
-        return !empty($this->info->capabilities['install']);
+        return !empty($this->info->capabilities['uninstall']);
     }
 
     /**


### PR DESCRIPTION
Vermutlich soll die Elternmethode uninstall() den String "uninstall" prüfen und nicht "install".
