### PR TITLE
Remove smarty var sCategoryInfo (duplicate of sCategoryContent)

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Blog.php
+++ b/engine/Shopware/Controllers/Frontend/Blog.php
@@ -247,7 +247,6 @@ class Shopware_Controllers_Frontend_Blog extends Enlight_Controller_Action
             'sFilterDate' => $this->getDateFilterData($blogCategoryIds, $filter),
             'sFilterAuthor' => $this->getAuthorFilterData($blogCategoryIds, $filter),
             'sFilterTags' => $this->getTagsFilterData($blogCategoryIds, $filter),
-            'sCategoryInfo' => $categoryContent,
             'sBlogArticles' => $blogArticles,
             'campaigns' => $campaigns
         );

--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -159,7 +159,6 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
         $viewAssignments = array(
             'sBanner' => Shopware()->Modules()->Marketing()->sBanner($categoryId),
             'sBreadcrumb' => $this->getBreadcrumb($categoryId),
-            'sCategoryInfo' => $categoryContent,
             'sCategoryContent' => $categoryContent,
             'campaigns' => $this->getCampaigns($categoryId),
             'activeFilterGroup' => $this->request->getQuery('sFilterGroup'),

--- a/themes/Frontend/Bare/frontend/blog/listing_actions.tpl
+++ b/themes/Frontend/Bare/frontend/blog/listing_actions.tpl
@@ -13,7 +13,7 @@
                 {* Pagination - Previous page *}
                 {block name='frontend_listing_actions_paging_previous'}
                     {if $sPage > 1}
-                        <a href="{$sPages.previous|rewrite:$sCategoryInfo.name}" title="{"{s name='ListingLinkPrevious'}{/s}"|escape}" class="paging--link paging--prev">
+                        <a href="{$sPages.previous|rewrite:$sCategoryContent.name}" title="{"{s name='ListingLinkPrevious'}{/s}"|escape}" class="paging--link paging--prev">
                             <i class="icon--arrow-left"></i>
                         </a>
                     {/if}
@@ -21,13 +21,13 @@
 
                 {* Pagination - current page *}
                 {block name='frontend_listing_actions_paging_numbers'}
-                    <a title="{$sCategoryInfo.name|escape}" class="paging--link is--active">{$sPage}</a>
+                    <a title="{$sCategoryContent.name|escape}" class="paging--link is--active">{$sPage}</a>
                 {/block}
 
                 {* Pagination - Next page *}
                 {block name='frontend_listing_actions_paging_next'}
                     {if $sPage < $sNumberPages}
-                        <a href="{$sPages.next|rewrite:$sCategoryInfo.name}" title="{"{s name='ListingLinkNext'}{/s}"|escape}" class="paging--link paging--next">
+                        <a href="{$sPages.next|rewrite:$sCategoryContent.name}" title="{"{s name='ListingLinkNext'}{/s}"|escape}" class="paging--link paging--next">
                             <i class="icon--arrow-right"></i>
                         </a>
                     {/if}

--- a/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
+++ b/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
@@ -28,7 +28,7 @@
     {* Pagination - current page *}
     {block name='frontend_listing_actions_paging_numbers'}
         {if $pages > 1}
-            <a title="{$sCategoryInfo.name|escape}" class="paging--link is--active">{$sPage}</a>
+            <a title="{$sCategoryContent.name|escape}" class="paging--link is--active">{$sPage}</a>
         {/if}
     {/block}
 


### PR DESCRIPTION
Smarty variable sCategoryInfo is duplicate of sCategoryContent. It's used in listing and blog-listing.
In detail there is also sCategoryInfo, but this one provides other informations!

Since 5.2 is a major update and old emotion templates using this listing smarty var, the duplicate should be removed. It may breaks some plugins depending on sCategoryContent, but I think the update to 5.2 will break many plugins itself.

Maybe I'm wrong using sContentCategory, but searching the code showed this many times more.

Thx André Schließer
zeroseven design studios
