### PR TITLE
Added cache clear commands

### DIFF
--- a/engine/Shopware/Commands/CacheConfigClearCommand.php
+++ b/engine/Shopware/Commands/CacheConfigClearCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Shopware 4
+ * Copyright © shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Shopware\Components\CacheManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Components\Console\Command
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ * @author    Benjamin Boit <bebo@posteo.de>
+ */
+class CacheConfigClearCommand extends ShopwareCommand
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sw:cache:config:clear')
+            ->setDescription('Clears the config-cache.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Clearing config-cache ...</info>');
+
+        /**
+         * @var CacheManager $cacheManager
+         */
+        $cacheManager = $this->container->get('shopware.cache_manager');
+
+        $cacheManager->clearConfigCache();
+    }
+
+}

--- a/engine/Shopware/Commands/CacheHttpClearCommand.php
+++ b/engine/Shopware/Commands/CacheHttpClearCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Shopware 4
+ * Copyright © shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Shopware\Components\CacheManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Components\Console\Command
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ * @author    Benjamin Boit <bebo@posteo.de>
+ */
+class CacheHttpClearCommand extends ShopwareCommand
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sw:cache:http:clear')
+            ->setDescription('Clears the http-cache.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Clearing http-cache ...</info>');
+
+        /**
+         * @var CacheManager $cacheManager
+         */
+        $cacheManager = $this->container->get('shopware.cache_manager');
+
+        $cacheManager->clearHttpCache();
+    }
+
+}

--- a/engine/Shopware/Commands/CacheProxyClearCommand.php
+++ b/engine/Shopware/Commands/CacheProxyClearCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Shopware 4
+ * Copyright © shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Shopware\Components\CacheManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Components\Console\Command
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ * @author    Benjamin Boit <bebo@posteo.de>
+ */
+class CacheProxyClearCommand extends ShopwareCommand
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sw:cache:proxy:clear')
+            ->setDescription('Clears the proxy-cache.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Clearing proxy-cache ...</info>');
+
+        /**
+         * @var CacheManager $cacheManager
+         */
+        $cacheManager = $this->container->get('shopware.cache_manager');
+
+        $cacheManager->clearProxyCache();
+    }
+
+}

--- a/engine/Shopware/Commands/CacheRewriteClearCommand.php
+++ b/engine/Shopware/Commands/CacheRewriteClearCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Shopware 4
+ * Copyright © shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Shopware\Components\CacheManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Components\Console\Command
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ * @author    Benjamin Boit <bebo@posteo.de>
+ */
+class CacheRewriteClearCommand extends ShopwareCommand
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sw:cache:rewrite:clear')
+            ->setDescription('Clears the rewrite-cache.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Clearing rewrite-cache ...</info>');
+
+        /**
+         * @var CacheManager $cacheManager
+         */
+        $cacheManager = $this->container->get('shopware.cache_manager');
+
+        $cacheManager->clearRewriteCache();
+    }
+
+}

--- a/engine/Shopware/Commands/CacheSearchClearCommand.php
+++ b/engine/Shopware/Commands/CacheSearchClearCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Shopware 4
+ * Copyright © shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Shopware\Components\CacheManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Components\Console\Command
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ * @author    Benjamin Boit <bebo@posteo.de>
+ */
+class CacheSearchClearCommand extends ShopwareCommand
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sw:cache:search:clear')
+            ->setDescription('Clears the search-cache.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Clearing search-cache ...</info>');
+
+        /**
+         * @var CacheManager $cacheManager
+         */
+        $cacheManager = $this->container->get('shopware.cache_manager');
+
+        $cacheManager->clearSearchCache();
+    }
+
+}

--- a/engine/Shopware/Commands/CacheTemplateClearCommand.php
+++ b/engine/Shopware/Commands/CacheTemplateClearCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Shopware 4
+ * Copyright © shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Shopware\Components\CacheManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Components\Console\Command
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ * @author    Benjamin Boit <bebo@posteo.de>
+ */
+class CacheTemplateClearCommand extends ShopwareCommand
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sw:cache:template:clear')
+            ->setDescription('Clears the template-cache.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Clearing template-cache ...</info>');
+
+        /**
+         * @var CacheManager $cacheManager
+         */
+        $cacheManager = $this->container->get('shopware.cache_manager');
+
+        $cacheManager->clearTemplateCache();
+    }
+
+}


### PR DESCRIPTION
Added cache-clear-commands which use the shopware cache-manager service to clear caches. Useful for deployments.
