### PR TITLE
Use sPerPage instead of sPage in LegacySearchSubscriber request values

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacySearchSubscriber.php
+++ b/engine/Shopware/Components/Compatibility/LegacySearchSubscriber.php
@@ -159,7 +159,7 @@ class LegacySearchSubscriber implements SubscriberInterface
             'sSearch'        => $criteria->getCondition('search')->getTerm(),
             'sPage'          => $request->getParam('sPage', 1),
             'sSort'          => $request->getParam('sSort'),
-            'sPerPage'       => $request->getParam('sPage', 12),
+            'sPerPage'       => $request->getParam('sPerPage', 12),
             'sFilter'        => array(
                 'category'   => $request->getParam('sFilter_category', null),
                 'supplier'   => $request->getParam('sFilter_supplier', null),


### PR DESCRIPTION
This was an insane expenditure to create this pull request in comparisation to the change. Hell, with all the travis and Scrutinizer stuff going on now I bet this wasted a huge amount of brown coal. 

@bcremer, @SimonBaeumer actually you two are now offically responsible for the climate Change.
