### PR TITLE
introduce variables for column count in masonry emotions

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/emotions.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/emotions.less
@@ -5,6 +5,11 @@ Contains the basic styles for the Shopware 5 shopping worlds and its elements.
 
 Shopware 5 provides 11 integrated elements inside the shopping worlds that can be chosen and modified inside the backend shopping world editor such as sliders, video elements and blog-articles.
 */
+
+@emotionsMasonryColumnsPhoneLandscape: 2;
+@emotionsMasonryColumnsTablet: 3;
+@emotionsMasonryColumnsTabletLandscape: 3;
+
 .createColumnSizes(@n, @i: 1) when (@i =< @n) {
 
     &.emotion--mode-resize {
@@ -20,7 +25,7 @@ Shopware 5 provides 11 integrated elements inside the shopping worlds that can b
     }
 
     @media screen and(min-width: @phoneLandscapeViewportWidth) {
-        @columns: 2;
+        @columns: @emotionsMasonryColumnsPhoneLandscape;
         &.emotion--mode-masonry {
             &.emotion--column-@{n} .column--@{i} when (@i <= @columns) {
                 width: (100% / @columns * @i);
@@ -29,7 +34,7 @@ Shopware 5 provides 11 integrated elements inside the shopping worlds that can b
     }
 
     @media screen and(min-width: @tabletViewportWidth) {
-        @columns: 3;
+        @columns: @emotionsMasonryColumnsTablet;
         &.emotion--mode-masonry {
             &.emotion--column-@{n} .column--@{i} when (@i <= @columns) {
                 width: (100% / @columns * @i);
@@ -38,7 +43,7 @@ Shopware 5 provides 11 integrated elements inside the shopping worlds that can b
     }
 
     @media screen and(min-width: @tabletLandscapeViewportWidth) {
-        @columns: 3;
+        @columns: @emotionsMasonryColumnsTabletLandscape;
         &.emotion--mode-masonry {
             &.emotion--column-@{n} .column--@{i} when (@i <= @columns) {
                 width: (100% / @columns * @i);


### PR DESCRIPTION
Make column count in masonry emotion worlds configurable, so you can define the column count by setting a LESS variable in your own theme.

No BC breaks as the default values are the old ones.

see also: http://forum.shopware.com/discussion/34740/override-einkaufswelt-spalten-anpassen-fuer-masonry-in-emotion-less
