### PR TITLE
Fix bug in Order\Shipping entity mapping leading to weird queries.

### DIFF
--- a/engine/Shopware/Models/Order/Shipping.php
+++ b/engine/Shopware/Models/Order/Shipping.php
@@ -159,7 +159,7 @@ class Shipping extends ModelEntity
      * The association is joined over the shipping userID and the customer id
      *
      * @var \Shopware\Models\Customer\Customer $customer
-     * @ORM\OneToOne(targetEntity="Shopware\Models\Customer\Customer", inversedBy="shipping")
+     * @ORM\ManyToOne(targetEntity="Shopware\Models\Customer\Customer")
      * @ORM\JoinColumn(name="userID", referencedColumnName="id")
      */
     protected $customer;


### PR DESCRIPTION
Fixes the bug where in some cirtumstances `Customer\Customer#shipping` contains a `Order\Shipping` instead of an `Customer\Shipping`.
