### PR TITLE
Always add packunit-property to article

### DIFF
--- a/engine/core/class/sArticles.php
+++ b/engine/core/class/sArticles.php
@@ -1350,6 +1350,7 @@ class sArticles
             $articles[$articleKey]["referenceunit"] = empty($calculatedBasePriceData["referenceunit"]) ? null: $calculatedBasePriceData["referenceunit"];
             $articles[$articleKey]["sUnit"] = empty($calculatedBasePriceData["sUnit"]) ? null: $calculatedBasePriceData["sUnit"];
             $articles[$articleKey]["referenceprice"] = empty($calculatedBasePriceData["referenceprice"]) ? null: $calculatedBasePriceData["referenceprice"];
+            $articles[$articleKey]["packunit"] = empty($calculatedBasePriceData["packunit"]) ? null: $calculatedBasePriceData["packunit"];
 
             $articles[$articleKey] = Enlight()->Events()->filter('Shopware_Modules_Articles_sGetArticlesByCategory_FilterLoopEnd', $articles[$articleKey], array('subject' => $this, 'id' => $categoryId));
         } // For every article in this list
@@ -3816,6 +3817,7 @@ class sArticles
             $getPromotionResult["referenceunit"] = empty($calculatedBasePriceData["referenceunit"]) ? null: $calculatedBasePriceData["referenceunit"];
             $getPromotionResult["sUnit"] = empty($calculatedBasePriceData["sUnit"]) ? null: $calculatedBasePriceData["sUnit"];
             $getPromotionResult['referenceprice'] = empty($calculatedBasePriceData["referenceprice"]) ? null: $calculatedBasePriceData["referenceprice"];
+            $getPromotionResult['packunit'] = empty($calculatedBasePriceData["packunit"]) ? null: $calculatedBasePriceData["packunit"];
         }
 
         // Strip tags from descriptions


### PR DESCRIPTION
In the single article detail views this property is already present, but it also makes sense to have it available in the article listing views. This is most relevant for custom templates, where one might want to use/show this value.
