### PR TITLE
Do not ignore the htaccess files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ Thumbs.db
 
 # Composer
 /composer.phar
-/vendor/
+/vendor/*
 
 # Internal Repositories
 /internal
@@ -51,3 +51,6 @@ Thumbs.db
 
 # Snippet exports
 /snippetsExport/
+
+# never skip an .htaccess
+!**/.htaccess


### PR DESCRIPTION
After a clone the .htaccess in the vendor dir is ignored. With this fix, no .htaccess should be ignored, espacially in the vendor dir.
