### PR TITLE
Fix nullable annotation of customerId in the Basket model

### DIFF
--- a/engine/Shopware/Models/Order/Basket.php
+++ b/engine/Shopware/Models/Order/Basket.php
@@ -52,9 +52,9 @@ class Basket extends ModelEntity
     /**
      * @var integer $customerId
      *
-     * @ORM\Column(name="userID", type="integer", nullable=true)
+     * @ORM\Column(name="userID", type="integer", nullable=false)
      */
-    protected $customerId = null;
+    protected $customerId = 0;
 
     /**
      * @var integer $articleId


### PR DESCRIPTION
The userID column of the s_order_basket table is set to NOT NULL (https://github.com/shopware/shopware/blob/master/_sql/install/latest.sql#L5343) and the corresponding variable of the model should have an appropriate annotation. This change should be unproblematic, because the Basket model is not being used yet (the basket logic uses the deprecated sBasket class at the moment).
