### PR TITLE
PHP Warning on Component createField() method

### DIFF
--- a/engine/Shopware/Models/Emotion/Library/Component.php
+++ b/engine/Shopware/Models/Emotion/Library/Component.php
@@ -715,7 +715,8 @@ class Component extends ModelEntity
                 function ($field) {return $field->getPosition();},
                 $this->getFields()->toArray()
             );
-            $this->maxFieldPositionValue = max($positions) ? : 0;
+            
+            $this->maxFieldPositionValue = !empty($positions) ? max($positions) : 0;
         }
 
         return $this->maxFieldPositionValue;


### PR DESCRIPTION
Me and my work colleges we were having an issue with ansible installing a shopping worlds plugin.

The problem is that the PHP function max() raises a warning when you pass as an argument an empty array, I'm aware that Shopware is expecting it because of this line:
- $this->maxFieldPositionValue = max($positions) ? : 0;
  but the problem is that PHP Warnings are unnecessary. Our suggestion  is not raising warnings.

Thanks
