### PR TITLE
Fix transparent search-icon

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/header.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/header.less
@@ -135,12 +135,6 @@ More precise designations are commented inside the document.
     }
 
     .entry--search {
-        .btn:hover {
-            background: inherit;
-            color: @btn-default-hover-text-color;
-            border-color: @btn-default-hover-border-color;
-        }
-
         .is--active.btn {
             background: @btn-default-hover-bg;
             color: @btn-default-hover-text-color;


### PR DESCRIPTION
I think that this part is not necessary because the button should behave like the other buttons just next to it.
That makes this .btn:hover entry obsolete. Additionally this causes the search-button to become transparent when it's hovered or active.

Usually one doesn't notice this because the standard background behind the buttons is also white, but if you change your header to a diffrent color you can see it. Actually not that important but it may save some bytes in the CSS files as long there is no good reason to keep this entry. I didn't find one.
