### PR TITLE
reversed js-file order because setting inheritanceConfig to false cre…

### DIFF
--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -369,14 +369,14 @@ class Compiler
 
         $files = array_merge(
             $files,
-            $this->collectPluginJavascript($shop, $template)
+            $this->collectInheritanceJavascript($inheritances['custom'])
         );
 
         $files = array_merge(
             $files,
-            $this->collectInheritanceJavascript($inheritances['custom'])
+            $this->collectPluginJavascript($shop, $template)
         );
-
+        
         return $files;
     }
 


### PR DESCRIPTION
At the moment there seems to be a problem with template-inheritance and the console-command sw:theme:dump:configuration. When i have a theme and i dont want to have inheritanceConfig enabled the order of js-files in the dumped config is reversed.

This means, that plugin js-files are concatted first, which leads to a failing dependency with jquery. Probably im doing it wrong, but this looks like a bug to me.
