### PR TITLE
Property doesn't get found if ID is not integer

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -1610,7 +1610,9 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
                 $propertyValueModel = null;
                 if (is_array($value) && !empty($value["raw"])) {
                     $value = $value["raw"]["id"];
-                }
+                }elseif(is_array($value) && !isset($value["raw"])){
+					$value = (int)$value["id"];
+				}
                 if (is_int($value)) {
                     // search for property id
                     $propertyValueModel = $propertyValueRepository->find($value);

--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -1609,7 +1609,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
             foreach ((array)$property['value'] as $value) {
                 $propertyValueModel = null;
                 if (is_array($value) && !empty($value["raw"])) {
-                    $value = $value["raw"]["id"];
+                    $value = (int)$value["raw"]["id"];
                 }elseif(is_array($value) && !isset($value["raw"])){
 					$value = (int)$value["id"];
 				}


### PR DESCRIPTION
In some cases $value is array but $value["id"] is string.
So the propertyValueRepository can't find the correct property.

In my spedific case I wanted to change a property value of an article but after saving the value falls back to the previous. After this little changes everything works just fine.
