### PR TITLE
show newsletter sent-date instead of create-date in newsletter archiv…

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Newsletter.php
+++ b/engine/Shopware/Controllers/Frontend/Newsletter.php
@@ -191,7 +191,7 @@ class Shopware_Controllers_Frontend_Newsletter extends Enlight_Controller_Action
         $perPage = (int) Shopware()->Config()->get('contentPerPage', 12);
 
         $sql = "
-            SELECT SQL_CALC_FOUND_ROWS id, IF(datum IS NULL,'',datum) as `date`, subject as description, sendermail, sendername
+            SELECT SQL_CALC_FOUND_ROWS id, IF(locked IS NULL, IF(datum IS NULL,'',datum), locked) as `date`, subject as description, sendermail, sendername
             FROM `s_campaigns_mailings`
             WHERE `status`!=0
             AND plaintext=0


### PR DESCRIPTION
…e listing

imho it makes more sense to show the date when the newsletter was sent instead of when you started to work on it
