### PR TITLE
Workaround for overlay in Firefox

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/overlay.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/overlay.less
@@ -31,11 +31,13 @@ default color:`#000000` default opacity (alpha):`0.7`
     top: 0;
     z-index: @zindex-overlay;
     visibility: hidden;
+    pointer-events: none;
 
     &.is--open {
         .transition-delay(0);
         .opacity(1);
         visibility: visible;
+        pointer-events: auto;
     }
 
     &.is--closable {


### PR DESCRIPTION
When opening the overlay (for example in the offcanvas cart) several times at some point Firefox 41.0.1 under Windows 7 has an issue that the overlay still "takes" all the clicks and scroll events. Therefore no button can be clicked and scrolling does not work either. 
I think this is an Firefox issue since when resizing the Window or changing one CSS value (disable and enable it with Firebug), everything works again as expected. 
This PR fixes this issue by disabling all pointer events in the closed overlay and enable them again in the opened overlay.
