### PR TITLE
Apply select box replacement after reloading shipping payment form

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.shipping-payment.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.shipping-payment.js
@@ -53,6 +53,7 @@
                 success: function(res) {
                     me.$el.empty().html(res);
                     me.$el.find('input[type="submit"][form], button[form]').swFormPolyfill();
+                    me.$el.find('select:not([data-no-fancy-select="true"])').swSelectboxReplacement();
                     $.loadingIndicator.close();
                     window.picturefill();
 


### PR DESCRIPTION
When selecting a different payment method during the checkout process, the payment form is reloaded synchronously and injected into the DOM. In case the now active payment method contains a select box in its form, it is not replaced with a fancy box. This PR calls the select box replacement plugin again on all respective select boxes, as soon as the new payment form is loaded.
