### PR TITLE
Fail entire build if unit tests fail

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -224,7 +224,7 @@
     </target>
 
     <target name="unit-shopware-continuous" depends="build-unit">
-        <exec executable="${script.phpunit}" dir="${test.dir.shopware}">
+        <exec executable="${script.phpunit}" failonerror="true" dir="${test.dir.shopware}">
             <arg value="--log-junit=${log.dir}/junit.xml"/>
         </exec>
     </target>


### PR DESCRIPTION
This fixes Travis-CI build not detecting failed unit tests. See: https://github.com/shopware/shopware/pull/220#discussion_r22810458
