### PR TITLE
REST API: Put/Update Bugfix

### DIFF
--- a/engine/Shopware/Controllers/Api/Articles.php
+++ b/engine/Shopware/Controllers/Api/Articles.php
@@ -123,7 +123,6 @@ class Shopware_Controllers_Api_Articles extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 
     /**


### PR DESCRIPTION
Die REST Api erfüllte nichtmehr Ihren Zweck und leitet um, nachdem man einen Artikel aktualisiert hat, dieser kleine Patch entfernt die (ungewollte) Umleitung
