### PR TITLE
[response needed] Add a method to set the variable encoderName

### DIFF
--- a/engine/Shopware/Models/Customer/Customer.php
+++ b/engine/Shopware/Models/Customer/Customer.php
@@ -417,6 +417,26 @@ class Customer extends LazyFetchModelEntity
         $this->hashPassword = null;
         $this->rawPassword  = $rawPassword;
     }
+    
+    /**
+     * Setter method for the encoder column
+     * 
+     * @param string $encoderName
+     */
+     public function setEncoderName($encoderName)
+     {
+        $this->encoderName = $encoderName;
+     }
+	 
+     /**
+      * Getter method for the encoder column
+      * 
+      * @return string
+      */
+     public function getEncoderName()
+     {
+        return $this->encoderName;
+     }
 
     /**
      * Setter function for the email column property of the customer.


### PR DESCRIPTION
To create or set a customer via api, the variable encoderName could not be set. This variable is shown in the actual api doku (http://wiki.shopware.de/_detail_1687.html) but without function.
