### PR TITLE
Speed up risk rule loading

### DIFF
--- a/templates/_default/backend/risk_management/controller/risk_management.js
+++ b/templates/_default/backend/risk_management/controller/risk_management.js
@@ -284,13 +284,13 @@ Ext.define('Shopware.apps.RiskManagement.controller.RiskManagement', {
 		var me = this,
 			newSelection;
 		me.panel = panel;
-		panel.riskFieldSet.show();
-		panel.exampleFieldSet.show();
 		newSelection = me.subApplication.paymentStore.data.findBy(function(item){
 			if(item.internalId == newValue) {
 				return true;
 			}
 		});
+		//By hiding the fieldset while manipulating its items, we prevent it from being rendered multiple times
+		panel.riskFieldSet.hide();
 		//Remove all container, before adding the new ones
 		panel.riskFieldSet.removeAll();
 		Ext.each(newSelection.data.getRuleSets, function(item){
@@ -317,5 +317,8 @@ Ext.define('Shopware.apps.RiskManagement.controller.RiskManagement', {
 		/*{if {acl_is_allowed privilege=save}}*/
 		panel.riskFieldSet.add(Ext.create('Shopware.apps.RiskManagement.view.risk_management.Container'));
 		/*{/if}*/
+		// Show the fieldsets after everything has been added
+		panel.riskFieldSet.show();
+		panel.exampleFieldSet.show();
 	}
 });


### PR DESCRIPTION
When having many risk rules (>50), the risk management panel takes a lot of time to load the rules. With ~250 rules the panel becomes nearly unusable with a delay > 2:30 minutes. The problem is that with the current implementation, the rule fieldset gets rerendered for every single rule that exists. By hiding the fieldset prior to adding the rules and showing it only after all rules have been added, this process is immensely accelerated.
