### PR TITLE
Hide compare entry after onDeleteCompare

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-menu.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-menu.js
@@ -159,7 +159,7 @@
                 'url': deleteUrl,
                 'dataType': 'jsonp',
                 'success': function () {
-                    $menu.empty();
+                    $menu.empty().addClass(me.opts.hiddenCls);
 
                     $.publish('plugin/swProductCompareMenu/onDeleteCompareSuccess', [ me ]);
                 }


### PR DESCRIPTION
I'd like to propose that after deleting a comparison, the menu item should be re-hid again. 
Inside jquery.product-compare-add.js inside onAddArticleCompare() the class is removed, if a new compare item is added. Hiding it after deleting the comparison would be consistent action to do. 

```
if (compareMenu.hasClass(me.opts.hiddenCls)) {
    compareMenu.removeClass(me.opts.hiddenCls);
}
```

I'm using custom styling on my top-bar elements and after deleting the comparison, the element stays visible. Thats how I noticed the missing feature.
