### PR TITLE
[BUGFIX] Notification Plugin redirects after notify actions and view fixed

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
@@ -79,6 +79,9 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
 
         $notificationVariants = array();
 
+        $view->NotifyAlreadyRegistered = false;
+        $view->showEmailForm = true;
+
         if (!empty(Shopware()->Session()->sNotificatedArticles)) {
             $sql = 'SELECT `ordernumber` FROM `s_articles_details` WHERE `articleID`=?';
             $ordernumbers = Shopware()->Db()->fetchCol($sql, $id);
@@ -98,11 +101,17 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
         $view->NotifyHideBasket = Shopware()->Config()->sDEACTIVATEBASKETONNOTIFICATION;
 
         $view->NotificationVariants = $notificationVariants;
-        $view->NotifyEmailError = $view->NotifyEmailError;
-        $view->NotifyValid = $view->NotifyValid;
-        $view->NotifyInvalid = $view->NotifyInvalid;
+        $view->NotifyEmailError = $args->getSubject()->Request()->NotifyEmailError;
+        $view->NotifyValid = $args->getSubject()->Request()->NotifyValid;
+        $view->NotifyInvalid = $args->getSubject()->Request()->NotifyInvalid;
         $view->ShowNotification = true;
-        $view->NotifyAlreadyRegistered = $view->NotifyAlreadyRegistered;
+
+        if( $view->NotifyValid == true
+            || $view->NotifyAlreadyRegistered == true
+            || $view->WaitingForOptInApprovement == true) {
+            $view->showEmailForm = false;
+        }
+
         $view->WaitingForOptInApprovement = Shopware()->Session()->sNotifcationArticleWaitingForOptInApprovement[$view->sArticle['ordernumber']];
     }
 
@@ -118,7 +127,6 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
         $args->setProcessed(true);
 
         $action = $args->getSubject();
-
         $id = (int) $action->Request()->sArticle;
         $email = $action->Request()->sNotificationEmail;
 
@@ -197,7 +205,12 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
             }
         }
 
