### PR TITLE
prevent a php warning due to the nature of max()

### DIFF
--- a/engine/Shopware/Models/Emotion/Library/Component.php
+++ b/engine/Shopware/Models/Emotion/Library/Component.php
@@ -715,7 +715,12 @@ class Component extends ModelEntity
                 function ($field) {return $field->getPosition();},
                 $this->getFields()->toArray()
             );
-            $this->maxFieldPositionValue = max($positions) ? : 0;
+
+            if (0 === count($positions)) {
+                $this->maxFieldPositionValue = 0;
+            } else {
+                $this->maxFieldPositionValue = max($positions);
+            }
         }
 
         return $this->maxFieldPositionValue;


### PR DESCRIPTION
Small PR to fix the following Warning:

PHP Warning:  max(): Array must contain at least one element in /engine/Shopware/Models/Emotion/Library/Component.php on line 718

Steps to Reproduce:

inside Bootstrap.php:

$component = $this->createEmotionComponent(array(
  'name' => 'Test'
  'template' => 'Test',
  'description' => 'A small test',
));
$component->createHiddenField([
  'name' => 'test_field',
  'defaultValue' => 'true'
]);
