### PR TITLE
Allow generated attribute models to be referenced in custom models via a ManyToOne mapping

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,8 @@ In this document you will find a changelog of the important changes related to t
 ## 4.3.3
 * The config option `showException` now only applies to frontend errors. Backend errors will always display the exception details.
 * New event `Shopware_Modules_Basket_AddArticle_CheckBasketForArticle` in class sBasket
-* The `Google Analytics` plugin is deprecated and will be removed in the next release. Please use the new `Google Services` plugin instead, available on the community store. 
+* The `Google Analytics` plugin is deprecated and will be removed in the next release. Please use the new `Google Services` plugin instead, available on the community store.
+* Allow generated attribute models to be referenced in custom models via a `ManyToOne` mapping
 
 ## 4.3.1
 * Fixed name used as reference when setting attributes of an order document.

--- a/engine/Library/Enlight/Loader.php
+++ b/engine/Library/Enlight/Loader.php
@@ -330,4 +330,26 @@ class Enlight_Loader
     {
         return !preg_match('/[^a-z0-9\\/\\\\_. :-]/i', $path);
     }
+
+    /**
+     * Returns an array containing all namespaces registered using registerNamespace().
+     * If the optional parameter $namespace is provided, only the entries having that
+     * namespace will be returned.
+     *
+     * @param   string $namespace
+     * @return  array
+     */
+    public function getRegisteredNamespaces($namespace = null)
+    {
+        if ($namespace !== null) {
+            // Return only the entries, whose 'namespace' matches the given namespace
+            return array_filter($this->namespaces, function($entry) use ($namespace) {
+                return $entry['namespace'] === $namespace;
+            });
+        } else {
+            // Return all entries
+            return $this->namespaces;
+        }
+    }
+
 }


### PR DESCRIPTION
Sometimes it is desirable to have a `ManyToOne` mapping from a custom model in a plugin to a default Shopware model. By utilizing the attribute model generation, this commit dynamically adds properties to the attribute models, which have the inverting `OneToMany` annotation. In addition, a custom constructor for initializing the `ArrayCollection`s as well as respective getter functions are added. This is done by just adding the `ManyToOne` annotation to a property in a custom model and setting the `targetEntity` and `inversedBy` attributes accordingly. That information will then be used to determine the name of the property and getter method in the generated model.

Example:

``` php
<?php

namespace Shopware\CustomModels\UniquePrefix;

...

/**
 * @ORM\Table(name="s_test_attribute_feature")
 * @ORM\Entity
 */
class AttributeFeature extends ModelEntity
{

    ...

    /**
     * OWNING SIDE
     *
     * @ORM\ManyToOne(targetEntity="Shopware\Models\Attribute\Blog", inversedBy="uniquePrefixAttributeFeatures")
     * @ORM\JoinColumn(name="attribute_id", referencedColumnName="id")
     */
    private $attribute;

    ...

}

```

Please note that it's essential to use a unique prefix for the `inversedBy` attribute, since an exception will be thrown, if any two generated `OneToMany` properties have the same name. Additionally, only models, which are registered in the namespace `Shopware\CustomModels`, will be considered when generating the inverting `OneToMany` properties.

To create such a mapping in a plugin, just add the following steps to the plugin `Bootstrap.php`:

``` php
// 1. Register the custom models:
$this->registerCustomModels();

// 2. Re-generate the referenced ('inversedBy') attribute models
Shopware()->Models()->generateAttributeModels(array(
    's_blog_attributes'
));

// 3. Create the schema for the custom models
$em = Shopware()->Models();
$tool = new \Doctrine\ORM\Tools\SchemaTool($em);
$tool->createSchema(array(
    $em->getClassMetadata('Shopware\CustomModels\UniquePrefix\AttributeFeature')
));
```

Steps `2.` and `3.` can be performed in any order. However, the custom models having the `ManyToOne` mappings must be registered before, using `registerCustomModels()` as defined in `Shopware_Components_Plugin_Bootstrap`.
