### PR TITLE
convertMediaStruct() retinaSource null value

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -560,10 +560,9 @@ class LegacyStructConverter
         $thumbnails = [];
 
         foreach ($media->getThumbnails() as $thumbnail) {
-            $retina = null;
             $thumbnails[] = [
                 'source' => $thumbnail->getSource(),
-                'retinaSource' => $retina,
+                'retinaSource' => $thumbnail->getRetinaSource(),
                 'sourceSet' => $this->getSourceSet($thumbnail),
                 'maxWidth' => $thumbnail->getMaxWidth(),
                 'maxHeight' => $thumbnail->getMaxHeight()


### PR DESCRIPTION
The convertMediaStruct function doesn't include the single retinaSource value properly into thumbnails array.
