### PR TITLE
Fix for #SW-11616 - Click area on article detail page

### DIFF
--- a/templates/_emotion/frontend/_resources/javascript/jquery.shopware.js
+++ b/templates/_emotion/frontend/_resources/javascript/jquery.shopware.js
@@ -4398,7 +4398,7 @@ jQuery.effects||function(a,b){function c(b){var c;return b&&b.constructor==Array
              We need the dummy background image as IE does not trap mouse events on
              transparent parts of a div.
              */
-            $mouseTrap = jWin.parent().append($.format("<div class='mousetrap' style='z-index:999;position:absolute;width:auto;height:%1px;left:%2px;top:%3px;\'></div>", sImg.outerHeight(), 0, 0)).find(':last');
+            $mouseTrap = jWin.parent().append($.format("<div class='mousetrap' style='z-index:999;position:absolute;width:100%;height:%0px;left:%1px;top:%2px;\'></div>", sImg.outerHeight(), 0, 0)).find(':last');
 
             if ($.browser.msie && parseInt($.browser.version) < 10) {
                 $mouseTrap.css('background', 'url(".")');

--- a/templates/_emotion/frontend/_resources/javascript/jquery.shopware.js
+++ b/templates/_emotion/frontend/_resources/javascript/jquery.shopware.js
@@ -4398,7 +4398,7 @@ jQuery.effects||function(a,b){function c(b){var c;return b&&b.constructor==Array
              We need the dummy background image as IE does not trap mouse events on
              transparent parts of a div.
              */
-            $mouseTrap = jWin.parent().append($.format("<div class='mousetrap' style='z-index:999;position:absolute;width:%0px;height:%1px;left:%2px;top:%3px;\'></div>", sImg.outerWidth(), sImg.outerHeight(), 0, 0)).find(':last');
+            $mouseTrap = jWin.parent().append($.format("<div class='mousetrap' style='z-index:999;position:absolute;width:auto;height:%1px;left:%2px;top:%3px;\'></div>", sImg.outerHeight(), 0, 0)).find(':last');
 
             if ($.browser.msie && parseInt($.browser.version) < 10) {
                 $mouseTrap.css('background', 'url(".")');


### PR DESCRIPTION
The click area for the lightbox is based on the image width and height. When the width and height is smaller then the wrapper class itself the result is a click area which is not directly placed on top of the image but aligned to the left. Making the click on the image not getting recognized.

By changing the width of the click area to auto the area has the needed width to make sure that every click is getting recognized.
