### PR TITLE
[imported] Fix wrong reference in setAttribute method of order document model

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,9 @@
 # Shopware Upgrade Information
 In this document you will find a changelog of the important changes related to the code base of Shopware.
 
+## Next
+* Fixed name used as reference when setting attributes of an order document.
+
 ## 4.3.0
 * Removed `location` header in responses for all REST-API PUT routes (e.g. PUT /api/customers/{id}).
 * Removed deprecated Zend Framework components:

--- a/engine/Shopware/Models/Order/Document/Document.php
+++ b/engine/Shopware/Models/Order/Document/Document.php
@@ -326,7 +326,7 @@ class Document extends ModelEntity
      */
     public function setAttribute($attribute)
     {
-        return $this->setOneToOne($attribute, '\Shopware\Models\Attribute\Document', 'attribute', 'orderDocument');
+        return $this->setOneToOne($attribute, '\Shopware\Models\Attribute\Document', 'attribute', 'document');
     }
 
 }

--- a/tests/Shopware/Tests/Models/Order/OrderDocumentDocumentTest.php
+++ b/tests/Shopware/Tests/Models/Order/OrderDocumentDocumentTest.php
@@ -1,0 +1,14 @@
+<?php
+
+class Shopware_Tests_Models_Order_Document_DocumentTest extends Enlight_Components_Test_TestCase
+{
+    public function testSetAttribute()
+    {
+        $document = new \Shopware\Models\Order\Document\Document();
+        $attribute = new \Shopware\Models\Attribute\Document();
+        $document->setAttribute($attribute);
+
+        $this->assertSame($document, $attribute->getDocument());
+        $this->assertSame($attribute, $document->getAttribute());
+    }
+}


### PR DESCRIPTION
This fix changes the reference, which is used to set the one-to-one relationship between the order document and its attributes. In the attribute field's [mappedBy annotation](https://github.com/VIISON/shopware-4/blob/fix-model-order-document-document-setattribute/engine/Shopware/Models/Order/Document/Document.php#L120) the name `document` is used, while in the `setAttribute()` method `orderDocument` was passed when setting the one-to-one relationship. That made it impossible to add attributes to an order document.

This pull request changes the used reference name, which is passed to `setOneToOne()`, to `document`  making it conform with the value used in the `mappedBy` annotation.
