### PR TITLE
Fix enlight event subscriber remove listener

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,7 @@ In this document you will find a changelog of the important changes related to t
 * Fixed `AND` search logic for search terms which not exist in the s_articles table.
 * Added order and payment state constants in `\Shopware\Models\Order\Status`
 * change email validation to a simple regex: `/^.+\@\S+\.\S+$/`. You can implement your own email validation by implementing the `EmailValidatorInterface`. 
+* Fixed the `removeListener` method in `Enlight_Event_Subscriber_Config`, `Enlight_Event_Subscriber_Array` and `Enlight_Event_EventManager`
 
 ## 5.1.3
 * Switch Grunt to relativeUrls to unify the paths to less.php

--- a/engine/Library/Enlight/Event/EventManager.php
+++ b/engine/Library/Enlight/Event/EventManager.php
@@ -127,7 +127,10 @@ class Enlight_Event_EventManager extends Enlight_Class
         $eventName = strtolower($handler->getName());
 
         if (!empty($this->listeners[$eventName])) {
-            $this->listeners[$eventName] = array_diff($this->listeners[$eventName], array($handler));
+            $handlerIndex = array_search($handler, $this->listeners[$eventName]);
+            if ($handlerIndex !== false) {
+                array_splice($this->listeners[$eventName], $handlerIndex, 1);
+            }
         }
 
         return $this;

--- a/engine/Library/Enlight/Event/Subscriber/Array.php
+++ b/engine/Library/Enlight/Event/Subscriber/Array.php
@@ -90,7 +90,10 @@ class Enlight_Event_Subscriber_Array extends Enlight_Event_Subscriber
      */
     public function removeListener(Enlight_Event_Handler $handler)
     {
-        $this->listeners = array_diff($this->listeners, array($handler));
+        $handlerIndex = array_search($handler, $this->listeners);
+        if ($handlerIndex !== false) {
+            array_splice($this->listeners, $handlerIndex, 1);
+        }
         return $this;
     }
 }

--- a/engine/Library/Enlight/Event/Subscriber/Config.php
+++ b/engine/Library/Enlight/Event/Subscriber/Config.php
@@ -103,7 +103,10 @@ class Enlight_Event_Subscriber_Config extends Enlight_Event_Subscriber
      */
     public function removeListener(Enlight_Event_Handler $handler)
     {
-        $this->listeners = array_diff($this->listeners, array($handler));
+        $handlerIndex = array_search($handler, $this->listeners);
+        if ($handlerIndex !== false) {
+            array_splice($this->listeners, $handlerIndex, 1);
+        }
         return $this;
     }
 

--- a/engine/Library/Enlight/Event/Subscriber/Config.php
+++ b/engine/Library/Enlight/Event/Subscriber/Config.php
@@ -66,7 +66,7 @@ class Enlight_Event_Subscriber_Config extends Enlight_Event_Subscriber
         } elseif (isset($options['storage']) && $options['storage'] instanceof Enlight_Config) {
             $this->storage = $options['storage'];
         } else {
-            throw new Enlight_Event_Exception('');
+            throw new Enlight_Event_Exception('No storage provided');
         }
     }
 

--- a/tests/Shopware/Tests/Components/Event/ManagerTest.php
+++ b/tests/Shopware/Tests/Components/Event/ManagerTest.php
@@ -313,6 +313,37 @@ class Shopware_Tests_Components_Event_ManagerTest extends \PHPUnit_Framework_Tes
         $listener = $listeners[5];
         $this->assertEquals(5, $listener->getPosition());
     }
+
+    public function testRemoveSubscriber()
+    {
+        $handler0 = new Enlight_Event_Handler_Default(
+            'Example',
+            function ($args) {
+                return 'foo';
+            }
+        );
+        $this->eventManager->registerListener($handler0);
+
+        $handler1 = new Enlight_Event_Handler_Default(
+            'Example',
+            function ($args) {
+                return 'bar';
+            }
+        );
+        $this->eventManager->registerListener($handler1);
+
+        // Remove first subscriber
+        $this->eventManager->removeListener($handler0);
+
+        $result = $this->eventManager->collect(
+            'Example',
+            new ArrayCollection()
+        );
+
+        // Only the second one should be left
+        $this->assertCount(1, $result->getValues());
+        $this->assertEquals('bar', $result->get(0));
+    }
 }
 
 

