### PR TITLE
Fix the 'removeListener' method in 'Enlight_Event_Subscriber_Config'

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,7 @@ In this document you will find a changelog of the important changes related to t
 * Added index on `s_article_img_mapping_rules`.`mapping_id` and `s_article_img_mapping_rules`.`option_id`
 * Fixed `AND` search logic for search terms which not exist in the s_articles table.
 * Added order and payment state constants in `\Shopware\Models\Order\Status`
+* Fixed the `removeListener` method in `Enlight_Event_Subscriber_Config`
 
 ## 5.1.3
 * Switch Grunt to relativeUrls to unify the paths to less.php

--- a/engine/Library/Enlight/Event/Subscriber/Config.php
+++ b/engine/Library/Enlight/Event/Subscriber/Config.php
@@ -103,7 +103,10 @@ class Enlight_Event_Subscriber_Config extends Enlight_Event_Subscriber
      */
     public function removeListener(Enlight_Event_Handler $handler)
     {
-        $this->listeners = array_diff($this->listeners, array($handler));
+        $handlerIndex = array_search($handler, $this->listeners);
+        if ($handlerIndex !== false) {
+            array_splice($this->listeners, $handlerIndex, 1);
+        }
         return $this;
     }
 


### PR DESCRIPTION
This fix uses 'array_search' and 'array_splice' to actually find and remove a given handler from the listeners. This is necessary, because the previously used method 'array_diff' doesn't work with objects.

This is a new version of PR https://github.com/shopware/shopware/pull/174 against the current branch.
