### PR TITLE
[BUGFIX] use plain sql query instead of querybuilder in sAdmin

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2479,21 +2479,17 @@ class sAdmin
     /**
      * Returns the given user's shipping address attributes
      *
-     * @param $userId User id
+     * @param $shipping Shipping Address
      * @return array The given user's shipping address attributes
      */
-    private function getUserShippingAddressAttributes($userId)
+    private function getUserShippingAddressAttributes($shipping)
     {
-        $builder = Shopware()->Models()->createQueryBuilder();
-        $attributes = $builder->select(array('attributes'))
-            ->from('Shopware\Models\Attribute\CustomerShipping', 'attributes')
-            ->innerJoin('attributes.customerShipping', 'shipping')
-            ->where('shipping.customerId = :userId')
-            ->setParameter('userId', $userId)
-            ->setFirstResult(0)
-            ->setMaxResults(1)
-            ->getQuery()
-            ->getOneOrNullResult(\Doctrine\ORM\AbstractQuery::HYDRATE_ARRAY);
+        if (!empty($shipping['id'])) {
+            $attributes = $this->db->fetchRow(
+                'SELECT * FROM s_user_shippingaddress_attributes WHERE shippingID = ?',
+                array((int)$shipping['id'])
+            );
+        }
 
         if (!is_array($attributes)) {
             return array();
@@ -4482,7 +4478,8 @@ class sAdmin
             array($userId)
         );
         $shipping = $shipping ? : array();
-        $attributes = $this->getUserShippingAddressAttributes($userId);
+        $attributes = $this->getUserShippingAddressAttributes($shipping);
+
         $userData["shippingaddress"] = array_merge($attributes, $shipping);
 
         // If shipping address is not available, billing address is coeval the shipping address
@@ -4554,16 +4551,13 @@ class sAdmin
         );
         $billing = $billing ? : array();
 
-        $builder = Shopware()->Models()->createQueryBuilder();
-        $attributes = $builder->select(array('attributes'))
-            ->from('Shopware\Models\Attribute\CustomerBilling', 'attributes')
-            ->innerJoin('attributes.customerBilling', 'billing')
-            ->where('billing.customerId = :userId')
-            ->setParameter('userId', $userId)
-            ->setFirstResult(0)
-            ->setMaxResults(1)
-            ->getQuery()
-            ->getOneOrNullResult(\Doctrine\ORM\AbstractQuery::HYDRATE_ARRAY);
+        if (!empty($billing['id'])) {
+            $attributes = $this->db->fetchRow(
+                'SELECT * FROM s_user_billingaddress_attributes WHERE billingID = ?',
+                array((int)$billing['id'])
+            );
+        }
+
         if (!is_array($attributes)) {
             $attributes = array();
         } else {


### PR DESCRIPTION
Hey folks,
although it physically hurts me to replace the querybuilder with a plain sql query, this is a nessecary bugfix.

The problem:
We are adding some custom fields to the billing address attributes.
The registration uses sAdmin functions to validate and persist fields, which themselves all use plain sql queries. Thats why its nessecary to have underscored values for name and value attributes in the template (as the db column names).

Eg: `<input name="register[billing][foo_bar_baz]" value="{$form_data.foo_bar_baz}" type="text" />`

But in the Account settings (/account/billing) which use the same template, the values are not set. This is because the querybuilder returns lowerCamelCased results which do not match the template variables.

For the default attributes this is not a problem, because text1 etc is of course the same lowerCamelCased an underscored.

Regards,
Thomas

**EDIT**: added a new patch which includes same logic for shipping address attributes.
