### PR TITLE
don't set the article cache invalidate by postUpdate or postPersists …

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -122,9 +122,6 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
         $this->subscribeEvent('Shopware\Models\Article\Article::postUpdate', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Article\Article::postPersist', 'onPostPersist');
 
-        $this->subscribeEvent('Shopware\Models\Article\Detail::postUpdate', 'onPostPersist');
-        $this->subscribeEvent('Shopware\Models\Article\Detail::postPersist', 'onPostPersist');
-
         $this->subscribeEvent('Shopware\Models\Category\Category::postPersist', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Category\Category::postUpdate', 'onPostPersist');
 
@@ -931,9 +928,6 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
         switch ($entityName) {
             case 'Shopware\Models\Article\Article':
                 $cacheIds[] = 'a' . $entity->getId();
-                break;
-            case 'Shopware\Models\Article\Detail':
-                $cacheIds[] = 'a' . $entity->getArticleId();
                 break;
             case 'Shopware\Models\Category\Category':
                 $cacheIds[] = 'c' . $entity->getId();


### PR DESCRIPTION
…on variants

If an item with 120 variants is updated, the cache of the item will be set invalidate over 120 times.
An article update requires considerable time and performance.

We test it with the Plentymarkets Plugin. In SW 4.3.6, before the variants were included in httpcache, an import of an article with 120 variants was finished in 20 seconds. And now with SW 5.0.3 a import is finished with the same article in over 2-15 minutes.
