### PR TITLE
AdvancedMenu new feature: Menu open delay on hover.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,7 @@ In this document you will find a changelog of the important changes related to t
 ## 5.0.4
 * Change file extension of `Shopware_Components_Convert_Excel::generateXML` to .xls
 * Fixed jsonrenderer for backend order batchprocessing
+* Added AdvancedMenu feature to configure menu opening delay on mouse hover
 
 ## 5.0.3
 * The variant API resource now supports the getList method. It will return all variants with prices and attributes. You can optionally calculate the gross price by using the "considerTaxInput" parameter.

--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
@@ -84,6 +84,11 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
             'scope' => \Shopware\Models\Config\Element::SCOPE_SHOP
         ));
 
+        $form->setElement('number', 'hoverDelay', array(
+            'label' => 'Hover Verzögerung (ms)',
+            'value' => 250
+        ));
+
         $form->setElement('text', 'levels', array(
             'label' => 'Anzahl Ebenen',
             'value' => 3,
@@ -129,7 +134,8 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
                 'levels' => array('label' => 'Category levels'),
                 'caching' => array('label' => 'Enable caching'),
                 'cachetime' => array('label' => 'Caching time'),
-                'columnAmount' => array('label' => 'Teaser width')
+                'columnAmount' => array('label' => 'Teaser width'),
+                'hoverDelay' => array('label' => 'Hover delay (ms)')
             )
         );
 
@@ -205,6 +211,8 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
         $view->assign('sAdvancedMenu', $menu);
 
         $view->assign('columnAmount', $config->columnAmount);
+
+        $view->assign('hoverDelay', $config->hoverDelay);
 
         $view->addTemplateDir($this->Path() . 'Views');
         $view->extendsTemplate('frontend/plugins/advanced_menu/index.tpl');

--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
@@ -207,7 +207,7 @@
 
             $el.addClass(opts.itemHoverClass);
 
-            if (me._shouldPrevent) {
+            if (!opts.hoverDelay || me._shouldPrevent) {
                 me.onMouseEnter(event);
             } else if (!me.hoverDelayTimeoutId) {
                 me.hoverDelayTimeoutId = window.setTimeout(function () {

--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
@@ -62,7 +62,14 @@
              *
              * @type {String}
              */
-            'itemHoverClass': 'is--hovered'
+            'itemHoverClass': 'is--hovered',
+
+            /**
+             * Menu open on hover delay in milliseconds
+             *
+             * @type {Number}
+             */
+            'hoverDelay': 0
         },
 
         /**
@@ -200,7 +207,13 @@
 
             $el.addClass(opts.itemHoverClass);
 
-            me.onMouseEnter(event);
+            if (me._shouldPrevent) {
+                me.onMouseEnter(event);
+            } else if (!me.hoverDelayTimeoutId) {
+                me.hoverDelayTimeoutId = window.setTimeout(function () {
+                    this.onMouseEnter(event);
+                }.bind(me), opts.hoverDelay);
+            }
         },
 
         /**
@@ -242,6 +255,11 @@
 
             if (pluginEl === target || $.contains(me.$el[0], target) || me._$listItems.has(target).length) {
                 return;
+            }
+
+            if (me.hoverDelayTimeoutId) {
+                window.clearTimeout(me.hoverDelayTimeoutId);
+                delete me.hoverDelayTimeoutId;
             }
 
             me.closeMenu();

--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/plugins/advanced_menu/index.tpl
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/plugins/advanced_menu/index.tpl
@@ -26,7 +26,7 @@
         </ul>
     {/function}
 
-    <div class="advanced-menu" data-advanced-menu="true">
+    <div class="advanced-menu" data-advanced-menu="true" data-hoverDelay="{$hoverDelay}">
         {block name="frontend_plugins_advanced_menu"}
             {foreach $sAdvancedMenu as $mainCategory}
                 {if !$mainCategory.active || $mainCategory.hidetop}


### PR DESCRIPTION
Add option hoverDelay to set delay in milliseconds before opening the frontend menu when mouse cursor hovers over it.

The open menu got constantly in my way during development, specifically when the menu is tall and browser inspector is open at the bottom of the window. And as a client i would find it less annoying for the menu not opening when i just want to move the mouse cursor over/past it.
