### PR TITLE
Added codesniffer for using the build/ruleset.xml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "behat/mink-extension": "@stable",
         "behat/mink-sahi-driver": "@stable",
         "behat/mink-goutte-driver": "@stable",
-        "sensiolabs/behat-page-object-extension": "*"
+        "sensiolabs/behat-page-object-extension": "*",
+        "squizlabs/php_codesniffer": "~2.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
What do you guys think about including the codesniffer, to "enable" it out of the box without external setup?
