### PR TITLE
Add attributes to a document when creating or updating it

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,7 @@ In this document you will find a changelog of the important changes related to t
 * Fixed name used as reference when setting attributes of an order document.
 * Added new event `Shopware_Modules_Articles_sGetArticlesByCategory_FilterCountSql`
 * `Forgotten password` feature now takes into account the configured minimum password length when generating new passwords
+* Create an attributes entity when creating an order document using the Document component and check for an `attributes` array in the document config, whose key/value pairs will be set as the document's attributes
 
 ## 4.3.0
 * Removed `location` header in responses for all REST-API PUT routes (e.g. PUT /api/customers/{id}).


### PR DESCRIPTION
When a new document is created using the `Document` component, a new entry in `s_order_documents` is created, but no associated entry in `s_order_documents_attributes`. This pull request adds a new attributes entry when creating or updating a document, which doesn't have attributes yet. Furthermore it is now possible to add an `attributes` array to the config, which is passed to the document creation method `initDocument()`. The contained key/value pairs will then be inserted or updated in the attributes entity. The code is backwards compatible, meaning that on an update no exception will be thrown, if no attributes exist yet, but actually a new attributes entity is created and saved in the database.
