### PR TITLE
update to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# EDITS 
+
+install ant https://ant.apache.org/manual/install.html
+use setx command
+set ANT_HOME=c:\ant
+set JAVA_HOME=C:\Program Files (x86)\Java\jdk1.8.0
+set PATH=%PATH%;%ANT_HOME%\bin
+
 # Shopware 4
 
 - **License**: Dual license AGPL v3 / Proprietary

--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-# EDITS 
-
-install ant https://ant.apache.org/manual/install.html
-use setx command
-set ANT_HOME=c:\ant
-set JAVA_HOME=C:\Program Files (x86)\Java\jdk1.8.0
-set PATH=%PATH%;%ANT_HOME%\bin
-
 # Shopware 4
 
 - **License**: Dual license AGPL v3 / Proprietary
@@ -56,6 +48,10 @@ those files.
 
     cd build/
     ant configure
+  # EDITS 
+
+The ant build requires six arguments to be entered in the command line. While the first four are self explanetory, the last two relating to the app.path and host.path could use some clarification.
+    
     ant build-config build-composer-install build-database
 
 4.) Download the demo data files and extract them:


### PR DESCRIPTION
The ant build requires six arguments to be entered in the command line. While the first four are self explanetory, the last two relating to the app.path and host.path could use some clarification.
