### PR TITLE
Fix first-line issue when plugin JS files get merged

### DIFF
--- a/engine/Shopware/Components/Plugin/Bootstrap.php
+++ b/engine/Shopware/Components/Plugin/Bootstrap.php
@@ -892,7 +892,11 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
         $regex = new \RegexIterator($directoryIterator,  '/^.+\.js$/i', \RecursiveRegexIterator::GET_MATCH);
         foreach ($regex as $file) {
             $path = 'backend/' . $file[0];
-            $view->extendsBlock('backend/Emotion/app', '{include file="'. $path .'"}', 'append');
+            $view->extendsBlock(
+                'backend/Emotion/app',
+                PHP_EOL . '{include file="'. $path .'"}',
+                'append'
+            );
         }
     }
 


### PR DESCRIPTION
This will fix an issue when several plugin javascript files are merged into a single compiled template file by Smarty.

Because the last line of the app.js is //{/block}, the first two characters for starting a comment will be in front of the first line of the next plugin JS file. Because comments will get removed afterwards, the first line of a plugin JS file will be completely removed.
So currently plugin developers always need to add a useless first line into their javascript files (most likely a comment) to make the plugin work.
This commit will fix this by adding a new line character between the merged files.
