### PR TITLE
Add aggregation size to prevent doc_count_error_upper_bound

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleES/FacetHandler/PropertyFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/FacetHandler/PropertyFacetHandler.php
@@ -53,6 +53,8 @@ use Shopware\Components\QueryAliasMapper;
 
 class PropertyFacetHandler implements HandlerInterface, ResultHydratorInterface
 {
+    const AGGREGATION_SIZE = 5000;
+    
     /**
      * @var QueryAliasMapper
      */
@@ -118,6 +120,7 @@ class PropertyFacetHandler implements HandlerInterface, ResultHydratorInterface
     ) {
         $aggregation = new TermsAggregation('properties');
         $aggregation->setField('properties.id');
+        $aggregation->addParameter('size', self::AGGREGATION_SIZE);
         $search->addAggregation($aggregation);
     }
 


### PR DESCRIPTION
When you got a large amount of propertys you ran fast in the "doc_count_error_upper_bound" trap.
To prevent that, set good default. I think 5000 is enough for the most environments.
