### PR TITLE
[TASK] Add payment and dispatch attributes to OrderQueryBuilder

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -184,6 +184,8 @@ class Repository extends ModelRepository
             'detailAttribute',
             'documentAttribute',
             'shippingAttribute',
+            'paymentAttribute',
+            'dispatchAttribute',
             'subShop',
             'locale',
             'debit'
@@ -204,6 +206,8 @@ class Repository extends ModelRepository
                 ->leftJoin('orders.shipping', 'shipping')
                 ->leftJoin('orders.shop', 'shop')
                 ->leftJoin('orders.dispatch', 'dispatch')
+                ->leftJoin('payment.attribute', 'paymentAttribute')
+                ->leftJoin('dispatch.attribute', 'dispatchAttribute')
                 ->leftJoin('billing.attribute', 'billingAttribute')
                 ->leftJoin('shipping.attribute', 'shippingAttribute')
                 ->leftJoin('details.attribute', 'detailAttribute')


### PR DESCRIPTION
With this PR the attributes for payment and dispatch will be included in the REST API. We need this because we added codes to both models for our customers ERP. I think there is no reason to exclude the attributes. 
