### PR TITLE
Add parameters and events to avoid redirecting after saving payment/shipping

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -509,8 +509,10 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
 	 * Save shipping action
 	 *
 	 * Save shipping address data
+	 * 
+	 * @param boolean $redirect
 	 */
-	public function savePaymentAction()
+	public function savePaymentAction($redirect = true)
 	{
 		if($this->Request()->isPost())
 		{
@@ -526,7 +528,13 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
 				    $this->View()->sErrorFlag = $checkData['checkPayment']['sErrorFlag'];
 				    $this->View()->sErrorMessages = $checkData['checkPayment']['sErrorMessages'];
                 }
-				return $this->forward('payment');
+				
+		        if ($redirect == false ){
+			        return;
+		        }
+				else{
+					return $this->forward('payment');
+				}
 			}
 			else
 			{
@@ -546,11 +554,20 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
 				}
 			}
 		}
+		
+		if ($redirect == false ){
+			return;
+		}
 
+		if (Enlight()->Events()->notifyUntil('Shopware_Controllers_Frontend_Account_SavePayment_Redirect', array('subject'=>$this))){
+			return;
+		}
+        
 		if(!$target = $this->Request()->getParam('sTarget'))
 		{
 			$target = 'account';
 		}
+		
 		$this->redirect(array('controller'=>$target, 'action'=>'index', 'success'=>'payment'));
 	}
 

--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -452,8 +452,10 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action
     /**
      * On any change on country, payment or dispatch recalculate shipping costs
      * and forward to cart / confirm view
+     *
+     * @param boolean $forward
      */
-    public function calculateShippingCostsAction()
+    public function calculateShippingCostsAction($forward = true)
     {
         if ($this->Request()->getPost('sCountry')) {
             $this->session['sCountry'] = (int) $this->Request()->getPost('sCountry');
@@ -474,7 +476,15 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action
         if ($this->Request()->getPost('sState')) {
             $this->session['sState'] = (int) $this->Request()->getPost('sState');
         }
+        
+        if ($forward == false){
+            return;
+        }
 
+		if (Enlight()->Events()->notifyUntil('Shopware_Controllers_Frontend_Checkout_CalculateShippingCosts_Forward', array('subject'=>$this))){
+			return;
+		}
+        
         $this->forward($this->Request()->getParam('sTargetAction', 'index'));
     }
 


### PR DESCRIPTION
To use the built in "save payment" and "save shipping" methods while writing a plugin to customize the checkout, we need to add events and/or parameters to avoid the default forwarding mechanism within those methods.
