### PR TITLE
Grunt: use chokidar instead of grunt-contrib-watch

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -201,7 +201,7 @@ In this document you will find a changelog of the important changes related to t
 * `\Shopware\Bundle\StoreFrontBundle\Gateway\GraduatedPricesGatewayInterface` requires now a provided `ShopContextInterface`
 * Categories of `Shopware\Components\Api\Resource\Article::getArticleCategories($articleId)` are no longer indexed by category id
 * Moved `<form>` element in checkout confirm outside the agreement box to wrap around address and payment boxes
-
+* Grunt now using [grunt-chokidar](https://github.com/JimRobs/grunt-chokidar) instead of [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch) for watching files, in order to catch events like file-adds. Also speed-up of watch-task.
 
 ## 5.1.5
 * The smarty variable `sCategoryInfo` in Listing and Blog controllers is now deprecated and will be removed soon. Use `sCategoryContent` instead, it's a drop in replacement. 

--- a/themes/Gruntfile.js
+++ b/themes/Gruntfile.js
@@ -70,14 +70,20 @@ module.exports = function (grunt) {
                     '../engine/Shopware/Plugins/**/*.less',
                     '../themes/Frontend/**/*.less'
                 ],
-                tasks: ['less:development']
+                tasks: ['less:development'],
+                options: {
+                    spawn: false
+                }
             },
             js: {
                 files: [
                     '../themes/Frontend/**/_public/src/js/*.js',
                     '../engine/Shopware/Plugins/**/frontend/**/src/js/**/*.js'
                 ],
-                tasks: ['uglify:development']
+                tasks: ['uglify:development'],
+                options: {
+                    spawn: false
+                }
             }
         },
         jshint: {
@@ -98,10 +104,11 @@ module.exports = function (grunt) {
     });
 
     grunt.loadNpmTasks('grunt-contrib-less');
-    grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-chokidar');
 
+    grunt.renameTask('chokidar', 'watch');
     grunt.registerTask('production', [ 'jshint', 'less:production', 'uglify:production' ]);
     grunt.registerTask('default', [ 'less:development', 'uglify:development', 'watch' ]);
 };

--- a/themes/package.json
+++ b/themes/package.json
@@ -5,6 +5,6 @@
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-less": "^1.0.1",
     "grunt-contrib-uglify": "^0.9.1",
-    "grunt-contrib-watch": "^0.6.1"
+    "grunt-chokidar": "^1.0.0"
   }
 }


### PR DESCRIPTION
grunt-contrib-watch has some serious flaws, especially when using vagrant-boxes. Developers should not have to work for their tools, the tools should work for them!

_[grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch) is based on [gaze](https://github.com/shama/gaze/)_
_[grunt-chokidar](https://github.com/JimRobs/grunt-chokidar) is a fork of grunt-contrib-watch (pretty much compatible) based on [chokidar](https://github.com/paulmillr/chokidar)_
## What this change does:
- Use [grunt-chokidar](https://github.com/JimRobs/grunt-chokidar) instead of [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch)
- Work around problems like not catching file-added events.
- Use the option `spawn: false` to speed up tasks, by eliminating the ~500ms delay, which comes when spawning tasks instead of just running them. I have tested this for a whole day of frontend-work without issues. Notable speed-up!
- Rename the chokidar-task to watch, so no compatibility-issues arise
## Why chokidar over gaze:

_stolen from the chokidar project-page_

> Node.js `fs.watch`:
> - Doesn't report filenames on OS X.
> - Doesn't report events at all when using editors like Sublime on OS X.
> - Often reports events twice.
> - Emits most changes as `rename`.
> - Has [a lot of other issues](https://github.com/joyent/node/search?q=fs.watch&type=Issues)
> - Does not provide an easy way to recursively watch file trees.
> 
> Node.js `fs.watchFile`:
> - Almost as bad at event handling.
> - Also does not provide any recursive watching.
> - Results in high CPU utilization.
> 
> Chokidar resolves these problems.
## What will be broken:

**Nothing**
