### PR TITLE
Wrong JSON Fromat - Update Article.php

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -338,7 +338,7 @@ class Article extends Resource implements BatchInterface
     {
         $builder = $this->getManager()->createQueryBuilder();
         $builder->select(['categories.id', 'categories.name'])
-            ->from('Shopware\Models\Category\Category', 'categories', 'categories.id')
+            ->from('Shopware\Models\Category\Category', 'categories')
             ->innerJoin('categories.articles', 'articles')
             ->where('articles.id = :articleId')
             ->setParameter('articleId', $articleId);


### PR DESCRIPTION
Old: `[...] ,"categories":{"47":{"id":47,"name":"Text Category"},"118":{"id":118,"name":"Text Category"}}, [...]`
New: `[...] ,"categories":[{"id":47,"name":"Wartungsfreie Batterien"},{"id":118,"name":"Wartungsfreie Batterien"}], [...]`

documentation reference: [Article endpoint - Category](http://community.shopware.com/_detail_1681.html#Category)
