### PR TITLE
Update icon-set.less - fix styletile docs, rename progress-icon

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/icon-set.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/icon-set.less
@@ -88,7 +88,7 @@ Example: `<i class="icon--cart"></i>`
             </td>
 
             <td><i class="icon--numbered-list"></i><br/>
-                icon--numbered
+                icon--numbered-list
             </td>
 
             <td><i class="icon--menu"></i><br/>
@@ -503,8 +503,8 @@ Example: `<i class="icon--cart"></i>`
                 icon--progress-2
             </td>
 
-            <td><i class="icon--brogress-1"></i><br/>
-                icon--brogress-1
+            <td><i class="icon--progress-1"></i><br/>
+                icon--progress-1
             </td>
 
             <td><i class="icon--progress-0"></i><br/>
@@ -951,41 +951,41 @@ Example: `<i class="icon--cart"></i>`
             </td>
 
             <td><i class="icon--arrow-right4"></i><br/>
-                icon--right4
+                icon--arrow-right4
             </td>
 
             <td><i class="icon--arrow-left5"></i><br/>
-                icon--left5
+                icon--arrow-left5
             </td>
 
             <td><i class="icon--arrow-down5"></i><br/>
-                icon--down5
+                icon--arrow-down5
             </td>
 
             <td><i class="icon--arrow-up4"></i><br/>
-                icon--up4
+                icon--arrow-up4
             </td>
 
             <td><i class="icon--arrow-right5"></i><br/>
-                icon--right5
+                icon--arrow-right5
             </td>
         </tr>
 
         <tr>
             <td><i class="icon--arrow-left6"></i><br/>
-                icon--left6
+                icon--arrow-left6
             </td>
 
             <td><i class="icon--arrow-down6"></i><br/>
-                icon--down6
+                icon--arrow-down6
             </td>
 
             <td><i class="icon--arrow-up5"></i><br/>
-                icon--up5
+                icon--arrow-up5
             </td>
 
             <td><i class="icon--arrow-right6"></i><br/>
-                icon--right6
+                icon--arrow-right6
             </td>
 
             <td><i class="icon--menu2"></i><br/>
@@ -1636,6 +1636,10 @@ Example: `<i class="icon--cart"></i>`
 .icon--progress-2:before {
     content: "\e66c";
 }
+.icon--progress-1:before {
+    content: "\e66d";
+}
+/* for backwards-compatibility */
 .icon--brogress-1:before {
     content: "\e66d";
 }


### PR DESCRIPTION
The Styletile Docs have been updated to correctly indicate the names of certain icons.

Also the icon with the name `icon--brogress-1` has been renamed to `icon--progress-1` while preserving a copy of `brogress` for backwards-compatibility.
