### PR TITLE
Always save amount actually printed on the document

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -507,7 +507,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
             UPDATE `s_order_documents` SET `date` = now(),`amount` = ?
             WHERE `type` = ? AND userID = ? AND orderID = ? LIMIT 1
             ";
-            $amount = $this->_config["netto"] == true ? round($this->_order->amountNetto,2) : round($this->_order->amount,2);
+            $amount = ($this->_order->order->taxfree ? true : $this->_config["netto"]) ? round($this->_order->amountNetto,2) : round($this->_order->amount,2);
             if ($typID == 4) {
                 $amount *= -1;
             }
@@ -547,7 +547,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
 
             $hash = md5(uniqid(rand()));
 
-            $amount = $this->_config["netto"] == true ? round($this->_order->amountNetto,2) : round($this->_order->amount,2);
+            $amount = ($this->_order->order->taxfree ? true : $this->_config["netto"]) ? round($this->_order->amountNetto,2) : round($this->_order->amount,2);
             if ($typID == 4) {
                 $amount *= -1;
             }


### PR DESCRIPTION
The `saveDocument` method used a different way to decide between netto and brutto than `assignValues4x`. Because of this, the amount shown in the document tab is incorrect when creating a document for a tax free order (`taxfree` flag in `s_order` is `1`) but unchecking the tax free checkbox in the backend. The document is still generated _without_ tax, but the amount displayed in the documents tab in the backend _does_ include tax.

We already documented this behavior with #178.

Instead of just merging this pull request, it would probably make more sense to also change the behavior of the `netto` flag for `Shopware_Components_Document::initDocument()` like this:
- If not set: Fall back to the `taxfree` flag from `s_order` as default
- If set to `true`: Generate a tax-free document
- If set to `false`: Generate the document with tax (this last part would theoretically be a backwards incompatible change and should be documented in `UPGRADE.md`)
