### PR TITLE
Declare getDataOfArticleImage() as protected

### DIFF
--- a/engine/core/class/sArticles.php
+++ b/engine/core/class/sArticles.php
@@ -3845,7 +3845,7 @@ class sArticles
      * @param $articleAlbum \Shopware\Models\Media\Album
      * @return array
      */
-    private function getDataOfArticleImage($image, $articleAlbum)
+    protected function getDataOfArticleImage($image, $articleAlbum)
     {
         //initial the data array
         $imageData = array();


### PR DESCRIPTION
It would be very helpful for a new plugin if the getDataOfArticleImage() method would be declared as protected to hook it.
