### PR TITLE
Fix createHtmlEditorField

### DIFF
--- a/engine/Shopware/Models/Emotion/Library/Component.php
+++ b/engine/Shopware/Models/Emotion/Library/Component.php
@@ -518,7 +518,7 @@ class Component extends ModelEntity
     public function createHtmlEditorField(array $options)
     {
         $options += array(
-            'xtype' => 'htmleditor'
+            'xtype' => 'tinymce'
         );
 
         return $this->createField($options);


### PR DESCRIPTION
The createHtmlEditorField-Function sets the wrong x-type. Due to this HTML-Editor fields created for Emotions are not working correctly. Changing the x-type to tinymce fixes that.
