### PR TITLE
Product Detail Page: Image check fails

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/index.tpl
+++ b/themes/Frontend/Bare/frontend/detail/index.tpl
@@ -96,8 +96,8 @@
         <div class="product--detail-upper block-group">
             {* Product image *}
             {block name='frontend_detail_index_image_container'}
-                <div class="product--image-container image-slider{if $sArticle.image && {config name=sUSEZOOMPLUS}} product--image-zoom{/if}"
-                    {if $sArticle.image}
+                <div class="product--image-container image-slider{if $sArticle.image.id && {config name=sUSEZOOMPLUS}} product--image-zoom{/if}"
+                    {if $sArticle.image.id}
                      data-image-slider="true"
                      data-image-gallery="true"
                      data-maxZoom="{$theme.lightboxZoomFactor}"


### PR DESCRIPTION
Even if no image is set for the product, the $sArticle.image variable
will be initialized with a empty array. The check always returns true
and the image zoom will try to zoom a empty image.
Better check if the $sArticle.image.id variable is set.
