### PR TITLE
Grid size

### DIFF
--- a/templates/_default/frontend/content/index.tpl
+++ b/templates/_default/frontend/content/index.tpl
@@ -5,7 +5,7 @@
 
 {* Main content *}
 {block name='frontend_index_content'}
-	<div id="center" class="grid_13">
+	<div id="center" class="grid_16">
 		<div class="contentlisting_box">
 		
 			{* include paging *}


### PR DESCRIPTION
.container_20 - .grid_4 = .grid_16
Das spart dann auch einiges an verwirrenden Breitenangaben im CSS.
