### PR TITLE
made sAdmin::loginUser public

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -4129,7 +4129,7 @@ class sAdmin
      * @param $plaintext
      * @param $hash
      */
-    private function loginUser($getUser, $email, $password, $isPreHashed, $encoderName, $plaintext, $hash)
+    public function loginUser($getUser, $email, $password, $isPreHashed, $encoderName, $plaintext, $hash)
     {
         $this->regenerateSessionId();
 


### PR DESCRIPTION
Currently it is not possible, or very complicated, to overwrite `sAdmin::sLogin` and the checks in it, this PR fixes this by making `sAdmin::loginUser` public.

With this fix it is possible to do the following:
1. replace `sAdmin::sLogin` using `$this->subscribeEvent('sAdmin::sLogin::replace',           'replaceSLogin');`
2. implement custom logic to verify that the user has entered the right credentials in `replaceSLogin`
3. trigger `sAdmin::loginUser` using `$arguments->getSubject()->executeParent(              'loginUser', $getUser, $email, $password, $isPreHashed, $encoderName, $plaintext, $hash);`

This wont be a BC break.
