### PR TITLE
Add a document attributes entry to the database when creating a new document

### DIFF
--- a/engine/Shopware/Models/Order/Document/Document.php
+++ b/engine/Shopware/Models/Order/Document/Document.php
@@ -333,7 +333,7 @@ class Document extends ModelEntity
      */
     public function setAttribute($attribute)
     {
-        return $this->setOneToOne($attribute, '\Shopware\Models\Attribute\Document', 'attribute', 'orderDocument');
+        return $this->setOneToOne($attribute, '\Shopware\Models\Attribute\Document', 'attribute', 'document');
     }
 
 }


### PR DESCRIPTION
When a new document is created using the `Document` component, a new entry in `s_order_documents` is created, but no associated entry in `s_order_documents_attributes`. Besides that the `setAttribute` method of the `Shopware\Models\Order\Document\Document` entity is broken. This pull request not only fixes this broken method, but also adds a new attributes entry when creating a document. Furthermore it is possible to add an `attributes` array to the config, which is passed to the document creation. The contained key/value pairs will be inserted or updated in the attributes entity. This fix is backwards compatible, meaning that on an update no exception will be thrown, if no attributes exist yet, but actually a new attributes entity is created and saved in the database.
