### PR TITLE
SW-14164 - Introduce DetachedShop to prevent shop duplication issues

### DIFF
--- a/engine/Shopware/Components/Model/ModelRepository.php
+++ b/engine/Shopware/Components/Model/ModelRepository.php
@@ -25,7 +25,6 @@
 namespace Shopware\Components\Model;
 
 use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Query\Expr;
 
 /**
@@ -46,10 +45,16 @@ use Doctrine\ORM\Query\Expr;
 class ModelRepository extends EntityRepository
 {
     /**
-     * {@inheritdoc}
+     * Creates a new QueryBuilder instance that is prepopulated for this entity name.
+     *
+     * @param string $alias
+     * @param string $indexBy The index for the from.
+     *
+     * @return QueryBuilder
      */
     public function createQueryBuilder($alias, $indexBy = null)
     {
+        /** @var QueryBuilder $builder */
         $builder = parent::createQueryBuilder($alias, $indexBy = null);
         $builder->setAlias($alias);
 

--- a/engine/Shopware/Models/Order/Order.php
+++ b/engine/Shopware/Models/Order/Order.php
@@ -251,7 +251,7 @@ class Order extends ModelEntity
      *
      * Used for the language subshop association
      * @var \Shopware\Models\Shop\Shop
-     * @ORM\ManyToOne(targetEntity="Shopware\Models\Shop\Shop", cascade={"persist"})
+     * @ORM\ManyToOne(targetEntity="Shopware\Models\Shop\Shop")
      * @ORM\JoinColumn(name="language", referencedColumnName="id")
      */
     private $languageSubShop;

--- a/engine/Shopware/Models/Shop/DetachedShop.php
+++ b/engine/Shopware/Models/Shop/DetachedShop.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Models\Shop;
+
+/**
+ * Representation of the current storefront shop (Shopware()->Shop()).
+ *
+ * This has the same identity as Shopware\Models\Shop\Shop
+ * but is no doctrine managed entity.
+ * The ORM\Entity annotation is omited intentionally.
+ */
+class DetachedShop extends Shop
+{
+    /**
+     * @param Shop $shop
+     * @return DetachedShop
+     */
+    public static function createFromShop(Shop $shop)
+    {
+        $self = new self();
+
+        foreach ($shop as $field => $value) {
+            $self->{$field} = $value;
+        }
+
+        return $self;
+    }
+}

--- a/engine/Shopware/Models/Shop/Repository.php
+++ b/engine/Shopware/Models/Shop/Repository.php
@@ -25,10 +25,10 @@
 namespace Shopware\Models\Shop;
 
 use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Query;
 use Shopware\Components\Model\ModelRepository;
+use Shopware\Components\Model\QueryBuilder;
 
-/**
- */
 class Repository extends ModelRepository
 {
     /**
@@ -38,7 +38,7 @@ class Repository extends ModelRepository
      * @param null $order
      * @param null $offset
      * @param null $limit
-     * @return \Doctrine\ORM\Query
+     * @return Query
      */
     public function getLocalesListQuery($filter = null, $order = null, $offset = null, $limit = null)
     {
@@ -56,7 +56,7 @@ class Repository extends ModelRepository
      *
      * @param null $filter
      * @param null $order
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return QueryBuilder
      */
     public function getLocalesListQueryBuilder($filter = null, $order = null)
     {
@@ -83,7 +83,7 @@ class Repository extends ModelRepository
      * @param array $order
      * @param int $offset
      * @param int $limit
-     * @return \Doctrine\ORM\Query
+     * @return Query
      */
     public function getBaseListQuery($filter = null, $order = null, $offset = null, $limit = null)
     {
@@ -102,7 +102,7 @@ class Repository extends ModelRepository
      * @param array $order
      * @param int $offset
      * @param int $limit
-     * @return \Doctrine\ORM\Query
+     * @return Query
      */
     public function getShopsWithThemes($filter = null, $order = null, $offset = null, $limit = null)
     {
@@ -134,7 +134,7 @@ class Repository extends ModelRepository
      *
      * @param array $filter
      * @param array $order
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return QueryBuilder
      */
     public function getBaseListQueryBuilder($filter = null, $order = null)
     {
@@ -165,7 +165,6 @@ class Repository extends ModelRepository
         return $builder;
     }
 
-
     /**
      * Returns the \Doctrine\ORM\Query to select all categories for example for the backend tree
      *
@@ -173,7 +172,7 @@ class Repository extends ModelRepository
      * @param array $orderBy
      * @param null $limit
      * @param null $offset
-     * @return \Doctrine\ORM\Query
+     * @return Query
      */
     public function getListQuery(array $filterBy, array $orderBy, $limit = null, $offset = null)
     {
@@ -189,7 +188,7 @@ class Repository extends ModelRepository
      * @param   array $orderBy
      * @param   null $limit
      * @param   null $offset
-     * @return  \Shopware\Components\Model\QueryBuilder
+     * @return  QueryBuilder
      */
     public function getListQueryBuilder(array $filterBy, array $orderBy, $limit = null, $offset = null)
     {
@@ -223,7 +222,7 @@ class Repository extends ModelRepository
     /**
      * Helper function to create the query builder for the "getShopsQuery" function.
      * This function can be hooked to modify the query builder of the query object.
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return QueryBuilder
      */
     public function getMainListQueryBuilder()
     {
@@ -236,7 +235,7 @@ class Repository extends ModelRepository
     /**
      * Returns an instance of \Doctrine\ORM\Query object which selects a list of
      * sub shops. Used for the shop combo box on the article detail page in the article backend module.
-     * @return \Doctrine\ORM\Query
+     * @return Query
      */
     public function getMainListQuery()
     {
@@ -245,11 +244,11 @@ class Repository extends ModelRepository
     }
 
     /**
-     * @return \Shopware\Components\Model\QueryBuilder
+     * @return QueryBuilder
      */
     public function getActiveQueryBuilder()
     {
-        /** @var $builder \Shopware\Components\Model\QueryBuilder */
+        /** @var $builder QueryBuilder */
         $baseBuilder = $this->createQueryBuilder('shop')
             ->leftJoin('shop.main', 'main')
             ->leftJoin('shop.locale', 'locale')
@@ -278,8 +277,8 @@ class Repository extends ModelRepository
     }
 
     /**
-     * @param $id
-     * @return \Shopware\Models\Shop\Shop
+     * @param int $id
+     * @return DetachedShop
      */
     public function getActiveById($id)
     {
@@ -289,7 +288,7 @@ class Repository extends ModelRepository
         $shop = $builder->getQuery()->getOneOrNullResult();
 
         if ($shop !== null) {
-            $this->fixActive($shop);
+            $shop = $this->fixActive($shop);
         }
 
         return $shop;
@@ -298,7 +297,7 @@ class Repository extends ModelRepository
     /**
      * Returns the default shop with additional data
      *
-     * @return \Shopware\Models\Shop\Shop
+     * @return DetachedShop
      */
     public function getActiveDefault()
     {
@@ -307,7 +306,7 @@ class Repository extends ModelRepository
         $shop = $builder->getQuery()->getOneOrNullResult();
 
         if ($shop !== null) {
-            $this->fixActive($shop);
+            $shop = $this->fixActive($shop);
         }
 
         return $shop;
@@ -316,7 +315,7 @@ class Repository extends ModelRepository
     /**
      * Returns only the default shop model
      *
-     * @return \Shopware\Models\Shop\Shop
+     * @return Shop
      */
     public function getDefault()
     {
@@ -330,7 +329,8 @@ class Repository extends ModelRepository
     /**
      * Returns the active shops
      *
-     * @return mixed
+     * @param int $hydrationMode
+     * @return array
      */
     public function getActiveShops($hydrationMode = AbstractQuery::HYDRATE_OBJECT)
     {
@@ -343,16 +343,15 @@ class Repository extends ModelRepository
 
     /**
      * @param \Enlight_Controller_Request_Request $request
-     * @return \Shopware\Models\Shop\Shop
+     * @return DetachedShop
      */
     public function getActiveByRequest($request)
     {
-        /** @var $shop \Shopware\Models\Shop\Shop */
-        $shop = null;
         $host = $request->getHttpHost();
         if (empty($host)) {
-            return $shop;
+            return null;
         }
+
         $requestPath = $request->getRequestUri();
 
         $builder = $this->getActiveQueryBuilder();
@@ -362,11 +361,11 @@ class Repository extends ModelRepository
         }
         $builder->setParameter('host', $host);
 
-        /** @var $shops \Shopware\Models\Shop\Shop[] */
+        /** @var $shops Shop[] */
         $shops = $builder->getQuery()->getResult();
 
-        foreach ($shops as $currentShop) {
-            $this->fixActive($currentShop);
+        foreach ($shops as $key => $currentShop) {
+            $shops[$key] = $this->fixActive($currentShop);
         }
 
         //returns the right shop depending on the url
@@ -385,21 +384,23 @@ class Repository extends ModelRepository
         $shop = $builder->getQuery()->getOneOrNullResult();
 
         if ($shop !== null) {
-            $this->fixActive($shop);
+            $shop = $this->fixActive($shop);
         }
 
         return $shop;
     }
 
     /**
-     * @param \Shopware\Models\Shop\Shop $shop
+     * @param Shop $shop
+     * @return DetachedShop
      */
-    protected function fixActive($shop)
+    protected function fixActive(Shop $shop)
     {
-        $this->getEntityManager()->detach($shop);
+        $shop = DetachedShop::createFromShop($shop);
+
         $main = $shop->getMain();
         if ($main !== null) {
-            $this->getEntityManager()->detach($main);
+            $main = DetachedShop::createFromShop($main);
             $shop->setHost($main->getHost());
             $shop->setSecure($main->getSecure());
             $shop->setAlwaysSecure($main->getAlwaysSecure());
@@ -411,6 +412,7 @@ class Repository extends ModelRepository
             $shop->setChildren($main->getChildren());
             $shop->setCustomerScope($main->getCustomerScope());
         }
+
         $shop->setBaseUrl($shop->getBaseUrl() ?: $shop->getBasePath());
         if ($shop->getSecure()) {
             $shop->setSecureHost($shop->getSecureHost()?: $shop->getHost());
@@ -425,14 +427,16 @@ class Repository extends ModelRepository
             }
             $shop->setSecureBaseUrl($baseUrl);
         }
+
+        return DetachedShop::createFromShop($shop);
     }
 
     /**
      * returns the right shop depending on the request object
      *
-     * @param \Shopware\Models\Shop\Shop[] $shops
+     * @param Shop[] $shops
      * @param string $requestPath
-     * @return null|\Shopware\Models\Shop\Shop $shop
+     * @return null|Shop $shop
      */
     protected function getShopByRequest($shops, $requestPath)
     {

--- a/engine/Shopware/Models/Shop/Shop.php
+++ b/engine/Shopware/Models/Shop/Shop.php
@@ -26,8 +26,8 @@ namespace Shopware\Models\Shop;
 
 use Shopware\Components\Model\ModelEntity;
 use Doctrine\ORM\Mapping as ORM;
-use Shopware\Components\Theme\Inheritance;
 use Doctrine\Common\Collections\ArrayCollection;
+use Shopware\Components\Theme\Inheritance;
 
 /**
  *
@@ -43,165 +43,165 @@ class Shop extends ModelEntity
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
-    private $id;
+    protected $id;
 
     /**
      * @var integer $mainId
      * @ORM\Column(name="main_id", type="integer", nullable=true)
      */
-    private $mainId;
+    protected $mainId;
 
     /**
      * @var integer $categoryId
      * @ORM\Column(name="category_id", type="integer", nullable=true)
      */
-    private $categoryId;
+    protected $categoryId;
 
     /**
      * @var Shop $main
      * @ORM\ManyToOne(targetEntity="Shop", inversedBy="children")
      */
-    private $main;
+    protected $main;
 
     /**
      * @var string $name
      * @ORM\Column(name="name", type="string", length=255, nullable=false)
      */
-    private $name;
+    protected $name;
 
     /**
      * @var string $title
      * @ORM\Column(name="title", type="string", length=255, nullable=true)
      */
-    private $title;
+    protected $title;
 
     /**
      * @var integer $position
      * @ORM\Column(name="position", type="integer", nullable=false)
      */
-    private $position = 0;
+    protected $position = 0;
 
     /**
      * @var string $name
      * @ORM\Column(name="host", type="string", length=255, nullable=true)
      */
-    private $host;
+    protected $host;
 
     /**
      * @var string $basePath
      * @ORM\Column(name="base_path", type="string", length=255, nullable=true)
      */
-    private $basePath;
+    protected $basePath;
 
     /**
      * @var string $baseUrl
      * @ORM\Column(name="base_url", type="string", length=255, nullable=true)
      */
-    private $baseUrl;
+    protected $baseUrl;
 
     /**
      * @var string $hosts
      * @ORM\Column(name="hosts", type="text", nullable=false)
      */
-    private $hosts = '';
+    protected $hosts = '';
 
     /**
      * @var boolean $secure
      * @ORM\Column(name="secure", type="boolean", nullable=false)
      */
-    private $secure = false;
+    protected $secure = false;
 
     /**
      * @var boolean $secure
      * @ORM\Column(name="always_secure", type="boolean", nullable=false)
      */
-    private $alwaysSecure = false;
+    protected $alwaysSecure = false;
 
     /**
      * @var string $name
      * @ORM\Column(name="secure_host", type="string", length=255, nullable=true)
      */
-    private $secureHost;
+    protected $secureHost;
 
     /**
      * @var string $secureBasePath
      * @ORM\Column(name="secure_base_path", type="string", length=255, nullable=true)
      */
-    private $secureBasePath;
+    protected $secureBasePath;
 
     /**
      * @var string $secureBaseUrl
      */
-    private $secureBaseUrl;
+    protected $secureBaseUrl;
 
     /**
      * @var $template int
      * @ORM\Column(name="template_id", type="integer", nullable=true)
      */
-    private $templateId;
+    protected $templateId;
 
     /**
      * @var Template $template
      * @ORM\ManyToOne(targetEntity="Template", inversedBy="shops")
      * @ORM\JoinColumn(name="template_id", referencedColumnName="id")
      */
-    private $template;
+    protected $template;
 
     /**
      * @var Template $documentTemplate
      * @ORM\ManyToOne(targetEntity="Template")
      * @ORM\JoinColumn(name="document_template_id", referencedColumnName="id")
      */
-    private $documentTemplate;
+    protected $documentTemplate;
 
     /**
      * @var \Shopware\Models\Category\Category $category
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Category\Category")
      */
-    private $category;
+    protected $category;
 
     /**
      * @var Locale $locale
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Shop\Locale")
      */
-    private $locale;
+    protected $locale;
 
     /**
      * @var Currency $currency
      * @ORM\ManyToOne(targetEntity="Currency")
      */
-    private $currency;
+    protected $currency;
 
     /**
      * @var \Shopware\Models\Customer\Group $customerGroup
      * @ORM\ManyToOne(targetEntity="\Shopware\Models\Customer\Group")
      * @ORM\JoinColumn(name="customer_group_id", referencedColumnName="id")
      */
-    private $customerGroup;
+    protected $customerGroup;
 
     /**
      * @var boolean $default
      * @ORM\Column(name="`default`", type="boolean", nullable=false)
      */
-    private $default = false;
+    protected $default = false;
 
     /**
      * @var boolean $active
      * @ORM\Column(name="active", type="boolean", nullable=false)
      */
-    private $active = true;
+    protected $active = true;
 
     /**
      * @var Shop $fallback
      * @ORM\ManyToOne(targetEntity="Shop")
      */
-    private $fallback;
+    protected $fallback;
 
     /**
      * @var boolean $default
      * @ORM\Column(name="customer_scope", type="boolean", nullable=false)
      */
-    private $customerScope = false;
+    protected $customerScope = false;
 
     /**
      * @var Currency[]|\Doctrine\Common\Collections\ArrayCollection
@@ -209,7 +209,7 @@ class Shop extends ModelEntity
      * @ORM\JoinTable(name="s_core_shop_currencies")
      * @ORM\OrderBy({"position" = "ASC", "id" = "ASC"})
      */
-    private $currencies;
+    protected $currencies;
 
     /**
      * @var \Shopware\Models\Site\Group[]|\Doctrine\Common\Collections\ArrayCollection
@@ -217,14 +217,14 @@ class Shop extends ModelEntity
      * @ORM\JoinTable(name="s_core_shop_pages")
      * @ORM\OrderBy({"id" = "ASC"})
      */
-    private $pages;
+    protected $pages;
 
     /**
      * @var Shop[]|\Doctrine\Common\Collections\ArrayCollection
      * @ORM\OneToMany(targetEntity="Shop", mappedBy="main", cascade={"all"}))
      * @ORM\OrderBy({"position" = "ASC", "id" = "ASC"})
      */
-    private $children;
+    protected $children;
 
     /**
      * Class constructor.
@@ -672,7 +672,9 @@ class Shop extends ModelEntity
 
     /**
      * @param \Enlight_Bootstrap $bootstrap
-     * @return Shop
+     * @return DetachedShop
+     * @throws \Exception
+     * @throws \Zend_Currency_Exception
      */
     public function registerResources(\Enlight_Bootstrap $bootstrap)
     {
@@ -695,12 +697,10 @@ class Shop extends ModelEntity
         $snippets = $bootstrap->getResource('Snippets');
         $snippets->setShop($this);
 
-        /** @var $snippets \Enlight_Plugin_PluginManager */
+        /** @var $plugins \Enlight_Plugin_PluginManager */
         $plugins = $bootstrap->getResource('Plugins');
 
         /** @var $pluginNamespace  \Shopware_Components_Plugin_Namespace */
-        $pluginNamespace = null;
-
         foreach ($plugins as $pluginNamespace) {
             if ($pluginNamespace instanceof \Shopware_Components_Plugin_Namespace) {
                 $pluginNamespace->setShop($this);
@@ -712,6 +712,7 @@ class Shop extends ModelEntity
         if ($this->getTemplate() !== null) {
             /** @var $templateManager \Enlight_Template_Manager */
             $templateManager = $bootstrap->getResource('Template');
+
             $template = $this->getTemplate();
             $localeName = $this->getLocale()->toString();
 
@@ -734,9 +735,9 @@ class Shop extends ModelEntity
 
             $templateManager->setCompileId(
                 'frontend' .
-                    '_' . $template->toString() .
-                    '_' . $localeName .
-                    '_' . $this->getId()
+                '_' . $template->toString() .
+                '_' . $localeName .
+                '_' . $this->getId()
             );
         }
 

--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -23,6 +23,8 @@
  */
 
 use Enlight_Controller_Request_Request as Request;
+use Shopware\Models\Shop\DetachedShop;
+use Shopware\Models\Shop\Repository;
 use Shopware\Models\Shop\Shop;
 
 /**
@@ -144,6 +146,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
             $requestUri = substr($requestUri, 0, $pos);
         }
 
+        /** @var $repository Shopware\Models\Shop\Repository */
         $repository = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop');
         $requestShop = $repository->getActiveByRequest($request);
 
@@ -222,7 +225,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
 
         $bootstrap = $this->Application()->Bootstrap();
         if ($bootstrap->issetResource('Shop')) {
-            /** @var Shop $shop */
+            /** @var DetachedShop $shop */
             $shop = $this->Application()->Shop();
 
             if ($request->isSecure() && $request->getHttpHost() !== $shop->getSecureHost()) {
@@ -269,7 +272,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
     protected function upgradeShop($request, $response)
     {
         $bootstrap = $this->Application()->Bootstrap();
-        /** @var $shop Shop */
+        /** @var $shop DetachedShop */
         $shop = $this->Application()->Shop();
 
         $cookieKey = null;
@@ -404,10 +407,11 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
 
     /**
      * @param Request $request
-     * @return Shop
+     * @return DetachedShop
      */
     protected function getShopByRequest(Request $request)
     {
+        /** @var Repository $repository */
         $repository = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop');
 
         $shop = null;
@@ -439,6 +443,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
         Request $request,
         Shop $newShop
     ) {
+        /** @var Repository $repository */
         $repository = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop');
         $requestShop = $repository->getActiveByRequest($request);
 


### PR DESCRIPTION
Alternative fix for https://github.com/shopware/shopware/pull/437.

Issue https://issues.shopware.com/#/issues/SW-14164.

This PR introduces a new `\Shopware\Models\Shop\DetachedShop` object that will be returned for `Shopware()->Shop()` , `$shopRepository->getActiveByRequest()` and similar methods.

 `\Shopware\Models\Shop\DetachedShop`  extends `\Shopware\Models\Shop\Shop` to preserve BC with typehints.

This new object is not managed/attached to Doctrines Entity manager. 
