### PR TITLE
fix fatal error on OSX System update process

### DIFF
--- a/recovery/update/src/DummyPluginFinder.php
+++ b/recovery/update/src/DummyPluginFinder.php
@@ -50,7 +50,7 @@ class DummyPluginFinder
 
         foreach ($types as $type) {
             foreach (new \DirectoryIterator($pluginPath . '/' . $type) as $dir) {
-                if (!$dir->isDir() || $dir->isDot()) {
+                if (!$dir->isDir() || $dir->isDot() || preg_match('/.AppleDouble/' , $dir )) {
                     continue;
                 }
 


### PR DESCRIPTION
without this fix, every update process stops with a fatal error on osx filesystems
