### PR TITLE
Add 'unsubscribeEvent' method to 'Enlight_Plugin_Bootstrap_Config'

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,7 @@ In this document you will find a changelog of the important changes related to t
     * Exceptions are logged in a logfile since 4.2.0 (/logs)
     * The old behaviour can be restored by setting `'front' => array('showException' => true)` in the projects `config.php`
 * Hiding the country field for shipping addresses will also hide the state field. The option label in the backend was adjusted to better describe this behaviour.
+* Add a new `unsubscribeEvent` method to `Enlight_Plugin_Bootstrap_Config` for removing existing event subscriptions
 
 ## 4.3.0
 * Removed `location` header in responses for all REST-API PUT routes (e.g. PUT /api/customers/{id}).

--- a/engine/Library/Enlight/Plugin/Bootstrap/Config.php
+++ b/engine/Library/Enlight/Plugin/Bootstrap/Config.php
@@ -92,6 +92,32 @@ class Enlight_Plugin_Bootstrap_Config extends Enlight_Plugin_Bootstrap
     }
 
     /**
+     * Removes an existing plugin event.
+     *
+     * First all subscribed listeners are looped to find the one, which matches the given
+     * event and listener names and also the name of this plugin. Finally the matching listener
+     * is removed from the namespace subscriber.
+     *
+     * @param string|Enlight_Event_Handler $event The name of the event or the event itself, which shall be removed.
+     * @param string $listener The name of the listener, which shall be removed.
+     * @return Enlight_Plugin_Bootstrap_Config This instance.
+     */
+    public function unsubscribeEvent($event, $listener)
+    {
+        // Find the listener instance matching the plugin, event and listener names
+        $subscriber = $this->Collection()->Subscriber();
+        foreach ($subscriber->getListeners() as $handler) {
+            $handlerInfo = $handler->toArray();
+            if ($handlerInfo['plugin'] === $this->getName() && $handlerInfo['name'] === $event && $handlerInfo['listener'] === $listener) {
+                // Remove the matching handler
+                $subscriber->removeListener($handler);
+                break;
+            }
+        }
+        return $this;
+    }
+
+    /**
      * This function installs the plugin.
      *
      * @return bool

--- a/engine/Shopware/Components/Plugin/Namespace.php
+++ b/engine/Shopware/Components/Plugin/Namespace.php
@@ -356,7 +356,7 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
             $plugin->setInstalled(new DateTime());
             $plugin->setUpdated(new DateTime());
             $em->flush($plugin);
-            $this->write();
+            $this->write($bootstrap);
 
             $em->flush();
 
@@ -577,7 +577,7 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
             $this->registerPlugin($plugin);
 
             // Save events / Hooks
-            $this->write();
+            $this->write($plugin);
 
             $form = $plugin->Form();
             if ($form->hasElements()) {
@@ -598,15 +598,32 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
     }
 
     /**
-     * Writes all registered plugins into the storage.
-     * The subscriber and the registered plugins are converted to an array.
+     * Synchronizes the plugin subscribes with the storage.
+     * All remaining subscribes are inserted or updated in the storage. If the optional bootstrap
+     * parameter is given, all subscribes of that plugin are loaded and compared to the
+     * given subscribes. Finally the subscribes, which were removed from the list,
+     * are also removed from the storage.
      *
+     * @param Shopware_Components_Plugin_Bootstrap $bootstrap
      * @return  Enlight_Plugin_Namespace_Config
      */
-    public function write()
+    public function write(Shopware_Components_Plugin_Bootstrap $bootstrap = null)
     {
-        $subscribes = $this->Subscriber()->toArray();
+        $obsoleteSubscribes = array();
+        if ($bootstrap !== null) {
+            // Fetch all existing subscribes of the given plugin
+            $pluginId = $this->getPluginId($bootstrap->getName());
+            $sql = '
+                SELECT `subscribe`, `listener`, `pluginID`
+                FROM `s_core_subscribes`
+                WHERE pluginID = ?
+            ';
+            $obsoleteSubscribes = $this->Application()->Db()->fetchAll($sql, array(
+                $pluginId
+            ));
+        }
 
+        $subscribes = $this->Subscriber()->toArray();
         foreach ($subscribes as $subscribe) {
             $subscribe['pluginID'] = $this->getInfo($subscribe['plugin'], 'id');
             if (!isset($subscribe['pluginID'])) {
@@ -634,6 +651,31 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
                 $subscribe['listener'],
                 $subscribe['position'],
                 $subscribe['pluginID'],
+            ));
+
+            if ($subscribe['pluginID'] === $pluginId) {
+                // Remove the subscribe from the list of obsolete subscribes
+                for ($i = 0; $i < count($obsoleteSubscribes); $i++) {
+                    if ($obsoleteSubscribes[$i]['subscribe'] === $subscribe['name'] && $obsoleteSubscribes[$i]['listener'] === $subscribe['listener']){
+                        array_splice($obsoleteSubscribes, $i, 1);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Delete all subscribes, that are left in obsoleteSubscribes
+        foreach ($obsoleteSubscribes as $subscribe) {
+            $sql = '
+                DELETE FROM `s_core_subscribes`
+                WHERE `subscribe` = ?
+                AND `listener` = ?
+                AND `pluginID` = ?
+            ';
+            $this->Application()->Db()->query($sql, array(
+                $subscribe['subscribe'],
+                $subscribe['listener'],
+                $subscribe['pluginID']
             ));
         }
 


### PR DESCRIPTION
In some plugin updates it is desirable to remove old event subscriptions, since they are no longer used. This commit adds a new method to `Enlight_Plugin_Bootstrap_Config`, from which all plugin bootstrap implementations inherit.

The `unsubscribeEvent` method requires only the event name and listener name to remove an existing subscription, just like `subscribeEvent` requires those two parameters to add a subscription in the first place.

In order to make this work, it is also necessary to adapt the `write` method of `Shopware_Components_Plugin_Namespace`, so that the removed subscribes are also removed from the database. Therefore it has now an optional parameter of type `Shopware_Components_Plugin_Bootstrap`. If it is present, that plugin's subscribes will be fully synced, meaning that its removed subscribes will be deleted from the database.
