### PR TITLE
Use extended article name in add article popup

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -324,6 +324,8 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action
                     if($item['id']==$insertID)
                     {
                         $this->View()->sArticle = $item;
+                        // Article name should equal the one used in shopping basket: display name = articlename + additionaltext
+                        $this->View()->sArticleName = $item['articlename'];
                         break;
                     }
                 }


### PR DESCRIPTION
The article name used inside the shopping basket is composed as articlename + additionaltext, where the additionaltext covers information about the variant-options. This name should also be used inside the add article popup.

![before](https://f.cloud.github.com/assets/833300/1297490/5e2c1198-30e3-11e3-936c-bb97979e51cb.png)

![after](https://f.cloud.github.com/assets/833300/1297491/637b91fa-30e3-11e3-8f6d-926c99c5d32c.png)
