### PR TITLE
Fixed W3C Error - div as ul child

### DIFF
--- a/themes/Frontend/Bare/frontend/index/sidebar.tpl
+++ b/themes/Frontend/Bare/frontend/index/sidebar.tpl
@@ -18,14 +18,13 @@
 						</a>
 					</li>
 				{/block}
-
-				{* Switches for currency and language on mobile devices *}
-				{block name="frontend_index_left_switches"}
-					<div class="mobile--switches">
-						{action module=widgets controller=index action=shopMenu}
-					</div>
-				{/block}
 			</ul>
+			{* Switches for currency and language on mobile devices *}
+			{block name="frontend_index_left_switches"}
+				<div class="mobile--switches">
+					{action module=widgets controller=index action=shopMenu}
+				</div>
+			{/block}
 		</div>
 	{/block}
 


### PR DESCRIPTION
W3C Error "Element div not allowed as child of element ul" fixed.
