### PR TITLE
restore scroll position when dropping on emotion details view

### DIFF
--- a/templates/_default/backend/emotion/view/detail/designer.js
+++ b/templates/_default/backend/emotion/view/detail/designer.js
@@ -526,6 +526,7 @@ Ext.define('Shopware.apps.Emotion.view.detail.Designer', {
                    x = e.getX(),
                    y = e.getY(),
                    id = me.getId(),
+                   scroll = me.body.getScroll(),
                    colHeight = 44,
                    colWidth = (Ext.get(id).getWidth() - 40) / me.dataviewStore.getAt(0).data.settings.cols,
                    startCol, startRow, record = data.draggedRecord, endRow, endCol,
@@ -616,7 +617,9 @@ Ext.define('Shopware.apps.Emotion.view.detail.Designer', {
                     });
                 }
 
+                // Refresh dataView and restore scroll offset
                 me.dataView.refresh();
+                me.body.scrollTo('top', scroll.top);
 
                 // Remove class from the sourceEl element
                 Ext.get(data.sourceEl).removeCls('dragged');


### PR DESCRIPTION
Quick fixed the scroll offset when dropping elements on the emotion details view. Unfortunately the dataView's preserveScrollOnRefresh config property conflicts with the current drag/drop configuration.
