### PR TITLE
Fix shop duplication bug

### DIFF
--- a/engine/Shopware/Models/Shop/Repository.php
+++ b/engine/Shopware/Models/Shop/Repository.php
@@ -357,10 +357,9 @@ class Repository extends ModelRepository
      */
     protected function fixActive($shop)
     {
-        $this->getEntityManager()->detach($shop);
+        $this->getEntityManager()->getUnitOfWork()->markReadOnly($shop);
         $main = $shop->getMain();
         if ($main !== null) {
-            $this->getEntityManager()->detach($main);
             $shop->setHost($main->getHost());
             $shop->setSecure($main->getSecure());
             $shop->setSecureHost($main->getSecureHost());

--- a/tests/Hotfix/Tests/Models/Shop/ShopRepositoryTest.php
+++ b/tests/Hotfix/Tests/Models/Shop/ShopRepositoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Tests the shop duplication bug caused by the fixActive method
+ * of the shop repository (Shopware\Models\Shop\Repsoitory).
+ *
+ * Remark: This is a simple testcase, that is only intended to showcase the bug
+ * and it's hotfix. Therefore it is based on the current demo dataset and
+ * changes made to the database will not be cleaned up.
+ */
+class Hotfix_Tests_Models_Shop_ShopRepositoryTest extends Enlight_Components_Test_TestCase
+{
+
+    public function testFixActive()
+    {
+        $em = Shopware()->Models();
+        $shopRepository = $em->getRepository('Shopware\Models\Shop\Shop');
+        $orderRepository = $em->getRepository('Shopware\Models\Order\Order');
+
+        // Get inital number of shops
+        $numberOfShopsBefore = Shopware()->Db()->fetchOne("SELECT count(*) FROM s_core_shops");
+
+        // Load arbitrary order from demo dataset
+        $orderId = 57;
+        $order = $orderRepository->find($orderId);
+
+        // Modify order entitiy to trigger an update action, when the entity is flushed to the database
+        $order->setComment('Dummy');
+
+        // Get shop entity via repository method. Among other things this will invoke the fixActive method
+        $shop = $shopRepository->getActiveById($order->getLanguageSubShop()->getId());
+
+        // Flush changes to the database
+        $em->flush($order);
+
+        // Get actual number of shops
+        $numberOfShopsAfter = Shopware()->Db()->fetchOne("SELECT count(*) FROM s_core_shops");
+
+        // Check that the number of shops has not been changed
+        $this->assertSame($numberOfShopsBefore, $numberOfShopsAfter);
+    }
+
+}

--- a/tests/Hotfix/phpunit.xml.dist
+++ b/tests/Hotfix/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../Shopware//TestHelper.php" colors="true">
+    <testsuites>
+        <testsuite name="AllTests">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
This pull request is a hotfix for the the shop duplication bug, which may occur in case that the associated shop entity of an order entity is processed by the `fixActive()` method of the shop repository and the order entity is flushed to the database thereafter. This behaviour is caused by [detaching the shop entity](https://github.com/ShopwareAG/shopware-4/blob/2dc9f4a33ef2ce247364428a0ad412d5f93e06b7/engine/Shopware/Models/Shop/Repository.php#L360) within the mentioned method in conjunction with the [cascading configuration of the order model](https://github.com/ShopwareAG/shopware-4/blob/2dc9f4a33ef2ce247364428a0ad412d5f93e06b7/engine/Shopware/Models/Order/Order.php#L253).

When the order entity is flushed to the database, doctrine evaluates the associated shop entity as `STATE_NEW` and processes an insert action for it (`cascade={"persist"}`), which leads to the duplication of the shop entity within the database.

Instead of detaching the shop entity, this hotfix marks the shop entity as read-only (no change-tracking) to prevent changes made to it from being flushed to the database. Nevertheless this hotfix is not a general solution. An implicit change of an entities behaviour (detatchment / mode change) is bad practice in general. The `fixActive()` method transfers missing properties to language subshops from the main shop. It should be removed to no longer change the behaviour of the shop entity. One approach to replace it would be to move the property transferring to the corresponding getters of the shop model like this:

```
    /**
     * @return string
     */
    public function getHost()
    {
        if ($this->getMain() !== null) {
            return $this->getMain()->getHost();
        }

        return $this->host;
    }

```

Remark: Because the main shop is not changed at all within the `fixActive()` method it is not necessary to detach it.

Run testcase:

```
vendor/bin/phpunit -c tests/Hotfix
```
