### PR TITLE
SW-13999 - Create attribute models on model manager initialization

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Models.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Models.php
@@ -102,6 +102,10 @@ class Models
 
         LazyFetchModelEntity::setEntityManager($entityManager);
 
+        if (!class_exists('Shopware\Models\Attribute\CustomerGroup')) {
+            $entityManager->generateAttributeModels();
+        }
+
         return $entityManager;
     }
 }


### PR DESCRIPTION
Create attribute models during model manager initialization. This could replace 
https://github.com/shopware/shopware/blob/5.1/engine/Shopware/Commands/GenerateAttributesCommand.php and https://github.com/shopware/shopware/blob/5.1/engine/Shopware/Components/AttributeSubscriber.php.
