### PR TITLE
Fix: Wrong Id/Number used for fetching premium articles

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -162,7 +162,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
         $request->setPathInfo();
 
         if (($host = $request->getHeader('X_FORWARDED_HOST')) !== null
-            && $host === $shop->getSecureHost()
+            && $host === $shop->getSecureHost() && $shop->getSecure() == true
         ) {
             $request->setSecure();
             $request->setBasePath($shop->getSecureBasePath());

--- a/engine/core/class/sMarketing.php
+++ b/engine/core/class/sMarketing.php
@@ -310,7 +310,7 @@ class sMarketing
 			}
 
             if (empty($premium["available"])) $premium["sDifference"] = $this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($premium["startprice"] - $sBasketAmount);
-            $premium["sArticle"] = $this->sSYSTEM->sMODULES['sArticles']->sGetPromotionById("fix", 0, $premium["articleID"]);
+            $premium["sArticle"] = $this->sSYSTEM->sMODULES['sArticles']->sGetPromotionById("fix", 0, $premium["premium_ordernumber"]);
             $premium["startprice"] = $this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($premium["startprice"]);
             $sql = "SELECT ordernumber, additionaltext FROM s_articles_details WHERE articleID={$premium["articleID"]} AND kind != 3";
             $premium["sVariants"] = $this->sSYSTEM->sDB_CONNECTION->GetAll($sql);


### PR DESCRIPTION
sArticles::sGetPromotionById() requires the ordernumber as thirt parameter, but in sMarketing::sGetPremiums() (line 314) the articleid is currently used.
