### PR TITLE
Use absolute paths for files and directories in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,29 +16,29 @@ Thumbs.db
 
 # Internal Repositories
 internal/
-engine/Shopware/Plugins/Commercial/
+/engine/Shopware/Plugins/Commercial/
 
 # User installed plugins
-engine/Shopware/Plugins/Community/
-engine/Shopware/Plugins/Local/
+/engine/Shopware/Plugins/Community/
+/engine/Shopware/Plugins/Local/
 
 # Userconfigurations
-config.php
-engine/Shopware/Configs/Custom.php
+/config.php
+/engine/Shopware/Configs/Custom.php
 
 # Caches/Proxies
-tests/Shopware/TempFiles/
-cache/
+/tests/Shopware/TempFiles/
+/cache/
 
 
 # User provided content
-media/archive/
-media/image/
-media/music/
-media/pdf/
-media/temp/
-media/unknown/
-media/video/
+/media/archive/
+/media/image/
+/media/music/
+/media/pdf/
+/media/temp/
+/media/unknown/
+/media/video/
 
-files/documents
-files/downloads
+/files/documents
+/files/downloads


### PR DESCRIPTION
Since plugins could be using filenames mentioned within the gitignore file (e.g., config.php) it is advisable to use absolute paths.
