### PR TITLE
Switch Grunt to relativeUrls to unify the paths to less.php

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,9 @@
 # Shopware Upgrade Information
 In this document you will find a changelog of the important changes related to the code base of Shopware.
 
+## 5.1.3
+* Switch Grunt to relativeUrls to unify the paths to less.php
+
 ## 5.1.2
 * Out-of-stock variants on the detail page are now selectable
 * `ProductNumberService::getAvailableNumber()` now returns the provided product variant to allow deep linking of out-of-stock variants
@@ -982,5 +985,3 @@ For further information have a look at the following wiki article:
 
 - GER: <http://wiki.shopware.de/_detail_1342.html>
 - ENG: <http://en.wiki.shopware.de/_detail_1398.html>
-
-

--- a/themes/Gruntfile.js
+++ b/themes/Gruntfile.js
@@ -6,10 +6,7 @@ module.exports = function (grunt) {
         jsFiles = [],
         jsTargetFile = {},
         content = '',
-        variables = {
-            'font-directory': '"../../themes/Frontend/Responsive/frontend/_public/src/fonts"',
-            'OpenSansPath': '"../../themes/Frontend/Responsive/frontend/_public/vendors/fonts/open-sans-fontface"'
-        };
+        variables = {};
 
     lessTargetFile['../' + config.lessTarget] = '../web/cache/all.less';
 
@@ -51,7 +48,8 @@ module.exports = function (grunt) {
             production: {
                 options: {
                     compress: true,
-                    modifyVars: variables
+                    modifyVars: variables,
+                    relativeUrls: true
                 },
                 files: lessTargetFile
             },
@@ -59,6 +57,7 @@ module.exports = function (grunt) {
                 options: {
                     modifyVars: variables,
                     dumpLineNumbers: 'all',
+                    relativeUrls: true,
                     sourceMap: true,
                     sourceMapFileInline: true
                 },


### PR DESCRIPTION
We have some problems in the projects with the less paths. Grunt currently doesnt modifiy the urls and the less.php makes relative to the files and this annoying the development. This PR should fix the issue and make the same paths like less.php.
