### PR TITLE
Update Property Group Model to fix bugs in the API

### DIFF
--- a/engine/Shopware/Models/Property/Group.php
+++ b/engine/Shopware/Models/Property/Group.php
@@ -214,11 +214,11 @@ class Group extends ModelEntity
     /**
      * Returns Array of associated Options
      *
-     * @return \Shopware\Models\Property\Option[]
+     * @return \Doctrine\Common\Collections\ArrayCollection
      */
     public function getOptions()
     {
-        return $this->options->toArray();
+        return $this->options;
     }
 
     /**

--- a/engine/Shopware/Models/Property/Group.php
+++ b/engine/Shopware/Models/Property/Group.php
@@ -212,7 +212,7 @@ class Group extends ModelEntity
     }
 
     /**
-     * Returns Array of associated Options
+     * Returns ArrayCollection of associated Options
      *
      * @return \Doctrine\Common\Collections\ArrayCollection
      */


### PR DESCRIPTION
Removed array conversion in the Property Group model. Should be more consistent to the other models. This should fix #SW-13924. As far as I see there are no sideeffects with other parts that rely on an array but I'm not sure about that. Please verify.
