### PR TITLE
SW-12175 - Fix non-persistence of text fields 1 to 6 for billing address

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Register.php
+++ b/engine/Shopware/Controllers/Frontend/Register.php
@@ -439,12 +439,6 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
             'lastname'=>array('required'=>1),
             'phone'=>array('required'=> $requirePhone),
             'fax'=>array('required'=>0),
-            'text1'=>array('required'=>0),
-            'text2'=>array('required'=>0),
-            'text3'=>array('required'=>0),
-            'text4'=>array('required'=>0),
-            'text5'=>array('required'=>0),
-            'text6'=>array('required'=>0),
             'sValidation'=>array('required'=>0),
             'birthyear'=>array('required'=> $requireBirthday),
             'birthmonth'=>array('required'=> $requireBirthday),
@@ -492,7 +486,13 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
             ),
             'additional_address_line2' => array(
                 'required' => (Shopware()->Config()->requireAdditionAddressLine2 && Shopware()->Config()->showAdditionAddressLine2) ? 1 : 0
-            )
+            ),
+            'text1'         => array('required' => 0),
+            'text2'         => array('required' => 0),
+            'text3'         => array('required' => 0),
+            'text4'         => array('required' => 0),
+            'text5'         => array('required' => 0),
+            'text6'         => array('required' => 0)
         );
 
         // Check if state selection is required


### PR DESCRIPTION
Möchte man bei der Registrierung etwas in die Freitextfelder 1 bis 6 bei der Rechnungsadresse speichern, werden diese nicht in der DB persistiert. Die Freitextfelder bei der Lieferanschrift funktionieren ohne Probleme.

Der Fehler tritt auf, da die Freitextfelder der Rechungsanschrift zusammen mit den Persönlichen Informationen und nicht mit der Rechnungsadresse validiert werden. Bei der Rechnungsadresse fehlt die Überprüfung, ob sie required sind oder nicht. Dadurch werden sie nicht in die Session übernommen und im weiteren Verlauf der Registrierung nicht mit in die DB übernommen.
