### PR TITLE
Save dispatch attributes in backend controller

### DIFF
--- a/engine/Shopware/Controllers/Backend/Shipping.php
+++ b/engine/Shopware/Controllers/Backend/Shipping.php
@@ -161,6 +161,8 @@ class Shopware_Controllers_Backend_Shipping extends Shopware_Controllers_Backend
             $params['bindTimeTo'] = null;
         }
 
+        $params['attribute'] = $params['attribute'][0];
+
         // convert params to model
         $dispatchModel->fromArray($params);
 


### PR DESCRIPTION
This is needed when adding new dispatch attributes. Other backend controllers like payment already have this.
