### PR TITLE
[FEATURE] add filter events to collect javascript and less methods

### DIFF
--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -321,6 +321,12 @@ class Compiler
             $this->collectInheritanceCss($inheritances['custom'])
         );
 
+        $definitions = $this->eventManager->filter(
+            'Theme_Compiler_Collect_Less_Definitions_FilterResult',
+            $definitions,
+            array('subject' => $this)
+        );
+
         return $definitions;
     }
 
@@ -375,6 +381,12 @@ class Compiler
         $files = array_merge(
             $files,
             $this->collectInheritanceJavascript($inheritances['custom'])
+        );
+
+        $files = $this->eventManager->filter(
+            'Theme_Compiler_Collect_Javascript_Files_FilterResult',
+            $files,
+            array('subject' => $this)
         );
 
         return $files;


### PR DESCRIPTION
At the moment is it not possible to remove javascript or less/css files which are added by plugins or even the core. These filter events solve this lack. In addition to removing files you can also reorder files with this events. This is pretty useful for javascript files.
