### PR TITLE
Adding media association to sproperties

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -599,6 +599,14 @@ class LegacyStructConverter
                 $group->getOptions()
             );
 
+            $mediaValues = array();
+            foreach ($group->getOptions() as $option) {
+                /**@var $option StoreFrontBundle\Struct\Property\Option */
+                if ($option->getMedia()) {
+                    $mediaValues[$option->getId()] = array_merge(array('valueId' => $option->getId()), $this->convertMediaStruct($option->getMedia()));
+                }
+            }
+
             $result[$group->getId()] = [
                 'id'        => $group->getId(),
                 'optionID'  => $group->getId(),
@@ -607,6 +615,7 @@ class LegacyStructConverter
                 'groupName' => $set->getName(),
                 'value'     => implode(', ', $values),
                 'values'    => $values,
+                'media'     => $mediaValues,
             ];
         }
 


### PR DESCRIPTION
This will add a new entry media in the sPropeties Array. Useful if you want to display the images associated to the properties in the frontend.

Same change as in #302 which I messed up.
