### PR TITLE
Add service for retrieving next number from range (s_order_number)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -199,6 +199,11 @@ In this document you will find a changelog of the important changes related to t
 * Fixed Shopware.form.plugin.Translation, the plugin can now be used in multiple forms at the same time.
     * Removed `clear`, `onOpenTranslationWindow`, `getFieldValues` and `onGetTranslatableFields` function
 * `\Shopware\Bundle\StoreFrontBundle\Gateway\GraduatedPricesGatewayInterface` requires now a provided `ShopContextInterface`
+* Added service `shopware.number_range_manager` for safely retrieving the next number of a number range (`s_order_number`)
+* Changed the following methods to use the `shopware.number_range_manager` service for retrieving the next number of a range:
+    * `sAdmin::assignCustomerNumber()`
+    * `sOrder::sGetOrderNumber()`
+    * `Shopware_Components_Document::saveDocument()`
 
 
 ## 5.1.5

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -419,5 +419,9 @@
         </service>
 
         <service id="shopware_core.local_license_unpack_service" class="Shopware\Components\License\Service\LocalLicenseUnpackService" />
+
+        <service id="shopware.number_range_manager" class="Shopware\Components\NumberRangeManager">
+            <argument type="service" id="shopware.model_manager"/>
+        </service>
     </services>
 </container>

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -658,18 +658,14 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
                     $numberrange = "doc_".$typID;
                 }
 
