### PR TITLE
Only write an error to the log when a mail attachment file is missing

### DIFF
--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -236,11 +236,11 @@ class Shopware_Components_TemplateMail
             }
 
             if (false === ($fileHandle = fopen($attachment->getPath(), 'r'))) {
-                throw new \Enlight_Exception('Could not load file: ' . $attachment->getPath());
+                Shopware()->Container()->get('corelogger')->error('Could not load file: ' . $attachment->getPath());
+            } else {
+                $fileAttachment = $mail->createAttachment($fileHandle);
+                $fileAttachment->filename = $attachment->getFileName();
             }
-
-            $fileAttachment = $mail->createAttachment($fileHandle);
-            $fileAttachment->filename = $attachment->getFileName();
         }
 
         return $mail;


### PR DESCRIPTION
Previously, this condition caused an exception. Throwing an exception here is problematic, because for example in a test environment, certain media files might be missing. It should still be possible to test a shop without having to have all media files available.
