### PR TITLE
Refine structure of 'build-database' target in 'build.xml'

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,7 @@ In this document you will find a changelog of the important changes related to t
 * Method `createMenuItem` in plugin bootstrap now results in an duplicate error when passing an existing label with the same parent
 * Removed `Shopware_Controllers_Backend_Order::getStatisticAction` and statistics in the order backend module.
 * It's no longer possible to have spaces in article numbers. Existing articles with spaces in their numbers will still work, but the article cannot be changed without fixing the number.
+* Change structure of `build-database` target in `build/build.xml` to allow a more fine grained build process.
 
 ## 5.0.1
 * Create `sw:theme:dump:configuration` command to generate watch files for theme compiling

--- a/build/build.xml
+++ b/build/build.xml
@@ -96,7 +96,9 @@
         </exec>
     </target>
 
-    <target name="build-database">
+    <target name="build-database" depends="build-database-foundation, build-database-apply-deltas, build-database-deploy-demodata" />
+
+    <target name="build-database-foundation">
         <concat destfile="${build.dir}/scripts/deploy.template.sql">
             <fileset file="${build.dir}/scripts/deploy.create.sql"/>
             <fileset file="${sql.dir}/install/latest.sql"/>
@@ -119,12 +121,19 @@
 
         <delete file="${build.dir}/scripts/deploy.template.sql"/>
         <delete file="${build.dir}/scripts/deploy.sql"/>
-
-        <antcall target="build-database-deploy"/>
-        <antcall target="build-demodata-deploy"/>
     </target>
 
-    <target name="build-demodata-deploy">
+    <target name="build-database-apply-deltas">
+        <exec executable="php" failonerror="true">
+            <arg value="${build.dir}/ApplyDeltas.php"/>
+            <arg value="--password=${db.password}"/>
+            <arg value="--host=${db.host}"/>
+            <arg value="--username=${db.user}"/>
+            <arg value="--dbname=${db.name}"/>
+        </exec>
+    </target>
+
+    <target name="build-database-deploy-demodata">
         <concat destfile="${build.dir}/scripts/demo.template.sql">
             <fileset file="${demo.data}"/>
             <fileset file="${build.dir}/scripts/deploy.shopconfig.sql"/>
@@ -148,16 +157,6 @@
 
         <delete file="${build.dir}/scripts/demo.template.sql"/>
         <delete file="${build.dir}/scripts/demo.deploy.sql"/>
-    </target>
-
-    <target name="build-database-deploy">
-        <exec executable="php" failonerror="true">
-            <arg value="${build.dir}/ApplyDeltas.php"/>
-            <arg value="--password=${db.password}"/>
-            <arg value="--host=${db.host}"/>
-            <arg value="--username=${db.user}"/>
-            <arg value="--dbname=${db.name}"/>
-        </exec>
     </target>
 
     <target name="build-generate-attributes">


### PR DESCRIPTION
Previously the `build-database` command always built the main database, applied the update deltas and then deployed the demo data. This patch refines the structure of this command to have three dependencies:
- `build-database-foundation`
- `build-database-apply-deltas`
- `build-database-deploy-demodata`

While calling `ant build-database` has the exact same behaviour as before, it is now also possible e.g. to build the database incl. deltas, but without installing the demo data, by calling `ant build-database-foundation build-database-apply-deltas`.
