### PR TITLE
add block definition for Shopware.component.Preloader

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.component.Preloader.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.component.Preloader.js
@@ -20,6 +20,7 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
+//{block name="backend/base/component/preloader"}
 Ext.define('Shopware.component.Preloader', {
 
     /**
@@ -173,3 +174,4 @@ Ext.define('Shopware.component.Preloader', {
         });
     }
 });
+//{/block}


### PR DESCRIPTION
We added a block definition for Shopware.component.Preloader.js. We need to modify / override the default preloaders behavior for plugin development purposes. 
