### PR TITLE
fix jquery.register.js to perform the ajax validations

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
@@ -517,7 +517,7 @@
         validateUsingAjax: function ($input, action) {
             var me = this,
                 data = 'action=' + action + '&' + me.$el.find('form').serialize(),
-                URL = window.controller.ajax_validate;
+                URL = window.controller.ajax_validate + '/' + action;
 
             if (!URL) {
                 return;


### PR DESCRIPTION
Without this fix, the ajax validations doesn't work on the register page. The fix was tested on 5.0.4, 5.1.1 and works fine. In your demoshop, the ajax validation doesn't work, too.
