### PR TITLE
$setFirstVariantMain bug

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -807,7 +807,7 @@ class Article extends Resource implements BatchInterface
         // if another variant has set isMain to true, this variant will become
         // a usual variant again
         if ($setFirstVariantMain) {
-            $data['variants']['isMain'] = true;
+            $data['variants'][0]['isMain'] = true;
         }
 
         $variants = array();


### PR DESCRIPTION
If $setFirstVariantMain is true a new variant element gets appended to $data['variants'] array which resolves in an ValidationException.

Fix by setting isMain on $data['variants'][0]
