### PR TITLE
Adds alias to supplierID to prevent ambiguity

### DIFF
--- a/engine/core/class/sArticles.php
+++ b/engine/core/class/sArticles.php
@@ -995,7 +995,7 @@ class sArticles
 
         if (!empty($this->sSYSTEM->_GET['sSupplier'])) {
             $supplierInfo = $this->sGetSupplierById($this->sSYSTEM->_GET['sSupplier']);
-            $supplierSQL = "AND supplierID=" . intval($this->sSYSTEM->_GET['sSupplier']);
+            $supplierSQL = "AND a.supplierID=" . intval($this->sSYSTEM->_GET['sSupplier']);
         } else {
             $supplierSQL = "";
             $supplierInfo = array();


### PR DESCRIPTION
When querying for all articles of a specific supplier, the article query ist extended with the following criteria:
    AND supplierID=<supplier-id>

Now, if one would modify this query in a plugin (e.g. by listening to 'Shopware_Modules_Articles_sGetArticlesByCategory_FilterSql') with an additional join to 's_articles_supplier_attributes', the query given above will fail as the field supplierID is ambiguous.
The workaround is to replace  'AND supplierID=' with 'AND a.supplierID=' in the plugin. However, as most of the other fields in the article query are addressed with their proper table alias, this might be a useful general modification.
