### PR TITLE
Fixes occaisonal rounding issues if voucher code matches total

### DIFF
--- a/engine/core/class/sBasket.php
+++ b/engine/core/class/sBasket.php
@@ -2056,8 +2056,8 @@ class sBasket
             }
 
             $totalAmount = round($totalAmount + round($getArticles[$key]["amount"],2), 2);
-			// Needed if shop is in net-mode
-			$totalAmountWithTax = rount($totalAmountWithTax + round($getArticles[$key]["amountWithTax"],2), 2);
+	    // Needed if shop is in net-mode
+	    $totalAmountWithTax = rount($totalAmountWithTax + round($getArticles[$key]["amountWithTax"],2), 2);
 
             // Ignore vouchers and premiums by counting articles
             if (!$getArticles[$key]["modus"]) {

--- a/engine/core/class/sBasket.php
+++ b/engine/core/class/sBasket.php
@@ -2055,9 +2055,10 @@ class sBasket
                 }
             }
 
-            $totalAmount += round($getArticles[$key]["amount"], 2);
-            // Needed if shop is in net-mode
-            $totalAmountWithTax += round($getArticles[$key]["amountWithTax"], 2);
+            $totalAmount = round($totalAmount + round($getArticles[$key]["amount"],2), 2);
+			// Needed if shop is in net-mode
+			$totalAmountWithTax = rount($totalAmountWithTax + round($getArticles[$key]["amountWithTax"],2), 2);
+
             // Ignore vouchers and premiums by counting articles
             if (!$getArticles[$key]["modus"]) {
                 $totalCount++;


### PR DESCRIPTION
If the basket contains a voucher code matching the exact total of the basket, there are rare occasions where the basket size could become a very small negative value, causing the basket to be shown as empty.

Sample:

``` php
<?php

$item1 = 19.95;
$item2 = 129.95;
$voucher = -149.90;
var_dump($item1 + $item2 + $voucher);

>> double(-2.8421709430404E-14);
```

So, just round after each addition and everythings smooth again.
