### PR TITLE
fixing http header error message

### DIFF
--- a/engine/Shopware/Controllers/Widgets/Captcha.php
+++ b/engine/Shopware/Controllers/Widgets/Captcha.php
@@ -35,6 +35,7 @@ class Shopware_Controllers_Widgets_Captcha extends Enlight_Controller_Action
     public function preDispatch()
     {
         $this->Front()->Plugins()->ViewRenderer()->setNoRender();
+        $this->Request()->setHeader('Surrogate-Capability', false);
     }
 
     /**


### PR DESCRIPTION
with activated http cache and a config.php file like this

```
<?php return array (
  'db' => 
  array (
    'username' => 'root',
    'password' => 'root',
    'host' => 'localhost',
    'port' => '3306',
    'dbname' => 'shopware',
  ),'front' => array(
          'noErrorHandler' => true,
          'throwExceptions' => true,
          'useDefaultControllerAlways' => true,
          'disableOutputBuffering' => true,
          'showException' => true,
      ),
      'template' => array(
          'forceCompile' => true,
      )
);
```

you will see an fatal error message under the captcha image like this: "Fatal error: Uncaught exception 'Zend_Controller_Response_Exception' with message 'Cannot send headers; headers already sent in /var/www/wentronic.it/htdocs/engine/Shopware/Controllers/Widgets/Captcha.php, line 59' in

With this fix we set the Surrogate-Capability to false. 
