### PR TITLE
Extend the ArticleSearch form field to support variant articles

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -486,8 +486,8 @@ class Repository extends ModelRepository
                         $builder->setParameter('orderTimeTo', $tmp->get('yyyy-MM-dd HH:mm:ss'));
                         break;
                     case 'details.articleNumber':
-                        $builder->andWhere('details.articleNumber LIKE :articleNumber');
-                        $builder->setParameter('articleNumber',  $filter['value'] . "%");
+                        $builder->andWhere('details.articleNumber = :articleNumber');
+                        $builder->setParameter('articleNumber',  $filter['value']);
                         break;
                     case 'customer.groupKey':
                         $builder->andWhere($expr->eq($filter['property'], "'" . $filter['value'] . "'"));

--- a/templates/_default/backend/base/bootstrap.js
+++ b/templates/_default/backend/base/bootstrap.js
@@ -97,6 +97,7 @@
 {include file='backend/base/model/supplier.js'}
 {include file='backend/base/model/country.js'}
 {include file='backend/base/model/article.js'}
+{include file='backend/base/model/article_detail.js'}
 {include file='backend/base/model/locale.js'}
 {include file='backend/base/model/currency.js'}
 {include file='backend/base/model/payment_status.js'}
@@ -129,6 +130,7 @@
 {include file='backend/base/store/supplier.js'}
 {include file='backend/base/store/country.js'}
 {include file='backend/base/store/article.js'}
+{include file='backend/base/store/article_detail.js'}
 {include file='backend/base/store/locale.js'}
 {include file='backend/base/store/currency.js'}
 {include file='backend/base/store/payment_status.js'}

