### PR TITLE
unnecessary array assignment by key

### DIFF
--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -2267,7 +2267,7 @@ class sArticles
             }
             $article['description_long'] = $this->sOptimizeText($article['description_long']);
 
-            $articles[$article['articleID']] = $article;
+            $articles[] = $article;
         }
 
         $pageSizes = explode("|", $this->config->get('numberArticlesToShow'));


### PR DESCRIPTION
Hallo,

i am currently working on an extended search bundle for a customer. We want to display certain variants of a product side by side to normal products in the list view. Unfortunately it wasnt enough to override the QueryBuilderFactory and change the query to reflect our needs. At some point down the road the results get preprocessed. At every other location where products get preprocessed (search for convertListProductStruct) these array assignments by key are not present, so i removed it from there and our changes just worked. Please find attached my small PR.

Best regards,
Jochen
