### PR TITLE
- new and not existing options were added with a wrong name instead of t...

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -688,9 +688,14 @@ class Variant extends Resource implements BatchInterface
             ));
 
             if (!$option) {
+
+                if (!$optionData['option']) {
+                    throw new ApiException\CustomValidationException('A new configurator option requires a name');
+                }
+
                 $option = new Option();
                 $option->setPosition(0);
-                $option->setName($option);
+                $option->setName($optionData['option']);
                 $option->setGroup($availableGroup);
                 $this->getManager()->persist($option);
             }


### PR DESCRIPTION
While creating and updating variation options, new configurator options got wrong names (`Object`) instead of the given option names
