### PR TITLE
Update Border Color of Fancy-Select Trigger

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/fields.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/fields.less
@@ -176,7 +176,7 @@ The plugin `jquery.selectbox-replacement.js` automaticly changes every `select` 
         position: absolute;
         right: 0;
         top: 0;
-        border-left: 1px solid @border-color;
+        border-left: 1px solid @btn-default-border-color;
         text-align: center;
         font-weight: bold;
     }


### PR DESCRIPTION
The trigger has to have the same border-color as the fancy-select itself. In order to prevent different colors when changing `@btn-default-border-color`.
