### PR TITLE
Updated .gitignore for media files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,13 +45,17 @@ Thumbs.db
 
 
 # User provided content
-/media/archive/
-/media/image/
-/media/music/
-/media/pdf/
-/media/temp/
-/media/unknown/
-/media/video/
+/media/archive/*
+/media/image/*.*
+/media/image/thumbnail/*
+!/media/image/thumbnail/.gitkeep
+/media/music/*
+/media/pdf/*
+/media/temp/*
+!/media/temp/.htaccess
+/media/unknown/*
+!/media/unknown/favicon.ico
+/media/video/*
 
 /files/documents/*
 !/files/documents/.htaccess


### PR DESCRIPTION
Enables the versioning of "fixed" user files like a favicon.ico and preserves the internal git files.
