### PR TITLE
fix memory leak when importing many images. #98

### DIFF
--- a/engine/Shopware/Controllers/Backend/ImportExport.php
+++ b/engine/Shopware/Controllers/Backend/ImportExport.php
@@ -1666,6 +1666,11 @@ class Shopware_Controllers_Backend_ImportExport extends Shopware_Controllers_Bac
             }
 
             $total++;
+            
+            //clear entities to avoid memory leak
+            if($total % 100 == 0) {
+                Shopware()->Models()->clear();
+            }
         }
 
         try {

--- a/engine/Shopware/Controllers/Backend/ImportExport.php
+++ b/engine/Shopware/Controllers/Backend/ImportExport.php
@@ -1668,7 +1668,7 @@ class Shopware_Controllers_Backend_ImportExport extends Shopware_Controllers_Bac
             $total++;
             
             //clear entities to avoid memory leak
-            if($total % 100 == 0) {
+            if ($total % 100 == 0) {
                 Shopware()->Models()->clear();
             }
         }


### PR DESCRIPTION
## snippet from #98:

i did a few tests and at least i could solve the image import issue. i tried a `Shopware()->Models()->clear()` every 100 rows and it works perfectly.

i measured the memory usage without this (memory raised exponentially):

```
[02-Sep-2013 22:28:33] current memory usage at 100 before gc: 45350912
[02-Sep-2013 22:29:06] current memory usage at 200 before gc: 53739520
[02-Sep-2013 22:29:56] current memory usage at 300 before gc: 62128128
[02-Sep-2013 22:30:45] current memory usage at 400 before gc: 96468992
[02-Sep-2013 22:31:46] current memory usage at 500 before gc: 159645696
[02-Sep-2013 22:32:52] current memory usage at 600 before gc: 251658240
[02-Sep-2013 22:34:15] current memory usage at 700 before gc: 377225216
[02-Sep-2013 22:35:46] PHP Fatal error:  Allowed memory size of 536870912 bytes exhausted (tried to allocate 262177 bytes) in /var/www/vhosts/watchshop4you.de/shopware/engine/Library/Symfony/Component/HttpFoundation/File/MimeType/FileinfoMimeTypeGuesser.php on line 57
```

and now with 

``` php
if($total % 100 == 0) {
    Shopware()->Models()->clear();
}
```

even 3000 rows are no problem and on top of that, it even runs twice as fast as before: (previous: about 100 rows/minute, now 200 rows/minute)

```
[03-Sep-2013 11:40:12] current memory usage at 100:43515904
[03-Sep-2013 11:40:38] current memory usage at 200:49283072
[03-Sep-2013 11:41:04] current memory usage at 300:53215232
[03-Sep-2013 11:41:33] current memory usage at 400:53215232
[03-Sep-2013 11:41:57] current memory usage at 500:55312384
[03-Sep-2013 11:42:29] current memory usage at 600:57147392
[03-Sep-2013 11:42:54] current memory usage at 700:57147392
[03-Sep-2013 11:43:22] current memory usage at 800:57147392
[03-Sep-2013 11:43:48] current memory usage at 900:57671680
[03-Sep-2013 11:44:17] current memory usage at 1000:57671680
[03-Sep-2013 11:44:51] current memory usage at 1100:57671680
[03-Sep-2013 11:45:19] current memory usage at 1200:57933824
[03-Sep-2013 11:45:50] current memory usage at 1300:57933824
[03-Sep-2013 11:46:16] current memory usage at 1400:57933824
[03-Sep-2013 11:46:44] current memory usage at 1500:58195968
[03-Sep-2013 11:47:13] current memory usage at 1600:58195968
[03-Sep-2013 11:47:42] current memory usage at 1700:58195968
[03-Sep-2013 11:48:11] current memory usage at 1800:58458112
[03-Sep-2013 11:48:41] current memory usage at 1900:58458112
[03-Sep-2013 11:49:14] current memory usage at 2000:58458112
[03-Sep-2013 11:49:46] current memory usage at 2100:58982400
[03-Sep-2013 11:50:18] current memory usage at 2200:58982400
[03-Sep-2013 11:50:48] current memory usage at 2300:58982400
[03-Sep-2013 11:51:26] current memory usage at 2400:59244544
[03-Sep-2013 11:51:55] current memory usage at 2500:59244544
[03-Sep-2013 11:52:23] current memory usage at 2600:59244544
[03-Sep-2013 11:52:56] current memory usage at 2700:59506688
[03-Sep-2013 11:53:28] current memory usage at 2800:59506688
[03-Sep-2013 11:54:06] current memory usage at 2900:59506688
[03-Sep-2013 11:54:37] current memory usage at 3000:59768832
```