-        return $action->forward('index');
+        $link = $action->Front()->Router()->assemble(array(
+            'sViewport' => 'detail',
+            'sArticle' => $id
+        ));
+
+        return $action->redirect($link);
     }
 
     /**
@@ -215,6 +228,8 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
 
         $action->View()->NotifyValid = false;
         $action->View()->NotifyInvalid = false;
+
+        $sArticleDetails = null;
 
         if (!empty($action->Request()->sNotificationConfirmation) && !empty($action->Request()->sNotify)) {
             $getConfirmation = Shopware()->Db()->fetchRow('
@@ -249,12 +264,29 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
                 ));
                 $action->View()->NotifyValid = true;
                 Shopware()->Session()->sNotifcationArticleWaitingForOptInApprovement[$json_data['notifyOrdernumber']] = false;
+
+                $sArticleDetails = Shopware()->Db()->fetchRow('
+                    SELECT * FROM s_articles_details WHERE ordernumber = ?
+                    ', array($json_data['notifyOrdernumber']));
+
+
             } else {
 
                 $action->View()->NotifyInvalid = true;
             }
         }
-        return $action->forward('index');
+
+
+        if($sArticleDetails != null && !empty($sArticleDetails)){
+            $link = $action->Front()->Router()->assemble(array(
+                'sViewport' => 'detail',
+                'sArticle' => $sArticleDetails["articleID"],
+                'NotifyValid' => true
+            ));
+            return $action->redirect($link);
+        }
+
+        return $action->forward("index", "index");
     }
 
     /**

--- a/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
@@ -226,10 +226,10 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
 
         $action = $args->getSubject();
 
-        $action->View()->NotifyValid = false;
-        $action->View()->NotifyInvalid = false;
-
         $sArticleDetails = null;
+        $json_data = null;
+        $notifyValid = false;
+        $notifyInValid = false;
 
         if (!empty($action->Request()->sNotificationConfirmation) && !empty($action->Request()->sNotify)) {
             $getConfirmation = Shopware()->Db()->fetchRow('
@@ -262,18 +262,16 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
                     $json_data['sLanguage'],
                     $json_data['sShopPath']
                 ));
-                $action->View()->NotifyValid = true;
+                $notifyValid = true;
                 Shopware()->Session()->sNotifcationArticleWaitingForOptInApprovement[$json_data['notifyOrdernumber']] = false;
+            }
+            else {
+                $notifyInValid = true;
+            }
 
-                $sArticleDetails = Shopware()->Db()->fetchRow('
+            $sArticleDetails = Shopware()->Db()->fetchRow('
                     SELECT * FROM s_articles_details WHERE ordernumber = ?
                     ', array($json_data['notifyOrdernumber']));
-
-
-            } else {
-
-                $action->View()->NotifyInvalid = true;
-            }
         }
 
 
@@ -281,7 +279,8 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
             $link = $action->Front()->Router()->assemble(array(
                 'sViewport' => 'detail',
                 'sArticle' => $sArticleDetails["articleID"],
-                'NotifyValid' => true
+                'NotifyValid' => $notifyValid,
+                'NotifyInValid' => $notifyInValid
             ));
             return $action->redirect($link);
         }

--- a/templates/_default/frontend/plugins/notification/index.tpl
+++ b/templates/_default/frontend/plugins/notification/index.tpl
@@ -6,7 +6,7 @@
         <div class="success">
             {se name='DetailNotifyInfoValid'}{/se}
         </div>
-    {elseif $NotifyInvalid == true && $NotifyAlreadyRegistered != true}
+    {elseif $NotifyInValid == true && $NotifyAlreadyRegistered != true}
         <div class="notice">
             {se name='DetailNotifyInfoInvalid'}{/se}
         </div>
@@ -74,4 +74,5 @@
     $('#sAdd').change(function() {
         $.checkNotification($(this).find(':selected').val())
     });
+
 </script>

--- a/templates/_default/frontend/plugins/notification/index.tpl
+++ b/templates/_default/frontend/plugins/notification/index.tpl
@@ -1,76 +1,77 @@
 <div id="article_notification">
-	<input type="hidden" value="{$NotifyHideBasket}" name="notifyHideBasket" id="notifyHideBasket" />
+    <input type="hidden" value="{$NotifyHideBasket}" name="notifyHideBasket" id="notifyHideBasket" />
 
 
-	{if $NotifyValid == true}
-		<div class="success">
-			{se name='DetailNotifyInfoValid'}{/se}
-		</div>
-	{elseif $NotifyInvalid == true && $NotifyAlreadyRegistered != true}
-				<div class="notice">
-					{se name='DetailNotifyInfoInvalid'}{/se}
-				</div>
+    {if $NotifyValid == true}
+        <div class="success">
+            {se name='DetailNotifyInfoValid'}{/se}
+        </div>
+    {elseif $NotifyInvalid == true && $NotifyAlreadyRegistered != true}
+        <div class="notice">
+            {se name='DetailNotifyInfoInvalid'}{/se}
+        </div>
     {elseif $NotifyEmailError == true}
-		<div class="error">
-			{se name='DetailNotifyInfoErrorMail'}{/se}
-		</div>
-	{elseif $WaitingForOptInApprovement}
-		<div id="articleNotificationWasSend" class="displaynone">
-			<div class="success">
-				{se name='DetailNotifyInfoSuccess'}{/se}
-			</div>
-		</div>
-	{elseif $NotifyAlreadyRegistered == true}
-		<div class="success">
-			<div class="center">
-				<strong>
-					{se name='DetailNotifyAlreadyRegistered'}{/se}
-				</strong>
-			</div>
-		</div>
-	{else}
-		{if $NotifyValid != true}
-		<div class="notice">
-		<div class="center">
-				<strong>
-					{se name='DetailNotifyHeader'}{/se}
-				</strong>
-			</div>
-		</div>
-		{/if}
-	{/if}
-	
-	<form method="post" action="{url action='notify' sArticle=$sArticle.articleID}" id="sendArticleNotification">
-		<input type="hidden" name="notifyOrdernumber" value="{$sArticle.ordernumber}" id="variantOrdernumber" />
-		
-		<fieldset>
-			
-			<div>
-				<label>{se name='DetailNotifyLabelMail'}{/se}</label>
-				<input name="sNotificationEmail" type="text" id="txtmail" class="text" />
-				
-				<div class="clear">&nbsp;</div>
-				
-				<input type="submit"  value="{s name='DetailNotifyActionSubmit'}{/s}" class="button-right small" />
-			</div>
-		</fieldset>
-		<div class="doublespace">&nbsp;</div>
-	</form>
+        <div class="error">
+            {se name='DetailNotifyInfoErrorMail'}{/se}
+        </div>
+    {elseif $WaitingForOptInApprovement}
+        <div id="articleNotificationWasSend" class="displaynone">
+            <div class="success">
+                {se name='DetailNotifyInfoSuccess'}{/se}
+            </div>
+        </div>
+    {elseif $NotifyAlreadyRegistered == true}
+        <div class="success">
+            <div class="center">
+                <strong>
+                    {se name='DetailNotifyAlreadyRegistered'}{/se}
+                </strong>
+            </div>
+        </div>
+    {else}
+        {if $NotifyValid != true}
+            <div class="notice">
+                <div class="center">
+                    <strong>
+                        {se name='DetailNotifyHeader'}{/se}
+                    </strong>
+                </div>
+            </div>
+        {/if}
+    {/if}
+
+    {if $showEmailForm == true}
+        <form method="post" action="{url action='notify' sArticle=$sArticle.articleID}" id="sendArticleNotification">
+            <input type="hidden" name="notifyOrdernumber" value="{$sArticle.ordernumber}" id="variantOrdernumber" />
+
+            <fieldset>
+
+                <div>
+                    <label>{se name='DetailNotifyLabelMail'}{/se}</label>
+                    <input name="sNotificationEmail" type="text" id="txtmail" class="text" />
+
+                    <div class="clear">&nbsp;</div>
+
+                    <input type="submit"  value="{s name='DetailNotifyActionSubmit'}{/s}" class="button-right small" />
+                </div>
+            </fieldset>
+            <div class="doublespace">&nbsp;</div>
+        </form>
+    {/if}
 </div>
 
 
 <script type="text/javascript">
-var variantOrdernumberArray = new Array();
-{foreach from=$NotificationVariants item=notify}
-	variantOrdernumberArray.push('{$notify}');
-{/foreach}
-var checkVariant = {if !$sArticle.sVariants}false{else}true{/if};
-var checkOrdernumber = '{$sArticle.ordernumber}';
-if (checkVariant==false){
-	$.checkNotification(checkOrdernumber);
-}
-$('#sAdd').change(function() {
-	$.checkNotification($(this).find(':selected').val())
-});
-
+    var variantOrdernumberArray = new Array();
+    {foreach from=$NotificationVariants item=notify}
+    variantOrdernumberArray.push('{$notify}');
+    {/foreach}
+    var checkVariant = {if !$sArticle.sVariants}false{else}true{/if};
+    var checkOrdernumber = '{$sArticle.ordernumber}';
+    if (checkVariant==false){
+        $.checkNotification(checkOrdernumber);
+    }
+    $('#sAdd').change(function() {
+        $.checkNotification($(this).find(':selected').val())
+    });
 </script>

--- a/templates/_emotion/frontend/plugins/notification/index.tpl
+++ b/templates/_emotion/frontend/plugins/notification/index.tpl
@@ -6,7 +6,7 @@
         <div class="success">
             {se name='DetailNotifyInfoValid'}{/se}
         </div>
-    {elseif $NotifyInvalid == true && $NotifyAlreadyRegistered != true}
+    {elseif $NotifyInValid == true && $NotifyAlreadyRegistered != true}
         <div class="notice">
             {se name='DetailNotifyInfoInvalid'}{/se}
         </div>

--- a/templates/_emotion/frontend/plugins/notification/index.tpl
+++ b/templates/_emotion/frontend/plugins/notification/index.tpl
@@ -2,24 +2,24 @@
     <input type="hidden" value="{$NotifyHideBasket}" name="notifyHideBasket" id="notifyHideBasket" />
 
 
-	{if $NotifyValid == true}
-		<div class="success">
-			{se name='DetailNotifyInfoValid'}{/se}
-		</div>
-	{elseif $NotifyInvalid == true && $NotifyAlreadyRegistered != true}
-		<div class="notice">
-			{se name='DetailNotifyInfoInvalid'}{/se}
-		</div>
+    {if $NotifyValid == true}
+        <div class="success">
+            {se name='DetailNotifyInfoValid'}{/se}
+        </div>
+    {elseif $NotifyInvalid == true && $NotifyAlreadyRegistered != true}
+        <div class="notice">
+            {se name='DetailNotifyInfoInvalid'}{/se}
+        </div>
     {elseif $NotifyEmailError == true}
         <div class="error">
             {se name='DetailNotifyInfoErrorMail'}{/se}
         </div>
-	{elseif $WaitingForOptInApprovement}
-		<div id="articleNotificationWasSend" class="displaynone">
-			<div class="success">
-				{se name='DetailNotifyInfoSuccess'}{/se}
-			</div>
-		</div>
+    {elseif $WaitingForOptInApprovement}
+        <div id="articleNotificationWasSend" class="displaynone">
+            <div class="success">
+                {se name='DetailNotifyInfoSuccess'}{/se}
+            </div>
+        </div>
     {elseif $NotifyAlreadyRegistered == true}
         <div class="success">
             <div class="center">
@@ -30,44 +30,49 @@
         </div>
     {else}
         {if $NotifyValid != true}
-        <div class="notice">
-        <div class="center">
-                <strong>
-                    {se name='DetailNotifyHeader'}{/se}
-                </strong>
+            <div class="notice">
+                <div class="center">
+                    <strong>
+                        {se name='DetailNotifyHeader'}{/se}
+                    </strong>
+                </div>
             </div>
-        </div>
         {/if}
     {/if}
-    <form method="post" action="{url action='notify' sArticle=$sArticle.articleID}" id="sendArticleNotification">
-		<input type="hidden" name="notifyOrdernumber" value="{$sArticle.ordernumber}" id="variantOrdernumber" />
-		<fieldset>
-			
-			<div>
-				<label>{se name='DetailNotifyLabelMail'}{/se}</label>
-				<input name="sNotificationEmail" type="text" id="txtmail" class="text" />
-				
-				<div class="clear">&nbsp;</div>
-				
-				<input type="submit"  value="{s name='DetailNotifyActionSubmit'}{/s}" class="button-right small_right" />
-			</div>
-		</fieldset>
-	</form>
+
+    {if $showEmailForm == true}
+        <form method="post" action="{url action='notify' sArticle=$sArticle.articleID}" id="sendArticleNotification">
+            <input type="hidden" name="notifyOrdernumber" value="{$sArticle.ordernumber}" id="variantOrdernumber" />
+
+            <fieldset>
+
+                <div>
+                    <label>{se name='DetailNotifyLabelMail'}{/se}</label>
+                    <input name="sNotificationEmail" type="text" id="txtmail" class="text" />
+
+                    <div class="clear">&nbsp;</div>
+
+                    <input type="submit"  value="{s name='DetailNotifyActionSubmit'}{/s}" class="button-right small" />
+                </div>
+            </fieldset>
+            <div class="doublespace">&nbsp;</div>
+        </form>
+    {/if}
 </div>
 
 
 <script type="text/javascript">
-var variantOrdernumberArray = new Array();
-{foreach from=$NotificationVariants item=notify}
-	variantOrdernumberArray.push('{$notify}');
-{/foreach}
-var checkVariant = {if !$sArticle.sVariants}false{else}true{/if};
-var checkOrdernumber = '{$sArticle.ordernumber}';
-if (checkVariant==false){
-	$.checkNotification(checkOrdernumber);
-}
-$('#sAdd').change(function() {
-	$.checkNotification($(this).find(':selected').val())
-});
+    var variantOrdernumberArray = new Array();
+    {foreach from=$NotificationVariants item=notify}
+    variantOrdernumberArray.push('{$notify}');
+    {/foreach}
+    var checkVariant = {if !$sArticle.sVariants}false{else}true{/if};
+    var checkOrdernumber = '{$sArticle.ordernumber}';
+    if (checkVariant==false){
+        $.checkNotification(checkOrdernumber);
+    }
+    $('#sAdd').change(function() {
+        $.checkNotification($(this).find(':selected').val())
+    });
 
 </script>


### PR DESCRIPTION
Broken:
After completeing the notification form the notify action does not forward to the article detail page due to a lingering request with wrong data.
The link generated in the mail doesn't direct to the article either.

Fixed:
After completing the notification form the customer is redirected to the article page with the view variables set to the correct messages.
The link in the verification email now directs the customer to the article detail page where a message will inform him that the notification is correctly set.
The notification form itselfe is disabled whenever it makes no sense for the customer to fill out the form e.g. after he is notified that an email was sent or after hes told that the notification was correctly set up.
