### PR TITLE
[BUGFIX] Write plugin changes to database only if it is a string

### DIFF
--- a/engine/Shopware/Components/Plugin/Namespace.php
+++ b/engine/Shopware/Components/Plugin/Namespace.php
@@ -295,7 +295,7 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
             'license' => isset($info['license']) ? $info['license'] : null,
             'support' => isset($info['support']) ? $info['support'] : null,
             'link' => isset($info['link']) ? $info['link'] : null,
-            'changes' => isset($info['changes']) ? $info['changes'] : null,
+            'changes' => isset($info['changes']) && is_string($info['changes']) ? $info['changes'] : null,
             'source' => isset($info['source']) ? $info['source'] : 'Default',
             'update_date' => isset($info['updateDate']) ? $info['updateDate'] : null,
             'update_version' => isset($info['updateVersion']) ? $info['updateVersion'] : null,


### PR DESCRIPTION
I found this by trying to install the latest update of the "FutiFAQManager" plugin which raised an error:

`bin/console sw:plugin:update FutiFAQManager`

`PHP Catchable fatal error:  Object of class Enlight_Config could not be converted to string engine/Library/Zend/Db/Statement/Pdo.php on line 228`

After digging in the code I found out that the Plugin Namespace Component tries to write an Enlight_Config object to the database.

This PR checks that the given info is a string. Even though I think writing the changes to the database isn't needed anymore. Looking into our production database there are only 2 entries both with the value "Object"...
