### PR TITLE
Fix subshop specific order count

### DIFF
--- a/engine/Shopware/Models/Analytics/Repository.php
+++ b/engine/Shopware/Models/Analytics/Repository.php
@@ -1278,7 +1278,7 @@ class Repository
                     "SUM(IF(orders.language=" . $shopId . ", invoice_amount / currencyFactor, 0)) as turnover" . $shopId
                 );
                 $builder->addSelect(
-                    "IF(orders.language=" . $shopId . ", COUNT(orders.id), 0) as orderCount" . $shopId
+                    "SUM(orders.language=" . $shopId . ") as orderCount" . $shopId
                 );
             }
         }


### PR DESCRIPTION
There was an error in the SQL query so that for every subshop either the total order number for all subshops or 0 was returned, but not the correct order count for the subshop.

To reproduce there need to be multiple subshops and each needs to have orders so that the bug becomes apparent.
