### PR TITLE
Return zero if a plugin to be updated via console is already up to date

### DIFF
--- a/engine/Shopware/Commands/PluginUpdateCommand.php
+++ b/engine/Shopware/Commands/PluginUpdateCommand.php
@@ -86,7 +86,7 @@ EOF
 
         if (!$plugin->getUpdateVersion()) {
             $output->writeln(sprintf('The plugin %s is up to date.', $pluginName));
-            return 1;
+            return 0;
         }
 
         $pluginManager->updatePlugin($plugin);


### PR DESCRIPTION
`php bin/console sw:plugin:update` returns 1 if a plugin is already up to date. This shouldn't happen, as it is not a failure if a plugin is already up to date. It would be a more standard approach to return a non-zero code only in case something really fails. In our deploy scripts, we use the `set -e` option, so a deployment fails if any part of it returns with a non-zero return code. Unfortunately, the return value breaks our deploy script and we currently need a workaround for it to work.
This PR shouldn't break anything.
