### PR TITLE
adding password field-type to plugin configuration

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.PluginPanel.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.PluginPanel.js
@@ -280,6 +280,10 @@ Ext.define('Shopware.form.PluginPanel',
                     field.value = new Date(field.value);
                     field.value = new Date((field.value.getTime() + (field.value.getTimezoneOffset() * 60 * 1000)));
                 }
+                else if ((field.xtype == "base-element-password")) {
+                    field.inputType = 'password';
+                    field.xtype = 'base-element-text';
+                }
 
                 fields.push(field);
 


### PR DESCRIPTION
With this small extension - it is possible to use the config type password instead of text for passwords which are needed for APIs etc.

Here a example of an installation() Menthod:

```
    public function install()
    {
        $form = $this->Form();
        $form->setElement(
            'text',
            'username',
            array(
                'label' => 'Username',
                'value' => null
            )
        );

        $form->setElement(
            'password',
            'text',
            array(
                'label' => 'Hidden Password',
                'value' => null
            )
        );

        return true;
    }
```
