### PR TITLE
[BUGFIX] add event to filter shippingaddress attributes params

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -1947,6 +1947,12 @@ class sAdmin
             $userObject["shipping"]["text5"],
             $userObject["shipping"]["text6"]
         );
+        $attributeParams = $this->eventManager->filter(
+            'Shopware_Modules_Admin_SaveRegisterShippingAttributes_FilterArray',
+            $attributeParams,
+            array('subject' => $this, 'user' => $userObject, 'id' => $userID)
+        );
+
         $saveAttributeData = $this->db->query($sqlAttributes, $attributeParams);
         $this->eventManager->notify(
             'Shopware_Modules_Admin_SaveRegisterShippingAttributes_Return',


### PR DESCRIPTION
Hey folks,
this event is missing if you want to save custom shipping attributes. There is an event to modify the sql, but not to modify the params. Now there is.

Regards,
Thomas
