### PR TITLE
Add Event "Shopware_Modules_Admin_regenerateSessionId_Start"

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,7 @@
 In this document you will find a changelog of the important changes related to the code base of Shopware.
 
 ## 5.1.5
+* Added new Event `Shopware_Modules_Admin_regenerateSessionId_Start` in sAdmin::regenerateSessionId
 * The smarty variable `sCategoryInfo` in Listing and Blog controllers is now deprecated and will be removed soon. Use `sCategoryContent` instead, it's a drop in replacement. 
 
 ## 5.1.4

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -1333,6 +1333,13 @@ class sAdmin
     private function regenerateSessionId()
     {
         $oldSessionId = session_id();
+
+        if (Enlight()->Events()->notifyUntil('Shopware_Modules_Admin_regenerateSessionId_Start',
+            array('subject' => $this, 'sessionId' => $oldSessionId))) {
+
+            return false;
+        }
+
         session_regenerate_id(true);
         $newSessionId = session_id();
 


### PR DESCRIPTION
I am currently buildung a Plugin, which replaces the Zend_Session and uses the Session Class from Symfony HttpFoundation. But the regenerateSessionId function breaks my sessionId from Symfony Session. This PR adds a new NotifyUntil Event, which allows to cancel this action.
