### PR TITLE
prevent infinite recursion for invalid group ids

### DIFF
--- a/engine/core/class/sConfigurator.php
+++ b/engine/core/class/sConfigurator.php
@@ -243,12 +243,10 @@ class sConfigurator
         if (!empty($selectedItems) && empty($selected)) {
             if ($settings['type'] == self::TYPE_STANDARD) {
                 unset($this->sSYSTEM->_POST["group"]);
-                return $this->getArticleConfigurator($id, $articleData, true);
-
             } elseif ($settings['type'] == self::TYPE_SELECTION) {
-                $group = $this->sSYSTEM->_POST["group"];
-                array_pop($group);
-                $this->sSYSTEM->_POST["group"] = $group;
+                array_pop($this->sSYSTEM->_POST["group"]);
+            }
+            if(sizeof($this->sSYSTEM->_POST["group"])) {
                 return $this->getArticleConfigurator($id, $articleData, true);
             }
         }

--- a/engine/core/class/sConfigurator.php
+++ b/engine/core/class/sConfigurator.php
@@ -246,7 +246,7 @@ class sConfigurator
             } elseif ($settings['type'] == self::TYPE_SELECTION) {
                 array_pop($this->sSYSTEM->_POST["group"]);
             }
-            if(sizeof($this->sSYSTEM->_POST["group"])) {
+            if (count($this->sSYSTEM->_POST["group"])) {
                 return $this->getArticleConfigurator($id, $articleData, true);
             }
         }


### PR DESCRIPTION
the patch fixes an inifinite recursion when calling a detail page with invalid group parameters, which floods the database until the script timeout kicks in. the affected core component is removed in 5.0. 
