### PR TITLE
SW-10910 - compile/compress theme LESS / CSS after plugin LESS / CSS

### DIFF
--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -166,13 +166,15 @@ class Compiler
 
         $this->buildConfig($template, $shop);
 
-        $this->compileThemeLess($template, $shop);
+        $this->compileThemeLess($template, $shop, true, false);
 
         $this->compilePluginLess($template, $shop);
 
-        $this->compressThemeCss($template, $shop);
-
         $this->compressPluginCss($template, $shop);
+
+        $this->compileThemeLess($template, $shop, false, true);
+
+        $this->compressThemeCss($template, $shop);
 
         $this->outputCompiledCss($timestamp, $shop);
     }
@@ -354,9 +356,9 @@ class Compiler
      * @param Shop\Template $template
      * @param Shop\Shop $shop
      */
-    protected function compileThemeLess(Shop\Template $template, Shop\Shop $shop)
+    protected function compileThemeLess(Shop\Template $template, Shop\Shop $shop, $includeBareAndResponsive = true, $includeOwnThemes = true)
     {
-        $hierarchy = $this->inheritance->buildInheritance($template);
+        $hierarchy = $this->inheritance->buildInheritance($template, $includeBareAndResponsive, $includeOwnThemes);
 
         //use array_reverse to compile the bare themes first.
         foreach (array_reverse($hierarchy) as $shopTemplate) {

--- a/engine/Shopware/Components/Theme/Inheritance.php
+++ b/engine/Shopware/Components/Theme/Inheritance.php
@@ -102,9 +102,9 @@ class Inheritance
      * @param \Shopware\Models\Shop\Template $template
      * @return \Shopware\Models\Shop\Template[]
      */
-    public function buildInheritance(Shop\Template $template)
+    public function buildInheritance(Shop\Template $template, $includeBareAndResponsive = true, $includeOwnThemes = true)
     {
-        $hierarchy = $this->buildInheritanceRecursive($template);
+        $hierarchy = $this->buildInheritanceRecursive($template, $includeBareAndResponsive, $includeOwnThemes);
 
         $hierarchy = $this->eventManager->filter('Theme_Inheritance_Built', $hierarchy, array(
             'template' => $template
@@ -285,14 +285,23 @@ class Inheritance
      * @param Shop\Template $template
      * @return array
      */
-    private function buildInheritanceRecursive(Shop\Template $template)
+    private function buildInheritanceRecursive(Shop\Template $template, $includeBareAndResponsive = true, $includeOwnThemes = true)
     {
         $hierarchy = array($template);
 
-        if ($template->getParent() instanceof Shop\Template) {
+        if ((!$includeBareAndResponsive) && (in_array($template->getName(), array('Bare', 'Responsive', '__theme_name__')))) {
+            $hierarchy = array();
+        }
+
+        if ((!$includeOwnThemes) && (!in_array($template->getName(), array('Bare', 'Responsive', '__theme_name__')))) {
+            $hierarchy = array();
+        }
+
+        $parent = $template->getParent();
+        if ($parent instanceof Shop\Template) {
             $hierarchy = array_merge(
                 $hierarchy,
-                $this->buildInheritanceRecursive($template->getParent())
+                $this->buildInheritanceRecursive($parent, $includeBareAndResponsive, $includeOwnThemes)
             );
         }
         return $hierarchy;


### PR DESCRIPTION
LESS- and CSS-files of your own theme should be compiled and compressed after LESS- and CSS-files of installed plugins have been processed.

So it is possible to overwrite LESS-/CSS-definitions of plugins in your own theme.

see also:
http://forum.shopware.com/themes-und-design-f101/less-files-von-plugins-uberschreiben-erweitern-t26259.html
