### PR TITLE
Make doctrine cache namespace configurable

### DIFF
--- a/engine/Shopware/Components/Model/Configuration.php
+++ b/engine/Shopware/Components/Model/Configuration.php
@@ -56,6 +56,13 @@ class Configuration extends BaseConfiguration
     protected $fileCacheDir;
 
     /**
+     * Custom namespace for doctrine cache provider
+     *
+     * @var string
+     */
+    protected $cacheNamespace = null;
+
+    /**
      * @param array $options
      * @param \Zend_Cache_Core $cache
      * @param \Enlight_Hook_HookManager $hookManager
@@ -87,6 +94,11 @@ class Configuration extends BaseConfiguration
         $this->addCustomStringFunction('DATE_FORMAT', 'Shopware\Components\Model\Query\Mysql\DateFormat');
         $this->addCustomStringFunction('IFNULL', 'Shopware\Components\Model\Query\Mysql\IfNull');
 
+        // Load custom namespace for doctrine cache provider, if provided
+        if (isset($options['cacheNamespace'])) {
+            $this->cacheNamespace = $options['cacheNamespace'];
+        }
+
         if (isset($options['cacheProvider'])) {
             $this->setCacheProvider($options['cacheProvider']);
         }
@@ -102,7 +114,9 @@ class Configuration extends BaseConfiguration
      */
     public function setCache(CacheProvider $cache)
     {
-        $cache->setNamespace("dc2_" . md5($this->getProxyDir() . \Shopware::REVISION) . "_"); // to avoid collisions
+        // Set namespace for doctrine cache provider to avoid collisions
+        $namespace =  ! is_null($this->cacheNamespace) ? $this->cacheNamespace : md5($this->getProxyDir() . \Shopware::REVISION);
+        $cache->setNamespace("dc2_" . $namespace  . "_");
 
         $this->setMetadataCacheImpl($cache);
         $this->setQueryCacheImpl($cache);

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -128,7 +128,8 @@ return array_merge($customConfig, array(
         'attributeDir' => $this->DocPath('cache_doctrine_attributes'),
         'proxyDir' => $this->DocPath('cache_doctrine_proxies'),
         'proxyNamespace' => $this->App() . '\Proxies',
-        'cacheProvider' => 'auto' // supports null, auto, Apc, Array, Wincache and Xcache
+        'cacheProvider' => 'auto', // supports null, auto, Apc, Array, Wincache and Xcache
+        'cacheNamespace' => null // custom namespace for doctrine cache provider (optional; null = auto-generated namespace)
     ), $customConfig['model']),
     'backendSession' => array_merge(array(
         'name' => 'SHOPWAREBACKEND',


### PR DESCRIPTION
This commit adds a configuration parameter to define a custom namespace for the doctrine cache provider. This feature is e.g. necessary if one wants to run multiple Shopware instances on one server using PHP FPM chroot containers. In this case the doctine proxy path inside the chroot, on which the current namespacing relies, may be equal for the different Shopware instances, whereby caching interferences will be caused.
