### PR TITLE
[TASK] wait for tinymce init before setting/getting contents

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.TinyMCE.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.TinyMCE.js
@@ -225,10 +225,6 @@ Ext.define('Shopware.form.field.TinyMCE',
         var me = this;
         me.callParent(arguments);
 
-        // Checks if the TinyMCE object is available in the DOM
-        if(window.tinymce) {
-            me.statics.initialized = true;
-        }
         // Register additional events
         me.registerEvents();
     },
@@ -361,6 +357,8 @@ Ext.define('Shopware.form.field.TinyMCE',
         // (e.g. in order to click the save button in the ExtJS window).
         // This solution still as some drawbacks as it image-resize-actions won't trigger a undo-step usually.
         me.tinymce.onInit.add(function(ed, evt) {
+            me.statics.initialized = true;
+
             var dom = ed.dom,
                 doc = ed.getDoc(),
                 el = doc.content_editable ? ed.getBody() : (tinymce.isGecko ? doc : ed.getWin());
@@ -394,6 +392,12 @@ Ext.define('Shopware.form.field.TinyMCE',
                     me.tinymce.setContent(me.emptyText);
                 }
             });
+
+            me.changeSniffer = window.setInterval(function() {
+                var value = me.tinymce.getContent();
+                value = me.replaceImagePathsWithSmartyPlugin(value);
+                me.setRawValue(value);
+            }, 300);
         });
 
         // Render the TinyMCE editor
@@ -401,14 +405,6 @@ Ext.define('Shopware.form.field.TinyMCE',
 
         // Fire the "afterrendereditor" event
         me.fireEvent('afterrendereditor', me, me.tinymce, input.id, me.config.editor);
-
-        window.setTimeout(function() {
-            me.changeSniffer = window.setInterval(function() {
-                var value = me.tinymce.getContent();
-                value = me.replaceImagePathsWithSmartyPlugin(value);
-                me.setRawValue(value);
-            }, 300);
-        }, 500);
     },
 
     _findImagesInDOMContent: function(content) {
@@ -688,7 +684,7 @@ Ext.define('Shopware.form.field.TinyMCE',
     setEditorValue: function(value, scope) {
         var me = scope;
 
-        if(!me.tinymce) {
+        if(!me.statics.initialized) {
             Ext.Function.defer(function() {
                 me.setEditorValue(value, me);
             }, 50);


### PR DESCRIPTION
Hey folks,
this patch fixes the JS Error "Uncaught TypeError: Cannot read property 'body' of undefined" thrown by tinymce in the backend.

This error occures when you try to call methods like `me.tinymce.getContent();` before the editor is completly initialized. The beatiful window.setTimout on the codesniffer was propably a first workaround for that.

I moved some stuff to the onInit Event which is already present to fix this error.
