### PR TITLE
Enable environment in UpdateCommand

### DIFF
--- a/recovery/common/autoload.php
+++ b/recovery/common/autoload.php
@@ -9,4 +9,8 @@ $autoloader->addPsr4(
     SW_PATH . '/engine/Shopware/Components/Migrations/'
 );
 
+$autoloader->addClassMap(array(
+    'Shopware\\Components\\ConfigLoader' => SW_PATH . '/engine/Shopware/Components/ConfigLoader.php'
+));
+
 return $autoloader;

--- a/recovery/update/src/Command/UpdateCommand.php
+++ b/recovery/update/src/Command/UpdateCommand.php
@@ -39,6 +39,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateCommand extends Command
@@ -64,6 +65,7 @@ class UpdateCommand extends Command
     protected function configure()
     {
         $this->setName('update');
+        $this->addOption('env', 'e', InputOption::VALUE_OPTIONAL, 'Sets the environment');
     }
 
     /**

--- a/recovery/update/src/Console/Application.php
+++ b/recovery/update/src/Console/Application.php
@@ -47,6 +47,7 @@ class Application extends BaseApplication
 
         $config = require __DIR__ . '/../../config/config.php';
         $this->container = new Container(new \Pimple(), $config);
+        $this->container->setParameter('environment', $env);
     }
 
     /**

--- a/recovery/update/src/Utils.php
+++ b/recovery/update/src/Utils.php
@@ -180,22 +180,12 @@ class Utils
     }
 
     /**
-     * @param string $shopPath
+     * @param array $config Shopware Configuration
      *
      * @return \PDO
      */
-    public static function getConnection($shopPath)
+    public static function getConnection(array $config = array())
     {
-        if (file_exists($shopPath . '/config.php')) {
-            $config = require $shopPath . '/config.php';
-        } elseif (file_exists($shopPath . '/config.update.php')) {
-            $config = require $shopPath . '/config.update.php';
-        } elseif (file_exists($shopPath . '/engine/Shopware/Configs/Custom.php')) {
-            $config = require $shopPath . '/engine/Shopware/Configs/Custom.php';
-        } else {
-            die('Could not find shopware config');
-        }
-
         $dbConfig = $config['db'];
         if (!isset($dbConfig['host'])) {
             $dbConfig['host'] = 'localhost';


### PR DESCRIPTION
At the moment it is not possible to set an environment in the shopware UpdateCommand. Although it is "prepared", which means that Shopware\Recovery\Update\Console\Application expects an environment variable, there is always the default config.php loaded. This resolves in not beeing able to connect to the databases on different systems.

This patch replaces the hard coded loading of config.php with enviroment based loading via the ConfigLoader.
