### PR TITLE
Add CreateTemporaryOrder_OrderSaved Event to sOrder

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -428,6 +428,15 @@ class sOrder
             throw new Enlight_Exception("##sOrder-sTemporaryOrder-#01: No rows affected or no order id saved", 0);
         }
 
+        $this->eventManager->notify(
+            'Shopware_Modules_Order_CreateTemporaryOrder_OrderSaved',
+            array(
+                'subject'   => $this,
+                'orderID'   => $orderID,
+                'data'      => $data,
+            )
+        );
+
         $position = 0;
         foreach ($this->sBasketData["content"] as $basketRow) {
             $position++;
@@ -476,6 +485,8 @@ class sOrder
                 throw new Enlight_Exception("##sOrder-sTemporaryOrder-Position-#02:" . $e->getMessage(), 0, $e);
             }
         } // For every article in basket
+
+
         return;
     }
 


### PR DESCRIPTION
We added the Event Shopware_Modules_Order_CreateTemporaryOrder_OrderSaved. This is handy for doing statistics and other stuff with temporary orders. 
