### PR TITLE
Smarty plugin {link} does not work if Plugins/Community is a symlink

### DIFF
--- a/engine/Library/Enlight/Template/Plugins/function.flink.php
+++ b/engine/Library/Enlight/Template/Plugins/function.flink.php
@@ -63,6 +63,15 @@ function smarty_function_flink($params, $template)
             $docPath = getcwd() . DIRECTORY_SEPARATOR;
         }
 
+        // If the Plugins/Community-folder is a symlink (e.g. as shared folder in a
+        // capistrano deployment environment), the following code block "some clean
+        // up code" will not work as expected. So we rewrite the path.
+        $canonicalCommunityPath = $docPath . 'engine/Shopware/Plugins/Community';
+        $realCommunityPath = realpath($canonicalCommunityPath);
+        if (($realCommunityPath != $canonicalCommunityPath) && (strpos($file, $realCommunityPath) === 0)) {
+            $file = $canonicalCommunityPath . substr($file, strlen($realCommunityPath));
+        }
+
         // some clean up code
         if (strpos($file, $docPath) === 0) {
             $file = substr($file, strlen($docPath));


### PR DESCRIPTION
We deploy our shops with Capistrano and use the Plugins/Community-folder as shared folder, so it is a symlink. 
The Smarty plugin {link} cannot handle this symlink, so that e.g. the PayPal logos are not shown.

In the patch we check if the real path of the Community folder differs from the expected path and rewrite it if necessary.
