### PR TITLE
Set default order if order is empty for getListQueryBuilder at Customer Repository

### DIFF
--- a/engine/Shopware/Models/Customer/Repository.php
+++ b/engine/Shopware/Models/Customer/Repository.php
@@ -119,6 +119,10 @@ class Repository extends ModelRepository
                     ->setParameter(4, $customerGroup);
         }
 
+        if (empty($orderBy)) {
+            $orderBy = array(array('property' => 'customer.id', 'direction' => 'DESC'));
+        }
+
         $this->addOrderBy($builder, $orderBy);
         return $builder;
     }


### PR DESCRIPTION
The function getListQueryBuilde is not usable without parameters, but it should be. If you use

`
$this->getListQueryBuilder();
`

it results in:

`
Doctrine\ORM\Query\QueryException: [Semantical Error] line 0, col -1 near 'SELECT customer.id,': Error: '' is not defined. in /var/www/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php on line 63
`
