### PR TITLE
Check VoteDisable in frontend_detail_tabs_rating

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/tabs.tpl
+++ b/themes/Frontend/Bare/frontend/detail/tabs.tpl
@@ -15,12 +15,14 @@
 
                         {* Rating tab *}
                         {block name="frontend_detail_tabs_rating"}
-                            <a href="#" class="tab--link" title="{s name='DetailTabsRating'}{/s}">
-                                {s name='DetailTabsRating'}{/s}
-                                {block name="frontend_detail_tabs_navigation_rating_count"}
-                                    <span class="product--rating-count">{$sArticle.sVoteAverage.count}</span>
-                                {/block}
-                            </a>
+                            {if !{config name=VoteDisable}}
+                                <a href="#" class="tab--link" title="{s name='DetailTabsRating'}{/s}">
+                                    {s name='DetailTabsRating'}{/s}
+                                    {block name="frontend_detail_tabs_navigation_rating_count"}
+                                        <span class="product--rating-count">{$sArticle.sVoteAverage.count}</span>
+                                    {/block}
+                                </a>
+                            {/if}
                         {/block}
                     {/block}
                 </div>


### PR DESCRIPTION
Voting is disabled in shop -> When adding custom tabs, the rating tab label shows up and shows the custom tabs content. custom label remains empty.
