### PR TITLE
[imported] PT-1846 InputFilter ignoriert Port

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
@@ -86,7 +86,8 @@ class Shopware_Plugins_Frontend_InputFilter_Bootstrap extends Shopware_Component
                 $shop->getSecureHost()
             );
             $host = parse_url($referer, PHP_URL_HOST);
-            if (!in_array($host, $validHosts)) {
+            $hostWithPort = $host . ':' .parse_url($referer, PHP_URL_PORT);
+            if (!in_array($host, $validHosts) && !in_array($hostWithPort, $validHosts)) {
                 $response->setException(
                     new Exception('Referer check for frontend session failed')
                 );


### PR DESCRIPTION
Der InputFilter berücksichtigt leider beim Referer Check nicht das Shop()->getHost() die Domain mit Port angibt und die Funktion parse_url mit dem Parameter PHP_URL_HOST nur den Hostteil ermittelt.
