### PR TITLE
Improve laststock evaluation in article listing

### DIFF
--- a/templates/_emotion/frontend/listing/box_article.tpl
+++ b/templates/_emotion/frontend/listing/box_article.tpl
@@ -58,7 +58,7 @@
 
         {block name='frontend_listing_box_article_actions_buy_now'}
         {* Buy now button *}
-        {if !$sArticle.sConfigurator && !$sArticle.variants && !$sArticle.sVariantArticle && !$sArticle.laststock == 1 && !($sArticle.notification == 1 && {config name="deactivatebasketonnotification"} == 1)}
+        {if !$sArticle.sConfigurator && !$sArticle.variants && !$sArticle.sVariantArticle && !($sArticle.laststock == 1 && $sArticle.instock <= 0) && !($sArticle.notification == 1 && {config name="deactivatebasketonnotification"} == 1)}
             <a href="{url controller='checkout' action='addArticle' sAdd=$sArticle.ordernumber}" title="{s name='ListingBoxLinkBuy'}{/s}" class="buynow">{s name='ListingBoxLinkBuy'}{/s}</a>
         {/if}
         {/block}


### PR DESCRIPTION
Currently the buy now button will not been displayed, if the laststock flag is set, even if the article is still available. This Pull-Request refines the display condition for the buy now button by putting the laststock flag in correlation to the current stock amount.
