### PR TITLE
Added default snippet value "surcharge_name"

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -872,7 +872,7 @@ class sBasket
                 $surcharge = $minimumOrderSurcharge * $factor;
                 $surchargeName = $this->snippetManager
                     ->getNamespace('backend/static/discounts_surcharges')
-                    ->get('surcharge_name');
+                    ->get('surcharge_name', '#surcharge_name#');
 
                 $this->db->insert(
                     's_order_basket',


### PR DESCRIPTION
Due to the fact that Enlight_Components_Snippet_Namespace's method get() will return null as default (if not explicitly set) there will be an integrity constraint "articlename cannot be null" while trying to insert a surcharge article to the s_order_basket table.

Because in sBasket the snippet snippet backend/static/discounts_surcharges#surcharge_name will be used for the $surchargeName and no default/fallback value is set, an error occurs when the snippet does not exist (for example if snippets readFromDb has been set to false in the config.php before and no explicit snippet dump to ini has taken place). 

To avoid a null value in $surchargeName that ends up in an integrity constraint on inserting to database I did set a default value as second param to the get() method.
