### PR TITLE
BugFix: Support readOnly-Setting in TinyMCE form field

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.TinyMCE.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.TinyMCE.js
@@ -330,7 +330,7 @@ Ext.define('Shopware.form.field.TinyMCE',
 
         // Support the readOnly property
         if(me.readOnly) {
-            me.config.editor.readOnly = true;
+            me.config.editor.readonly = true;
         }
 
         // Fire the "beforerendereditor" event


### PR DESCRIPTION
The editor configuration of tinyMCE expects the setting "readonly" to be in lower case, otherwise it is ignored.
