### PR TITLE
Bugfix article seo urls for shops with fallback translation

### DIFF
--- a/engine/Shopware/Core/sRewriteTable.php
+++ b/engine/Shopware/Core/sRewriteTable.php
@@ -898,11 +898,15 @@ class sRewriteTable
         $sql = $this->getSeoArticleQuery();
         $sql = $this->db->limit($sql, $limit);
 
+
+        $shopFallbackId = (Shopware()->Shop()->getFallback() instanceof \Shopware\Models\Shop\Shop) ? Shopware()->Shop()->getFallback()->getId():NULL;
+
         $result = $this->db->fetchAll(
             $sql,
             array(
                 Shopware()->Shop()->get('parentID'),
                 Shopware()->Shop()->getId(),
+                $shopFallbackId,
                 $lastUpdate
             )
         );
@@ -951,7 +955,7 @@ class sRewriteTable
     {
         return "
             SELECT a.*, d.ordernumber, d.suppliernumber, s.name as supplier, datum as date,
-                d.releasedate, changetime as changed, metaTitle, ct.objectdata, at.attr1, at.attr2,
+                d.releasedate, changetime as changed, metaTitle, ct.objectdata, ctf.objectdata as objectdataFallback, at.attr1, at.attr2,
                 at.attr3, at.attr4, at.attr5, at.attr6, at.attr7, at.attr8, at.attr9,
                 at.attr10,at.attr11, at.attr12, at.attr13, at.attr14, at.attr15, at.attr16,
                 at.attr17, at.attr18, at.attr19, at.attr20
@@ -974,6 +978,11 @@ class sRewriteTable
                 ON ct.objectkey=a.id
                 AND ct.objectlanguage=?
                 AND ct.objecttype='article'
+
+            LEFT JOIN s_core_translations ctf
+                ON ctf.objectkey=a.id
+                AND ctf.objectlanguage=?
+                AND ctf.objecttype='article'
 
             LEFT JOIN s_articles_supplier s
                 ON s.id=a.supplierID
@@ -1286,30 +1295,51 @@ class sRewriteTable
     public function mapArticleTranslationObjectData($articles)
     {
         foreach ($articles as &$article) {
-            if (empty($article['objectdata'])) {
+            if (empty($article['objectdata']) && empty($article['objectdataFallback'])) {
                 unset($article['objectdata']);
+                unset($article['objectdataFallback']);
                 continue;
             }
 
-            $data = unserialize($article['objectdata']);
-            if (!$data) {
+            $objectData = unserialize($article['objectdata']);
+            $objectDataFallback = unserialize($article['objectdataFallback']);
+            if (!$objectData && !$objectDataFallback) {
                 continue;
             }
 
-            $data['name'] = (!empty($data['txtArtikel'])) ? $data['txtArtikel'] : $article['name'];
-            $data['description_long'] = (!empty($data['txtlangbeschreibung'])) ? $data['txtlangbeschreibung'] : $article['description_long'];
-            $data['description'] = (!empty($data['txtshortdescription'])) ? $data['txtshortdescription'] : $article['description'];
-            $data['keywords'] = (!empty($data['txtkeywords'])) ? $data['txtkeywords'] : $article['keywords'];
+            $article=$this->mapArticleObjectField($article,$objectData,$objectDataFallback,'name','txtArtikel');
+            $article=$this->mapArticleObjectField($article,$objectData,$objectDataFallback,'description_long','txtlangbeschreibung');
+            $article=$this->mapArticleObjectField($article,$objectData,$objectDataFallback,'description','txtshortdescription');
+            $article=$this->mapArticleObjectField($article,$objectData,$objectDataFallback,'keywords','keywords');
+
 
             unset($article['objectdata']);
-            unset($data['txtArtikel']);
-            unset($data['txtlangbeschreibung']);
-            unset($data['txtlangbeschreibung']);
-            unset($data['txtkeywords']);
+            unset($article['objectdataFallback']);
 
-            $article = array_merge($article, $data);
         }
 
         return $articles;
+    }
+
+    /**
+     * map article core translation including fallback fields for given article
+     * @param array $article
+     * @param $objectData
+     * @param $objectDataFallback
+     * @param $articleFieldName
+     * @param $objectFieldName
+     * @return array $article
+     */
+    private function mapArticleObjectField(array $article,$objectData,$objectDataFallback,$articleFieldName,$objectFieldName )
+    {
+        if(!empty($objectData[$objectFieldName])){
+            $article[$articleFieldName]=$objectData[$objectFieldName];
+        }else{
+            if(!empty($objectDataFallback[$objectFieldName])){
+                $article[$articleFieldName]=$objectDataFallback[$objectFieldName];
+            }
+        }
+
+        return $article;
     }
 }

--- a/engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php
+++ b/engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php
@@ -206,9 +206,13 @@ class Shopware_Controllers_Backend_Seo extends Shopware_Controllers_Backend_ExtJ
         $sql = $this->RewriteTable()->getSeoArticleQuery();
         $sql = Shopware()->Db()->limit($sql, $limit, $offset);
 
+
+        $shopFallbackId = (Shopware()->Shop()->getFallback() instanceof \Shopware\Models\Shop\Shop) ? Shopware()->Shop()->getFallback()->getId():NULL;
+
         $articles = Shopware()->Db()->fetchAll($sql, array(
             $shop->get('parentID'),
             $shop->getId(),
+            $shopFallbackId,
             '1900-01-01'
         ));
 

--- a/engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php
+++ b/engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php
@@ -207,7 +207,7 @@ class Shopware_Controllers_Backend_Seo extends Shopware_Controllers_Backend_ExtJ
         $sql = Shopware()->Db()->limit($sql, $limit, $offset);
 
 
-        $shopFallbackId = (Shopware()->Shop()->getFallback() instanceof \Shopware\Models\Shop\Shop) ? Shopware()->Shop()->getFallback()->getId():NULL;
+        $shopFallbackId = ($shop->getFallback() instanceof \Shopware\Models\Shop\Shop) ? $shop->getFallback()->getId():NULL;
 
         $articles = Shopware()->Db()->fetchAll($sql, array(
             $shop->get('parentID'),


### PR DESCRIPTION
If more than one subshops do have the same language (e.g. english) and you intend to get the article translations inherited from one subshop to another, a bug occured. The newly generated seo url then will be translated in the language that has been set as default (e.g. german).
