### PR TITLE
Fix ordernumber length in s_order_basket

### DIFF
--- a/_sql/install/latest.sql
+++ b/_sql/install/latest.sql
@@ -5343,7 +5343,7 @@ CREATE TABLE IF NOT EXISTS `s_order_basket` (
   `userID` int(11) NOT NULL DEFAULT '0',
   `articlename` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `articleID` int(11) NOT NULL DEFAULT '0',
-  `ordernumber` varchar(30) COLLATE utf8_unicode_ci NOT NULL,
+  `ordernumber` varchar(40) COLLATE utf8_unicode_ci NOT NULL,
   `shippingfree` int(1) NOT NULL DEFAULT '0',
   `quantity` int(11) NOT NULL DEFAULT '0',
   `price` double NOT NULL DEFAULT '0',


### PR DESCRIPTION
ordernumber in s_articles_detail is varchar(40) so when trying to add an article with ordernumber longer than 30 chars it is not added to the basket
