### PR TITLE
Make thumbnail images fit to container on product detail page.

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/image-slider.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/image-slider.less
@@ -157,6 +157,9 @@ It contains the viewport specific styles inside media queries.
     .thumbnail--image {
         display: inline;
         vertical-align: middle;
+        object-fit: cover;
+        .unitize-width(70);
+        .unitize-height(70);
     }
 
     .thumbnails--arrow {


### PR DESCRIPTION
In order to make the thumbnail images always fit to the container I've edit the code.

Works fine for me in all tested browsers. What do you think?
