### PR TITLE
[FEATURE] add notifyUntil event to executeRiskRule

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2592,6 +2592,19 @@ class sAdmin
      */
     public function executeRiskRule($rule, $user, $basket, $value)
     {
+        if ($event = $this->eventManager->notifyUntil(
+            'Shopware_Modules_Admin_Execute_Risk_Rule_' . $rule,
+            array(
+                'subject' => $this,
+                'rule' => $rule,
+                'user' => $user,
+                'post' => $basket,
+                'value' => $value
+            )
+        )) {
+            return $event->getReturn();
+        }
+
         return $this->$rule($user, $basket, $value);
     }
 


### PR DESCRIPTION
Hey folks,
with this new event it is possible to add custom risk rules. The Extjs part is already prepared to add new rules:

```
...

data: [
    { description: '{s name=risks_store/comboBox/startValue}Please choose{/s}', value: "" },
    //{block name="backend/risk_management/store/risk/data"}{/block}
    { description: '{s name=risks_store/comboBox/orderValueGt}Ordervalue >={/s}', value: 'ORDERVALUEMORE' },

...
```

from themes/Backend/ExtJs/backend/risk_management/store/risks.js

But the sAdmin class does not offer any events to check those new risks.

I added the `$rule` into the event name to prevent accidentally overwriting all rules.

Regards,
Thomas
