### PR TITLE
Improve code style of Shopware_Components_Document->assignValues4x()

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -267,9 +267,20 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         if (empty($this->_config["date"])) {
             $this->_config["date"] = date("d.m.Y");
         }
-        $Document = array_merge($Document,array("comment"=>$this->_config["docComment"],"id"=>$id,"bid"=>$this->_documentBid,"date"=>$this->_config["date"],"deliveryDate"=>$this->_config["delivery_date"],"netto"=>$this->_order->order->taxfree ? true : $this->_config["netto"],"nettoPositions"=>$this->_order->order->net));
+        $Document = array_merge(
+            $Document,
+            array(
+                "comment" => $this->_config["docComment"],
+                "id" => $id,
+                "bid" => $this->_documentBid,
+                "date" =>$this->_config["date"],
+                "deliveryDate" => $this->_config["delivery_date"],
+                "netto" => $this->_order->order->taxfree ? true : $this->_config["netto"],
+                "nettoPositions" => $this->_order->order->net
+            )
+        );
         $Document["voucher"] = $this->getVoucher($this->_config["voucher"]);
-        $this->_view->assign('Document',$Document);
+        $this->_view->assign('Document', $Document);
 
         // Translate payment and dispatch depending on the order's language
         // and replace the default payment/dispatch text
@@ -296,8 +307,8 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
             }
         }
 
-        $this->_view->assign('Order',$this->_order->__toArray());
-        $this->_view->assign('Containers',$this->_document->containers->getArrayCopy());
+        $this->_view->assign('Order', $this->_order->__toArray());
+        $this->_view->assign('Containers', $this->_document->containers->getArrayCopy());
 
         $order = clone $this->_order;
 
@@ -309,18 +320,21 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         }
 
         if ($this->_config["_previewForcePagebreak"]) {
-            $positions = array_merge($positions,$positions);
+            $positions = array_merge($positions, $positions);
         }
 
         $positions = array_chunk($positions,$this->_document["pagebreak"],true);
-        $this->_view->assign('Pages',$positions);
+        $this->_view->assign('Pages', $positions);
 
         $user = array(
-            "shipping"=>$order->shipping,
-            "billing"=>$order->billing,
-            "additional"=>array("countryShipping"=>$order->shipping->country,"country"=>$order->billing->country)
+            "shipping" => $order->shipping,
+            "billing" => $order->billing,
+            "additional" => array(
+                "countryShipping" => $order->shipping->country,
+                "country"=>$order->billing->country
+            )
         );
-        $this->_view->assign('User',$user);
+        $this->_view->assign('User', $user);
     }
 
     /**

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -275,6 +275,9 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
                 "bid" => $this->_documentBid,
                 "date" =>$this->_config["date"],
                 "deliveryDate" => $this->_config["delivery_date"],
+                // The "netto" config flag, if set to true, allows creating
+                // netto documents for brutto orders. Setting it to false,
+                // does not however create brutto documents for netto orders.
                 "netto" => $this->_order->order->taxfree ? true : $this->_config["netto"],
                 "nettoPositions" => $this->_order->order->net
             )

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -273,7 +273,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
                 "comment" => $this->_config["docComment"],
                 "id" => $id,
                 "bid" => $this->_documentBid,
-                "date" =>$this->_config["date"],
+                "date" => $this->_config["date"],
                 "deliveryDate" => $this->_config["delivery_date"],
                 // The "netto" config flag, if set to true, allows creating
                 // netto documents for brutto orders. Setting it to false,
@@ -334,7 +334,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
             "billing" => $order->billing,
             "additional" => array(
                 "countryShipping" => $order->shipping->country,
-                "country"=>$order->billing->country
+                "country" => $order->billing->country
             )
         );
         $this->_view->assign('User', $user);


### PR DESCRIPTION
We had a hard time figuring out what the `netto` config flag really does in every possible case, so we wanted to document our findings. While we where at it, we also made the code, specifically the first `array_merge()`, more readable by improving the code style.

This PR is based on current master and does not introduce any logical changes, it's purely cosmetic.
