### PR TITLE
Clear association filters before saving configuration

### DIFF
--- a/themes/Backend/ExtJs/backend/config/controller/form.js
+++ b/themes/Backend/ExtJs/backend/config/controller/form.js
@@ -384,6 +384,11 @@ Ext.define('Shopware.apps.Config.controller.Form', {
         formPanel.disable();
         formPanel.loadRecord();
 
+		record.associations.each(function(association) {
+			var store = record[association.name]();
+			store.clearFilter(true);
+		});
+
         var message,
             title = me.messages.saveEntryTitle;
 


### PR DESCRIPTION
This fixes the bug that price group discounts are removed when no customer group is chosen from the combobox before 'save' is clicked:

![recorded](https://cloud.githubusercontent.com/assets/105166/7885200/c99cede2-0622-11e5-84b7-1966d0fb605a.gif)

When a customer group is chosen before clicking 'save', the loading of an empty record to the form
(https://github.com/shopware/shopware/blob/77661288fafc1f962e7e12510988cbc5084d93d7/themes/Backend/ExtJs/backend/config/controller/form.js#L385) triggers a change event on the combobox and therefore clears the filters (https://github.com/shopware/shopware/blob/77661288fafc1f962e7e12510988cbc5084d93d7/themes/Backend/ExtJs/backend/config/controller/form.js#L244). When no customer group is chosen, this does not happen, though, because the combobox does not get changed. When an ExtJS store is synced, only its filtered results get saved. This leads to removal of the discounts because they get filtered out.
