### PR TITLE
Make order billing and shipping addresses searchable

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -273,9 +273,11 @@ class Repository extends ModelRepository
                 ->leftJoin('orders.paymentStatus', 'paymentStatus')
                 ->leftJoin('orders.orderStatus', 'orderStatus')
                 ->leftJoin('orders.billing', 'billing')
+                ->leftJoin('orders.shipping', 'shipping')
                 ->leftJoin('orders.customer', 'customer')
                 ->leftJoin('orders.details', 'details')
                 ->leftJoin('billing.country', 'billingCountry')
+                ->leftJoin('shipping.country', 'shippingCountry')
                 ->leftJoin('orders.shop', 'shop')
                 ->leftJoin('orders.dispatch', 'dispatch')
                 ->leftJoin('billing.attribute', 'billingAttribute')
@@ -460,9 +462,22 @@ class Repository extends ModelRepository
                                 $expr->like('paymentStatus.description', '?1'),
                                 $expr->like('orders.orderTime', '?2'),
                                 $expr->like('billing.company', '?3'),
+                                $expr->like('shipping.company', '?3'),
+                                $expr->like('billing.department', '?3'),
+                                $expr->like('shipping.department', '?3'),
+                                $expr->like('billing.street', '?3'),
+                                $expr->like('shipping.street', '?3'),
+                                $expr->like('billing.zipCode', '?1'),
+                                $expr->like('shipping.zipCode', '?1'),
+                                $expr->like('billing.city', '?3'),
+                                $expr->like('shipping.city', '?3'),
+                                $expr->like('billingCountry.name', '?3'),
+                                $expr->like('shippingCountry.name', '?3'),
                                 $expr->like('customer.email', '?3'),
                                 $expr->like('billing.lastName', '?3'),
+                                $expr->like('shipping.lastName', '?3'),
                                 $expr->like('billing.firstName', '?3'),
+                                $expr->like('shipping.firstName', '?3'),
                                 $expr->like('shop.name', '?3'),
                                 $expr->like('orders.comment', '?3'),
                                 $expr->like('orders.customerComment', '?3'),


### PR DESCRIPTION
This makes it possible to search for orders with a specific address (street, city, country etc.) in the order dialog.
