### PR TITLE
Validate order number when creating variant using REST API

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -200,6 +200,7 @@ In this document you will find a changelog of the important changes related to t
     * Removed `clear`, `onOpenTranslationWindow`, `getFieldValues` and `onGetTranslatableFields` function
 * `\Shopware\Bundle\StoreFrontBundle\Gateway\GraduatedPricesGatewayInterface` requires now a provided `ShopContextInterface`
 * Moved `<form>` element in checkout confirm outside the agreement box to wrap around address and payment boxes
+* Added validation of order number to `Shopware\Components\Api\Resource\Variant::prepareData()` to respond with meaningful error message for duplicate order numbers
 
 
 ## 5.1.5

--- a/tests/Functional/Components/Api/VariantTest.php
+++ b/tests/Functional/Components/Api/VariantTest.php
@@ -245,6 +245,28 @@ class VariantTest extends TestCase
 
     /**
      * @depends testCreateShouldBeSuccessful
+     * @expectedException \Shopware\Components\Api\Exception\CustomValidationException
+     * @param \Shopware\Models\Article\Article $article
+     */
+    public function testCreateWithExistingOrderNumberShouldThrowCustomValidationException(\Shopware\Models\Article\Article $article)
+    {
+        $testData = [
+            'articleId' => $article->getId(),
+            'number' => $article->getMainDetail()->getNumber(),
+            'prices' => [
+                [
+                    'customerGroupKey' => 'EK',
+                    'price' => 100,
+                    'basePrice' => 50
+                ]
+            ]
+        ];
+
+        $this->resource->create($testData);
+    }
+
+    /**
+     * @depends testCreateShouldBeSuccessful
      * @param \Shopware\Models\Article\Article $article
      * @return \Shopware\Models\Article\Article
      */


### PR DESCRIPTION
When previously trying to create a variant using the REST API and passing a `number` that already exists in the database, the response was a `500 Internal Server Error` with the JSON message being the SQL error. This PR adds an explicit validation of the passed order number that checks whether it is already used by another existing variant. If already used, a `CustomValidationException` with a meaningful message is thrown, which results in a `400 Bad Request` response.

This PR does not introduce any breaking changes.
