### PR TITLE
Fix wrong array-key in MarketingAggregate-Plugin

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
@@ -450,7 +450,7 @@ class Shopware_Plugins_Core_MarketingAggregate_Bootstrap extends Shopware_Compon
 
         $details = $arguments->getDetails();
         foreach ($details as $article) {
-            if ($article['mode'] != 0 || empty($article['articleID'])) {
+            if ($article['modus'] != 0 || empty($article['articleID'])) {
                 continue;
             }
 


### PR DESCRIPTION
Changed `$article['mode']` to `$article['modus']`.

`$article` is a basket-record, which doesn't have a property called `mode`, but one that's called `modus`.
