### PR TITLE
remove useless hhvm-nightly job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 sudo: false
 
@@ -25,4 +24,3 @@ matrix:
   allow_failures:
     - php: 7.0
     - php: hhvm
-    - php: hhvm-nightly


### PR DESCRIPTION
HHVM nightly is no longer supported on Ubuntu Precise (see
facebook/hhvm#5220 and travis-ci/travis-ci#3788).
