### PR TITLE
Fix hooks with pass by ref method parameters

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,9 @@
 # Shopware Upgrade Information
 In this document you will find a changelog of the important changes related to the code base of Shopware.
 
+## 4.3.4
+* Add support for passing hook proxy arguments by reference to the hook listener.
+
 ## 4.3.3
 * The config option `showException` now only applies to frontend errors. Backend errors will always display the exception details.
 * New event `Shopware_Modules_Basket_AddArticle_CheckBasketForArticle` in class sBasket

--- a/engine/Library/Enlight/Hook/ProxyFactory.php
+++ b/engine/Library/Enlight/Hook/ProxyFactory.php
@@ -282,7 +282,13 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
                 }
                 $params .= '$' . $rp->getName();
                 $proxy_params .= '$' . $rp->getName();
-                $array_params .= '\'' . $rp->getName() . '\'=>$' . $rp->getName();
+
+                if ($rp->isPassedByReference()) {
+                    $array_params .= '\'' . $rp->getName() . '\'=>&$' . $rp->getName();
+                } else {
+                    $array_params .= '\'' . $rp->getName() . '\'=>$' . $rp->getName();
+                }
+
                 if ($rp->isOptional()) {
                     $params .= ' = ' . str_replace("\n", '', var_export($rp->getDefaultValue(), true));
                 }


### PR DESCRIPTION
This pull request adds support for hooks on methods that have pass by reference `&` parameters.
Currently the hook listener wouldn't get access to a parameter pointer.

I have the following subscription:

``` php
$this->subscribeEvent(
    'Shopware_Controllers_Backend_Article::prepareVariantData::after',
    'onAfterArticlePrepareVariantData'
);
```

Before this patch the following proxy will be generated:

``` php
<?php
class Shopware_Proxies_ShopwareControllersBackendArticleProxy extends Shopware_Controllers_Backend_Article implements Enlight_Hook_Proxy
{
    ...
    protected function prepareVariantData($variant, $detailData, &$counter, $dependencies, $priceSurcharges, $allOptions, $originals, $article, $mergeType)
    {
        return Enlight_Application::Instance()->Hooks()->executeHooks(
            $this, 'prepareVariantData', array('variant'=>$variant, 'detailData'=>$detailData, 'counter'=>$counter, 'dependencies'=>$dependencies, 'priceSurcharges'=>$priceSurcharges, 'allOptions'=>$allOptions, 'originals'=>$originals, 'article'=>$article, 'mergeType'=>$mergeType)
        );
    }
}
```

The fixed version will compile to: (see _'counter' => &$counter_)

``` php
<?php
class Shopware_Proxies_ShopwareControllersBackendArticleProxy extends Shopware_Controllers_Backend_Article implements Enlight_Hook_Proxy
{
    ...
    protected function prepareVariantData($variant, $detailData, &$counter, $dependencies, $priceSurcharges, $allOptions, $originals, $article, $mergeType)
    {
        return Enlight_Application::Instance()->Hooks()->executeHooks(
            $this, 'prepareVariantData', array('variant'=>$variant, 'detailData'=>$detailData, 'counter'=>&$counter, 'dependencies'=>$dependencies, 'priceSurcharges'=>$priceSurcharges, 'allOptions'=>$allOptions, 'originals'=>$originals, 'article'=>$article, 'mergeType'=>$mergeType)
        );
    }
}
```
