### PR TITLE
Change type hinting in Resource Component to interface

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Resource.php
+++ b/engine/Shopware/Components/Api/Resource/Resource.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Components\Api\Resource;
 
-use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Shopware\Components\Api\Exception as ApiException;
 use Shopware\Components\Api\BatchInterface;
 use Shopware\Components\DependencyInjection\Container;
@@ -267,13 +267,13 @@ abstract class Resource
      * If the data property contains the "__options_$optionName" value and this value contains
      * the "replace" parameter the collection will be cleared.
      *
-     * @param ArrayCollection $collection
+     * @param Collection $collection
      * @param $data
      * @param $optionName
      * @param $defaultReplace
-     * @return \Doctrine\Common\Collections\ArrayCollection
+     * @return \Doctrine\Common\Collections\Collection
      */
-    protected function checkDataReplacement(ArrayCollection $collection, $data, $optionName, $defaultReplace)
+    protected function checkDataReplacement(Collection $collection, $data, $optionName, $defaultReplace)
     {
         $key = '__options_' . $optionName;
         if (isset($data[$key])) {
@@ -288,13 +288,13 @@ abstract class Resource
     }
 
     /**
-     * @param ArrayCollection $collection
+     * @param Collection $collection
      * @param $property
      * @param $value
      * @throws \Exception
      * @return null
      */
-    protected function getCollectionElementByProperty(ArrayCollection $collection, $property, $value)
+    protected function getCollectionElementByProperty(Collection $collection, $property, $value)
     {
         foreach ($collection as $entity) {
             $method = 'get' . ucfirst($property);
@@ -313,11 +313,11 @@ abstract class Resource
     }
 
     /**
-     * @param ArrayCollection $collection
+     * @param Collection $collection
      * @param array $conditions
      * @return null
      */
-    protected function getCollectionElementByProperties(ArrayCollection $collection, array $conditions)
+    protected function getCollectionElementByProperties(Collection $collection, array $conditions)
     {
         foreach ($conditions as $property => $value) {
             $entity = $this->getCollectionElementByProperty(
@@ -372,14 +372,14 @@ abstract class Resource
      * If no property is set, the function creates a new entity and adds the instance into the
      * passed collection and persist the entity.
      *
-     * @param ArrayCollection $collection
+     * @param Collection $collection
      * @param $data
      * @param $entityType
      * @param array $conditions
      * @return null|object
      * @throws \Shopware\Components\Api\Exception\CustomValidationException
      */
-    protected function getOneToManySubElement(ArrayCollection $collection, $data, $entityType, $conditions = array('id'))
+    protected function getOneToManySubElement(Collection $collection, $data, $entityType, $conditions = array('id'))
     {
         foreach ($conditions as $property) {
             if (!isset($data[$property])) {
@@ -414,14 +414,14 @@ abstract class Resource
      * In case that the findOneBy statement finds no entity, the function throws an exception.
      * Otherwise the item will be
      *
-     * @param ArrayCollection $collection
+     * @param Collection $collection
      * @param $data
      * @param $entityType
      * @param array $conditions
      * @return null|object
      * @throws \Shopware\Components\Api\Exception\CustomValidationException
      */
-    protected function getManyToManySubElement(ArrayCollection $collection, $data, $entityType, $conditions = array('id'))
+    protected function getManyToManySubElement(Collection $collection, $data, $entityType, $conditions = array('id'))
     {
         $repo = $this->getManager()->getRepository($entityType);
         foreach ($conditions as $property) {


### PR DESCRIPTION
Changed type hinting from concrete class `Doctrine\Common\Collections\ArrayCollection` to the interface `Doctrine\Common\Collections\Collection` because of problems when using API locally.

I ran into the following error when using the API locally to update prices:

`Catchable fatal error: Argument 1 passed to Shopware\Components\Api\Resource\Resource::checkDataReplacement() must be an instance of Doctrine\Common\Collections\ArrayCollection, instance of Doctrine\ORM\PersistentCollection given, called in /var/www/htdocs/engine/Shopware/Components/Api/Resource/Variant.php on line 592 and defined in /var/www/htdocs/engine/Shopware/Components/Api/Resource/Resource.php on line 276`

An update without prices was no problem at all. After some googleing I found out that this is a common doctrine error and the solution always was to change type hinting to the interface. After changing the type hinting the product got updated with correct prices.

The code causing this error is the following (`$data` come from a CSV file provided by our customer):

``` php
        $number       = $data['ReferenzNr'];
        $price        = doubleval($data['VK']);
        $specialPrice = doubleval($data['VKShop']);

        $params = array(
            'name'        => $data['Beschreibung'],
            'description' => $data['Bemerkungen'],
            'active'      => true,
            'supplier'    => $data['Hersteller'],
            'mainDetail'  => array(
                'prices'  => array(
                    array(
                        'customerGroupKey' => 'EK',
                        'price'            => $specialPrice > 0 ? $specialPrice : $price,
                        'pseudoPrice'      => $specialPrice > 0 ? $price : '',
                        'from'             => 1,
                    )
                )
            )
        );

        try {
            $article = $this->articleResource->updateByNumber($number, $params);
        } catch(\Exception $e) {
            $this->output(sprintf("<error>Cannot update article %s: %s</error>", $number, $e->getMessage()));
        }
```