--- a/templates/_default/backend/base/component/Shopware.form.field.ArticleSearch.js
+++ b/templates/_default/backend/base/component/Shopware.form.field.ArticleSearch.js
@@ -224,12 +224,16 @@ Ext.define('Shopware.form.field.ArticleSearch',
 
         me.registerEvents();
 
+        me.articleClass = me.showVariants ?
+            'Shopware.apps.Base.store.ArticleDetail' :
+            'Shopware.apps.Base.store.Article';
+
         if (!(me.articleStore instanceof Ext.data.Store)) {
-            me.articleStore = Ext.create('Shopware.apps.Base.store.Article');
+            me.articleStore = Ext.create(me.articleClass);
         }
 
         // We need to filter the store on loading to prevent to show the first article in the store on startup
-        me.dropDownStore = Ext.create('Shopware.apps.Base.store.Article', {
+        me.dropDownStore = Ext.create(me.articleClass, {
             listeners: {
                 single: true,
                 load: function() {
@@ -483,7 +487,7 @@ Ext.define('Shopware.form.field.ArticleSearch',
             '<div class="content">',
                 '{literal}<tpl for=".">',
                     '<div class="item">',
-                        '<strong class="name">{name}</strong>',
+                        '<strong class="name">{name}<tpl if="additionalText">' + (me.showVariants ? ', {additionalText}' : '') + '</tpl></strong>',
                         '<span class="ordernumber">{number}</span>',
                     '</div>',
                 '</tpl>{/literal}',
@@ -701,7 +705,7 @@ Ext.define('Shopware.form.field.ArticleSearch',
         var me = this;
 
         if(!me.multiSelect) {
-            me.getSearchField().setValue(record.get(me.returnValue));
+            me.getSearchField().setValue(me.getReturnValue(record));
             me.getHiddenField().setValue(record.get(me.hiddenReturnValue));
             me.returnRecord = record;
             me.getDropDownMenu().hide();
@@ -713,7 +717,7 @@ Ext.define('Shopware.form.field.ArticleSearch',
             me.multiSelectStore.add(record);
             me.getDropDownMenu().getSelectionModel().deselectAll();
         }
-        me.fireEvent('valueselect', me, record.get(me.returnValue), record.get(me.hiddenReturnValue), record);
+        me.fireEvent('valueselect', me, me.getReturnValue(record), record.get(me.hiddenReturnValue), record);
     },
 
     /**
@@ -757,7 +761,7 @@ Ext.define('Shopware.form.field.ArticleSearch',
             hiddenReturnValue = '';
 
         Ext.each(records, function(record) {
-            returnValue += record.get(me.returnValue) + me.separator;
+            returnValue += me.getReturnValue(record) + me.separator;
             hiddenReturnValue += record.get(me.hiddenReturnValue) + me.separator;
         });
         returnValue = returnValue.substring(0, returnValue.length - 1);
@@ -794,13 +798,35 @@ Ext.define('Shopware.form.field.ArticleSearch',
     },
 
     /**
-     * Helper methiod which returns the multi select article store.
+     * Helper method which returns the multi select article store.
      *
      * @public
      * @return [object] store - Ext.data.Store
      */
     getArticleStore: function() {
         return this.multiSelectStore
+    },
+
+    /**
+     * Helper method which returns the value which will be set into the search field
+     * if the user clicks on an entry in the drop down menu.
+     *
+     * @public
+     * @param [object] record - Shopware.apps.Base.model.Article|Shopware.apps.Base.model.ArticleDetail
+     * @return [string]
+     */
+    getReturnValue: function(record) {
+        if(this.returnValue == 'name') {
+            if(this.showVariants) {
+                var additionalText = record.get('additionalText');
+                return record.get('name') + (additionalText ? ' ' + additionalText : '');
+            } else {
+                return record.get('name');
+            }
+        } else {
+            return record.get(this.returnValue);
+        }
     }
+
 });
 //{/block}

--- a/templates/_default/backend/base/model/article_detail.js
+++ b/templates/_default/backend/base/model/article_detail.js
@@ -1,0 +1,77 @@
+/**
+ * Shopware 4.0
+ * Copyright © 2012 shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    Base
+ * @subpackage Model
+ * @copyright  Copyright (c) 2012, shopware AG (http://www.shopware.de)
+ * @version    $Id$
+ * @author shopware AG
+ */
+
+/**
+ * Shopware Model - Global Stores and Models
+ *
+ * The article detail model represents a data row of the s_articles_details or the
+ * Shopware\Models\Article\Detail doctrine model.
+ */
+//{block name="backend/base/model/article_detail"}
+Ext.define('Shopware.apps.Base.model.ArticleDetail', {
+
+	/**
+	 * Defines an alternate name for this class.
+	 */
+	alternateClassName:'Shopware.model.ArticleDetail',
+
+	/**
+	 * Extends the standard Ext Model
+	 * @string
+	 */
+	extend:'Shopware.data.Model',
+
+	/**
+	 * unique id
+	 * @int
+	 */
+	idProperty:'id',
+
+	/**
+	 * The fields used for this model
+	 * @array
+	 */
+	fields:[
+		//{block name="backend/base/model/article_detail/fields"}{/block}
+		{ name:'id', type:'int' },
+		{ name:'number', type:'string' },
+		{ name:'name', type:'string' },
+		{ name:'additionalText', type:'string' },
+		{ name:'description', type:'string' },
+		{ name:'supplierName', type:'string' },
+		{ name:'supplierId', type:'int' },
+		{ name:'active', type:'int' },
+		{ name:'detailId', type:'int' },
+		{ name:'changeTime', type:'date' },
+		{ name:'inStock', type:'int' }
+	]
+});
+//{/block}
+

--- a/templates/_default/backend/base/store/article_detail.js
+++ b/templates/_default/backend/base/store/article_detail.js
@@ -1,0 +1,106 @@
+/**
+ * Shopware 4.0
+ * Copyright © 2012 shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    Base
+ * @subpackage Store
+ * @copyright  Copyright (c) 2012, shopware AG (http://www.shopware.de)
+ * @version    $Id$
+ * @author shopware AG
+ */
+
+/**
+ * Shopware Store - Global Stores and Models
+ *
+ * The article detail store contains all defined shop articles including variants.
+ */
+Ext.define('Shopware.apps.Base.store.ArticleDetail', {
+
+    /**
+     * Defines an alternate name for this class.
+     */
+    alternateClassName: 'Shopware.store.ArticleDetail',
+
+    /**
+     * Define that this component is an extension of the Ext.data.Store
+     */
+    extend: 'Ext.data.Store',
+
+    /**
+     * Define unique store id to create the store by the store manager
+     */
+    storeId: 'base.ArticleDetail',
+
+    /**
+     * Define how much rows loaded with one request
+     */
+    pageSize: 10,
+
+   /**
+    * Auto load the store after the component
+    * is initialized
+    * @boolean
+    */
+    autoLoad: false,
+
+    /**
+     * Enable remote sorting
+     */
+    remoteSort: true,
+
+    /**
+     * Enable remote filtering
+     */
+    remoteFilter: true,
+   /**
+    * Define the used model for this store
+    * @string
+    */
+    model : 'Shopware.apps.Base.model.ArticleDetail',
+
+    /**
+     * Configure the data communication
+     * @object
+     */
+    proxy:{
+        type:'ajax',
+
+        /**
+         * Configure the url mapping for the different
+         * store operations based on
+         * @object
+         */
+        url:'{url controller="base" action="getArticleDetails"}',
+
+        /**
+         * Configure the data reader
+         * @object
+         */
+        reader:{
+            type:'json',
+            root:'data',
+            totalProperty:'total'
+        }
+    }
+});
+
+

--- a/templates/_default/backend/order/view/detail/position.js
+++ b/templates/_default/backend/order/view/detail/position.js
@@ -445,6 +445,7 @@ Ext.define('Shopware.apps.Order.view.detail.Position', {
             returnValue: returnValue,
             hiddenReturnValue: hiddenReturnValue,
             articleStore: Ext.create('Shopware.store.Article'),
+            showVariants: true,
             allowBlank: false,
             getValue: function() {
                 return this.getSearchField().getValue();

--- a/templates/_default/backend/order/view/list/filter.js
+++ b/templates/_default/backend/order/view/list/filter.js
@@ -275,7 +275,8 @@ Ext.define('Shopware.apps.Order.view.list.Filter', {
         return Ext.create('Shopware.form.field.ArticleSearch', {
             name: 'details.articleNumber',
             fieldLabel: me.snippets.article,
-            articleStore: Ext.create('Shopware.store.Article')
+            articleStore: Ext.create('Shopware.store.Article'),
+            showVariants: true
         });
     },
 


### PR DESCRIPTION
At the moment, it is only possible to select main variants in article search fields. In some cases, this makes sense, e.g. when configuring an article slider (all variants look the same in the slider, so only the main variant should be selectable). In other cases, though, we need to be able to select individual variants, e.g. when editing positions in the order detail window. At the moment, it is only possible to assign a main variant to a order position. This pull request changes this behavior. Furthermore, it is also helpful to be able to search for orders containing a concrete variant. At the moment, the article filter in the order list tries to match all variants of an article by using a glob pattern '<ARTICLE_NUMBER>%' in the SQL Query (https://github.com/shopware/shopware/blob/fddab4a449ff95155b6711a18c2f3534a590fc51/engine/Shopware/Models/Order/Repository.php#L490). This behavior is flawed, though, because there is no guarantee that all articles whose article number start with a given string actually are variants of the original article. E.g, there might be an article with the article number "1" and another article with the article number "11" that have nothing to do with each other. Currently, a search for article "1" will also match the article "11". The most logical behaviour here is to only match the exact article that was chosen in the article search combobox and to list all variants in the combobox.
