### PR TITLE
Fix - jquery.shopware.js $.modal() overwriting base config

### DIFF
--- a/templates/_default/frontend/_resources/javascript/jquery.shopware.js
+++ b/templates/_default/frontend/_resources/javascript/jquery.shopware.js
@@ -3203,12 +3203,13 @@ jQuery.fn.liveSearch = function (conf) {
 
     //creates an modal window with text and headline
     $.modal = function (text, headline, settings) {
-        if (settings) $.extend(config, settings);
+        if (settings) lConfig = $.extend(true, {}, config, settings);
+        else lConfig = $.extend(true, {}, config);
         if ($('.modal')) $('.modal').remove();
         var modal = $('<div>', {
             'class': 'modal',
             'css': {
-                'width': config.width
+                'width': lConfig.width
             }
         });
 
@@ -3220,22 +3221,22 @@ jQuery.fn.liveSearch = function (conf) {
             }).appendTo(modal);
         }
         if (text.length) {
-            var container = $(config.textContainer, {
+            var container = $(lConfig.textContainer, {
                 'html': text
             });
 
-            if (config.textClass.length) {
-                container.addClass(config.textClass)
+            if (lConfig.textClass.length) {
+                container.addClass(lConfig.textClass)
             }
             container.appendTo(modal);
         }
 
         //get css properties
         modal.show();
-        if(!config.position) {
-            config.position = modal.css('position');
+        if(!lConfig.position) {
+            lConfig.position = modal.css('position');
         }
-        config.top = modal.css('top');
+        lConfig.top = modal.css('top');
         modal.hide();
 
 
@@ -3247,32 +3248,32 @@ jQuery.fn.liveSearch = function (conf) {
 
         modal.show().css('marginLeft', -(modal.width()/2)).hide();
 
-        if (config.useOverlay == true) {
+        if (lConfig.useOverlay == true) {
             $.modal.overlay.fadeIn();
 
-            $(config.overlay).bind('click', function (event) {
+            $(lConfig.overlay).bind('click', function (event) {
                 $.modalClose();
             });
         }
         $('.modal').fadeIn('fast');
 
         if($.browser.msie && parseInt($.browser.version) == 6) {
-            $.ie6fix.open(modal, config);
+            $.ie6fix.open(modal, lConfig);
         } else {
-            if (config.position == 'absolute') {
+            if (lConfig.position == 'absolute') {
                 modal.css({
-                    'position': config.position,
+                    'position': lConfig.position,
                     'bottom': 'auto'
-                }).fadeIn(config.animationSpeed);
-            } else if (config.position == 'fixed') {
+                }).fadeIn(lConfig.animationSpeed);
+            } else if (lConfig.position == 'fixed') {
                 $('.modal').fadeIn();
                 modal.css({
-                    'position': config.position,
+                    'position': lConfig.position,
                     'top': -(modal.height() + 100) + 'px',
                     'display': 'block'
                 }).animate({
                             'top': '40px'
-                        }, config.animationSpeed)
+                        }, lConfig.animationSpeed)
             }
         }
 
@@ -5668,7 +5669,7 @@ jQuery.effects||function(a,b){function c(b){var c;return b&&b.constructor==Array
             if(i != index) {
                 // Delete existing article on old position
                 localStorage.removeItem('lastSeenArticle-' + opts.shopId + i);
-    
+
                 // Downgrading all articles with higher index
                 var newIndex,
                     tmpData;
@@ -5679,13 +5680,13 @@ jQuery.effects||function(a,b){function c(b){var c;return b&&b.constructor==Array
                     localStorage.removeItem('lastSeenArticle-' + opts.shopId + j);
                     localStorage.setItem('lastSeenArticle-' + opts.shopId + newIndex, tmpData);
                 }
-    
+
                 // Adding this article on top index
                 localStorage.setItem('lastSeenArticle-'+opts.shopId + index, JSON.stringify(opts.lastArticles));
             }
             return false;
         }
-    
+
         localStorage.setItem('lastSeenArticleIndex-'+opts.shopId, ++index);
         localStorage.setItem('lastSeenArticle-'+opts.shopId + index, JSON.stringify(opts.lastArticles));
         localStorage.removeItem('lastSeenArticle-'+opts.shopId + (index - articleNum));


### PR DESCRIPTION
This fixes a problem with the $.modal function on the article detail page.

Steps to reproduce:

```
1. open any article detail page on www.shopwaredemo.de 
2. put article in the shoppingcart
3. click on 'zzgl. Versandkosten'
```

The popup is too small because

```
if (settings) $.extend(config, settings);
```

overwrites the modal default config
