### PR TITLE
SW-10224 removed limitation on main shop for snippet export

### DIFF
--- a/engine/Shopware/Controllers/Backend/Snippet.php
+++ b/engine/Shopware/Controllers/Backend/Snippet.php
@@ -508,7 +508,6 @@ class Shopware_Controllers_Backend_Snippet extends Shopware_Controllers_Backend_
                 ->select()
                 ->from(array('s1' => 's_core_snippets'), array('namespace', 'name', "value as $alias", "dirty as $alias-dirty"))
                 ->where('s1.localeId = ?', 1)
-                ->where('s1.shopId = ?', 1)
                 ->order('s1.namespace');
 
             $counter = 1;


### PR DESCRIPTION
This pull-request allows the export of all existing template snippets. This removes the limitation in shopware, that only snippets from the template used in the main shop are exported.
