### PR TITLE
[response needed] Api\Resource\Article create() erzeugt Exception

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -32,7 +32,7 @@ use Shopware\Models\Article\Detail;
 use Shopware\Models\Article\Image;
 use Shopware\Models\Article\Price;
 use Shopware\Models\Article\Unit;
-use Shopware\Models\Customer\Group as CustomerGroup;
+use Shopware\Models\Customer\Group as CustGroup;
 use Shopware\Models\Media\Media as MediaModel;
 use Shopware\Models\Tax\Tax;
 use Shopware\Components\Api\BatchInterface;
@@ -609,7 +609,7 @@ class Variant extends Resource implements BatchInterface
                 ->findOneBy(array('key' => $priceData['customerGroupKey']));
 
             /** @var CustomerGroup $customerGroup */
-            if (!$customerGroup instanceof CustomerGroup) {
+            if (!$customerGroup instanceof CustGroup) {
                 throw new ApiException\CustomValidationException(sprintf('Customer Group by key %s not found', $priceData['customerGroupKey']));
             }
 


### PR DESCRIPTION
Beim Erzeugen eines Artikels über die Resource kommt es zu einem Fehler.
Durch Ändern des Aliases im using wird dieses Problem behoben.
## 

Fatal error: Cannot use Shopware\Models\Customer\Group as CustomerGroup because the name is already in use in <Shopware_Path>\engine\Shopware\Components\Api\Resource\Variant.php on line 35

**StackTrace:**
15  9.1860  16935808    Shopware\Components\Api\Resource\Article->create( ??? ) ..\Article.php:690
16  10.8441 17052640    Shopware\Components\Api\Resource\Article->prepareAssociatedData( ???, ??? ) ..\Article.php:510
17  12.6738 17213432    Shopware\Components\Api\Resource\Article->prepareMainDetail( ???, ??? ) ..\Article.php:708
18  12.6779 17275800    Shopware\Components\Api\Resource\Article->getVariantResource( ) ..\Article.php:731
19  12.6779 17275912    Shopware\Components\Api\Resource\Resource->getResource( ??? )   ..\Article.php:69
20  12.6780 17276328    spl_autoload_call ( ??? )   ..\Article.php:120
21  12.6780 17276384    Composer\Autoload\ClassLoader->loadClass( ??? ) ..\Article.php:0 
22  12.6781 17276384    Composer\Autoload\includeFile( ??? )    ..\ClassLoader.php:269
## 
