### PR TITLE
Fix set-cookie sent multiple times when regenerating session

### DIFF
--- a/engine/core/class/sAdmin.php
+++ b/engine/core/class/sAdmin.php
@@ -1296,6 +1296,8 @@ class sAdmin
         session_regenerate_id(true);
         $newSessionId = session_id();
 
+        // clear any set-cokie header before opening a new session
+        header_remove('Set-Cookie');
         // close and restart session to make sure the db-session handler writes updates.
         session_write_close();
         session_start();


### PR DESCRIPTION
![bildschirmfoto 2014-02-27 um 13 17 22](https://f.cloud.github.com/assets/6330639/2282138/27fee1d8-9fa9-11e3-8903-9d62d1c19ee5.png)
When logging in (account/login), Shopware somtimes will return a Set-Cokie header for the same cookie name three times (old sessionID, new sessionID, new sessionID). This might lead to unexpected behavior, as it is not clear what happens in the browser when setting the same cookie multiple times.

This is not the fix for the root problem of, but mentioned in a sidenote here: http://jira.shopware.de/?ticket=SW-7684
