### PR TITLE
Can't unset filter in old templates

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyListingSubscriber.php
+++ b/engine/Shopware/Components/Compatibility/LegacyListingSubscriber.php
@@ -513,6 +513,12 @@ class LegacyListingSubscriber implements SubscriberInterface
             $filteredOptions = array();
         }
 
+        /** @var $mapper \Shopware\Components\QueryAliasMapper  */
+        $mapper = Shopware()->Container()->get('query_alias_mapper');
+
+        $shortAliasFilterProperties = $mapper->getShortAlias('sFilterProperties');
+
+
         $params = $this->getListingLinkParameters($config);
 
         $grouped = array();
@@ -562,11 +568,21 @@ class LegacyListingSubscriber implements SubscriberInterface
                 if ($group['active']) {
                     $removeOptions = array_diff($filteredOptions, $activeGroupOptions);
 
+                    if(!is_null($shortAliasFilterProperties)) {
+                        $filterParams = array(
+                            'sFilterProperties' => implode('|', $removeOptions),
+                            $shortAliasFilterProperties => implode('|', $removeOptions)
+                        );
+                    } else {
+                        $filterParams = array(
+                            'sFilterProperties' => implode('|', $removeOptions)
+                        );
+
+                    }
+
                     $params = array_merge(
                         $params,
-                        array(
-                            'sFilterProperties' => implode('|', $removeOptions)
-                        )
+                        $filterParams
                     );
 
                     $group['removeLink'] = $this->buildListingLink($params);


### PR DESCRIPTION
When using the old templates with the old style to filter you can't use the "Show all" Link to remove the filter already set.

The underlying problem is the introduction of the QueryAlias "f" for filtering, which is not set in the getFacetProperties function. By setting also the new short version to the correct value it is also possible to remove a filter when there is only one left.
