### PR TITLE
Interpret static page html as template

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Custom.php
+++ b/engine/Shopware/Controllers/Frontend/Custom.php
@@ -43,7 +43,7 @@ class Shopware_Controllers_Frontend_Custom extends Enlight_Controller_Action
         }
 
         if (!empty($staticPage['html'])) {
-            $this->View()->sContent = $staticPage['html'];
+            $this->View()->sContent = $this->View()->fetch('string:' . $staticPage['html']);
         }
 
         for ($i = 1; $i <= 3; $i++) {


### PR DESCRIPTION
The given change will fetch the html content of a static page, processing it as a regular smarty template instead of directly assigning the html content to the view. Therefore, any smarty function (e.g., {url}) can be used in a static content site.
For example, this enables a power user to easily create links between static pages.
