### PR TITLE
Make proxy file permissions configurable

### DIFF
--- a/engine/Library/Enlight/Hook/HookManager.php
+++ b/engine/Library/Enlight/Hook/HookManager.php
@@ -84,7 +84,8 @@ class Enlight_Hook_HookManager extends Enlight_Class
         $this->proxyFactory = new Enlight_Hook_ProxyFactory(
             $this,
             $options['proxyNamespace'],
-            $options['proxyDir']
+            $options['proxyDir'],
+            $options['proxyFilePermissions']
         );
 
         $loader->registerNamespace(

--- a/engine/Library/Enlight/Hook/ProxyFactory.php
+++ b/engine/Library/Enlight/Hook/ProxyFactory.php
@@ -51,6 +51,12 @@ class Enlight_Hook_ProxyFactory extends Enlight_Class
     protected $proxyDir;
 
     /**
+     * Chmod for proxy files
+     * @var int
+     */
+    protected $proxyFilePermissions = 0644;
+
+    /**
      * @var string extension of the hook files.
      */
     protected $fileExtension = '.php';
@@ -95,12 +101,14 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
      * @param  Enlight_Hook_HookManager $hookManager
      * @param  string                   $proxyNamespace
      * @param  string                   $proxyDir
+     * @param  int                      $proxyFilePermissions
      * @throws RuntimeException
      */
-    public function __construct($hookManager, $proxyNamespace, $proxyDir)
+    public function __construct($hookManager, $proxyNamespace, $proxyDir, $proxyFilePermissions = 644)
     {
         $this->hookManager = $hookManager;
         $this->proxyNamespace = $proxyNamespace;
+        $this->proxyFilePermissions = $proxyFilePermissions;
 
         if (!is_dir($proxyDir)) {
             if (false === @mkdir($proxyDir, 0777, true)) {
@@ -225,7 +233,7 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
             umask($oldMask);
             throw new Enlight_Exception('Unable to write file "' . $fileName . '"');
         }
-        chmod($fileName, 0644);
+        chmod($fileName, $this->proxyFilePermissions);
         umask($oldMask);
     }
 

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -137,7 +137,8 @@ return array_replace_recursive([
     ],
     'hook' => [
         'proxyDir' => $this->getCacheDir().'/proxies',
-        'proxyNamespace' => $this->App() . '_Proxies'
+        'proxyNamespace' => $this->App() . '_Proxies',
+        'proxyFilePermissions' => 0644
     ],
     'model' => [
         'autoGenerateProxyClasses' => false,


### PR DESCRIPTION
This PR ist the new version of #247.

The hardcoded file permissions 0664 can now be configured in the
config.php like:

'hook' => array(
'proxyFilePermissions' => 0660
)

The default file permissions remain untouched at 0644. With the option
to configure the proxy file permissions it is e.g. possible to add
group write rights to the files which is often needed.
