### PR TITLE
Fix for wrong error message

### DIFF
--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -416,7 +416,7 @@ class Compiler
         foreach ($collection as $file) {
             if (!file_exists($file)) {
                 throw new \Exception(
-                    sprintf("Some plugin tries to compress a css file, but the file %s doesn't exist", $file)
+                    sprintf("Some plugin tries to compress a javascript file, but the file %s doesn't exist", $file)
                 );
             }
         }


### PR DESCRIPTION
When the compiler checks, if the JS files exist, the error message says there is no CSS file instead of JS files
