### PR TITLE
Double-Check ordernumbers for uniqueness

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -232,11 +232,11 @@ class sOrder
             );
             $number += 1;
 
-            $doubleTap = $this->db()->select()
+            $doubleTap = $this->db->select()
                 ->from('s_order', 'ordernumber')
                 ->where('ordernumber = :number')
                 ->limit(1);
-            $doubleTap = $this->db()->executeQuery($doubleTap, ['number' => $number]);
+            $doubleTap = $this->db->executeQuery($doubleTap, ['number' => $number]);
             if ($doubleTap->rowCount() == 0 || $doCount > 3) {
                 break;
             }


### PR DESCRIPTION
A customer told me they experienced two orders with the same ordernumber. I guess this happens because of some racing stuff. Someone on IRC told me that this happens quite often, so here is a pull request.

If you have a better idea to solve this, feel free to tell me.

Note that this won't work if users decide to prefix / suffix the ordernumber in `Shopware_Modules_Order_GetOrdernumber_FilterOrdernumber`. We can't use `%:number%` here through (for obvious reasons). Basically this should be checked _after_ the event call, but if it isn't unique we would need to call the event again, which isn't good as well, right?

``` php
 $doCount = 1;
do {
    $number = $this->db->fetchOne(
        "/*NO LIMIT*/ SELECT number FROM s_order_number WHERE name='invoice' FOR UPDATE"
    );

    $this->db->executeUpdate(
        "UPDATE s_order_number SET number = number + 1 WHERE name='invoice'"
    );
    $number += 1;

    $number = $this->eventManager->filter(
        'Shopware_Modules_Order_GetOrdernumber_FilterOrdernumber',
        $number,
        array('subject'=>$this)
    );

    $doubleTap = $this->db->select()
        ->from('s_order', 'ordernumber')
        ->where('ordernumber = :number')
        ->limit(1);
    $doubleTap = $this->db->executeQuery($doubleTap, ['number' => $number]);

    if ($doubleTap->rowCount() == 0 || $doCount > 3) {
        break;
    }

    $doCount++;
} while(true);

return $number;
```
