### PR TITLE
Json Output enableJsonExprFinder

### DIFF
--- a/engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
+++ b/engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
@@ -220,10 +220,10 @@ class Enlight_Controller_Plugins_Json_Bootstrap extends Enlight_Plugin_Bootstrap
         }
         if ($this->formatDateTime === true && is_array($data)) {
             array_walk_recursive($data, array($this, 'convertDateTime'));
-            $data = Zend_Json::encode($data);
+            $data = Zend_Json::encode($data, false, array('enableJsonExprFinder' => true));
             $data = preg_replace('/"Date\((-?\d+)\)"/', 'new Date($1)', $data);
         } else {
-            $data = Zend_Json::encode($data);
+            $data = Zend_Json::encode($data, false, array('enableJsonExprFinder' => true));
         }
         return $data;
     }


### PR DESCRIPTION
enableJsonExprFinder for Zend_Json::encode so you can e.g. define listeners for plugin form elements
$form->setElement(
    'select',
    'mappingFilesPath',
    array(
        'label' => 'Modus',
        'required' => true,
        'store' => array(),
        'listeners' => array(
            'select' => new Zend_Json_Expr('function() { /_code_/ }')
        ),
        'scope' => Shopware\Models\Config\Element::SCOPE_SHOP
    )
);
