### PR TITLE
Added smarty block to Shopware.apps.Config.model.CountryAttribute

### DIFF
--- a/themes/Backend/ExtJs/backend/config/model/form/country.js
+++ b/themes/Backend/ExtJs/backend/config/model/form/country.js
@@ -71,6 +71,7 @@ Ext.define('Shopware.apps.Config.model.CountryAttribute', {
     extend: 'Ext.data.Model',
 
     fields : [
+        //{block name="backend/config/model/form/country_attribute/fields"}{/block}
         { name: 'id', type: 'int' }
     ]
 });


### PR DESCRIPTION
This block is missing and needed for adding new attributes to the country model.
