### PR TITLE
Add {block} tags for all .js files in the PluginManager

### DIFF
--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/app.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/app.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage App
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/applications"}
 Ext.define('Shopware.apps.PluginManager', {
     extend: 'Enlight.app.SubApplication',
     name: 'Shopware.apps.PluginManager',
@@ -203,3 +232,4 @@ Ext.define('Shopware.apps.PluginManager', {
         }
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/main.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/main.js
@@ -1,5 +1,35 @@
 
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Controller
+ * @version    $Id$
+ * @author shopware AG
+ */
+
 //{namespace name=backend/plugin_manager/translation}
+//{block name="backend/plugin_manager/controller/main"}
 Ext.define('Shopware.apps.PluginManager.controller.Main', {
     extend:'Ext.app.Controller',
     mainWindow: null,
@@ -120,3 +150,4 @@ Ext.define('Shopware.apps.PluginManager.controller.Main', {
         }, 1000);
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/navigation.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/navigation.js
@@ -1,3 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Controller
+ * @version    $Id$
+ * @author shopware AG
+ */
+
+//{block name="backend/plugin_manager/controller/navigation"}
 Ext.define('Shopware.apps.PluginManager.controller.Navigation', {
     extend: 'Ext.app.Controller',
 
@@ -368,3 +398,4 @@ Ext.define('Shopware.apps.PluginManager.controller.Navigation', {
         navigation.accountLicenceLink.removeCls('active');
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
@@ -1,5 +1,34 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Controller
+ * @version    $Id$
+ * @author shopware AG
+ */
 
 //{namespace name=backend/plugin_manager/translation}
+//{block name="backend/plugin_manager/controller/plugin"}
 Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
 
     extend:'Ext.app.Controller',
@@ -792,3 +821,4 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
         );
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/address.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/address.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/model/address"}
 Ext.define('Shopware.apps.PluginManager.model.Address', {
     extend: 'Ext.data.Model',
 
@@ -12,3 +41,4 @@ Ext.define('Shopware.apps.PluginManager.model.Address', {
         { name: 'lastName', type: 'string' }
     ]
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/basket.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/basket.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/model/basket"}
 Ext.define('Shopware.apps.PluginManager.model.Basket', {
     extend: 'Ext.data.Model',
 
@@ -33,3 +62,4 @@ Ext.define('Shopware.apps.PluginManager.model.Basket', {
     ]
 
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/basket_position.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/basket_position.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/model/basket_position"}
 Ext.define('Shopware.apps.PluginManager.model.BasketPosition', {
     extend: 'Ext.data.Model',
 
@@ -16,3 +45,4 @@ Ext.define('Shopware.apps.PluginManager.model.BasketPosition', {
     }]
 
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/category.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/category.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/model/category"}
 Ext.define('Shopware.apps.PluginManager.model.Category', {
     extend: 'Ext.data.Model',
 
@@ -15,3 +44,4 @@ Ext.define('Shopware.apps.PluginManager.model.Category', {
         associationKey: 'children'
     }]
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/comment.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/comment.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/model/comment"}
 Ext.define('Shopware.apps.PluginManager.model.Comment', {
     extend: 'Ext.data.Model',
 
@@ -10,3 +39,4 @@ Ext.define('Shopware.apps.PluginManager.model.Comment', {
         { name: 'text', type: 'string' }
     ]
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/domain.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/domain.js
@@ -1,5 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
-
+//{block name="backend/plugin_manager/model/domain"}
 Ext.define('Shopware.apps.PluginManager.model.Domain', {
     extend: 'Ext.data.Model',
 
@@ -10,3 +38,4 @@ Ext.define('Shopware.apps.PluginManager.model.Domain', {
         { name: 'isPartner', type: 'boolean' }
     ]
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/licence.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/licence.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/model/licence"}
 Ext.define('Shopware.apps.PluginManager.model.Licence', {
     extend: 'Ext.data.Model',
 
@@ -25,3 +54,4 @@ Ext.define('Shopware.apps.PluginManager.model.Licence', {
         associationKey: 'priceModel'
     }]
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/picture.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/picture.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/model/picture"}
 Ext.define('Shopware.apps.PluginManager.model.Picture', {
     extend: 'Ext.data.Model',
 
@@ -9,3 +38,4 @@ Ext.define('Shopware.apps.PluginManager.model.Picture', {
         { name: 'preview', type: 'boolean' }
     ]
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/plugin.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/plugin.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/model/plugin"}
 Ext.define('Shopware.apps.PluginManager.model.Plugin', {
     extend: 'Shopware.data.Model',
 
@@ -196,3 +225,4 @@ Ext.define('Shopware.apps.PluginManager.model.Plugin', {
         associationKey: 'licence'
     }]
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/price.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/price.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/model/price"}
 Ext.define('Shopware.apps.PluginManager.model.Price', {
     extend: 'Ext.data.Model',
 
@@ -10,3 +39,4 @@ Ext.define('Shopware.apps.PluginManager.model.Price', {
         { name: 'subscription', type: 'boolean' }
     ]
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/producer.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/model/producer.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/model/producer"}
 Ext.define('Shopware.apps.PluginManager.model.Producer', {
     extend: 'Ext.data.Model',
 
@@ -11,3 +40,4 @@ Ext.define('Shopware.apps.PluginManager.model.Producer', {
         { name: 'iconPath', type: 'string' }
     ]
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/basket.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/basket.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Store
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/store/basket"}
 Ext.define('Shopware.apps.PluginManager.store.Basket', {
     extend: 'Ext.data.Store',
 
@@ -16,3 +45,4 @@ Ext.define('Shopware.apps.PluginManager.store.Basket', {
 
     model: 'Shopware.apps.PluginManager.model.Basket'
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/category.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/category.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Store
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/store/category"}
 Ext.define('Shopware.apps.PluginManager.store.Category', {
     extend: 'Ext.data.Store',
 
@@ -16,3 +45,4 @@ Ext.define('Shopware.apps.PluginManager.store.Category', {
 
     model: 'Shopware.apps.PluginManager.model.Category'
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/licence.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/licence.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Store
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/store/licence"}
 Ext.define('Shopware.apps.PluginManager.store.Licence', {
     extend: 'Ext.data.Store',
 
@@ -18,3 +47,4 @@ Ext.define('Shopware.apps.PluginManager.store.Licence', {
         }
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/local_plugin.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/local_plugin.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Store
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/store/local_plugin"}
 Ext.define('Shopware.apps.PluginManager.store.LocalPlugin', {
     extend:'Shopware.store.Listing',
 
@@ -31,3 +60,4 @@ Ext.define('Shopware.apps.PluginManager.store.LocalPlugin', {
 
     model: 'Shopware.apps.PluginManager.model.Plugin'
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/store_plugin.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/store_plugin.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Store
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/store/store_plugin"}
 Ext.define('Shopware.apps.PluginManager.store.StorePlugin', {
     extend: 'Ext.data.Store',
 
@@ -18,3 +47,4 @@ Ext.define('Shopware.apps.PluginManager.store.StorePlugin', {
         }
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/update_plugins.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/store/update_plugins.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Store
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/store/update_plugin"}
 Ext.define('Shopware.apps.PluginManager.store.UpdatePlugins', {
     extend: 'Ext.data.Store',
 
@@ -18,3 +47,4 @@ Ext.define('Shopware.apps.PluginManager.store.UpdatePlugins', {
         }
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/account/checkout.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/account/checkout.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Account
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/account/checkout"}
 Ext.define('Shopware.apps.PluginManager.view.account.Checkout', {
     extend: 'Ext.window.Window',
 
@@ -310,3 +339,4 @@ Ext.define('Shopware.apps.PluginManager.view.account.Checkout', {
     }
 
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/account/login.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/account/login.js
@@ -1,4 +1,34 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Account
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/account/login"}
 Ext.define('Shopware.apps.PluginManager.view.account.Login', {
     extend: 'Ext.container.Container',
 
@@ -185,3 +215,4 @@ Ext.define('Shopware.apps.PluginManager.view.account.Login', {
         );
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/account/login_window.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/account/login_window.js
@@ -1,4 +1,34 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Account
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/account/login_window"}
 Ext.define('Shopware.apps.PluginManager.view.account.LoginWindow', {
     extend: 'Ext.window.Window',
     modal: true,
@@ -105,3 +135,4 @@ Ext.define('Shopware.apps.PluginManager.view.account.LoginWindow', {
     }
 
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/account/register.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/account/register.js
@@ -1,4 +1,34 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Account
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/account/register"}
 Ext.define('Shopware.apps.PluginManager.view.account.Register', {
     extend: 'Ext.container.Container',
 
@@ -247,3 +277,4 @@ Ext.define('Shopware.apps.PluginManager.view.account.Register', {
     }
 
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/account/upload.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/account/upload.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Account
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/account/upload"}
 Ext.define('Shopware.apps.PluginManager.view.account.Upload', {
     cls: 'plugin-manager-upload-window',
 
@@ -106,3 +135,4 @@ Ext.define('Shopware.apps.PluginManager.view.account.Upload', {
         });
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/container.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/container.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Components
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/view/components/container"}
 Ext.define('Shopware.apps.PluginManager.view.components.Container', {
     extend: 'Ext.container.Container',
     alternateClassName: 'PluginManager.container.Container',
@@ -27,3 +56,4 @@ Ext.define('Shopware.apps.PluginManager.view.components.Container', {
         me.callParent(arguments);
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/download_window.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/download_window.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Components
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/view/components/download_window"}
 Ext.define('Shopware.apps.PluginManager.view.components.DownloadWindow', {
     extend: 'Ext.window.Window',
 
@@ -164,3 +193,4 @@ Ext.define('Shopware.apps.PluginManager.view.components.DownloadWindow', {
         });
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/image_slider.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/image_slider.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Components
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/view/components/image_slider"}
 Ext.define('Shopware.apps.PluginManager.view.components.ImageSlider', {
     extend: 'Ext.container.Container',
     cls: 'plugin-manager-image-slider',
@@ -308,3 +337,4 @@ Ext.define('Shopware.apps.PluginManager.view.components.ImageSlider', {
         });
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/listing.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/listing.js
@@ -1,6 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Components
+ * @version    $Id$
+ * @author shopware AG
+ */
 
-//{namespace name=backend/plugin_manager_2/translation}
-
+//{block name="backend/plugin_manager/view/components/listing"}
 Ext.define('Shopware.apps.PluginManager.view.components.Listing', {
     extend: 'Ext.container.Container',
 
@@ -117,3 +144,4 @@ Ext.define('Shopware.apps.PluginManager.view.components.Listing', {
 
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/slider.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/slider.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Components
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/view/components/slider"}
 Ext.define('Shopware.apps.PluginManager.view.list.Slider', {
     extend: 'Ext.container.Container',
     cls: 'slider',
@@ -157,3 +186,4 @@ Ext.define('Shopware.apps.PluginManager.view.list.Slider', {
         );
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/store_plugin.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/store_plugin.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Components
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/components/store_plugin"}
 Ext.define('Shopware.apps.PluginManager.view.components.StorePlugin', {
     extend: 'Ext.container.Container',
 
@@ -285,3 +314,4 @@ Ext.define('Shopware.apps.PluginManager.view.components.StorePlugin', {
     }
 
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/tab.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/tab.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Components
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/view/components/tab"}
 Ext.define('Shopware.apps.PluginManager.view.components.Tab', {
     extend: 'Ext.container.Container',
     cls: 'shopware-plugin-manager-tab',
@@ -152,3 +181,4 @@ Ext.define('Shopware.apps.PluginManager.view.components.Tab', {
         });
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/tree.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/components/tree.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Components
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/view/components/tree"}
 Ext.define('Shopware.apps.PluginManager.view.components.Tree', {
     extend: 'Ext.container.Container',
     alternateClassName: 'PluginManager.category.Tree',
@@ -135,3 +164,4 @@ Ext.define('Shopware.apps.PluginManager.view.components.Tree', {
         });
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/actions.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/actions.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Detail
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/detail/action"}
 Ext.define('Shopware.apps.PluginManager.view.detail.Actions', {
 
     extend: 'Ext.container.Container',
@@ -120,3 +149,4 @@ Ext.define('Shopware.apps.PluginManager.view.detail.Actions', {
         me.callParent(arguments);
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/comments.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/comments.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Detail
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/detail/comments"}
 Ext.define('Shopware.apps.PluginManager.view.detail.Comments', {
     extend: 'Ext.container.Container',
     commentCount: 0,
@@ -97,3 +126,4 @@ Ext.define('Shopware.apps.PluginManager.view.detail.Comments', {
         });
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/container.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/container.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Detail
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/detail/container"}
 Ext.define('Shopware.apps.PluginManager.view.detail.Container', {
     extend: 'Ext.container.Container',
     cls: 'plugin-manager-detail-page',
@@ -484,3 +513,4 @@ Ext.define('Shopware.apps.PluginManager.view.detail.Container', {
     }
 
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/header.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/header.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Detail
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/detail/header"}
 Ext.define('Shopware.apps.PluginManager.view.detail.Header', {
     extend: 'Ext.container.Container',
     cls: 'store-plugin-detail-headline-container-content',
@@ -67,3 +96,4 @@ Ext.define('Shopware.apps.PluginManager.view.detail.Header', {
         me.callParent(arguments);
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/meta.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/meta.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Detail
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/detail/meta"}
 Ext.define('Shopware.apps.PluginManager.view.detail.Meta', {
     extend: 'Ext.container.Container',
 
@@ -64,3 +93,4 @@ Ext.define('Shopware.apps.PluginManager.view.detail.Meta', {
         me.callParent(arguments);
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/prices.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/prices.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Detail
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/detail/prices"}
 Ext.define('Shopware.apps.PluginManager.view.detail.Prices', {
     extend: 'PluginManager.tab.Panel',
     cls: 'store-plugin-detail-prices-tab shopware-plugin-manager-tab',
@@ -217,3 +246,4 @@ Ext.define('Shopware.apps.PluginManager.view.detail.Prices', {
     }
 
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/window.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/detail/window.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Detail
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/view/detail/window"}
 Ext.define('Shopware.apps.PluginManager.view.detail.Window', {
     extend: 'Enlight.app.Window',
 
@@ -48,3 +77,4 @@ Ext.define('Shopware.apps.PluginManager.view.detail.Window', {
         me.detailContainer.loadRecord(plugin);
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/home_page.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/home_page.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage List
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/list/home_page"}
 Ext.define('Shopware.apps.PluginManager.view.list.HomePage', {
     extend: 'Ext.container.Container',
     alias: 'widget.plugin-manager-home-page',
@@ -92,3 +121,4 @@ Ext.define('Shopware.apps.PluginManager.view.list.HomePage', {
         return me.dummyListing;
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/licence_page.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/licence_page.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage List
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/list/licence_page"}
 Ext.define('Shopware.apps.PluginManager.view.list.LicencePage', {
     extend: 'Shopware.grid.Panel',
     cls: 'plugin-manager-licence-page',
@@ -183,3 +212,4 @@ Ext.define('Shopware.apps.PluginManager.view.list.LicencePage', {
         return items;
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/local_plugin_listing_page.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/local_plugin_listing_page.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage List
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/list/local_plugin_listing_page"}
 Ext.define('Shopware.apps.PluginManager.view.list.LocalPluginListingPage', {
     extend: 'Shopware.grid.Panel',
     alias: 'widget.plugin-manager-local-plugin-listing',
@@ -373,3 +402,4 @@ Ext.define('Shopware.apps.PluginManager.view.list.LocalPluginListingPage', {
         return items;
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/navigation.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/navigation.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage List
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/list/navigation"}
 Ext.define('Shopware.apps.PluginManager.view.list.Navigation', {
     extend: 'Ext.container.Container',
 
@@ -194,3 +223,4 @@ Ext.define('Shopware.apps.PluginManager.view.list.Navigation', {
         return me.categoryTree;
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/premium_plugins_page.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/premium_plugins_page.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage List
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/list/premium_plugins_page"}
 Ext.define('Shopware.apps.PluginManager.view.list.PremiumPluginsPage', {
     extend: 'Shopware.apps.PluginManager.view.list.StoreListingPage',
     alias: 'widget.plugin-manager-premium-plugins-page',
@@ -160,3 +189,4 @@ Ext.define('Shopware.apps.PluginManager.view.list.PremiumPluginsPage', {
     }
 
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/store_listing_page.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/store_listing_page.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage List
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/list/store_listing_page"}
 Ext.define('Shopware.apps.PluginManager.view.list.StoreListingPage', {
     extend: 'Ext.container.Container',
     cls: 'plugin-manager-listing-page',
@@ -169,3 +198,4 @@ Ext.define('Shopware.apps.PluginManager.view.list.StoreListingPage', {
         return me.priceFilter;
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/update_page.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/update_page.js
@@ -1,4 +1,33 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage List
+ * @version    $Id$
+ * @author shopware AG
+ */
 
+//{block name="backend/plugin_manager/view/list/update_page"}
 Ext.define('Shopware.apps.PluginManager.view.list.UpdatePage', {
     extend: 'Ext.container.Container',
     autoScroll: true,
@@ -32,3 +61,4 @@ Ext.define('Shopware.apps.PluginManager.view.list.UpdatePage', {
         return me.content;
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/window.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/window.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage List
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/list/window"}
 Ext.define('Shopware.apps.PluginManager.view.list.Window', {
     extend: 'Enlight.app.Window',
 
@@ -141,3 +170,4 @@ Ext.define('Shopware.apps.PluginManager.view.list.Window', {
         return this.createPremiumPluginPage;
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/loading/mask.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/loading/mask.js
@@ -1,4 +1,34 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage Loading
+ * @version    $Id$
+ * @author shopware AG
+ */
+//{namespace name=backend/plugin_manager/translation}
 
+//{block name="backend/plugin_manager/view/loading/mask"}
 Ext.define('Shopware.apps.PluginManager.view.loading.Mask', {
     extend: 'Ext.window.Window',
 
@@ -84,3 +114,4 @@ Ext.define('Shopware.apps.PluginManager.view.loading.Mask', {
         return me.loadingIndicator;
     }
 });
+//{/block}

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/plugin_helper.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/plugin_helper.js
@@ -1,5 +1,34 @@
-
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    PluginManager
+ * @subpackage View
+ * @version    $Id$
+ * @author shopware AG
+ */
 //{namespace name=backend/plugin_manager/translation}
+
+//{block name="backend/plugin_manager/view/plugin_helper"}
 Ext.define('Shopware.apps.PluginManager.view.PluginHelper', {
 
     displayPluginEvent: function(record, callback) {
@@ -375,3 +404,4 @@ Ext.define('Shopware.apps.PluginManager.view.PluginHelper', {
         return null;
     }
 });
+//{/block}


### PR DESCRIPTION
I'd like to propose that the Plugin Manager to have the {block} tags in order to be extended by other plugins.

I've tried to override a backend plugin and I encountered this problem. More: 
[http://forum.shopware.com/discussion/35522/backend-plugins-manager-cannot-be-extended#latest](url)
