### PR TITLE
Update sExport.php

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -956,7 +956,7 @@ class sExport
                 pd.discount,
                 ROUND(CAST($pseudoprice*{$this->sCurrency["factor"]} AS DECIMAL(10,3)),2) as netpseudoprice,
                 ROUND(CAST($pseudoprice*(100+t.tax)*{$this->sCurrency["factor"]}/100 AS DECIMAL(10,3)),2) as pseudoprice,
-                $baseprice,
+                $baseprice as baseprice,
                 IF(file IS NULL,0,1) as esd
 
                 $sql_add_select


### PR DESCRIPTION
Change following line '$baseprice' to '$baseprice as baseprice,' which fix problems when you want access to baseprice in feeds.
Without it is baseprice register in SQL-Selecet as '$baseprice = "IFNULL(p2.baseprice, p.baseprice)";', in case when you don't use the default customergroup('EK').
