### PR TITLE
Update gitignore with excludes for .gitkeeps and .htaccess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,12 +31,18 @@ Thumbs.db
 /config_*.php
 
 # Caches/Proxies
-/tests/Shopware/TempFiles/
-/cache/
-/web/cache/
+/tests/Shopware/TempFiles/*
+!/tests/Shopware/TempFiles/.gitkeep
+/cache/*
+!/cache/.htaccess
+!/cache/clear_cache.sh
+/web/cache/*
+!/web/cache/.gitkeep
 
 # Log files
-/logs/
+/logs/*
+!/logs/.htaccess
+
 
 # User provided content
 /media/archive/
@@ -47,8 +53,12 @@ Thumbs.db
 /media/unknown/
 /media/video/
 
-/files/documents/
-/files/downloads/
+/files/documents/*
+!/files/documents/.htaccess
+/files/downloads/*
+!/files/downloads/.gitkeep
 
 # Snippet exports
 /snippetsExport/
+
+!**/.gitkeep


### PR DESCRIPTION
Without these excludes, your .gitkeeps and .htaccess are dropped out of remote repos, so i excluded them.
