### PR TITLE
Renamed block 'frontend_blog_bookmarks_deliciosus'

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -80,6 +80,7 @@ In this document you will find a changelog of the important changes related to t
     * `\Shopware\Models\Customer\Customer::setDebit()`
 * Added new configuration field to the emotion banner widget for link target.
 * Added composer dependency for Symfony Form and implemented FormBundle
+* Renamed block 'frontend_blog_bookmarks_deliciosus' to 'frontend_blog_bookmarks_delicious'
 
 ## 5.1.4
 * Customer logout will now regenerate the session id and clear the customers basket.

--- a/themes/Frontend/Bare/frontend/blog/bookmarks.tpl
+++ b/themes/Frontend/Bare/frontend/blog/bookmarks.tpl
@@ -24,7 +24,7 @@
 				{/block}
 
 				{* Del.icio.us *}
-				{block name='frontend_blog_bookmarks_deliciosus'}
+				{block name='frontend_blog_bookmarks_delicious'}
 					<a href="http://del.icio.us/post?url={url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}&amp;title={$sArticle.title|escape:'url'}"
 						title="{"{s name='BookmarkDeliciousShare'}{/s}"|escape}"
 						class="blog--bookmark icon--delicious"


### PR DESCRIPTION
there was a typo in the block 'frontend_blog_bookmarks_deliciosus' so i renamed it to 'frontend_blog_bookmarks_delicious'
