### PR TITLE
Make Symfony Request available from Container

### DIFF
--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -145,6 +145,7 @@ class Kernel implements HttpKernelInterface
 
         /** @var $front \Enlight_Controller_Front **/
         $front = $this->container->get('front');
+        $this->container->set('request', $request);
 
         $request = $this->transformSymfonyRequestToEnlightRequest($request);
 


### PR DESCRIPTION
The Symfony Request has more functions like getting files as the Enlight Request and we should place it in the container.
