### PR TITLE
SW-7979 Order Attributes are not displayed in Email

### DIFF
--- a/engine/core/class/sOrder.php
+++ b/engine/core/class/sOrder.php
@@ -641,10 +641,10 @@ class sOrder
             $attributeSql = $this->eventManager->filter('Shopware_Modules_Order_SaveOrderAttributes_FilterDetailsSQL', $attributeSql, array('subject'=>$this,'row'=>$basketRow,'user'=>$this->sUserData,'order'=>array("id"=>$orderID,"number"=>$orderNumber)));
             $this->db->executeUpdate($attributeSql);
 
-            $attributes = $this->getOrderDetailAttributes($orderdetailsID);
-            unset($attributes['id']);
-            unset($attributes['detailID']);
-            $this->sBasketData['content'][$key]['attributes'] = $attributes;
+            $detailAttributes = $this->getOrderDetailAttributes($orderdetailsID);
+            unset($detailAttributes['id']);
+            unset($detailAttributes['detailID']);
+            $this->sBasketData['content'][$key]['attributes'] = $detailAttributes;
 
             // Update sales and stock
             if ($basketRow["priceNumeric"] >= 0) {


### PR DESCRIPTION
Related ticket: http://jira.shopware.de?ticket=SW-7979
When using order attributes they are not displayed in the order email sent to the customer, since the $attributes variable gets overwritten.
This commit fixes the naming issue.
