### PR TITLE
fixed bug in IE(9) where clicking the edit icon results in an error

### DIFF
--- a/templates/_default/backend/base/application/Shopware.data.Model.js
+++ b/templates/_default/backend/base/application/Shopware.data.Model.js
@@ -244,7 +244,7 @@ Ext.define('Shopware.data.Model', {
         proxy.api.read = proxy.api.detail;
 
         var store = Ext.create('Ext.data.Store', {
-            model: me.__proto__.$className,
+            model: me.__proto__ === undefined ? Object.getPrototypeOf(me).$className : me.__proto__.$className,
             proxy: me.proxy
         });
 


### PR DESCRIPTION
This is a bugfix for some occasions where you click the edit icon and you'll get an error instead. Occurs only on IE9/10 (11 hasn't been tested), while every other browser is running fine.

This can't be reproduced for example within the default article overview functionality. It happens in a custom plugin functionality, so this might be the source for the problem itself. But irrespective of this, you may want to include this patch in order to enhance stability and get rid of deprecated standards.

Error message:

SCRIPT5007: Unable to get value of the property '$className': object is null or undefined 
base?file=bootstrap&loggedIn=1414148464, line 5558 character 1

Screenshots:

![m5lzy](https://cloud.githubusercontent.com/assets/3847901/4769345/99d9fb54-5b78-11e4-9c0f-1d4c67b38dd8.png)

![jlbke](https://cloud.githubusercontent.com/assets/3847901/4769564/d3198fe4-5b7b-11e4-8645-d23e50eb0a6e.png)

![xvtme](https://cloud.githubusercontent.com/assets/3847901/4770844/266420bc-5b89-11e4-8eb2-e43b1e3b0b78.png)

Notes:

Since `__proto__` is deprecated, you might even totally drop it in favor of `Object.getProrotypeOf()` ? See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto
