### PR TITLE
Always display document number when available

### DIFF
--- a/themes/Backend/ExtJs/backend/order/view/list/document.js
+++ b/themes/Backend/ExtJs/backend/order/view/list/document.js
@@ -151,7 +151,7 @@ Ext.define('Shopware.apps.Order.view.list.Document', {
             display = '',
             type = record.getDocType().first();
 
-        if (record.get('typeId') === 4) {
+        if ( ! record.get('documentId')) {
             display = type.get('name');
         } else {
             display = type.get('name') + ' ' + Ext.String.leftPad(record.get('documentId'), 8, '0');


### PR DESCRIPTION
Currently showing the document number (column `docID` in `s_order_documents`) in the order documents tab in the backend is specifically disabled for document type `4` (correction of invoice). Shopware doesn't even generate it by default for this type, but a plugin like [Pickware](http://www.pickware.de) might want to.
With this PR it is simply displayed when it's present, which doesn't change Shopwares default behavior but allows to generate/display it if wanted.

This reopens #181.
