### PR TITLE
Make sure that the article-purchase-unit paragraph has a close tag

### DIFF
--- a/templates/_default/widgets/emotion/slide_articles.tpl
+++ b/templates/_default/widgets/emotion/slide_articles.tpl
@@ -21,11 +21,10 @@
                     <span class="purchaseunit">
                         <strong>{se name="ListingBoxArticleContent" namespace="frontend/listing/box_article"}{/se}:</strong> {$article.purchaseunit} {$article.sUnit.description}
                     </span>
-            {/if}
-            {if $article.purchaseunit != $article.referenceunit}
-                    {if $article.referenceunit}
+
+                    {if $article.purchaseunit != $article.referenceunit && $article.referenceunit}
                         <span class="referenceunit">
-                         ({$article.referenceprice|currency} {s name="Star" namespace="frontend/listing/box_article"}{/s} / {$article.referenceunit} {$article.sUnit.description})
+                           ({$article.referenceprice|currency} {s name="Star" namespace="frontend/listing/box_article"}{/s} / {$article.referenceunit} {$article.sUnit.description})
                         </span>
                     {/if}
                 </p>


### PR DESCRIPTION
If the article has a purchaseunit, but the referenceunit equals the purchaseunit, the article-purchase-unit paragraph has previously not been getting closed. Furthermore, if only the referenceunit is set, but purchaseunit is not, the base price can not be calculated. Because of this, there is no point in displaying the reference price in this case.
