### PR TITLE
Allow anonymous event listeners

### DIFF
--- a/engine/Library/Enlight/Event/EventManager.php
+++ b/engine/Library/Enlight/Event/EventManager.php
@@ -355,6 +355,10 @@ class Enlight_Event_EventManager extends Enlight_Class
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
             if (is_string($params)) {
                 $this->addListener($eventName, array($subscriber, $params));
+            } elseif (is_callable($params)) {
+                $this->addListener($eventName, $params);
+            } elseif (is_callable($params[0])) {
+                $this->addListener($eventName, $params[0], isset($params[1]) ? $params[1] : 0);
             } elseif (is_string($params[0])) {
                 $this->addListener($eventName, array($subscriber, $params[0]), isset($params[1]) ? $params[1] : 0);
             } else {

--- a/tests/Shopware/Tests/Components/Event/ManagerTest.php
+++ b/tests/Shopware/Tests/Components/Event/ManagerTest.php
@@ -301,23 +301,30 @@ class Shopware_Tests_Components_Event_ManagerTest extends \PHPUnit_Framework_Tes
 
     public function testAddSubscriber()
     {
-        $eventSubscriber = new EventSubsciberTest();
+        $eventSubscriber = new EventSubscriberTest();
         $this->eventManager->addSubscriber($eventSubscriber);
 
         $this->assertCount(1, $this->eventManager->getListeners('eventName0'));
         $this->assertCount(1, $this->eventManager->getListeners('eventName1'));
         $this->assertCount(1, $this->eventManager->getListeners('eventName2'));
         $this->assertCount(3, $this->eventManager->getListeners('eventName3'));
+        $this->assertCount(1, $this->eventManager->getListeners('eventName4'));
 
         $listeners = $this->eventManager->getListeners('eventName3');
         $listener = $listeners[5];
         $this->assertEquals(5, $listener->getPosition());
+
+        $result = $this->eventManager->notifyUntil('eventName4');
+        $this->assertEquals("test", $result->getReturn());
+
+        $listeners = $this->eventManager->getListeners('eventName5');
+        $listener = $listeners[99];
+        $this->assertEquals(99, $listener->getPosition());
     }
 }
 
 
-
-class EventSubsciberTest implements SubscriberInterface
+class EventSubscriberTest implements SubscriberInterface
 {
     public static function getSubscribedEvents()
     {
@@ -329,6 +336,15 @@ class EventSubsciberTest implements SubscriberInterface
                 array('callback3_0', 5),
                 array('callback3_1'),
                 array('callback3_2')
+            ),
+            'eventName4' => function () {
+                    return "test";
+                },
+            'eventName5' => array(
+                function () {
+                    return "test";
+                },
+                99
             )
         );
     }


### PR DESCRIPTION
I added support for anonymous functions as event listeners. I think its pretty useful for those small event callbacks you use to have for e.g. RegisterResource-Events. 

Downsides: 
- another format to support
- currently all event listeners could easily be written to database or could be stored otherwise
