### PR TITLE
Exclude shipping costs from order amount when shipping costs are hidden

### DIFF
--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -303,20 +303,22 @@ class
             $taxShipping = Shopware()->Config()->sTAXSHIPPING;
         }
         $taxShipping = (float) $taxShipping;
-        if ($this->_order["taxfree"]) {
-            $this->_amountNetto =  $this->_amountNetto + $this->_order["invoice_shipping"];
 
-        } else {
-            $this->_amountNetto =  $this->_amountNetto + ($this->_order["invoice_shipping"]/(100+$taxShipping)*100);
-            if (!empty($taxShipping) && !empty($this->_order["invoice_shipping"])) {
-                $this->_tax[number_format($taxShipping,2)] += ($this->_order["invoice_shipping"]/(100+$taxShipping))*$taxShipping;
-            }
-        }
-
-        $this->_amount =  $this->_amount + $this->_order["invoice_shipping"];
         $this->_shippingCosts = $this->_order["invoice_shipping"];
 
         if ($this->_shippingCostsAsPosition == true && !empty($this->_shippingCosts)) {
+            if ($this->_order["taxfree"]) {
+                $this->_amountNetto =  $this->_amountNetto + $this->_order["invoice_shipping"];
+
+            } else {
+                $this->_amountNetto =  $this->_amountNetto + ($this->_order["invoice_shipping"]/(100+$taxShipping)*100);
+                if (!empty($taxShipping) && !empty($this->_order["invoice_shipping"])) {
+                    $this->_tax[number_format($taxShipping,2)] += ($this->_order["invoice_shipping"]/(100+$taxShipping))*$taxShipping;
+                }
+            }
+
+            $this->_amount =  $this->_amount + $this->_order["invoice_shipping"];
+
             $shipping = array();
             $shipping['quantity'] = 1;
 


### PR DESCRIPTION
When the document is configured to not include the shipping costs as a position, as is the case with delivery notes per default, the order amount should also not include the shipping costs, because otherwise the sum of the positions does not equal the order amount. This does normally not attract attention, but if for example the delivery note template is changed to also show the prices of the positions and the total order amount, the problem becomes obvious.

Before this change, the sum of the order positions does not equal the order amount:
![selection_295](https://cloud.githubusercontent.com/assets/105166/5416238/ccf9c1aa-822d-11e4-8c7f-cd7245dd5ec6.png)

After application of this fix:
![selection_294](https://cloud.githubusercontent.com/assets/105166/5416184/638cd892-822d-11e4-82ae-ad3f8d7efe61.png)
