### PR TITLE
Article Statistic: Calculate only Order Items with modus 0

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -4219,7 +4219,8 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
             MONTH(ordertime) as month,
             DATE_FORMAT(ordertime, '%Y-%m-%d') as date
             FROM s_order_details, s_order
-            WHERE articleID = :articleId
+            WHERE s_order_details.articleID = :articleId
+            AND s_order_details.modus = 0
             AND s_order.id = s_order_details.orderID
             AND s_order.status != 4
             AND s_order.status != -1


### PR DESCRIPTION
When a voucher has the same id as a article, it will be shown in the article statistics. That makes the revenue sum wrong. This pr should fix the problem
