### PR TITLE
[imported] Fix handling of arrays in addFilter method of QueryBuilder component

### DIFF
--- a/engine/Shopware/Components/Model/QueryBuilder.php
+++ b/engine/Shopware/Components/Model/QueryBuilder.php
@@ -190,7 +190,9 @@ class QueryBuilder extends BaseQueryBuilder
                 }
             }
 
-            $expression = new Expr\Comparison($exprKey, $expression, $where !== null ? (':' . $parameterKey) : null);
+            $exprParameterKey = ':' . $parameterKey;
+            if (is_array($where)) $exprParameterKey = '('.$exprParameterKey.')';
+            $expression = new Expr\Comparison($exprKey, $expression, $where !== null ? $exprParameterKey : null);
 
             if (isset($operator)) {
                 $this->orWhere($expression);


### PR DESCRIPTION
The REST API accepts filter parameters in the URL, which can contain multiple values for one property. The internal handling in the used query builder checks for arrays of filter values, to create `IN` expressions in the resulting SQL query. However, if an array is recognized, the term `IN` will be selected as the operator, but the value array will not be handled correctly. This leads to a syntax error like the following:

```
Errormesage: [Syntax Error] line 0, col 78: Error: Expected Doctrine\ORM\Query\Lexer::T_OPEN_PARENTHESIS, got ':cleared'
```

Simply adding parentheses in case an array of values is supplied fixes this error.

**Updated version of PR #128:** As requested by @bcremer we rebased it on the current master (as it is even newer than next currently) and added test cases.
