### PR TITLE
Exclude shipping costs from order amount when shipping costs are hidden

### DIFF
--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -301,19 +301,20 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
         }
 
         $taxShipping = (float) $taxShipping;
-        if ($this->_order["taxfree"]) {
-            $this->_amountNetto =  $this->_amountNetto + $this->_order["invoice_shipping"];
-        } else {
-            $this->_amountNetto =  $this->_amountNetto + ($this->_order["invoice_shipping"]/(100+$taxShipping)*100);
-            if (!empty($taxShipping) && !empty($this->_order["invoice_shipping"])) {
-                $this->_tax[number_format($taxShipping, 2)] += ($this->_order["invoice_shipping"]/(100+$taxShipping))*$taxShipping;
-            }
-        }
-
-        $this->_amount =  $this->_amount + $this->_order["invoice_shipping"];
         $this->_shippingCosts = $this->_order["invoice_shipping"];
 
         if ($this->_shippingCostsAsPosition == true && !empty($this->_shippingCosts)) {
+            if ($this->_order["taxfree"]) {
+                $this->_amountNetto =  $this->_amountNetto + $this->_order["invoice_shipping"];
+            } else {
+                $this->_amountNetto =  $this->_amountNetto + ($this->_order["invoice_shipping"]/(100+$taxShipping)*100);
+                if (!empty($taxShipping) && !empty($this->_order["invoice_shipping"])) {
+                    $this->_tax[number_format($taxShipping,2)] += ($this->_order["invoice_shipping"]/(100+$taxShipping))*$taxShipping;
+                }
+            }
+
+            $this->_amount =  $this->_amount + $this->_order["invoice_shipping"];
+
             $shipping = array();
             $shipping['quantity'] = 1;
 


### PR DESCRIPTION
When the document is configured to not include the shipping costs as a position, as is the case with delivery notes per default, the order amount should also not include the shipping costs, because otherwise the sum of the positions does not equal the order amount.

To reproduce this problem, the prices have to be made visible in the delivery note, e.g. by removing the following lines from the `themes/Frontend/Bare/documents/index_ls.tpl` template:

```
{block name="document_index_table_price"}
{/block}
{block name="document_index_amount"}
{/block}
```

Before the PR, the order amount is wrong:

![lieferschein1](https://cloud.githubusercontent.com/assets/105166/11215623/877fb438-8d47-11e5-8c81-c52dadaace11.png)

After the PR, the order amount is correct:

![lieferschein2](https://cloud.githubusercontent.com/assets/105166/11215634/901077a4-8d47-11e5-8a08-7a28058e48ce.png)
