### PR TITLE
removed default shop-id from gruntfile which overrides external argum…

### DIFF
--- a/themes/Gruntfile.js
+++ b/themes/Gruntfile.js
@@ -1,8 +1,4 @@
 module.exports = function (grunt) {
-    grunt.option.init({
-        shopId: 1
-    });
-
     var file = '../web/cache/config_' + grunt.option('shopId') + '.json',
         config = grunt.file.readJSON(file),
         lessTargetFile = {},


### PR DESCRIPTION
This option shouldn't be set there. Developers should run Grunt like this:

grunt production --shopId=2

Currently every shop-id parameter is overriden by these lines.
