### PR TITLE
CRITICAL: set doctrine-common to a more specific version to prevent lazy load bug on update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "monolog/monolog": "1.6.*",
         "ircmaxell/password-compat": "1.0.3",
         "rhumsaa/array_column": "~1.1",
-        "doctrine/common": "2.4.*",
+        "doctrine/common": "2.4.1",
         "doctrine/dbal": "2.4.1",
         "doctrine/orm": "2.4.1"
     },


### PR DESCRIPTION
We are using composer in production and used this composer.json als base. After we updated using "composer update" some days ago some things broke in shopware.

Creating / removing  customer-entities and even importing articles was not possible anymore.

Last known valid commit hash was: 9a7e20e779360f3b8a02c27a89d47d5a6fdce8d1
Broken for us at: b1a31ae3df2c18c24bec42e2cc32e3e4bedc07c7

Please be carefull at next build ;)
