### PR TITLE
Not able to generate multishop css with grunt

### DIFF
--- a/themes/Gruntfile.js
+++ b/themes/Gruntfile.js
@@ -1,7 +1,9 @@
 module.exports = function (grunt) {
-    grunt.option.init({
-        shopId: 1
-    });
+    if (typeof grunt.option('shopId') == "undefined") {
+        grunt.option.init({
+            shopId: 1
+        });
+    }
 
     var file = '../web/cache/config_' + grunt.option('shopId') + '.json',
         config = grunt.file.readJSON(file),


### PR DESCRIPTION
Currently it's not possible to do a

grunt --shopId=2

This will be overwritten by the grunt.option.init, so grunt always creates the css for the first shop

Occurs with

grunt-cli v0.1.13
grunt v0.4.5
