### PR TITLE
Make proxy file permissions configurable

### DIFF
--- a/engine/Library/Enlight/Hook/HookManager.php
+++ b/engine/Library/Enlight/Hook/HookManager.php
@@ -83,7 +83,8 @@ class Enlight_Hook_HookManager extends Enlight_Class
         $this->proxyFactory = new Enlight_Hook_ProxyFactory(
             $this,
             $options['proxyNamespace'],
-            $options['proxyDir']
+            $options['proxyDir'],
+            $options['proxyChmod']
         );
 
         $loader->registerNamespace(

--- a/engine/Library/Enlight/Hook/ProxyFactory.php
+++ b/engine/Library/Enlight/Hook/ProxyFactory.php
@@ -56,6 +56,12 @@ class Enlight_Hook_ProxyFactory extends Enlight_Class
     protected $fileExtension = '.php';
 
     /**
+     * Chmod for proxy files
+     * @var int
+     */
+    protected $fileChmod = 0644;
+
+    /**
      * @var string Default proxy class template.
      */
     protected $proxyClassTemplate =
@@ -101,10 +107,11 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
      * @param string $proxyNamespace
      * @param string $proxyDir
      */
-    public function __construct($hookManager, $proxyNamespace, $proxyDir)
+    public function __construct($hookManager, $proxyNamespace, $proxyDir, $proxyChmod = 0644)
     {
         $this->hookManager = $hookManager;
         $this->proxyNamespace = $proxyNamespace;
+        $this->fileChmod = $proxyChmod;
 
         if (!is_dir($proxyDir)) {
             throw new \InvalidArgumentException(sprintf('The directory "%s" does not exist.', $proxyDir));
@@ -228,7 +235,7 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
             throw new Enlight_Exception('Unable to write file "' . $fileName . '"');
             return false;
         }
-        chmod($fileName, 0644);
+        chmod($fileName, $this->fileChmod);
         umask($oldMask);
     }
 

--- a/engine/Shopware/Components/Api/Resource/Resource.php
+++ b/engine/Shopware/Components/Api/Resource/Resource.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Components\Api\Resource;
 
-use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Shopware\Components\Api\Exception as ApiException;
 use Shopware\Components\Api\BatchInterface;
 use Shopware\Components\DependencyInjection\Container;
@@ -267,13 +267,13 @@ abstract class Resource
      * If the data property contains the "__options_$optionName" value and this value contains
      * the "replace" parameter the collection will be cleared.
      *
-     * @param ArrayCollection $collection
+     * @param Collection $collection
      * @param $data
      * @param $optionName
      * @param $defaultReplace
-     * @return \Doctrine\Common\Collections\ArrayCollection
+     * @return \Doctrine\Common\Collections\Collection
      */
-    protected function checkDataReplacement(ArrayCollection $collection, $data, $optionName, $defaultReplace)
+    protected function checkDataReplacement(Collection $collection, $data, $optionName, $defaultReplace)
     {
         $key = '__options_' . $optionName;
         if (isset($data[$key])) {
@@ -288,13 +288,13 @@ abstract class Resource
     }
 
     /**
-     * @param ArrayCollection $collection
+     * @param Collection $collection
      * @param $property
      * @param $value
      * @throws \Exception
      * @return null
      */
-    protected function getCollectionElementByProperty(ArrayCollection $collection, $property, $value)
+    protected function getCollectionElementByProperty(Collection $collection, $property, $value)
     {
         foreach ($collection as $entity) {
             $method = 'get' . ucfirst($property);
@@ -313,11 +313,11 @@ abstract class Resource
     }
 
     /**
-     * @param ArrayCollection $collection
+     * @param Collection $collection
      * @param array $conditions
      * @return null
      */
-    protected function getCollectionElementByProperties(ArrayCollection $collection, array $conditions)
+    protected function getCollectionElementByProperties(Collection $collection, array $conditions)
     {
         foreach ($conditions as $property => $value) {
             $entity = $this->getCollectionElementByProperty(
@@ -372,14 +372,14 @@ abstract class Resource
      * If no property is set, the function creates a new entity and adds the instance into the
      * passed collection and persist the entity.
      *
-     * @param ArrayCollection $collection
+     * @param Collection $collection
      * @param $data
      * @param $entityType
      * @param array $conditions
      * @return null|object
      * @throws \Shopware\Components\Api\Exception\CustomValidationException
      */
-    protected function getOneToManySubElement(ArrayCollection $collection, $data, $entityType, $conditions = array('id'))
+    protected function getOneToManySubElement(Collection $collection, $data, $entityType, $conditions = array('id'))
     {
         foreach ($conditions as $property) {
             if (!isset($data[$property])) {
@@ -414,14 +414,14 @@ abstract class Resource
      * In case that the findOneBy statement finds no entity, the function throws an exception.
      * Otherwise the item will be
      *
-     * @param ArrayCollection $collection
+     * @param Collection $collection
      * @param $data
      * @param $entityType
      * @param array $conditions
      * @return null|object
      * @throws \Shopware\Components\Api\Exception\CustomValidationException
      */
-    protected function getManyToManySubElement(ArrayCollection $collection, $data, $entityType, $conditions = array('id'))
+    protected function getManyToManySubElement(Collection $collection, $data, $entityType, $conditions = array('id'))
     {
         $repo = $this->getManager()->getRepository($entityType);
         foreach ($conditions as $property) {

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -123,7 +123,8 @@ return array_merge($customConfig, array(
     ),
     'hook' => array_merge(array(
         'proxyDir' => $this->DocPath('cache_proxies'),
-        'proxyNamespace' => $this->App() . '_Proxies'
+        'proxyNamespace' => $this->App() . '_Proxies',
+        'proxyChmod' => 0644
     ), $customConfig['hook']),
     'model' => array_merge(array(
         'autoGenerateProxyClasses' => false,


### PR DESCRIPTION
The hardcoded file permissions 0664 can now be configured in the
config.php like:

'hook' => array(
'proxyChmod' => 0660
)

The default file permissions remain untouched at 0644. With the option
to configure the proxy file permissions it is e.g. possible to add
group write rights to the files which is often needed.
