### PR TITLE
getting new amount array in case of negativ payment fees

### DIFF
--- a/engine/core/class/sBasket.php
+++ b/engine/core/class/sBasket.php
@@ -871,6 +871,7 @@ class sBasket
 				$surchargename = $this->sSYSTEM->sCONFIG["sPAYMENTSURCHARGEADD"];
 			}else {
 				$surchargename = $this->sSYSTEM->sCONFIG["sPAYMENTSURCHARGEDEV"];
+				$amount = $this->sGetAmountArticles();
 			}
 			//print_r($amount); exit;
 			$surcharge = $amount["totalAmount"] / 100 * $percent;


### PR DESCRIPTION
This change is necessary to disable payment discount on products with disabled discounts (like http://store.shopware.de/werbung-marketing/artikel-von-rabatt-ausschlieeen with the following events

$this->subscribeEvent('sBasket::sInsertSurchargePercent::before', 'beforeInsertDiscount');
$this->subscribeEvent('sBasket::sInsertSurchargePercent::after', 'afterInsertDiscount');
)
