### PR TITLE
Allow manyToOne associations to Shopware.apps.Property.model.Set

### DIFF
--- a/themes/Backend/ExtJs/backend/property/model/set.js
+++ b/themes/Backend/ExtJs/backend/property/model/set.js
@@ -34,10 +34,10 @@
 Ext.define('Shopware.apps.Property.model.Set', {
 
     /**
-     * Extends the standard ExtJS 4
+     * Extends the standard ExtJS Model
      * @string
      */
-    extend: 'Ext.data.Model',
+    extend: 'Shopware.data.Model',
 
     /**
      * The fields used for this model


### PR DESCRIPTION
While following your [ManyToOne associations guide](http://community.shopware.com/Shopware-4-models_detail_1252.html#OneToMany_.2F_ManyToOne_annotations), I tried to set up an ManyToOne association to the Shopware.apps.Property.model.Set ExtJS model.

Now, if I open up the detail window which was created as described in the documentation, the function `createModelField` in class `Shopware.model.Container` calls `fieldModel.getConfig('field')` which doesn't exist and leads to an `Uncaught TypeError`.

This PR fixes that.