-                $getNumber = Shopware()->Db()->fetchRow("
-                    SELECT `number`+1 as next FROM `s_order_number` WHERE `name` = ?", array($numberrange));
-
+                // Get the next number and save it in the document
+                $numberRangeManager = Shopware()->Container()->get('shopware.number_range_manager');
+                $nextNumber = $numberRangeManager->getNextNumber($numberrange);
                 Shopware()->Db()->query("
                     UPDATE `s_order_documents` SET `docID` = ? WHERE `ID` = ? LIMIT 1 ;
-                ", array($getNumber['next'], $rowID));
+                ", array($nextNumber, $rowID));
 
-                Shopware()->Db()->query("
-                    UPDATE `s_order_number` SET `number` = ? WHERE `name` = ? LIMIT 1 ;
-                ", array($getNumber['next'], $numberrange));
-
-                $bid = $getNumber["next"];
+                $bid = $nextNumber;
             }
         }
         $this->_documentID = $bid;

--- a/engine/Shopware/Components/NumberRangeManager.php
+++ b/engine/Shopware/Components/NumberRangeManager.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components;
+
+use Shopware\Components\Model\ModelManager;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Components\NumberRangeManager
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class NumberRangeManager
+{
+    /**
+     * @var ModelManager The entity manager
+     */
+    private $em;
+
+    /**
+     * @param ModelManager $em
+     */
+    public function __construct(ModelManager $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * @param string $name
+     * @return int
+     * @throws \Exception
+     */
+    public function getCurrentNumber($name)
+    {
+        $numberRange = $this->em->getRepository('Shopware\Models\Order\Number')->findOneBy([
+            'name' => $name
+        ]);
+        if (!$numberRange) {
+            throw new \Exception('Number range with name "' . $name . '" does not exist.');
+        }
+
+        return $numberRange->getNumber();
+    }
+
+    /**
+     * Fetches the number range with the given name and increases its value by one to the get
+     * the next number, which is than written back to the database. The fetch and update are performed
+     * within a transaction using 'locking reads' to block all other transactions from overwriting the
+     * value until the update is committed. Finally the next number is returned.
+     *
+     * @param string $name
+     * @return int
+     * @throws \Exception
+     */
+    public function getNextNumber($name)
+    {
+        // Begin a new transaction
+        $this->em->getConnection()->beginTransaction();
+        try {
+            // Select the number range with the given name using the 'PESSIMISTIC_WRITE' lock mode,
+            // which results in a 'SELECT ... FOR UPDATE' query
+            $builder = $this->em->createQueryBuilder();
+            $builder->select('numberRange')
+                ->from('Shopware\Models\Order\Number', 'numberRange')
+                ->where('numberRange.name = :name')
+                ->setParameter('name', $name);
+            $query = $builder->getQuery();
+            $query->setLockMode(\Doctrine\DBAL\LockMode::PESSIMISTIC_WRITE);
+            $numberRange = $query->getOneOrNullResult();
+            if (!$numberRange) {
+                $this->em->getConnection()->rollBack();
+                throw new \Exception(sprintf('Number range with name "%s" does not exist.', $name));
+            }
+
+            // Increase the number by one and write it back to the database
+            $nextNumber = $numberRange->getNumber() + 1;
+            $numberRange->setNumber($nextNumber);
+            $this->em->flush($numberRange);
+            $this->em->getConnection()->commit();
+        } catch (Exception $e) {
+            $this->em->getConnection()->rollBack();
+            throw $e;
+        }
+
+        return $nextNumber;
+    }
+}

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -26,6 +26,7 @@ use Shopware\Bundle\AccountBundle\Service\AddressServiceInterface;
 use Shopware\Bundle\AccountBundle\Service\AddressImportServiceInterface;
 use Shopware\Bundle\StoreFrontBundle;
 use Shopware\Components\Validator\EmailValidatorInterface;
+use Shopware\Components\NumberRangeManager;
 use Shopware\Models\Customer\Address;
 
 /**
@@ -139,6 +140,11 @@ class sAdmin
      */
     private $addressService;
 
+    /**
+     * @var NumberRangeManager
+     */
+    private $numberRangeManager;
+
     public function __construct(
         Enlight_Components_Db_Adapter_Pdo_Mysql          $db                    = null,
         Enlight_Event_EventManager                       $eventManager          = null,
@@ -152,7 +158,8 @@ class sAdmin
         StoreFrontBundle\Service\ContextServiceInterface $contextService        = null,
         EmailValidatorInterface                          $emailValidator        = null,
         AddressImportServiceInterface                    $addressImportService  = null,
-        AddressServiceInterface                          $addressService        = null
+        AddressServiceInterface                          $addressService        = null,
+        NumberRangeManager                               $numberRangeManager    = null
     ) {
         $this->db = $db ? : Shopware()->Db();
         $this->eventManager = $eventManager ? : Shopware()->Events();
@@ -172,6 +179,7 @@ class sAdmin
         $this->subshopId = $this->contextService->getShopContext()->getShop()->getParentId();
         $this->addressImportService = $addressImportService ? : Shopware()->Container()->get('shopware_account.address_import_service');
         $this->addressService = $addressService ? : Shopware()->Container()->get('shopware_account.address_service');
+        $this->numberRangeManager = $numberRangeManager ? : Shopware()->Container()->get('shopware.number_range_manager');
     }
 
     /**
@@ -4480,27 +4488,22 @@ SQL;
     }
 
     /**
-     * Assigns the next CustomerNumber from s_order_number
-     * to given $userId and updates s_order_number
-     * in an atomic operation.
+     * Assigns the next available customer ('user') number to the customer
+     * with the given ID.
      *
      * @param int $userId
      */
     private function assignCustomerNumber($userId)
     {
-        $sql = <<<SQL
-UPDATE
-    s_order_number,
-    s_user_billingaddress
-SET
-    s_order_number.number = s_order_number.number+1,
-    s_user_billingaddress.customernumber = s_order_number.number
-WHERE
-    s_order_number.name = 'user'
-AND
-    s_user_billingaddress.userID = ?
-SQL;
-
-        $this->db->query($sql, array($userId));
+        $nextNumber = $this->numberRangeManager->getNextNumber('user');
+        $this->db->query(
+           'UPDATE s_user_billingaddress
+            SET customernumber = ?
+            WHERE userID = ?',
+            [
+                $nextNumber,
+                $userId
+            ]
+        );
     }
 }

--- a/tests/Functional/Components/NumberRangeManagerTest.php
+++ b/tests/Functional/Components/NumberRangeManagerTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Components;
+
+use Shopware\Components\NumberRangeManager;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Tests\Components
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class NumberRangeManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Shopware\Components\Model\ModelManager
+     */
+    public $em;
+
+    /**
+     * @var \Zend_Db_Adapter_Pdo_Abstract
+     */
+    public $db;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->em = Shopware()->Models();
+        $this->db = Shopware()->Db();
+    }
+
+    public function testGetCurrentNumber()
+    {
+        // Fetch actual number from DB
+        $rangeName = 'invoice';
+        $expectedNumber = $this->db->fetchOne(
+           'SELECT number
+            FROM s_order_number
+            WHERE name = ?',
+            array(
+                $rangeName
+            )
+        );
+
+        $manager = new NumberRangeManager($this->em);
+
+        $currentNumber = $manager->getCurrentNumber($rangeName);
+
+        $this->assertEquals($expectedNumber, $currentNumber);
+    }
+
+    public function testGetNextNumber()
+    {
+        $manager = new NumberRangeManager($this->em);
+
+        $rangeName = 'invoice';
+        $currentNumber = $manager->getCurrentNumber($rangeName);
+        $nextNumber = $manager->getNextNumber($rangeName);
+
+        $this->assertEquals(($currentNumber + 1), $nextNumber);
+    }
+}


### PR DESCRIPTION
Previously there existed three different ways to get the next number of a number range (`s_order_number`) from the database and save it back. However, two of them were not safe and might resulted in using the same number twice due to a lack of locking the `s_order_number` table. This PR adds a new service `shopware.number_range_manager`, which can be used to safely retrieve the current and next number of a range by just passing its name. Furthermore it makes use of that service in three places, which previously used a separate (potentially unsafe) implementation to get the next number:
- Customer creation (via shop frontend)
- Order creation
- Order document creation

This PR does not introduce any breaking changes.

**Note:** The new `shopware.number_range_manager` service can only be used in places, where it's possible to create a new transaction. Hence it doesn't work in Doctrine hooks, e.g. [Shopware\Models\Customer\Billing::onSave()](https://github.com/shopware/shopware/blob/6c6fdcdb11cd8c9a30076d0e394bc48118b4fdee/engine/Shopware/Models/Customer/Billing.php#L580-L597). That said, the code that requires this specific hook (most likely the customer creation via the Shopware backend) should probably be refactored to make `Shopware\Models\Customer\Billing::onSave()` obsolete.
