### PR TITLE
Better error messages for permission problems on plugin download

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/PluginManager/Components/Store.php
+++ b/engine/Shopware/Plugins/Default/Core/PluginManager/Components/Store.php
@@ -306,8 +306,9 @@ class CommunityStore
     {
         $target = Shopware()->AppPath('Plugins_' . $source);
 
-        if (!$this->isPluginDirectoryWritable($target, true)) {
-            throw new Enlight_Exception("A directory or a file in ". $target ." is not writable, please change the permissions recursively");
+        $error = null; // Variable to store error information
+        if (!$this->isPluginDirectoryWritable($target, true, $error)) {
+            throw new Enlight_Exception($error ." is not writable, please change the permissions of ". $target ." recursively");
         }
         $filter = new Zend_Filter_Decompress(array(
             'adapter' => 'Zip',
@@ -894,10 +895,11 @@ class CommunityStore
      *
      * @param $directory | the directory in which the permissions are checked
      * @param bool $recursive | if true, the directory will be checked recursively
+     * @param string $error | filled with the path which was not writable in case of an error
      *
      * @return bool
      */
-    protected function isPluginDirectoryWritable($directory, $recursive = false)
+    protected function isPluginDirectoryWritable($directory, $recursive = false, &$error = false)
     {
         if (!$recursive) {
             return is_writable($directory);
@@ -909,6 +911,10 @@ class CommunityStore
 
             foreach ($iterator as $path) {
                 if (!is_writable($path->__toString())) {
+                    if ($error !== false) {
+                        $error = $path->getRealPath();
+                    }
+
                     return false;
                 }
             }


### PR DESCRIPTION
Currently when the permissions of the plugin folders are wrong and you try to download something from the community store you only get a message that you should change `engine/Shopware/Plugins/(Community/Default/Core)` recursively. There are two problems with that:
- Actually `engine/Shopware/Plugins` needs to be writeable as well, as `..` is also walked by the recursive iterator
- The message is really unspecific and on some webhosters it's really clumsy to change everything recursively

So this commit adds the actual path, which is not writeable, to the error message to make fixing problems like this easier.
