### PR TITLE
Add backend self healing for attribute models

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,7 @@ In this document you will find a changelog of the important changes related to t
 
 ## 5.1.0 RC3
 * Activated media fallback by default so that old media paths get resolved to the new location
+* Add backend self healing for attribute models
 
 ## 5.1.0 RC2
 * Update ongr/elasticsearch-dsl to version 1.0.0-RC1

--- a/engine/Shopware/Components/AttributeSubscriber.php
+++ b/engine/Shopware/Components/AttributeSubscriber.php
@@ -48,9 +48,12 @@ class AttributeSubscriber implements SubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            'Enlight_Controller_Front_RouteShutdown'        => ['onDispatchEvent', 100],
-            'Enlight_Controller_Front_PostDispatch'         => ['onDispatchEvent', 100],
-            'Enlight_Controller_Front_DispatchLoopShutdown' => ['onDispatchEvent', 100],
+            'Enlight_Controller_Front_RouteShutdown'          => ['onDispatchEvent', 100],
+            'Enlight_Controller_Front_PostDispatch'           => ['onDispatchEvent', 100],
+            'Enlight_Controller_Front_DispatchLoopShutdown'   => ['onDispatchEvent', 100],
+            'Enlight_Controller_Backend_RouteShutdown'        => ['onDispatchEvent', 100],
+            'Enlight_Controller_Backend_PostDispatch'         => ['onDispatchEvent', 100],
+            'Enlight_Controller_Backend_DispatchLoopShutdown' => ['onDispatchEvent', 100]
         ];
     }
 
@@ -87,7 +90,7 @@ class AttributeSubscriber implements SubscriberInterface
         $request = new \Enlight_Controller_Request_RequestHttp();
         $response = new \Enlight_Controller_Response_ResponseHttp();
 
-        if ($this->isModelException($exception)) {
+        if ($this->isModelException($exception) || ($exception->getPrevious() !== null && $this->isModelException($exception->getPrevious()))) {
             $generator = $this->container->get('models')->createModelGenerator();
             $result = $generator->generateAttributeModels();
             if ($result['success'] === true) {


### PR DESCRIPTION
This PR expands the 'self healing' to the backend to automatically fix problems with corrupted attribute models. This is useful e.g. if a plugin installation fails after changing certain attribute fields, but before regenerating the respective model files. If you end up receiving exceptions when loading backend applications, you currently have to visit the shop frontend to trigger the self healing. However, this will not necessarily trigger it, because the exception might occur only in the backend. With this PR, the same self healing logic is also executed for exceptions in backend requests.
