### PR TITLE
bugfix: sConfiguratorSelection is ignoring lastStock = true

### DIFF
--- a/engine/core/class/sConfigurator.php
+++ b/engine/core/class/sConfigurator.php
@@ -267,7 +267,15 @@ class sConfigurator
             foreach ($sConfigurator as &$group) {
                 $preSelectedOption = $preSelectedOptions[$group['groupID']];
                 $id = $preSelectedOption['id'];
+
                 if (array_key_exists($id, $group['values'])) {
+                    // reset selection
+                    foreach ($group['values'] as &$value) {
+                        $value['user_selected'] = 0;
+                        $value['selected'] = 0;
+                    }
+
+                    // set the correct one instead
                     $group['values'][$preSelectedOption['id']]['user_selected'] = 1;
                     $group['values'][$preSelectedOption['id']]['selected'] = 1;
                 }

--- a/engine/core/class/sConfigurator.php
+++ b/engine/core/class/sConfigurator.php
@@ -255,7 +255,7 @@ class sConfigurator
 
         if (empty($selected)) {
             // Limiting the results with setMaxResults(1) will result in only one price being selected SW-4465
-            $query = $repository->getConfiguratorTablePreSelectionItemQuery($id, $customerGroupKey, ($article['lastStock'] === 1));
+            $query = $repository->getConfiguratorTablePreSelectionItemQuery($id, $customerGroupKey, $article);
             $query->setFirstResult(0)->setMaxResults(1);
             $detail = $this->getOneOrNullResult($query);
 


### PR DESCRIPTION
When working with the configurator i noticed an odd behaviour. The Main Article was set to lastStock = true, and the first variant had no stock left. Instead of displaying the second variant, the first variant was dispalyed instead.
