### PR TITLE
Fixed manufacturer link output in emotion slider

### DIFF
--- a/engine/Shopware/Controllers/Widgets/Emotion.php
+++ b/engine/Shopware/Controllers/Widgets/Emotion.php
@@ -629,8 +629,10 @@ class Shopware_Controllers_Widgets_Emotion extends Enlight_Controller_Action
                 if (!empty($category) && $category != Shopware()->Shop()->getCategory()->getId()) {
                     $query['sCategory'] = $category;
                 }
-
-                $value["link"] = Shopware()->Router()->assemble($query);
+				// build manufacturer link only if no link already defined in backend
+				if(strlen($value["link"]) === 0) {
+					$value["link"] = Shopware()->Router()->assemble($query);
+                }
             }
         }
 


### PR DESCRIPTION
Manufacturer slider builds url's always for the listing.
So if you defines url 'Link to manufacturer website' in shopware backend
![image](https://cloud.githubusercontent.com/assets/6016485/11814301/4b580ff4-a346-11e5-960e-b151237dd7ad.png)
it has no affection to the output. With this patch you will be able to overwrite the standard listing url.
