### PR TITLE
Fix handling of arrays in the REST API filter

### DIFF
--- a/engine/Shopware/Components/Model/QueryBuilder.php
+++ b/engine/Shopware/Components/Model/QueryBuilder.php
@@ -122,7 +122,19 @@ class QueryBuilder extends BaseQueryBuilder
                 }
             }
 
-            $expression = new Expr\Comparison($exprKey, $expression, $where !== null ? (':' . $parameterKey) : null);
+            $assocWhere = array();
+            if (is_array($where)) {
+                // Create one key for every value in the array
+                foreach ($where as $key => $value) {
+                    $assocWhere[':'.str_replace('.', '_', $exprKey).$key] = $value;
+                }
+                // Include all keys in the 'IN' expression
+                $inSet = '(' . implode(',', array_keys($assocWhere)) . ')';
+                $expression = new Expr\Comparison($exprKey, $expression, $inSet);
+            } else {
+                // Handling of default filter values
+                $expression = new Expr\Comparison($exprKey, $expression, $where !== null ? (':' . $parameterKey) : null);
+            }
 
             if (isset($operator)) {
                 $this->orWhere($expression);
@@ -130,7 +142,13 @@ class QueryBuilder extends BaseQueryBuilder
                 $this->andWhere($expression);
             }
 
-            if ($where !== null) {
+            if (count($assocWhere) > 0) {
+                // Replace all previously created keys with their corresponding values
+                foreach ($assocWhere as $key => $value) {
+                    $this->setParameter($key, $value);
+                }
+            } else if($where !== null) {
+                // Handling of default filter values
                 $this->setParameter($parameterKey, $where);
             }
         }


### PR DESCRIPTION
The REST API accepts filter parameters in the URL, which can contain multiple values for one property. The internal handling in the used query builder checks for arrays of filter values, to create `IN` expressions in the resulting SQL query. However, if an array is recognized, the term `IN` will be selected as the operator, but the value array will not be handled correctly. This leads to a syntax error like the following:

```
Errormesage: [Syntax Error] line 0, col 78: Error: Expected Doctrine\ORM\Query\Lexer::T_OPEN_PARENTHESIS, got ':cleared'
```

Adding parentheses, as well as one parameter key for each value in the array and replacing all these keys with their values later fixes this error.
