### PR TITLE
This fixes a namespace clash in our connector tool including Categories,...

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -26,7 +26,6 @@ namespace Shopware\Components\Api\Resource;
 
 use Shopware\Components\Api\Exception as ApiException;
 use Shopware\Models\Article\Article as ArticleModel;
-use Shopware\Models\Media\Media;
 
 /**
  * Article API Resource
@@ -1330,7 +1329,7 @@ class Article extends Resource
                 $image->setExtension($media->getExtension());
             } else if (!empty($imageData['mediaId'])) {
                 $media = $this->getManager()->find('Shopware\Models\Media\Media', (int) $imageData['mediaId']);
-                if (!($media instanceof Media)) {
+                if (!($media instanceof \Shopware\Models\Media\Media)) {
                     throw new ApiException\CustomValidationException(sprintf("Media by mediaId %s not found", $imageData['mediaId']));
                 }
                 $image->setPath($media->getName());


### PR DESCRIPTION
... Articles and Media at once. As all other instanceof appearances in the file are with the fully qualified class name i found this to be a rather rational approach being unable to find a solution outside of the Resource code.

Basic testing yields no effect on functionality and it resolves the following namespace clash error:

Cannot use Shopware\Models\Media\Media as Media because the name is already in use in /var/www/html/shopware/engine/Shopware/Components/Api/Resource/Article.php on line 29
