### PR TITLE
Shopware Debug plugin

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/Debug/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Debug/Bootstrap.php
@@ -236,7 +236,7 @@ class Shopware_Plugins_Core_Debug_Bootstrap extends Shopware_Components_Plugin_B
 
         $handlers = array();
         foreach ($handlerRegister as $handler) {
-            if ($handler instanceof HandlerInterface && $handler->acceptsRequest($request)) {
+            if ($handler instanceof HandlerInterface) {
                 $handlers[] = $handler;
             }
         }

--- a/engine/Shopware/Plugins/Default/Core/Debug/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Debug/Bootstrap.php
@@ -141,43 +141,55 @@ class Shopware_Plugins_Core_Debug_Bootstrap extends Shopware_Components_Plugin_B
     {
         $this->get('loader')->registerNamespace('Shopware\Plugin\Debug', __DIR__ . '/');
 
+        $collectors = array();
         $eventManager = $this->get('events');
         $utils = new Utils();
         $errorHandler = $this->Collection()->get('ErrorHandler');
 
         if ($this->Config()->get('logTemplateVars')) {
-            $this->pushCollector(new TemplateVarCollector($eventManager));
+            $collectors[] = new TemplateVarCollector($eventManager);
         }
 
         if ($this->Config()->get('logErrors')) {
-            $this->pushCollector(new ErrorCollector($errorHandler, $utils));
+            $collectors[] = new ErrorCollector($errorHandler, $utils);
         }
 
         if ($this->Config()->get('logExceptions')) {
-            $this->pushCollector(new ExceptionCollector($eventManager, $utils));
+            $collectors[] = new ExceptionCollector($eventManager, $utils);
         }
 
         if ($this->Config()->get('logDb')) {
-            $this->pushCollector(new DatabaseCollector($this->get('db')));
+            $collectors[] = new DatabaseCollector($this->get('db'));
         }
 
         if ($this->Config()->get('logModel')) {
-            $this->pushCollector(new DbalCollector($this->get('modelconfig')));
+            $collectors[] = new DbalCollector($this->get('modelconfig'));
         }
 
         if ($this->Config()->get('logTemplate')) {
-            $this->pushCollector(new TemplateCollector($this->get('template'), $utils, $this->get('kernel')->getRootDir()));
+            $collectors[] = new TemplateCollector($this->get('template'), $utils, $this->get('kernel')->getRootDir());
         }
 
         if ($this->Config()->get('logController')) {
-            $this->pushCollector(new ControllerCollector($eventManager, $utils));
+            $collectors[] = new ControllerCollector($eventManager, $utils);
         }
 
         if ($this->Config()->get('logEvents')) {
-            $this->pushCollector(new EventCollector($eventManager, $utils));
+            $collectors[] = new EventCollector($eventManager, $utils);
         }
 
-        foreach ($this->collectors as $collector) {
+        $collectors = Enlight()->Events()->filter(
+            'Shopware_Plugins_Core_Debug_Bootstrap_FilterCollectors',
+            $collectors,
+            array(
+                'eventManager' => $eventManager,
+                'utils' => $utils,
+                'errorHandler' => $errorHandler
+            )
+        );
+
+        foreach ($collectors as $collector) {
+            $this->pushCollector($collector);
             $collector->start();
         }
     }

--- a/engine/Shopware/Plugins/Default/Core/Debug/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Debug/Bootstrap.php
@@ -22,6 +22,7 @@
  * our trademarks remain entirely with us.
  */
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Monolog\Handler\HandlerInterface;
 use Shopware\Components\Logger;
 use Shopware\Plugin\Debug\Components\ControllerCollector;
@@ -229,9 +230,13 @@ class Shopware_Plugins_Core_Debug_Bootstrap extends Shopware_Components_Plugin_B
      */
     public function getHandlers(\Enlight_Controller_Request_Request $request)
     {
-        $handlerRegister = Enlight()->Events()->filter(
+        $handlerRegister = new ArrayCollection([
+            $this->get('monolog.handler.firephp')
+        ]);
+
+        $handlerRegister = $this->get('events')->collect(
             'Shopware_Plugins_Core_Debug_Bootstrap_FilterHandlerRegister',
-            [ $this->get('monolog.handler.firephp') ]
+            $handlerRegister
         );
 
         $handlers = array();

--- a/engine/Shopware/Plugins/Default/Core/Debug/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Debug/Bootstrap.php
@@ -217,9 +217,16 @@ class Shopware_Plugins_Core_Debug_Bootstrap extends Shopware_Components_Plugin_B
      */
     public function getHandlers(\Enlight_Controller_Request_Request $request)
     {
+        $handlerRegister = Enlight()->Events()->filter(
+            'Shopware_Plugins_Core_Debug_Bootstrap_FilterHandlerRegister',
+            [ $this->get('monolog.handler.firephp') ]
+        );
+
         $handlers = array();
-        if ($this->get('monolog.handler.firephp')->acceptsRequest($request)) {
-            $handlers[] = $this->get('monolog.handler.firephp');
+        foreach ($handlerRegister as $handler) {
+            if ($handler instanceof HandlerInterface && $handler->acceptsRequest($request)) {
+                $handlers[] = $handler;
+            }
         }
 
         return $handlers;

--- a/engine/Shopware/Plugins/Default/Core/Debug/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Debug/Bootstrap.php
@@ -179,14 +179,9 @@ class Shopware_Plugins_Core_Debug_Bootstrap extends Shopware_Components_Plugin_B
             $collectors[] = new EventCollector($eventManager, $utils);
         }
 
-        $collectors = Enlight()->Events()->filter(
+        $collectors = $this->get('events')->filter(
             'Shopware_Plugins_Core_Debug_Bootstrap_FilterCollectors',
-            $collectors,
-            array(
-                'eventManager' => $eventManager,
-                'utils' => $utils,
-                'errorHandler' => $errorHandler
-            )
+            $collectors
         );
 
         foreach ($collectors as $collector) {

--- a/engine/Shopware/Plugins/Default/Core/Debug/Components/ErrorCollector.php
+++ b/engine/Shopware/Plugins/Default/Core/Debug/Components/ErrorCollector.php
@@ -40,7 +40,7 @@ class ErrorCollector implements CollectorInterface
     /**
      * @var Utils
      */
-    private $utils;
+    protected $utils;
 
     /**
      * @param \Shopware_Plugins_Core_ErrorHandler_Bootstrap $handler

--- a/engine/Shopware/Plugins/Default/Core/Debug/Components/EventCollector.php
+++ b/engine/Shopware/Plugins/Default/Core/Debug/Components/EventCollector.php
@@ -45,7 +45,7 @@ class EventCollector implements CollectorInterface
     /**
      * @var Utils
      */
-    private $utils;
+    protected $utils;
 
     /**
      * @param \Enlight_Event_EventManager $eventManager

--- a/engine/Shopware/Plugins/Default/Core/Debug/Components/ExceptionCollector.php
+++ b/engine/Shopware/Plugins/Default/Core/Debug/Components/ExceptionCollector.php
@@ -46,7 +46,7 @@ class ExceptionCollector implements CollectorInterface
     /**
      * @var Utils
      */
-    private $utils;
+    protected $utils;
 
     /**
      * @param \Enlight_Event_EventManager $eventManager

--- a/engine/Shopware/Plugins/Default/Core/Debug/Components/TemplateCollector.php
+++ b/engine/Shopware/Plugins/Default/Core/Debug/Components/TemplateCollector.php
@@ -46,7 +46,7 @@ class TemplateCollector implements CollectorInterface
     /**
      * @var Utils
      */
-    private $utils;
+    protected $utils;
 
     /**
      * @param \Enlight_Template_Manager $template


### PR DESCRIPTION
Hello,

I wrote a plugin for shopware, which makes the [Debug-Plugin](https://github.com/shopware/shopware/tree/5.1/engine/Shopware/Plugins/Default/Core/Debug) available for [Clockwork](https://github.com/itsgoingd/clockwork-chrome) integration. 
All relevant informations can now be displayed in a chrome-tab which provides all features from the FirePHP-version in a more readable overlay. In addition there are some timelines for informations like how long did it take to load an event or to render the site.

For this I need:
- inside the collectors class the attribute 'utils' (protected) to have it available by extending the class
- two "filter"-events in the Bootstrap.php of the Debug-plugin
  - Shopware_Plugins_Core_Debug_Bootstrap_FilterCollectors in the "registerCollectors"-Methode to change the Collector
  - Shopware_Plugins_Core_Debug_Bootstrap_FilterHandlerRegister in the "getHandlers"-Methode to add the ClockworkHandlers
