### PR TITLE
left-join for "joinDefaultPrices"

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/PriceHelper.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/PriceHelper.php
@@ -163,7 +163,7 @@ class PriceHelper implements PriceHelperInterface
             $graduation = "defaultPrice.to = 'beliebig'";
         }
 
-        $query->innerJoin(
+        $query->leftJoin(
             'product',
             's_articles_prices',
             'defaultPrice',


### PR DESCRIPTION
We have some customer-environments without prices for the customer group "EK".
The "defaultPrice"-fallback-routine fails in this case and destroy price-features in product-listings: 
Price-filter has no values and price-sorting is not possible.
With the commited left-join everything is fine :)
