### PR TITLE
Fix für #SW-11616 - Klick Bereich im Artikeldetail

### DIFF
--- a/templates/_emotion/frontend/_resources/javascript/jquery.shopware.js
+++ b/templates/_emotion/frontend/_resources/javascript/jquery.shopware.js
@@ -4398,7 +4398,7 @@ jQuery.effects||function(a,b){function c(b){var c;return b&&b.constructor==Array
              We need the dummy background image as IE does not trap mouse events on
              transparent parts of a div.
              */
-            $mouseTrap = jWin.parent().append($.format("<div class='mousetrap' style='z-index:999;position:absolute;width:%0px;height:%1px;left:%2px;top:%3px;\'></div>", sImg.outerWidth(), sImg.outerHeight(), 0, 0)).find(':last');
+            $mouseTrap = jWin.parent().append($.format("<div class='mousetrap' style='z-index:999;position:absolute;width:auto;height:%1px;left:%2px;top:%3px;\'></div>", sImg.outerHeight(), 0, 0)).find(':last');
 
             if ($.browser.msie && parseInt($.browser.version) < 10) {
                 $mouseTrap.css('background', 'url(".")');


### PR DESCRIPTION
Der Klick Bereich im Artikeldetail über dem Bild ist leider nicht passend wenn das Bild was angezeigt wird kleiner ist als der Wrapper.

Das hat zur Folge das bei einem Klick auf das Bild dieses als URL angesehen wird und direkt aufgerufen wird.

http://i.imgur.com/nGx5HFR.png
