### PR TITLE
Fix shop duplication bug

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,7 @@ In this document you will find a changelog of the important changes related to t
 * Fixed `AND` search logic for search terms which not exist in the s_articles table.
 * Added order and payment state constants in `\Shopware\Models\Order\Status`
 * change email validation to a simple regex: `/^.+\@\S+\.\S+$/`. You can implement your own email validation by implementing the `EmailValidatorInterface`. 
+* Deprecated `Shopware\Models\Shop\Repository::fixActive`
 
 ## 5.1.3
 * Switch Grunt to relativeUrls to unify the paths to less.php

--- a/engine/Shopware/Models/Shop/Repository.php
+++ b/engine/Shopware/Models/Shop/Repository.php
@@ -288,10 +288,6 @@ class Repository extends ModelRepository
         $builder->setParameter('shopId', $id);
         $shop = $builder->getQuery()->getOneOrNullResult();
 
-        if ($shop !== null) {
-            $this->fixActive($shop);
-        }
-
         return $shop;
     }
 
@@ -305,10 +301,6 @@ class Repository extends ModelRepository
         $builder = $this->getActiveQueryBuilder();
         $builder->where('shop.default = 1');
         $shop = $builder->getQuery()->getOneOrNullResult();
-
-        if ($shop !== null) {
-            $this->fixActive($shop);
-        }
 
         return $shop;
     }
@@ -365,10 +357,6 @@ class Repository extends ModelRepository
         /** @var $shops \Shopware\Models\Shop\Shop[] */
         $shops = $builder->getQuery()->getResult();
 
-        foreach ($shops as $currentShop) {
-            $this->fixActive($currentShop);
-        }
-
         //returns the right shop depending on the url
         $shop = $this->getShopByRequest($shops, $requestPath);
 
@@ -384,10 +372,6 @@ class Repository extends ModelRepository
 
         $shop = $builder->getQuery()->getOneOrNullResult();
 
-        if ($shop !== null) {
-            $this->fixActive($shop);
-        }
-
         return $shop;
     }
 
@@ -396,35 +380,7 @@ class Repository extends ModelRepository
      */
     protected function fixActive($shop)
     {
-        $this->getEntityManager()->detach($shop);
-        $main = $shop->getMain();
-        if ($main !== null) {
-            $this->getEntityManager()->detach($main);
-            $shop->setHost($main->getHost());
-            $shop->setSecure($main->getSecure());
-            $shop->setAlwaysSecure($main->getAlwaysSecure());
-            $shop->setSecureHost($main->getSecureHost());
-            $shop->setSecureBasePath($main->getSecureBasePath());
-            $shop->setBasePath($shop->getBasePath() ?: $main->getBasePath());
-            $shop->setTemplate($main->getTemplate());
-            $shop->setCurrencies($main->getCurrencies());
-            $shop->setChildren($main->getChildren());
-            $shop->setCustomerScope($main->getCustomerScope());
-        }
-        $shop->setBaseUrl($shop->getBaseUrl() ?: $shop->getBasePath());
-        if ($shop->getSecure()) {
-            $shop->setSecureHost($shop->getSecureHost()?: $shop->getHost());
-            $shop->setSecureBasePath($shop->getSecureBasePath()?: $shop->getBasePath());
-            $baseUrl = $shop->getSecureBasePath();
-            if ($shop->getBaseUrl() != $shop->getBasePath()) {
-                if (!$shop->getBasePath()) {
-                    $baseUrl .= $shop->getBaseUrl();
-                } elseif (strpos($shop->getBaseUrl(), $shop->getBasePath()) === 0) {
-                    $baseUrl .= substr($shop->getBaseUrl(), strlen($shop->getBasePath()));
-                }
-            }
-            $shop->setSecureBaseUrl($baseUrl);
-        }
+
     }
 
     /**

--- a/engine/Shopware/Models/Shop/Repository.php
+++ b/engine/Shopware/Models/Shop/Repository.php
@@ -376,6 +376,7 @@ class Repository extends ModelRepository
     }
 
     /**
+     * @deprecated
      * @param \Shopware\Models\Shop\Shop $shop
      */
     protected function fixActive($shop)

