### PR TITLE
Fix the 'removeListener' method in 'Enlight_Event_Subscriber_Config'

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,7 @@ In this document you will find a changelog of the important changes related to t
     * Exceptions are logged in a logfile since 4.2.0 (/logs)
     * The old behaviour can be restored by setting `'front' => array('showException' => true)` in the projects `config.php`
 * Hiding the country field for shipping addresses will also hide the state field. The option label in the backend was adjusted to better describe this behaviour.
+* Fix the `removeListener` method in `Enlight_Event_Subscriber_Config`
 
 ## 4.3.0
 * Removed `location` header in responses for all REST-API PUT routes (e.g. PUT /api/customers/{id}).

--- a/engine/Library/Enlight/Event/Subscriber/Config.php
+++ b/engine/Library/Enlight/Event/Subscriber/Config.php
@@ -103,7 +103,10 @@ class Enlight_Event_Subscriber_Config extends Enlight_Event_Subscriber
      */
     public function removeListener(Enlight_Event_Handler $handler)
     {
-        $this->listeners = array_diff($this->listeners, array($handler));
+        $handlerIndex = array_search($handler, $this->listeners);
+        if ($handlerIndex !== false) {
+            array_splice($this->listeners, $handlerIndex, 1);
+        }
         return $this;
     }
 


### PR DESCRIPTION
Currently the `removeListener` method in `Enlight_Event_Subscriber_Config` uses `array_diff` to remove a given `Enlight_Event_Handler` object from the `listeners` array. The problem is, that `array_diff` doesn't work with object arrays. This fix uses `array_search` and `array_splice` instead, to first find and then remove a given handler from the listeners.
