### PR TITLE
Fix handling of HTTP 'Location' headers and status codes in REST API responses to POST and PUT requests

### DIFF
--- a/engine/Shopware/Controllers/Api/Articles.php
+++ b/engine/Shopware/Controllers/Api/Articles.php
@@ -96,7 +96,7 @@ class Shopware_Controllers_Api_Articles extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
+        $this->Response()->setRedirect($location, 201);
     }
 
     /**
@@ -123,7 +123,6 @@ class Shopware_Controllers_Api_Articles extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 
     /**

--- a/engine/Shopware/Controllers/Api/Categories.php
+++ b/engine/Shopware/Controllers/Api/Categories.php
@@ -83,7 +83,7 @@ class Shopware_Controllers_Api_Categories extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
+        $this->Response()->setRedirect($location, 201);
     }
 
     /**
@@ -105,7 +105,6 @@ class Shopware_Controllers_Api_Categories extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 
     /**

--- a/engine/Shopware/Controllers/Api/CustomerGroups.php
+++ b/engine/Shopware/Controllers/Api/CustomerGroups.php
@@ -83,7 +83,7 @@ class Shopware_Controllers_Api_CustomerGroups extends Shopware_Controllers_Api_R
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
+        $this->Response()->setRedirect($location, 201);
     }
 
     /**
@@ -105,7 +105,6 @@ class Shopware_Controllers_Api_CustomerGroups extends Shopware_Controllers_Api_R
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 
     /**

--- a/engine/Shopware/Controllers/Api/Customers.php
+++ b/engine/Shopware/Controllers/Api/Customers.php
@@ -88,7 +88,7 @@ class Shopware_Controllers_Api_Customers extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
+        $this->Response()->setRedirect($location, 201);
     }
 
     /**
@@ -116,7 +116,6 @@ class Shopware_Controllers_Api_Customers extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 
     /**

--- a/engine/Shopware/Controllers/Api/Media.php
+++ b/engine/Shopware/Controllers/Api/Media.php
@@ -83,7 +83,7 @@ class Shopware_Controllers_Api_Media extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
+        $this->Response()->setRedirect($location, 201);
     }
 
     /**
@@ -105,7 +105,6 @@ class Shopware_Controllers_Api_Media extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 
     /**

--- a/engine/Shopware/Controllers/Api/Orders.php
+++ b/engine/Shopware/Controllers/Api/Orders.php
@@ -96,6 +96,5 @@ class Shopware_Controllers_Api_Orders extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 }

--- a/engine/Shopware/Controllers/Api/PropertyGroups.php
+++ b/engine/Shopware/Controllers/Api/PropertyGroups.php
@@ -83,7 +83,7 @@ class Shopware_Controllers_Api_PropertyGroups extends Shopware_Controllers_Api_R
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
+        $this->Response()->setRedirect($location, 201);
     }
 
     /**
@@ -105,7 +105,6 @@ class Shopware_Controllers_Api_PropertyGroups extends Shopware_Controllers_Api_R
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 
     /**

--- a/engine/Shopware/Controllers/Api/Shops.php
+++ b/engine/Shopware/Controllers/Api/Shops.php
@@ -83,7 +83,7 @@ class Shopware_Controllers_Api_Shops extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
+        $this->Response()->setRedirect($location, 201);
     }
 
     /**
@@ -105,7 +105,6 @@ class Shopware_Controllers_Api_Shops extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 
     /**

--- a/engine/Shopware/Controllers/Api/Translations.php
+++ b/engine/Shopware/Controllers/Api/Translations.php
@@ -75,7 +75,7 @@ class Shopware_Controllers_Api_Translations extends Shopware_Controllers_Api_Res
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
+        $this->Response()->setRedirect($location, 201);
     }
 
     /**
@@ -103,7 +103,6 @@ class Shopware_Controllers_Api_Translations extends Shopware_Controllers_Api_Res
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 
     /**

--- a/engine/Shopware/Controllers/Api/Variants.php
+++ b/engine/Shopware/Controllers/Api/Variants.php
@@ -74,7 +74,7 @@ class Shopware_Controllers_Api_Variants extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
+        $this->Response()->setRedirect($location, 201);
     }
 
     /**
@@ -101,7 +101,6 @@ class Shopware_Controllers_Api_Variants extends Shopware_Controllers_Api_Rest
         );
 
         $this->View()->assign(array('success' => true, 'data' => $data));
-        $this->Response()->setHeader('Location', $location);
     }
 
     /**


### PR DESCRIPTION
When using `POST` and `PUT` requests with the REST API, it always explicitly sets a HTTP `Location` header, when the requests succeed. This was done using the `setHeader()` method. The problem with this approach is twofold: Firstly the location header should only be set on successful `POST` requests, because only in these cases a new resource with a new location has been created. `PUT` requests on the other hand don't create new resources and hence don't result in new locations, the requesting party could be interested in (it is still contained in the response data, though). Secondly, using the `setHeader()` method only adds a new entry to the list of headers to be sent. These headers are later sent with PHP's `header()` method, which has, according to its documentation (http://www.php.net/manual/en/function.header.php), two special-case header calls. Important for this fix is the second one:

> The second special case is the "Location:" header. Not only does it send this header back to the browser, but it also returns a REDIRECT (302) status code to the browser unless the 201 or a 3xx status code has already been set.

This behavior is responsible for the problem, that Shopware's REST API always returns a `302` in case of a successful `PUT` or `POST` request. To fix this, I replaced each `setHeader()` call for `POST` requests with the more meaningful `setRedirect()` call, which accepts a status code as an optional parameter. When passing a `201` for the status code, PHP's `header()` method will, as described in the docs, not replace the already set `201` with a `302` by setting the `Location` header. Furthermore I removed all calls to `setHeader()` for `PUT` requests completely. Now a successful `POST` request will result in a `HTTP/1.1 201 Created` with a `Location` header, while a successful `PUT` request will just result in a `HTTP/1.1 200 OK`.
