### PR TITLE
Added opacity polyfills

### DIFF
--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/opacity.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/opacity.less
@@ -14,4 +14,6 @@ Please refer to <http://caniuse.com/css-opacity> to see the browser support tabl
 
 .opacity(@opacity) {
 	opacity: @opacity;
+    	@opacity-ie: @opacity * 100;
+    	filter: alpha(opacity=@opacity-ie);
 }


### PR DESCRIPTION
The opacity mixin was pretty useless before, as it only included a simple 'opacity: @opacity;'. I included IE fallbacks.
