### PR TITLE
Caching the return value of sgetPromotionsById

### DIFF
--- a/engine/core/class/sArticles.php
+++ b/engine/core/class/sArticles.php
@@ -74,6 +74,14 @@ class sArticles
      */
     protected $mediaRepository = null;
 
+
+    /**
+     * Internal helper
+     *
+     * @var array
+     */
+    protected $cachedPromotions = array();
+
     /**
      * Constant for the alphanumeric sort configuration of the category filters
      */
@@ -3699,6 +3707,12 @@ class sArticles
         }
 
         $category = (int) $category;
+
+        $cacheKey = implode('-', array($mode, $category, $value, $withImage));
+        if(isset($this->cachedPromotions[$cacheKey])) {
+            return $this->cachedPromotions[$cacheKey];
+        }
+
         $categoryJoin = "";
 
         if (!empty($category)) {
@@ -3990,6 +4004,8 @@ class sArticles
             $getPromotionResult,
             array('subject' => $this, 'mode' => $mode, 'category' => $category, 'value' => $value)
         );
+
+        $this->cachedPromotions[$cacheKey] = $getPromotionResult;
 
         return $getPromotionResult;
     }


### PR DESCRIPTION
Implementing a cache for the return value of sArticle::sgetPromotionsById
This speeded up the product pages on our own installation with many promotions by at least 20-30% for signed in users. 
The method was requested multiple times with the same parameters. Though the database answered quite fast for subsequent requests, because of the query cache there was quite a lot overhead, which could be bypassed by this implementation

If this code could be merged into the 4.3 branch, I would be very happy.
I don't really care about the License, so pick, which ever suits you best (if you want to merge this code).