--- a/engine/Shopware/Models/Shop/Shop.php
+++ b/engine/Shopware/Models/Shop/Shop.php
@@ -572,19 +572,15 @@ class Shop extends ModelEntity
      */
     public function getSecureBaseUrl()
     {
-        if($this->main !== null) {
-            return $this->main->getSecureBaseUrl();
-        } elseif($this->secureBaseUrl === null) {
-            $baseUrl = $this->getSecureBasePath();
-            if ($this->getBaseUrl() != $this->getBasePath()) {
-                if (!$this->getBasePath()) {
-                    $baseUrl .= $this->getBaseUrl();
-                } elseif (strpos($this->getBaseUrl(), $this->getBasePath()) === 0) {
-                    $baseUrl .= substr($this->getBaseUrl(), strlen($this->getBasePath()));
-                }
+        $baseUrl = $this->getSecureBasePath();
+        if ($this->getBaseUrl() != $this->getBasePath()) {
+            if (!$this->getBasePath()) {
+                $baseUrl .= $this->getBaseUrl();
+            } elseif (strpos($this->getBaseUrl(), $this->getBasePath()) === 0) {
+                $baseUrl .= substr($this->getBaseUrl(), strlen($this->getBasePath()));
             }
-            $this->setSecureBaseUrl($baseUrl);
         }
+        return $baseUrl;
     }
 
     /**

--- a/engine/Shopware/Models/Shop/Shop.php
+++ b/engine/Shopware/Models/Shop/Shop.php
@@ -296,7 +296,7 @@ class Shop extends ModelEntity
      */
     public function getHost()
     {
-        return $this->host;
+        return $this->main !== null ? $this->main->getHost() : $this->host;
     }
 
     /**
@@ -312,7 +312,11 @@ class Shop extends ModelEntity
      */
     public function getBasePath()
     {
-        return $this->basePath;
+        if($this->main !== null) {
+            return $this->main->getBasePath();
+        } else {
+            return $this->basePath;
+        }
     }
 
     /**
@@ -328,7 +332,11 @@ class Shop extends ModelEntity
      */
     public function getBaseUrl()
     {
-        return $this->baseUrl;
+        if($this->baseUrl !== null) {
+            return $this->baseUrl;
+        } else {
+            return $this->getBasePath();
+        }
     }
 
     /**
@@ -360,7 +368,7 @@ class Shop extends ModelEntity
      */
     public function getTemplate()
     {
-        return $this->template;
+        return $this->main !== null ? $this->main->getTemplate() : $this->template;
     }
 
     /**
@@ -472,7 +480,7 @@ class Shop extends ModelEntity
      */
     public function getCurrencies()
     {
-        return $this->currencies;
+        return $this->main !== null ? $this->main->getCurrencies() : $this->currencies;
     }
 
     /**
@@ -504,7 +512,7 @@ class Shop extends ModelEntity
      */
     public function getSecure()
     {
-        return $this->secure;
+        return $this->main !== null ? $this->main->getSecure() : $this->secure;
     }
 
     /**
@@ -520,7 +528,13 @@ class Shop extends ModelEntity
      */
     public function getSecureHost()
     {
-        return $this->secureHost;
+        if($this->main !== null) {
+            return $this->main->getSecureHost();
+        } elseif($this->secureHost !== null) {
+            return $this->secureHost;
+        } else {
+            return $this->getHost();
+        }
     }
 
     /**
@@ -536,7 +550,13 @@ class Shop extends ModelEntity
      */
     public function getSecureBasePath()
     {
-        return $this->secureBasePath;
+        if($this->main !== null) {
+            return $this->main->getSecureBasePath();
+        } elseif($this->secureBasePath !== null) {
+            return $this->secureBasePath;
+        } else {
+            return $this->getBasePath();
+        }
     }
 
     /**
@@ -552,7 +572,19 @@ class Shop extends ModelEntity
      */
     public function getSecureBaseUrl()
     {
-        return $this->secureBaseUrl;
+        if($this->main !== null) {
+            return $this->main->getSecureBaseUrl();
+        } elseif($this->secureBaseUrl === null) {
+            $baseUrl = $this->getSecureBasePath();
+            if ($this->getBaseUrl() != $this->getBasePath()) {
+                if (!$this->getBasePath()) {
+                    $baseUrl .= $this->getBaseUrl();
+                } elseif (strpos($this->getBaseUrl(), $this->getBasePath()) === 0) {
+                    $baseUrl .= substr($this->getBaseUrl(), strlen($this->getBasePath()));
+                }
+            }
+            $this->setSecureBaseUrl($baseUrl);
+        }
     }
 
     /**
@@ -584,7 +616,7 @@ class Shop extends ModelEntity
      */
     public function getCustomerScope()
     {
-        return $this->customerScope;
+        return $this->main !== null ? $this->main->getCustomerScope() : $this->customerScope;
     }
 
     /**
@@ -616,7 +648,7 @@ class Shop extends ModelEntity
      */
     public function getChildren()
     {
-        return $this->children;
+        return $this->main !== null ? $this->main->getChildren() : $this->children;
     }
 
     /**

--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -92,14 +92,6 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
             $shop->setSecureHost($shop->getHost());
         }
 
-        $main = $shop->getMain() !== null ? $shop->getMain() : $shop;
-        if (!$main->getDefault()) {
-            $main = $repository->getActiveDefault();
-            $shop->setTemplate($main->getTemplate());
-            $shop->setHost($main->getHost());
-            $shop->setSecureHost($main->getSecureHost() ?: $main->getHost());
-        }
-
         // Read original base path for resources
         $request->getBasePath();
 


### PR DESCRIPTION
This is a new pull request for the shop duplication bug previously discussed in #169 and #356 (based on 5.0).

The proposed fix is based on @hlohaus changes as mentioned in https://github.com/shopware/shopware/pull/169#issuecomment-49440259.

This is a big issue for a many plugin vendors as a lot of constellations as simple as calling `createStatusMail()` at the "wrong" time can lead to duplicated shop entities and the only workaround currently is to not use any Doctrine in these cases.

The changes to `engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php` are necessary so that real subshops created with the SwagMultiShop plugin still work after the fix. Without these changes, the user is always redirected to the main shop. I successfully tested that language subshops still work without these lines.
