### PR TITLE
Fix 'from' filter to include orders created at 00:00:00

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -477,7 +477,7 @@ class Repository extends ModelRepository
                         break;
                     case "from":
                         $tmp = new \DateTime($filter['value']);
-                        $builder->andWhere('orders.orderTime > :orderTimeFrom');
+                        $builder->andWhere('orders.orderTime >= :orderTimeFrom');
                         $builder->setParameter('orderTimeFrom', $tmp->format('Ymd'));
                         break;
                     case "to":


### PR DESCRIPTION
If an order has been created at midnight (e.g. exactly '2016-02-01 00:00:00'), it should be included in the order list dialog when setting the 'from' filter to the respective date ('2016-02-01' in the example). This was previously not the case because of the use of the '>' operator instead of '>='.
