### PR TITLE
Fix instock check for articles that are already in the basket

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1536,7 +1536,7 @@ class sBasket
                 $article["laststock"] == true
                 && $article["instock"] < ($chkBasketForArticle["quantity"] + $quantity)
             ) {
-                $quantity -= $chkBasketForArticle["quantity"];
+                $quantity = $article["instock"] - $chkBasketForArticle["quantity"];
             }
         } else {
             if ($article["laststock"] == true && $article["instock"] <= $quantity) {


### PR DESCRIPTION
Currently the basket has a strange behaviour when adding articles with limited stock, this PR changes that behaviour.

Scenario: Article marked as laststock, instock = 3
Current behaviour:
Adding the article with amount 2: quantity in basket is set to 2
Adding the article again with amount 1: quantity is set to 3
Adding the article again with amount 1: quantity will be reset to 1

Behaviour after this change:
Adding the article with amount 2: quantity in basket is set to 2
Adding the article again with amount 1: quantity is set to 3
Adding the article again with amount 1: quantity will be kept at 3

Another Scenario: laststock = true, instock = 5
Current behaviour:
Add the article with amount 2, do it again: Basket will add quantity auf 2 two times, resulting in 4
Add it again with amount 2: Basket-Quantity of this article will be reset to 2

After this change the amount in the Basket will be set to the maximum possible: 5
