### PR TITLE
changed URL of Developer's Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,5 @@ The changelog and all available commits are located under <https://github.com/Sh
 * [Shopware Wiki](http://wiki.shopware.de) - Shopware Wiki
 * [Shopware Forum](http://forum.shopware.de) - Community forum
 * [Shopware Marketplace](http://store.shopware.de) - Shopware Store
-* [Shopware Developer Guide](http://wiki.shopware.de/Developers-Guide_cat_487.html) - Shopware 4 Developer Guide
+* [Shopware Developer Guide](http://wiki.shopware.de/Developers-Guide_cat_796.html) - Shopware 4 Developer Guide
 * [Shopware Designer Guide](http://wiki.shopware.de/Designers-Guide_cat_486.html) - Shopware 4 Designer Guide


### PR DESCRIPTION
Hi,

changed the URL of the link to Developer's Guide to point to the Developer's Guide in the Wiki. The old URL pointed to the "Archive" section in your labs wiki (which was quite vexing).

Björn
