### PR TITLE
Update jquery.state-manager.js to throw informative error

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
@@ -824,6 +824,10 @@
                 plugin = element.data('plugin_' + pluginName);
 
             if (!plugin) {
+                if(!element[pluginName]) {
+                    throw new Error('Plugin ' + pluginName + ' is not a valid jQuery-plugin!');
+                }
+
                 element[pluginName](currentConfig);
                 return;
             }


### PR DESCRIPTION
Checks whether a plugin which should be added actually exists.

Currently when a plugin is missing the javascript-execution halts with a cryptic:
`Uncaught TypeError: element[pluginName] is not a function` (in chrome) which doesn't say what plugin is missing. It actually reads this way.

This way there's also an error thrown which halts javascript-execution, but it reads like this:
`Uncaught Error: Plugin <pluginName> is not a valid jQuery-plugin!` Where `<pluginName>` is the name of the plugin missing.

This will help developers to better debug what plugin is missing.
