### PR TITLE
[imported] Neuer Artikel mit 0% MwSt erzeugt Exception

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -983,7 +983,7 @@ class Article extends Resource implements BatchInterface
                 throw new ApiException\CustomValidationException(sprintf("Tax by id %s not found", $data['taxId']));
             }
 
-        } elseif (!empty($data['tax'])) {
+        } elseif (isset($data['tax']) && ($data['tax'] >= 0)) {
             $tax = $this->getManager()->getRepository('Shopware\Models\Tax\Tax')->findOneBy(array('tax' => $data['tax']));
             if (!$tax) {
                 throw new ApiException\CustomValidationException(sprintf("Tax by taxrate %s not found", $data['tax']));


### PR DESCRIPTION
Legt man einen Artikel mit 0% MwSt an, so wird dies nicht erkannt bei Verwendung der PHP-Funktion `empty()`. Die Funktion interpretiert 0, 0.00 und "0" immer als leer, sodass der Artikel nicht hinzugefügt werden kann, weil das Feld 'tax' nicht mehr gesetzt ist (s. else-Zweig).
Die Überprüfung mit `isset()` und `>= 0` behebt dieses Problem.
