### PR TITLE
individual voucher code query performance fix

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -616,22 +616,21 @@ class sBasket
         } else {
             // If we don't have voucher details yet, need to check if its a one-time code
             $voucherDetails = $this->db->fetchRow(
-                'SELECT s_emarketing_voucher_codes.id AS id, s_emarketing_voucher_codes.code AS vouchercode,
-                    description, numberofunits, customergroup, value, restrictarticles,
-                    minimumcharge, shippingfree, bindtosupplier, taxconfig, valid_from,
-                    valid_to, ordercode, modus, percental, strict, subshopID
-                FROM s_emarketing_vouchers, s_emarketing_voucher_codes
-                WHERE modus = 1
-                AND s_emarketing_vouchers.id = s_emarketing_voucher_codes.voucherID
-                AND LOWER(code) = ?
-                AND cashed != 1
+                'SELECT
+                    c.id AS id, c.code AS vouchercode, v.description, v.numberofunits,  v.customergroup, v.value, v.restrictarticles,
+                    v.minimumcharge, v.shippingfree, v.bindtosupplier, v.taxconfig, v.valid_from, v.valid_to, v.ordercode, v.modus, v.percental, v.strict, v.subshopID
+                FROM s_emarketing_voucher_codes c
+                LEFT JOIN s_emarketing_vouchers v on (c.voucherID = v.id)
+                WHERE c.id = (
+                    SELECT id from s_emarketing_voucher_codes where code = ?
+                )
+                AND  v.modus =1
+                AND  c.cashed !=1
                 AND (
-                      (s_emarketing_vouchers.valid_to >= now()
-                          AND s_emarketing_vouchers.valid_from <= now()
-                      )
-                      OR s_emarketing_vouchers.valid_to is NULL
+                    (v.valid_to >= now() AND v.valid_from <= now())
+                    OR v.valid_to IS NULL
                 )',
-                array($voucherCode)
+                array(strtoupper($voucherCode))
             );
             $individualCode = ($voucherDetails && $voucherDetails["description"]);
         }


### PR DESCRIPTION
Restored pull request after multiple failed attempts. Sorry about the additional carbon footprint.

The original query quickly becomes very taxing on the database. It does a full table scan on the voucher codes table while joining voucher data on each code-row. These queries are run on every request processed by a webserver if the current user served has a voucher in the basket. In setups with big quantities of generated codes this can easily cause persistent soft locks of both the voucher and the voucher code table which in turn can cause database connection pileups and associated nastiness. The proposed substitute performs orders of magnitudes better, at least if an index is present on the code field in the voucher code table. It is not as of 4.3.6. The query should be functionally equivalent.
The function is marked as deprecated but still seems to be in use as of 5.2.
