### PR TITLE
Allow clearing caches after plugin update

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,7 @@ In this document you will find a changelog of the important changes related to t
 
 ## 5.1.0 RC3
 * Activated media fallback by default so that old media paths get resolved to the new location
+* Allow clearing caches after plugin update
 
 ## 5.1.0 RC2
 * Update ongr/elasticsearch-dsl to version 1.0.0-RC1

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
@@ -419,7 +419,12 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
         me.sendAjaxRequest(
             '{url controller=PluginInstaller action=update}',
             { technicalName: plugin.get('technicalName') },
-            callback
+            function(response) {
+                me.handleCrudResponse(response, plugin);
+                if (typeof callback == 'function') {
+                    callback(response);
+                }
+            }
         );
     },
 


### PR DESCRIPTION
Currently the response of a request to the `PluginInstaller` is evaluated in all plugin install/uninstall related actions except for an update. Hence it is neither possible to prompt the user to clear certain caches after updating a plugin, nor to display a sticky notification with a custom message. This PR fixes this behaviour by invoking the common `handleCrudResponse` handler before the passed callback function.
