### PR TITLE
partnerID in s_order should be nullable

### DIFF
--- a/_sql/migrations/317-update-order-nullable-fields.php
+++ b/_sql/migrations/317-update-order-nullable-fields.php
@@ -1,0 +1,18 @@
+<?php
+class Migrations_Migration317 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up()
+    {
+        $this->addSql("
+            ALTER TABLE `s_order` CHANGE `partnerID` `partnerID` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL;
+            ALTER TABLE `s_order` CHANGE `transactionID` `transactionID` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL;
+            ALTER TABLE `s_order` CHANGE `temporaryID` `temporaryID` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL;
+            ALTER TABLE `s_order` CHANGE `referer` `referer` MEDIUMTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+            ALTER TABLE `s_order` CHANGE `trackingcode` `trackingcode` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL;
+            ALTER TABLE `s_order` CHANGE `remote_addr` `remote_addr` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL;
+            ALTER TABLE `s_order` CHANGE `comment` `comment` MEDIUMTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+            ALTER TABLE `s_order` CHANGE `customercomment` `customercomment` MEDIUMTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+            ALTER TABLE `s_order` CHANGE `internalcomment` `internalcomment` MEDIUMTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+        ");
+    }
+}

--- a/engine/Shopware/Models/Order/Order.php
+++ b/engine/Shopware/Models/Order/Order.php
@@ -123,7 +123,7 @@ class Order extends ModelEntity
     /**
      * @var string $partnerId
      *
-     * @ORM\Column(name="partnerID", type="string", length=255, nullable=false)
+     * @ORM\Column(name="partnerID", type="string", length=255, nullable=true)
      */
     private $partnerId;
 
@@ -172,28 +172,28 @@ class Order extends ModelEntity
     /**
      * @var string $transactionId
      *
-     * @ORM\Column(name="transactionID", type="string", length=255, nullable=false)
+     * @ORM\Column(name="transactionID", type="string", length=255, nullable=true)
      */
     private $transactionId;
 
     /**
      * @var string $comment
      *
-     * @ORM\Column(name="comment", type="text", nullable=false)
+     * @ORM\Column(name="comment", type="text", nullable=true)
      */
     private $comment;
 
     /**
      * @var string $customerComment
      *
-     * @ORM\Column(name="customercomment", type="text", nullable=false)
+     * @ORM\Column(name="customercomment", type="text", nullable=true)
      */
     private $customerComment;
 
     /**
      * @var string $internalComment
      *
-     * @ORM\Column(name="internalcomment", type="text", nullable=false)
+     * @ORM\Column(name="internalcomment", type="text", nullable=true)
      */
     private $internalComment;
 
@@ -214,14 +214,14 @@ class Order extends ModelEntity
     /**
      * @var string $temporaryId
      *
-     * @ORM\Column(name="temporaryID", type="string", length=255, nullable=false)
+     * @ORM\Column(name="temporaryID", type="string", length=255, nullable=true)
      */
     private $temporaryId;
 
     /**
      * @var string $referer
      *
-     * @ORM\Column(name="referer", type="text", nullable=false)
+     * @ORM\Column(name="referer", type="text", nullable=true)
      */
     private $referer;
 
@@ -235,7 +235,7 @@ class Order extends ModelEntity
     /**
      * @var string $trackingCode
      *
-     * @ORM\Column(name="trackingcode", type="string", length=255, nullable=false)
+     * @ORM\Column(name="trackingcode", type="string", length=255, nullable=true)
      */
     private $trackingCode;
 
@@ -273,7 +273,7 @@ class Order extends ModelEntity
     /**
      * @var string $remoteAddress
      *
-     * @ORM\Column(name="remote_addr", type="string", length=255, nullable=false)
+     * @ORM\Column(name="remote_addr", type="string", length=255, nullable=true)
      */
     private $remoteAddress;
 


### PR DESCRIPTION
partnerID should be nullable to reflect s_order_basket and make it more doctrine orm friendlier. its a foreign key on an empty string right now, there are also some other sideeffects. "migrations" not provided by pull request...
