### PR TITLE
Fix initialization of attribute fields having default values

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -199,6 +199,7 @@ In this document you will find a changelog of the important changes related to t
 * Fixed Shopware.form.plugin.Translation, the plugin can now be used in multiple forms at the same time.
     * Removed `clear`, `onOpenTranslationWindow`, `getFieldValues` and `onGetTranslatableFields` function
 * `\Shopware\Bundle\StoreFrontBundle\Gateway\GraduatedPricesGatewayInterface` requires now a provided `ShopContextInterface`
+* Added creation of custom `__construct()` method to `Shopware\Components\Model\Generator`, which initializes any default values of properties when generating attribute models
 
 
 ## 5.1.5

--- a/tests/Functional/Components/Model/GeneratorTest.php
+++ b/tests/Functional/Components/Model/GeneratorTest.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Components;
+
+use Shopware\Components\Model\Generator;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Tests\Components
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class GeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_TABLE_NAME = 's_articles_attributes';
+    const TEST_ATTRIBUTE_FIELD_PREFIX = 'test';
+    const TEST_ATTRIBUTE_FIELD_NAME = 'not_null_default_value_field';
+    const TEST_ATTRIBUTE_PROPERTY_NAME = 'testNotNullDefaultValueField';
+
+    /**
+     * @var \Shopware\Components\Model\ModelManager
+     */
+    public $em;
+
+    /**
+     * @var \Shopware\Components\Model\Generator
+     */
+    public $generator;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->em = Shopware()->Models();
+        $this->generator = new Generator(
+            $this->em->getConnection()->getSchemaManager(),
+            $this->em->getConfiguration()->getAttributeDir(),
+            Shopware()->AppPath('Models')
+        );
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->em->removeAttribute(
+            self::TEST_TABLE_NAME,
+            self::TEST_ATTRIBUTE_FIELD_PREFIX,
+            self::TEST_ATTRIBUTE_FIELD_NAME
+        );
+    }
+
+    public function testDefaultInitializationString()
+    {
+        $default = 'test 123';
+        $this->addAndEvaluateInitialization(
+            'VARCHAR(255)',
+            $default,
+            '"'.$default.'"'
+        );
+    }
+
+    public function testDefaultInitializationInteger()
+    {
+        $default = 123;
+        $this->addAndEvaluateInitialization(
+            'INT(11)',
+            $default,
+            $default
+        );
+    }
+
+    public function testDefaultInitializationBooleanTrue()
+    {
+        $this->addAndEvaluateInitialization(
+            'TINYINT(1)',
+            1,
+            'true'
+        );
+    }
+
+    public function testDefaultInitializationBooleanFalse()
+    {
+        $this->addAndEvaluateInitialization(
+            'TINYINT(1)',
+            0,
+            'false'
+        );
+    }
+
+    public function testDefaultInitializationFloat()
+    {
+        $default = 123.45;
+        $this->addAndEvaluateInitialization(
+            'DECIMAL(10,2)',
+            $default,
+            $default
+        );
+    }
+
+    public function testDefaultInitializationDate()
+    {
+        $default = '2016-01-02';
+        $this->addAndEvaluateInitialization(
+            'DATE',
+            $default,
+            'new \DateTime("'.$default.'")'
+        );
+    }
+
+    public function testDefaultInitializationDateTime()
+    {
+        $default = '2016-01-02 12:13:14';
+        $this->addAndEvaluateInitialization(
+            'DATETIME',
+            $default,
+            'new \DateTime("'.$default.'")'
+        );
+    }
+
+    public function testDefaultInitializationNotNullConstraint()
+    {
+        $default = 'test 123 with not NULL constraint';
+        $this->addAndEvaluateInitialization(
+            'VARCHAR(255)',
+            $default,
+            '"'.$default.'"',
+            false
+        );
+    }
+
+    public function testDefaultInitializationTwoProperties()
+    {
+        // Add two attribute fields
+        $firstDefault = 'test 123';
+        $this->em->addAttribute(
+            self::TEST_TABLE_NAME,
+            self::TEST_ATTRIBUTE_FIELD_PREFIX,
+            self::TEST_ATTRIBUTE_FIELD_NAME,
+            'VARCHAR(255)',
+            false,
+            $firstDefault
+        );
+        $secondDefault = 123;
+        $this->em->addAttribute(
+            self::TEST_TABLE_NAME,
+            self::TEST_ATTRIBUTE_FIELD_PREFIX,
+            self::TEST_ATTRIBUTE_FIELD_NAME.'_two',
+            'INT(11)',
+            false,
+            $secondDefault
+        );
+
+        // Generate updated attribute source code
+        $modelSourceCode = $this->generator->getSourceCodeForTable(self::TEST_TABLE_NAME);
+
+        $initialization = '
+    public function __construct()
+    {
+        $this->'.self::TEST_ATTRIBUTE_PROPERTY_NAME.' = "'.$firstDefault.'";
+        $this->'.self::TEST_ATTRIBUTE_PROPERTY_NAME.'Two = '.$secondDefault.';
+    }';
+        $this->assertTrue(strpos($modelSourceCode, $initialization) !== false);
+
+        // Clean up second field
+        $this->em->removeAttribute(
+            self::TEST_TABLE_NAME,
+            self::TEST_ATTRIBUTE_FIELD_PREFIX,
+            self::TEST_ATTRIBUTE_FIELD_NAME.'_two'
+        );
+    }
+
+    /**
+     * @param string $type
+     * @param string|int|float|boolean $default
+     * @param string $initializedValue
+     * @param boolean $allowNull (optional)
+     */
+    private function addAndEvaluateInitialization($type, $default, $initializedValue, $allowNull = true)
+    {
+        // Add attribute field
+        $this->em->addAttribute(
+            self::TEST_TABLE_NAME,
+            self::TEST_ATTRIBUTE_FIELD_PREFIX,
+            self::TEST_ATTRIBUTE_FIELD_NAME,
+            $type,
+            $allowNull,
+            $default
+        );
+
+        // Generate updated attribute source code
+        $modelSourceCode = $this->generator->getSourceCodeForTable(self::TEST_TABLE_NAME);
+
+        $initialization = '
+    public function __construct()
+    {
+        $this->'.self::TEST_ATTRIBUTE_PROPERTY_NAME.' = '.$initializedValue.';
+    }';
+        $this->assertTrue(strpos($modelSourceCode, $initialization) !== false);
+    }
+}


### PR DESCRIPTION
It has always been possible to add a default value to attribute fields. However, previously these fields were not initialized with the respective default value when creating a new entity instance. Hence, when adding an attribute field that used a combination of a not NULL constraint and a default value, one always had to explicitly initialize the fields when creating the instance to avoid integrity constraint violations. This commit fixes this behaviour by adding a constructor to the generated attribute models, which explicitly initializes all properties with a configured default value.

This PR does not introduce any breaking changes.
