### PR TITLE
Added a path fallback for the Path()-Getter

### DIFF
--- a/engine/Shopware/Components/Plugin/Bootstrap.php
+++ b/engine/Shopware/Components/Plugin/Bootstrap.php
@@ -206,7 +206,19 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
      */
     final public function Path()
     {
-        return $this->info->path;
+        $return = '';
+
+        if ($this->info instanceof Enlight_Config) {
+            $return = $this->info->path;
+        } else {
+            $reflection = new \ReflectionClass($this);
+
+            if ($fileName = $reflection->getFileName()) {
+                $return = dirname($fileName) . DIRECTORY_SEPARATOR;
+            }
+        }
+
+        return $return;
     }
 
     /**


### PR DESCRIPTION
Many Plugins (SwagPaymentKlarna, SwagTrustedShopsExcellence ...) use Shopware_Components_Plugin_Bootstrap::Path() before the required info property is loaded, so I inserted a fallback.
