### PR TITLE
using ssl in light backend modules

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.ModuleManager.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.ModuleManager.js
@@ -130,7 +130,7 @@ Ext.define('Shopware.ModuleManager', {
             'width': '100%',
             'height': '100%',
             'border': '0',
-            'src': (fullPath ? name : '{url module="backend" controller="" fullPath}' + name),
+            'src': (fullPath ? name : '{url module="backend" controller="" forceSecure}' + name),
             'data-instance': instance
         }));
 


### PR DESCRIPTION
Currently there is a problem with the new light backend-modules, when using ssl in backend. The module iframe will be generated with a http-url, even though the backend is opened via https. Browsers will block this unsafe request.

I dont know if this is a proper solution, because shopware-backends with ssl not enabled will probably break.
