### PR TITLE
[TASK] prevent empty property sets from causing non object errors

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -591,23 +591,26 @@ class LegacyStructConverter
     public function convertPropertySetStruct(StoreFrontBundle\Struct\Property\Set $set)
     {
         $result = [];
-        foreach ($set->getGroups() as $group) {
-            $values = array_map(
-                function (StoreFrontBundle\Struct\Property\Option $option) {
-                    return $option->getName();
-                },
-                $group->getOptions()
-            );
 
-            $result[$group->getId()] = [
-                'id'        => $group->getId(),
-                'optionID'  => $group->getId(),
-                'name'      => $group->getName(),
-                'groupID'   => $set->getId(),
-                'groupName' => $set->getName(),
-                'value'     => implode(', ', $values),
-                'values'    => $values,
-            ];
+        if ($set instanceof StoreFrontBundle\Struct\Property\Set) {
+            foreach ($set->getGroups() as $group) {
+                $values = array_map(
+                    function (StoreFrontBundle\Struct\Property\Option $option) {
+                        return $option->getName();
+                    },
+                    $group->getOptions()
+                );
+
+                $result[$group->getId()] = [
+                    'id'        => $group->getId(),
+                    'optionID'  => $group->getId(),
+                    'name'      => $group->getName(),
+                    'groupID'   => $set->getId(),
+                    'groupName' => $set->getName(),
+                    'value'     => implode(', ', $values),
+                    'values'    => $values,
+                ];
+            }
         }
 
         return $result;


### PR DESCRIPTION
Hey folks,
if you assign a property set to an article in the backend but do not put any values to the properties the whole frontend listings crash. The reason is this error:

```
Fatal error: Call to a member function getGroups() on a non-object in /engine/Shopware/Components/Compatibility/LegacyStructConverter.php on line 594
503 Service Unavailable
```

I know it does not make sense to assign empty properties, but this happened to our customer editors two times now.

This simple instanceof condition solves that issue.

Regards,
Thomas Christiansen
