### PR TITLE
Fix articleId on backend order position updates

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1208,21 +1208,9 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
             unset($data['tax']);
         }
 
-        $articleDetails = null;
-        // Add articleId if it's not provided by the client
-        if ($data['articleId'] == 0 && !empty($data['articleNumber'])) {
-            $detailRepo = Shopware()->Models()->getRepository('Shopware\Models\Article\Detail');
-            /** @var \Shopware\Models\Article\Detail $articleDetails */
-            $articleDetails = $detailRepo->findOneBy(array('number' => $data['articleNumber']));
-            if ($articleDetails) {
-                $data['articleId'] = $articleDetails->getArticle()->getId();
-            }
-        }
-        if (!$articleDetails && $data['articleId']) {
-            /** @var \Shopware\Models\Article\Detail $articleDetails */
-            $articleDetails = Shopware()->Models()->getRepository('Shopware\Models\Article\Detail')
-                ->findOneBy(array('number' => $data['articleNumber']));
-        }
+        /** @var \Shopware\Models\Article\Detail $articleDetails */
+        $articleDetails = Shopware()->Models()->getRepository('Shopware\Models\Article\Detail')
+            ->findOneBy(array('number' => $data['articleNumber']));
 
         //Load ean, unit and pack unit (translate if needed)
         if ($articleDetails) {

--- a/themes/Backend/ExtJs/backend/order/controller/detail.js
+++ b/themes/Backend/ExtJs/backend/order/controller/detail.js
@@ -344,6 +344,9 @@ Ext.define('Shopware.apps.Order.controller.Detail', {
         updateButton.setDisabled(false);
         columns[1].setValue(record.get('number'));
         columns[2].setValue(record.get('name'));
+
+        // Update articleId for row
+        editor.context.record.set('articleId', record.get('articleId'));
     },
 
 


### PR DESCRIPTION
Before #145 alls changes to order positions in the backend would not update the `articleId` correctly. #145 fixed this for newly added positions but altering the article of an order position (by using the article search dropdown) would not update `articleId` yet. This PR fixes this and also makes the PHP code of the original PR irrelevant and is much shorter!

**tl;dr** The icon to jump to the article from an order position now always opens the correct article as the `articleId` in the database is correct.
