### PR TITLE
ignore inactive variants for price count

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ListProductGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ListProductGateway.php
@@ -180,7 +180,12 @@ class ListProductGateway implements Gateway\ListProductGatewayInterface
         }
 
         $query->from('s_articles_prices', 'prices')
-            ->innerJoin('prices', 's_articles_details', 'priceVariant', 'priceVariant.id = prices.articledetailsID')
+            ->innerJoin(
+                'prices',
+                's_articles_details',
+                'priceVariant',
+                'priceVariant.id = prices.articledetailsID and priceVariant.active = 1'
+            )
             ->andWhere('prices.from = 1')
             ->andWhere('prices.pricegroup = ' . $key)
             ->andWhere('prices.articleID = product.id');


### PR DESCRIPTION
Given an article with some variants. All except 1 variants are active and have the same price (1,00 EUR). One variant is inactive and has another price (0,50 EUR). 
In the listing there is "from 1,00 EUR" instead of just "1,00 EUR" (without "from").

This PR corrects the behaviour.
