### PR TITLE
Fix newcomer product identification

### DIFF
--- a/engine/Shopware/Controllers/Widgets/Emotion.php
+++ b/engine/Shopware/Controllers/Widgets/Emotion.php
@@ -537,7 +537,7 @@ class Shopware_Controllers_Widgets_Emotion extends Enlight_Controller_Action
 
         $values = array();
         foreach ($articles as &$article) {
-            $articleId = $article["id"];
+            $articleId = (int) $article["id"];
 
             $value = Shopware()->Modules()->Articles()->sGetPromotionById('fix', 0, $articleId, false);
             if (!$value) {


### PR DESCRIPTION
A customer reported the problem that the newcomer widget is showing wrong products. This error occurs when an order number exists that is equal to an article id that is to be shown in the newcomer widget.

Technical details of the fix:

The sGetPromotionById method accepts both order numbers and article ids. When the article id is passed as a string, the sGetPromotionById interprets the argument as an order number - that is, it tries to find an article with an order number that equals the passed value. Since we are passing an article id to the method and not an order number, we can only ensure correct behaviour by passing the article id as an integer.
