### PR TITLE
Breaks if there is a category without parent

### DIFF
--- a/engine/Shopware/Components/Model/CategorySubscriber.php
+++ b/engine/Shopware/Components/Model/CategorySubscriber.php
@@ -333,10 +333,14 @@ class CategorySubscriber implements BaseEventSubscriber
     public function setPathForCategory(Category $category)
     {
         $parent = $category->getParent();
-        $parentId = $parent->getId();
+        
+        if(!empty($parent)) {
+            $parentId = $parent->getId();
+    
+            $parents = $this->getCategoryComponent()->getParentCategoryIds($parentId);
+            $path = implode('|', $parents);            
+        }
 
-        $parents = $this->getCategoryComponent()->getParentCategoryIds($parentId);
-        $path = implode('|', $parents);
         if (empty($path)) {
             $path = null;
         } else {


### PR DESCRIPTION
I got an error while importing parentless categories from xtc with SwagMigration, fixed it with !empty check
