### PR TITLE
[BUGFIX] Fixed manufacturer attribute join condition

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ListProductGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ListProductGateway.php
@@ -149,7 +149,7 @@ class ListProductGateway implements Gateway\ListProductGatewayInterface
             ->leftJoin('product', 's_articles_supplier', 'manufacturer', 'manufacturer.id = product.supplierID')
             ->leftJoin('product', 's_core_pricegroups', 'priceGroup', 'priceGroup.id = product.pricegroupID')
             ->leftJoin('variant', 's_articles_attributes', 'productAttribute', 'productAttribute.articledetailsID = variant.id')
-            ->leftJoin('product', 's_articles_supplier_attributes', 'manufacturerAttribute', 'manufacturerAttribute.id = product.supplierID')
+            ->leftJoin('product', 's_articles_supplier_attributes', 'manufacturerAttribute', 'manufacturerAttribute.supplierID = product.supplierID')
             ->leftJoin('product', 's_articles_top_seller_ro', 'topSeller', 'topSeller.article_id = product.id')
             ->leftJoin('variant', 's_articles_esd', 'esd', 'esd.articledetailsID = variant.id')
             ->leftJoin('esd', 's_articles_esd_attributes', 'esdAttribute', 'esdAttribute.esdID = esd.id')


### PR DESCRIPTION
Fixed manufacturer attribute join condition in ListProductGateway to use supplierID instead of id. This bugs leads to wrong manufacturer attributes when the supplierID differs from the id in s_articles_supplier_attributes.