--- a/tests/Shopware/Tests/Components/Event/SubscriberArrayTest.php
+++ b/tests/Shopware/Tests/Components/Event/SubscriberArrayTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Tests
+ * @copyright Copyright (c) 2012, shopware AG (http://www.shopware.de)
+ */
+class Shopware_Tests_Components_Event_SubscriberArrayTest extends Enlight_Components_Test_Plugin_TestCase
+{
+    /**
+     * @var \Enlight_Event_Subscriber_Array
+     */
+    protected $eventManager;
+
+    public function setUp()
+    {
+        $this->eventManager = new Enlight_Event_Subscriber_Array();
+    }
+
+    public function testCanCreateInstance()
+    {
+        $this->assertInstanceOf('Enlight_Event_Subscriber_Array', $this->eventManager);
+    }
+
+    public function testAddSubscriber()
+    {
+        // Add to subscribers
+        $handler0 = new Enlight_Event_Handler_Default(
+            'Example',
+            function ($args) {
+                return 'foo';
+            }
+        );
+        $this->eventManager->registerListener($handler0);
+
+        $handler1 = new Enlight_Event_Handler_Default(
+            'Example',
+            function ($args) {
+                return 'bar';
+            }
+        );
+        $this->eventManager->registerListener($handler1);
+
+        $result = $this->eventManager->getListeners();
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('foo', $result[0]->execute($this->createEventArgs()));
+        $this->assertEquals('bar', $result[1]->execute($this->createEventArgs()));
+    }
+
+    public function testRemoveSubscriber()
+    {
+        // Add to subscribers
+        $handler0 = new Enlight_Event_Handler_Default(
+            'Example',
+            function ($args) {
+                return 'foo';
+            }
+        );
+        $this->eventManager->registerListener($handler0);
+
+        $handler1 = new Enlight_Event_Handler_Default(
+            'Example',
+            function ($args) {
+                return 'bar';
+            }
+        );
+        $this->eventManager->registerListener($handler1);
+
+        // Remove first subscriber
+        $this->eventManager->removeListener($handler0);
+
+        $result = $this->eventManager->getListeners();
+
+        // Only the second one should be left
+        $this->assertCount(1, $result);
+        $this->assertEquals('bar', $result[0]->execute($this->createEventArgs()));
+    }
+}

--- a/tests/Shopware/Tests/Components/Event/SubscriberConfigTest.php
+++ b/tests/Shopware/Tests/Components/Event/SubscriberConfigTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Tests
+ * @copyright Copyright (c) 2012, shopware AG (http://www.shopware.de)
+ */
+class Shopware_Tests_Components_Event_SubscriberConfigTest extends Enlight_Components_Test_Plugin_TestCase
+{
+    /**
+     * @var \Enlight_Event_Subscriber_Config
+     */
+    protected $eventManager;
+
+    public function setUp()
+    {
+        $this->eventManager = new Enlight_Event_Subscriber_Config('test');
+    }
+
+    public function testCanCreateInstance()
+    {
+        $this->assertInstanceOf('Enlight_Event_Subscriber_Config', $this->eventManager);
+    }
+
+    public function testAddSubscriber()
+    {
+        // Add to subscribers
+        $handler0 = new Enlight_Event_Handler_Default(
+            'Example',
+            function ($args) {
+                return 'foo';
+            }
+        );
+        $this->eventManager->registerListener($handler0);
+
+        $handler1 = new Enlight_Event_Handler_Default(
+            'Example',
+            function ($args) {
+                return 'bar';
+            }
+        );
+        $this->eventManager->registerListener($handler1);
+
+        $result = $this->eventManager->getListeners();
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('foo', $result[0]->execute($this->createEventArgs()));
+        $this->assertEquals('bar', $result[1]->execute($this->createEventArgs()));
+    }
+
+    public function testRemoveSubscriber()
+    {
+        // Add to subscribers
+        $handler0 = new Enlight_Event_Handler_Default(
+            'Example',
+            function ($args) {
+                return 'foo';
+            }
+        );
+        $this->eventManager->registerListener($handler0);
+
+        $handler1 = new Enlight_Event_Handler_Default(
+            'Example',
+            function ($args) {
+                return 'bar';
+            }
+        );
+        $this->eventManager->registerListener($handler1);
+
+        // Remove first subscriber
+        $this->eventManager->removeListener($handler0);
+
+        $result = $this->eventManager->getListeners();
+
+        // Only the second one should be left
+        $this->assertCount(1, $result);
+        $this->assertEquals('bar', $result[0]->execute($this->createEventArgs()));
+    }
+}


### PR DESCRIPTION
Currently the `removeListener` method in `Enlight_Event_Subscriber_Config`, `Enlight_Event_Subscriber_Array` and `Enlight_Event_EventManager` use `array_diff()` to remove a given `Enlight_Event_Handler` object from the `listeners` array. The problem is, that `array_diff()` doesn't work with object arrays and instead removed all listeners. This fix uses `array_search()` and `array_splice()` instead, to first find and then remove just the given handler from the listeners.

This is a new version of PR #174 against the current branch and includes more fixes than #441 and also brings tests.

Please merge this fix, it's really a pity that this never worked and the fix was first submitted shortly after `4.3.0` was released.
