### PR TITLE
fixing Smarty fetch error for reset password

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -940,7 +940,7 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
         ) {
             $errorMessages[] = $this->View()->fetch('string:'.$frontendNamespace->get(
                 'RegisterPasswordLength',
-                'Your password should contain at least {config name=\"MinPassword\"} characters'
+                'Your password should contain at least {config name="MinPassword"} characters'
             ));
             $errors['password'] = true;
             $errors['passwordConfirmation'] = true;


### PR DESCRIPTION
There was a Smarty fetch error when you tried to display the account reset form with an error message.

The error occurs when you leave the reset input field empty or with false data.
https://adamhall.dev/shop/de-de/account/resetPassword
