### PR TITLE
[imported] Set articleId when manually adding an order position

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1323,6 +1323,14 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
             unset($data['tax']);
         }
 
+        // Add articleId if it's not provided by the client
+        if ($data['articleId'] == 0) {
+            $articleDetails = Shopware()->Models()->getRepository('Shopware\Models\Article\Detail')->findOneByNumber($data['articleNumber']);
+            if ( ! is_null($articleDetails)) {
+                $data['articleId'] = $articleDetails->getArticle()->getId();
+            }
+        }
+
         return $data;
     }
 


### PR DESCRIPTION
When manually adding a new order position via the backend, the `articleId` column is not set in the database. This is inconsistent, especially if one uses the autocomplete tooltip to select the article. Also the open article button is not displayed because of this for example.
