### PR TITLE
fixed wrong passed limit for initial article-slider

### DIFF
--- a/engine/Shopware/Controllers/Widgets/Emotion.php
+++ b/engine/Shopware/Controllers/Widgets/Emotion.php
@@ -643,7 +643,7 @@ class Shopware_Controllers_Widgets_Emotion extends Enlight_Controller_Action
                     $category,
                     $customerGroupId,
                     0,
-                    $perPage,
+                    $max,
                     $data["article_slider_type"]
                 );
                 $values = $temp["values"];


### PR DESCRIPTION
Currently only the number of per page articles is loaded in total. This fix loads all matching articles for the inital state after loading.
