### PR TITLE
SEO optimization: Show always h1 in category listing, including fallb…

### DIFF
--- a/themes/Frontend/Bare/frontend/listing/text.tpl
+++ b/themes/Frontend/Bare/frontend/listing/text.tpl
@@ -2,60 +2,60 @@
 
 {* Categorie headline *}
 {block name="frontend_listing_text"}
-    {if $sCategoryContent.cmsheadline || $sCategoryContent.cmstext}
-        <div class="hero-unit category--teaser panel has--border is--rounded">
+    <div class="hero-unit category--teaser panel has--border is--rounded">
 
-            {* Headline *}
-            {block name="frontend_listing_text_headline"}
-                {if $sCategoryContent.cmsheadline}
-                    <h1 class="hero--headline panel--title">{$sCategoryContent.cmsheadline}</h1>
-                {/if}
-            {/block}
+        {* Headline *}
+        {block name="frontend_listing_text_headline"}
+            {if $sCategoryContent.cmsheadline}
+                <h1 class="hero--headline panel--title">{$sCategoryContent.cmsheadline}</h1>
+            {else}
+                <h1 class="hero--headline panel--title">{$sCategoryContent.name}</h1>
+            {/if}
+        {/block}
 
-            {* Category text *}
-            {block name="frontend_listing_text_content"}
+        {* Category text *}
+        {block name="frontend_listing_text_content"}
+            {if $sCategoryContent.cmstext}
                 <div class="hero--text panel--body is--wide">
-                    {if $sCategoryContent.cmstext}
 
-                        {* Long description *}
-                        {block name="frontend_listing_text_content_long"}
-                            <div class="teaser--text-long">
-                                {$sCategoryContent.cmstext}
-                            </div>
-                        {/block}
+                    {* Long description *}
+                    {block name="frontend_listing_text_content_long"}
+                        <div class="teaser--text-long">
+                            {$sCategoryContent.cmstext}
+                        </div>
+                    {/block}
 
-                        {* Short description *}
-                        {block name="frontend_listing_text_content_short"}
-                            <div class="teaser--text-short is--hidden">
-                                {$sCategoryContent.cmstext|strip_tags|truncate:200}
-                                <a href="#" title="{"{s namespace="frontend/listing/listing" name="ListingActionsOpenOffCanvas"}{/s}"|escape}" class="text--offcanvas-link">
-                                    {s namespace="frontend/listing/listing" name="ListingActionsOpenOffCanvas"}{/s} &raquo;
+                    {* Short description *}
+                    {block name="frontend_listing_text_content_short"}
+                        <div class="teaser--text-short is--hidden">
+                            {$sCategoryContent.cmstext|strip_tags|truncate:200}
+                            <a href="#" title="{"{s namespace="frontend/listing/listing" name="ListingActionsOpenOffCanvas"}{/s}"|escape}" class="text--offcanvas-link">
+                                {s namespace="frontend/listing/listing" name="ListingActionsOpenOffCanvas"}{/s} &raquo;
+                            </a>
+                        </div>
+                    {/block}
+
+                    {* Off Canvas Container *}
+                    {block name="frontend_listing_text_content_offcanvas"}
+                        <div class="teaser--text-offcanvas is--hidden">
+
+                            {* Close Button *}
+                            {block name="frontend_listing_text_content_offcanvas_close"}
+                                <a href="#" title="{"{s namespace="frontend/listing/listing" name="ListingActionsCloseOffCanvas"}{/s}"|escape}" class="close--off-canvas">
+                                    <i class="icon--arrow-left"></i> {s namespace="frontend/listing/listing" name="ListingActionsCloseOffCanvas"}{/s}
                                 </a>
-                            </div>
-                        {/block}
-
-                        {* Off Canvas Container *}
-                        {block name="frontend_listing_text_content_offcanvas"}
-                            <div class="teaser--text-offcanvas is--hidden">
-
-                                {* Close Button *}
-                                {block name="frontend_listing_text_content_offcanvas_close"}
-                                    <a href="#" title="{"{s namespace="frontend/listing/listing" name="ListingActionsCloseOffCanvas"}{/s}"|escape}" class="close--off-canvas">
-                                        <i class="icon--arrow-left"></i> {s namespace="frontend/listing/listing" name="ListingActionsCloseOffCanvas"}{/s}
-                                    </a>
-                                {/block}
-                                {* Off Canvas Content *}
-                                {block name="frontend_listing_text_content_offcanvas_content"}
-                                    <div class="offcanvas--content">
-                                        <div class="content--title">{$sCategoryContent.cmsheadline}</div>
-                                        {$sCategoryContent.cmstext}
-                                    </div>
-                                {/block}
-                            </div>
-                        {/block}
-                    {/if}
+                            {/block}
+                            {* Off Canvas Content *}
+                            {block name="frontend_listing_text_content_offcanvas_content"}
+                                <div class="offcanvas--content">
+                                    <div class="content--title">{$sCategoryContent.cmsheadline}</div>
+                                    {$sCategoryContent.cmstext}
+                                </div>
+                            {/block}
+                        </div>
+                    {/block}
                 </div>
-            {/block}
-        </div>
-    {/if}
+            {/if}
+        {/block}
+    </div>
 {/block}


### PR DESCRIPTION
SEO optimization: Show always h1 in category listing, including fallback "$sCategoryContent.name"

For good SEO every page should have a h1.
In Line 5 we removed:
`{if $sCategoryContent.cmsheadline || $sCategoryContent.cmstext}`
and added category description as Fallback:
`{else}<h1 class="hero--headline panel--title">{$sCategoryContent.name}</h1>`

Also we put the container "hero--text" inside the {if}:
`{block name="frontend_listing_text_content"}
            {if $sCategoryContent.cmstext}
                <div class="hero--text panel--body is--wide">`
