### PR TITLE
Fix error in article statistics due to mixup of article and voucher ids

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -3989,6 +3989,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
                 AND s_order.id = s_order_details.orderID
                 AND s_order.status != 4
                 AND s_order.status != -1
+                AND s_order_details.modus = 0
             GROUP BY groupdate
             ORDER BY groupdate ASC
             LIMIT %d
@@ -4269,6 +4270,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
             AND s_order.id = s_order_details.orderID
             AND s_order.status != 4
             AND s_order.status != -1
+            AND s_order_details.modus = 0
             AND TO_DAYS(ordertime) <= TO_DAYS(:endDate)
             AND TO_DAYS(ordertime) >= TO_DAYS(:startDate)
             GROUP BY TO_DAYS(ordertime)


### PR DESCRIPTION
We found that article statistics erroneously show redeemed vouchers that have nothing to do with the respective article:

![workspace 1_305](https://cloud.githubusercontent.com/assets/105166/5705168/651d535a-9a77-11e4-85bc-79614ceeac49.png)

The problem arises in the statistics tab of the article that has the same id as the respective voucher.
### Technical details for the proposed fix:

The articleID column of the s_order_details table only represents a real article id when modus is 0. When modus is 2, for example, the articleID column contains a voucher id instead.
