### PR TITLE
Remove @covers annotation for not existing method

### DIFF
--- a/tests/Shopware/Tests/Core/sAdminTest.php
+++ b/tests/Shopware/Tests/Core/sAdminTest.php
@@ -2272,7 +2272,6 @@ class sAdminTest extends PHPUnit_Framework_TestCase
      * @covers sAdmin::sRiskARTICLESFROM
      * @covers sAdmin::sRiskLASTORDERSLESS
      * @covers sAdmin::sRiskPREGSTREET
-     * @covers sAdmin::sRiskBILLINGPREGSTREET
      * @covers sAdmin::sRiskDIFFER
      * @covers sAdmin::sRiskCUSTOMERNR
      * @covers sAdmin::sRiskLASTNAME


### PR DESCRIPTION
Hi,

running PHPUnit with coverage throws the error `Trying to @cover or @use not existing method "sAdmin::sRiskBILLINGPREGSTREET"`. The method doesn't exist anymore, so I removed the annotation.
