### PR TITLE
Nicht vorausgewählte Varianten setzen

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -850,9 +850,16 @@ class Article extends Resource implements BatchInterface
 
                 $data['mainDetail'] = $newMain;
             }
+            
+            if (!$variantData['isMain']){
+	            $variant->setKind(2);
+            }
 
             $variants[] = $variant;
         }
+
+
+
 
         $data['details'] = $variants;
         unset($data['variants']);

--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -858,9 +858,6 @@ class Article extends Resource implements BatchInterface
             $variants[] = $variant;
         }
 
-
-
-
         $data['details'] = $variants;
         unset($data['variants']);
 

--- a/templates/_emotion/frontend/_resources/javascript/jquery.emotion.js
+++ b/templates/_emotion/frontend/_resources/javascript/jquery.emotion.js
@@ -240,7 +240,7 @@
 			return outer;
 		}
 	
-		return this.each(function() {
+		return this.not('.no_style').each(function() {
 			var $this = $(this),
 				initalWidth = $this.is(':hidden') ? $this.width() + 3 : $this.width() + 15,
 				selected = $this.find(':selected'),


### PR DESCRIPTION
REST API: Wenn beim Update die Vorauswahl der Varianten geändert wird, kommt es zum Fehler, da die anderen Varianten nicht deaktiviert werden. So habe ich das Problem behoben.
