### PR TITLE
Add order detail window to footer buttons

### DIFF
--- a/themes/Backend/ExtJs/backend/order/view/detail/window.js
+++ b/themes/Backend/ExtJs/backend/order/view/detail/window.js
@@ -85,11 +85,6 @@ Ext.define('Shopware.apps.Order.view.detail.Window', {
      */
     stateId:'shopware-order-detail-window',
     /**
-     * Display no footer button for the detail window
-     * @boolean
-     */
-    footerButton:false,
-    /**
      * Contains all snippets for this component
      */
     snippets: {


### PR DESCRIPTION
Its very annoying, to search every time where the order detail is =)
We should add the window to the footer buttons (footer window dinger(™) @t2oh4e)
