### PR TITLE
SW-14293 - Fix deletion of first subshop in config module

### DIFF
--- a/themes/Backend/ExtJs/backend/config/model/form/shop.js
+++ b/themes/Backend/ExtJs/backend/config/model/form/shop.js
@@ -82,7 +82,7 @@ Ext.define('Shopware.apps.Config.model.form.Shop', {
         { name: 'fallbackId', convert: function(v, record) {
             return v || record.raw && record.raw.fallback && record.raw.fallback.id;
         }, useNull: true },
-        { name: 'deletable', type: 'boolean', convert: function(v, r) { return r.data.id > 2; } }
+        { name: 'deletable', type: 'boolean', convert: function(v, r) { return r.data.id > 1; } }
     ],
 
     associations: [{


### PR DESCRIPTION
Fix for https://issues.shopware.com/#/issues/SW-14293
See: https://twitter.com/msslovi0/status/702099567291068416

It is not possible to delete the first subhop / language shop in the shop section of the config module in the shopware backend.
