### PR TITLE
Regenerate attributes instead only clearing them

### DIFF
--- a/cache/clear_cache.sh
+++ b/cache/clear_cache.sh
@@ -14,6 +14,7 @@ rm -rf $DIR/mpdf/tmp/*
 rm -rf $DIR/mpdf/ttfontdata/*
 
 if [[ $1 = "-f" ]] || [[ $1 = "--force" ]]; then
-    echo "Clearing attributes"
+    echo "Regenerating attributes"
     rm -rf $DIR/doctrine/attributes/*
+    $DIR/../bin/console sw:generate:attributes
 fi


### PR DESCRIPTION
When using the backend after clearing the attribute models with `./cache/clear_cache.sh -f` strange errors like this might appear when updating a plugin for example:

```
{The target-entity Shopware\\Models\\Attribute\\Payment cannot be found in 'Shopware\\Models\\Payment\\Payment#attribute'.
```

They seem to be totally random as the are unrelated to the action that is actually performed and other parts of the backend still work as expected. The problem is, that the attribute models are not regenerated when only using the backend. They will only be regenerated in the following cases:
- by the self healing plugin when an [correlating exception](https://github.com/shopware/shopware/blob/309b14c332ee88550aabe5b0e39374d1234e7655/engine/Shopware/Plugins/Default/Core/SelfHealing/Bootstrap.php#L153-L158) occurs in the fronted
- when running test cases (via `TestHelper::start()`)
- via the GenerateAttributesCommand (`php bin/console sw:generate:attributes`)

Attribute models are not regenerated from backend requests, as the self healing plugin only [listens for frontend events](https://github.com/shopware/shopware/blob/309b14c332ee88550aabe5b0e39374d1234e7655/engine/Shopware/Plugins/Default/Core/SelfHealing/Bootstrap.php#L54-L70).

Since the only way to delete the attributes model is via the cache clear script with the `--force` option (or manually of course), it makes of sense to regenerate them directly afterwards. The script is probably always used with the intention to actually regenerate the models anyways and relying on an the self healing plugin for this (which actually catches an exception, generates the attribute models if necessary and the redirects to/reloads the same page) ist kind of nasty.

Regenerating them prevents spurious errors when only using the backend and therefore makes developers happy :wink:
