### PR TITLE
Include the country in the address comparison

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,10 @@
 # Shopware Upgrade Information
 In this document you will find a changelog of the important changes related to the code base of Shopware.
 
+## 4.3.2
+* Include the departments, salutations, cities and countries in the address comparison of the backend order details
+* Display the departments and salutations in the backend order details overview
+
 ## 4.3.1
 * Fixed name used as reference when setting attributes of an order document.
 * Added new event `Shopware_Modules_Articles_sGetArticlesByCategory_FilterCountSql`


### PR DESCRIPTION
Currently, the address comparison in the backend order details does not include the countries of the billing and shipping addresses. However, since some customers change the country to get around certain country restrictions, it is important to compare the countries, too. This PR adds this check, by comparing the `countryId`s of the two addresses.

Because this fix is located in the ExtJS backend order app, I didn't include test cases.
