### PR TITLE
Increase customernumber on registration because it's possibly already used

### DIFF
--- a/engine/core/class/sAdmin.php
+++ b/engine/core/class/sAdmin.php
@@ -2282,7 +2282,7 @@ class sAdmin
                           s_order_number, s_user_billingaddress
                         SET
                           s_order_number.number = s_order_number.number+1,
-                          s_user_billingaddress.customernumber = s_order_number.number
+                          s_user_billingaddress.customernumber = s_order_number.number+1
                         WHERE s_order_number.name = 'user'
                         AND s_user_billingaddress.userID = ?
                     ";


### PR DESCRIPTION
We faced a problem where customers get the same customernumber. That's because in https://github.com/shopware/shopware/blob/master/engine/Shopware/Models/Customer/Billing.php under onSave the customernumber in s_order_number is used and is not increased to an unique/unused one. So we have here also to increase the number to guarantee unique customernumbers.
We ran into this because we imported customers without customernumber (thought Shopware assign the correct customernumber on its own).
