### PR TITLE
Die Spalte "group" ist ein reservierte Begriff und muss gequotet werden

### DIFF
--- a/engine/Shopware/Models/Order/Status.php
+++ b/engine/Shopware/Models/Order/Status.php
@@ -79,7 +79,7 @@ class Status extends ModelEntity
     /**
      * @var string $group
      *
-     * @ORM\Column(name="group", type="string", length=25, nullable=false)
+     * @ORM\Column(name="`group`", type="string", length=25, nullable=false)
      */
     private $group;
 


### PR DESCRIPTION
Beim flushen des Models "\Shopware\Models\Order\Status()" kommt ein Syntax Error.
Ursache dafür ist, das die Spalte "group" ein reservierter Begriff von MySql weshalb dieser gequotet werden muss.
Fehlerbehebung ist durch ein simples quoten in der Doctrine-Annotation möglich.

Liste aller reservierten Begriffe: http://dev.mysql.com/doc/refman/5.5/en/reserved-words.html
