### PR TITLE
[response needed] fixed saving of wrong media-path

### DIFF
--- a/engine/Shopware/Models/Media/Media.php
+++ b/engine/Shopware/Models/Media/Media.php
@@ -751,8 +751,14 @@ class Media extends ModelEntity
                 return $e;
             }
         }
+
+        // update new path
+        $this->path = $this->getRelativeUploadDir() . '/' . $this->getFileName();
+
+        // remove temporary upload-file
         unlink($this->file->getPathname());
         unlink($this->file);
+
         return true;
     }
 
@@ -881,6 +887,15 @@ class Media extends ModelEntity
     {
         // the absolute directory path where uploaded documents should be saved
         return Shopware()->DocPath('media_' . strtolower($this->type));
+    }
+
+    /**
+     * Returns the the relative path to the upload-directory
+     * @return string
+     */
+    private function getRelativeUploadDir()
+    {
+        return 'media/' . strtolower($this->type);
     }
 
     /**


### PR DESCRIPTION
Hallo,

beim Bilder-Import von Artikeln wird in unregelmäßigen Abständen der Fehler "File not found:" (/mnt/vagrant/shopware-4/engine/Shopware/Components/Thumbnail/Generator/Basic.php:55) geworfen. Diese Fehlermeldung bezieht sich auf das Originalbild, welches nicht an dem richtigen Zielort liegen soll.

Tatsächlich liegt das Bild an der richtigen Stelle mit richtigem Namen, nur die Referenz in der Media-Entity zeigt auf einen leicht anderen Pfad (bsp: x-FILENAME.jpg). Dieser Fix aktualisiert die Referenz auf den richtigen Pfad.

Eventuell ist dies eher ein Workaround ...
