### PR TITLE
Clear cache after composer install/update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,13 @@
     },
     "config": {
         "autoloader-suffix": "Shopware"
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "cache/clear_cache.sh -f"
+        ],
+        "post-update-cmd": [
+            "cache/clear_cache.sh -f"
+        ]
     }
 }


### PR DESCRIPTION
Clearing the cache after composer runs is generally a good idea to prevent spurious errors caused by outdated outdated cache files.

Together with #210 this prevents even more strange errors in the backend.
