### PR TITLE
SW-13731 - Respect umask for all created cache files

### DIFF
--- a/engine/Library/Enlight/Hook/ProxyFactory.php
+++ b/engine/Library/Enlight/Hook/ProxyFactory.php
@@ -103,7 +103,7 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
         $this->proxyNamespace = $proxyNamespace;
 
         if (!is_dir($proxyDir)) {
-            if (false === @mkdir($proxyDir, 0777, true)) {
+            if (false === @mkdir($proxyDir, 0777, true) && !is_dir($proxyDir)) {
                 throw new \RuntimeException(sprintf("Unable to create the %s directory (%s)\n", "Proxy", $proxyDir));
             }
         } elseif (!is_writable($proxyDir)) {
@@ -220,13 +220,14 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
      */
     protected function writeProxyClass($fileName, $content)
     {
-        $oldMask = umask(0);
-        if (!file_put_contents($fileName, $content)) {
-            umask($oldMask);
-            throw new Enlight_Exception('Unable to write file "' . $fileName . '"');
+        $tmpFile = tempnam(dirname($fileName), basename($fileName));
+        if (false !== @file_put_contents($tmpFile, $content) && @rename($tmpFile, $fileName)) {
+            @chmod($fileName, 0666 & ~umask());
+
+            return;
         }
-        chmod($fileName, 0644);
-        umask($oldMask);
+
+        throw new Enlight_Exception('Unable to write file "' . $fileName . '"');
     }
 
     /**

--- a/engine/Library/Enlight/Template/Manager.php
+++ b/engine/Library/Enlight/Template/Manager.php
@@ -71,6 +71,9 @@ class Enlight_Template_Manager extends Smarty
 
         $this->start_time = microtime(true);
 
+        $this->_file_perms = 0666 & ~umask();
+        $this->_dir_perms = 0777 & ~umask();
+
         // set default dirs
         $this->setTemplateDir('.' . DS . 'templates' . DS)
             ->setCompileDir('.' . DS . 'templates_c' . DS)
@@ -103,15 +106,19 @@ class Enlight_Template_Manager extends Smarty
      */
     public function setOptions($options = null)
     {
+        if ($options === null) {
+            return $this;
+        }
+
         if ($options instanceof Enlight_Config) {
             $options = $options->toArray();
         }
-        if ($options !== null) {
-            foreach ($options as $key => $option) {
-                $key = str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
-                $this->{'set' . $key}($option);
-            }
+
+        foreach ($options as $key => $option) {
+            $key = str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
+            $this->{'set' . $key}($option);
         }
+
         return $this;
     }
 

--- a/engine/Shopware/Components/Model/Generator.php
+++ b/engine/Shopware/Components/Model/Generator.php
@@ -261,9 +261,10 @@ class %className% extends ModelEntity
             $this->tableMapping = $this->createTableMapping();
         }
 
-        $this->createTargetDirectory();
-        if (!file_exists($this->getPath())) {
-            return array('success' => false, 'error' => self::CREATE_TARGET_DIRECTORY_FAILED);
+        try {
+            $this->createTargetDirectory($this->getPath());
+        } catch (\Exception $e) {
+            return array('success' => false, 'error' => self::CREATE_TARGET_DIRECTORY_FAILED, 'message' => $e->getMessage());
         }
 
         $errors = array();
@@ -316,13 +317,17 @@ class %className% extends ModelEntity
 
     /**
      * Creates a new directory for the models which will be generated.
+     * @param string $dir
      */
-    protected function createTargetDirectory()
+    protected function createTargetDirectory($dir)
     {
-        if (file_exists($this->getPath())) {
-            return true;
+        if (!is_dir($dir)) {
+            if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
+                throw new \RuntimeException(sprintf("Unable to create directory (%s)\n", $dir));
+            }
+        } elseif (!is_writable($dir)) {
+            throw new \RuntimeException(sprintf("Unable to write in directory (%s)\n", $dir));
         }
-        return mkdir($this->getPath(), 0777);
     }
 
     /**

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -128,8 +128,8 @@ return array_replace_recursive([
         ],
         'backend' => 'auto', // e.G auto, apc, xcache
         'backendOptions' => [
-            'hashed_directory_perm' => 0771,
-            'cache_file_perm' => 0644,
+            'hashed_directory_perm' => 0777 & ~umask(),
+            'cache_file_perm' => 0666 & ~umask(),
             'hashed_directory_level' => 3,
             'cache_dir' => $this->getCacheDir().'/general',
             'file_name_prefix' => 'shopware'


### PR DESCRIPTION
Alternative for Pull Request https://github.com/shopware/shopware/pull/366 by @FiveDigital
Internal Issue: https://issues.shopware.com/#/issues/SW-13731

**Problem**
Instead of a dozen different settings for file and directory permissions I would like Shopware to respect the [`umask`](http://php.net/manual/en/function.umask.php) of the PHP Process for all generated caches.

**Example:**
Your desired permissions for files of `660` and `770` for directories can be archived by setting the `umask` to `007`.

This can be either done in the Apache configuration/startup script, or during early Shopware boot in the PHP Process itself. For that add `umask(0007);` to your `config.php`.

**Implementation:**
Most caches already did respect the `umask`. 
This pull request fixes the remaining template and the proxy caches.

The only hardcoded permission of `0664` and `0775` are the generated Doctrine Proxies. This is due to the recent changes regarding a possible Security Misconfiguration Vulnerability in Doctrine: http://www.doctrine-project.org/2015/08/31/security_misconfiguration_vulnerability_in_various_doctrine_projects.html

I already reported that issue to Doctrine Upstream and provided a pull request to fix that. See:
https://github.com/doctrine/doctrine2/pull/5602

@FiveDigital @roman-1983 
Can you please verify that this pull request will fix your permission issues?
