### PR TITLE
CLI: Plugin Reinstall

### DIFF
--- a/engine/Shopware/Commands/PluginReinstallCommand.php
+++ b/engine/Shopware/Commands/PluginReinstallCommand.php
@@ -27,6 +27,7 @@ namespace Shopware\Commands;
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
 use Shopware\Components\Console\Application;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -44,6 +45,11 @@ class PluginReinstallCommand extends ShopwareCommand
                 'plugin',
                 InputArgument::REQUIRED,
                 'Name of the plugin to be installed.'
+            )->addOption(
+                'removedata',
+            	'r',
+                InputOption::VALUE_NONE,
+                'if supplied plugin data will be removed'
             );
     }
 
@@ -62,7 +68,8 @@ class PluginReinstallCommand extends ShopwareCommand
             $output->writeln(sprintf('Plugin by name "%s" was not found.', $pluginName));
             return 1;
         }
-        $pluginManager->uninstallPlugin($plugin, false);
+        $rmd = $input->getOption('removedata');
+        $pluginManager->uninstallPlugin($plugin, $rmd);
         $pluginManager->installPlugin($plugin);
         $pluginManager->activatePlugin($plugin);
     }


### PR DESCRIPTION
Added option (-r) to also remove the plugins data upon reinstallation. Previously it was hard set to `false`.
