### PR TITLE
Fix OSX compatibility of clear_cache.sh

### DIFF
--- a/var/cache/clear_cache.sh
+++ b/var/cache/clear_cache.sh
@@ -9,7 +9,7 @@ fi
 
 echo "Clearing caches"
 mkdir $DIR/delete
-find $DIR -mindepth 1 -maxdepth 1 -type d ! -name delete -print0 | xargs -0 mv -t $DIR/delete/
+find $DIR -mindepth 1 -maxdepth 1 -type d ! -name delete -print0 | xargs -I{} -0 mv {} $DIR/delete/
 
 rm -Rf $DIR/delete/
 


### PR DESCRIPTION
The mv command has a different syntax under BSD systems. (-t argument does not exist)

Since xargs by default appends the stdin as argument for the mv command, the of `mv -t` was used to switch the argument order of mv around. This argument is not supported for OSX (BSD in general).

With the replace-string argument of xargs this problem can be avoided. (`xargs -I{}`)

https://www.freebsd.org/cgi/man.cgi?query=mv
http://linux.die.net/man/1/mv
