### PR TITLE
Add 'countries' API endpoint and resource

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -202,6 +202,7 @@ In this document you will find a changelog of the important changes related to t
 * Categories of `Shopware\Components\Api\Resource\Article::getArticleCategories($articleId)` are no longer indexed by category id
 * Moved `<form>` element in checkout confirm outside the agreement box to wrap around address and payment boxes
 * Removed smarty variable `sCategoryInfo` in listing and blog controllers. Use `sCategoryContent` instead. 
+* Added new API resource 'Country' and respective REST API controller 'countries'
 
 ## 5.1.5
 * The smarty variable `sCategoryInfo` in Listing and Blog controllers is now deprecated and will be removed soon. Use `sCategoryContent` instead, it's a drop in replacement. 

--- a/engine/Shopware/Components/Api/Resource/Country.php
+++ b/engine/Shopware/Components/Api/Resource/Country.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Api\Resource;
+
+use Shopware\Components\Api\Exception as ApiException;
+
+/**
+ * Country API Resource
+ *
+ * @category  Shopware
+ * @package   Shopware\Components\Api\Resource
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class Country extends Resource
+{
+    /**
+     * @return \Doctrine\ORM\EntityRepository
+     */
+    public function getRepository()
+    {
+        return $this->getManager()->getRepository('Shopware\Models\Country\Country');
+    }
+
+    /**
+     * Returns the data of the Country with the given ID.
+     *
+     * @param int $id
+     * @return array|\Shopware\Models\Country\Country
+     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
+     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     */
+    public function getOne($id)
+    {
+        $this->checkPrivilege('read');
+
+        if (empty($id)) {
+            throw new ApiException\ParameterMissingException('id');
+        }
+
+        $filters = [
+            [
+                'property' => 'countries.id',
+                'expression' => '=',
+                'value' => $id
+            ]
+        ];
+        $builder = $this->getRepository()->getCountriesWithStatesQueryBuilder($filters);
+        /** @var $country \Shopware\Models\Country\Country */
+        $country = $builder->getQuery()->getOneOrNullResult($this->getResultMode());
+        if (!$country) {
+            throw new ApiException\NotFoundException("Country by id $id not found");
+        }
+
+        return $country;
+    }
+
+    /**
+     * Returns an array containing the total count of existing countries as well as the data of countries
+     * that match the given criteria.
+     *
+     * @param int $offset
+     * @param int $limit
+     * @param array $criteria
+     * @param array $orderBy
+     * @return array
+     */
+    public function getList($offset = 0, $limit = 25, array $criteria = array(), array $orderBy = array())
+    {
+        $this->checkPrivilege('read');
+
+        // Build query
+        $builder = $this->getRepository()->getCountriesWithStatesQueryBuilder();
+        $builder->addFilter($criteria)
+                ->addOrderBy($orderBy)
+                ->setFirstResult($offset)
+                ->setMaxResults($limit);
+
+        // Set hydration mode
+        $query = $builder->getQuery();
+        $query->setHydrationMode($this->getResultMode());
+
+        // Get result
+        $paginator = $this->getManager()->createPaginator($query);
+        $totalResult = $paginator->count();
+        $countries = $paginator->getIterator()->getArrayCopy();
+
+        return [
+            'data' => $countries,
+            'total' => $totalResult
+        ];
+    }
+
+    /**
+     * Creates a new Country entity using the passed params.
+     *
+     * @param array $params
+     * @return \Shopware\Models\Country\Country
+     * @throws \Shopware\Components\Api\Exception\ValidationException
+     */
+    public function create(array $params)
+    {
+        $this->checkPrivilege('create');
+
+        $params = $this->prepareCountryData($params);
+
+        $country = new \Shopware\Models\Country\Country();
+        $country->fromArray($params);
+
+        $violations = $this->getManager()->validate($country);
+        if ($violations->count() > 0) {
+            throw new ApiException\ValidationException($violations);
+        }
+
+        $this->getManager()->persist($country);
+        $this->flush();
+
+        return $country;
+    }
+
+    /**
+     * Updates the Country entity with the given ID using the passed params.
+     *
+     * @param int $id
+     * @param array $params
+     * @return \Shopware\Models\Country\Country
+     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
+     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     * @throws \Shopware\Components\Api\Exception\ValidationException
+     */
+    public function update($id, array $params)
+    {
+        $this->checkPrivilege('update');
+
+        if (empty($id)) {
+            throw new ApiException\ParameterMissingException('id');
+        }
+
+        /** @var $country \Shopware\Models\Country\Country */
+        $country = $this->getRepository()->find($id);
+        if (!$country) {
+            throw new ApiException\NotFoundException("Country by id $id not found");
+        }
+
+        $params = $this->prepareCountryData($params, $country);
+        $country->fromArray($params);
+
+        $violations = $this->getManager()->validate($country);
+        if ($violations->count() > 0) {
+            throw new ApiException\ValidationException($violations);
+        }
+
+        $this->flush();
+
+        return $country;
+    }
+
+    /**
+     * Deletes the Country entity with the given ID.
+     *
+     * @param int $id
+     * @return \Shopware\Models\Country\Country
+     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
+     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     */
+    public function delete($id)
+    {
+        $this->checkPrivilege('delete');
+
+        if (empty($id)) {
+            throw new ApiException\ParameterMissingException('id');
+        }
+
+        /** @var $country \Shopware\Models\Country\Country */
+        $country = $this->getRepository()->find($id);
+        if (!$country) {
+            throw new ApiException\NotFoundException("Country by id $id not found");
+        }
+
+        $this->getManager()->remove($country);
+        $this->flush();
+
+        return $country;
+    }
+
+    /**
+     * @param array $params
+     * @param \Shopware\Models\Country\Country $country
+     * @return array
+     * @throws \Shopware\Components\Api\Exception\CustomValidationException
+     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
+     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     */
+    private function prepareCountryData(array $params, \Shopware\Models\Country\Country $country = null)
+    {
+        $requiredParams = [
+            'name',
+            'iso',
+            'iso3',
+            'isoName'
+        ];
+        foreach ($requiredParams as $param) {
+            if (!$country) {
+                if (!isset($params[$param]) || empty($params[$param])) {
+                    throw new ApiException\ParameterMissingException($param);
+                }
+            } else {
+                if (isset($params[$param]) && empty($params[$param])) {
+                    throw new ApiException\CustomValidationException("Param $param may not be empty");
+                }
+            }
+        }
+
+        if (isset($params['areaId'])) {
+            $area = $this->getManager()->find('\Shopware\Models\Country\Area', $params['areaId']);
+            if ($area) {
+                $params['area'] = $area;
+            } else {
+                throw new ApiException\NotFoundException("Area by id {$params['areaId']} not found");
+            }
+        }
+
+        $params = $this->prepareCountryStatesData($params);
+
+        return $params;
+    }
+
+    /**
+     * @param array $params
+     * @return array
+     * @throws \Shopware\Components\Api\Exception\CustomValidationException
+     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
+     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     */
+    private function prepareCountryStatesData(array $params)
+    {
+        if (!isset($params['states']) || !is_array($params['states'])) {
+            return $params;
+        }
+
+        foreach ($params['states'] as &$state) {
+            if (!isset($state['id']) || empty($state['id'])) {
+                throw new ApiException\CustomValidationException('You need to specify the id of the state you want to modify');
+            }
+
+            // Find the state
+            /** @var \Shopware\Models\Country\State $stateModel */
+            $stateModel = $this->getManager()->find('Shopware\Models\Country\State', $state['id']);
+            if (!$stateModel) {
+                throw new ApiException\NotFoundException("State by id {$state['id']} not found");
+            }
+
+            // Update state
+            $stateModel->fromArray($state);
+            $state = $stateModel;
+        }
+
+        return $params;
+    }
+}

--- a/engine/Shopware/Components/Api/Resource/Translation.php
+++ b/engine/Shopware/Components/Api/Resource/Translation.php
@@ -32,7 +32,6 @@ use Shopware\Models\Article\Configurator\Group as ConfiguratorGroup;
 use Shopware\Models\Article\Configurator\Option as ConfiguratorOption;
 use Shopware\Models\Article\Detail;
 use Shopware\Models\Article\Supplier;
-use Shopware\Models\Country\Country;
 use Shopware\Models\Country\State;
 use Shopware\Models\Dispatch\Dispatch;
 use Shopware\Models\Payment\Payment;

--- a/engine/Shopware/Controllers/Api/Countries.php
+++ b/engine/Shopware/Controllers/Api/Countries.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Shopware_Controllers_Api_Countries extends Shopware_Controllers_Api_Rest
+{
+    /**
+     * @var \Shopware\Components\Api\Resource\Country
+     */
+    protected $resource = null;
+
+    public function init()
+    {
+        $this->resource = \Shopware\Components\Api\Manager::getResource('country');
+    }
+
+    /**
+     * Get list of countries
+     *
+     * GET /api/countries
+     */
+    public function indexAction()
+    {
+        $limit  = $this->Request()->getParam('limit', 1000);
+        $offset = $this->Request()->getParam('start', 0);
+        $sort = $this->Request()->getParam('sort', []);
+        $filter = $this->Request()->getParam('filter', []);
+
+        $result = $this->resource->getList($offset, $limit, $filter, $sort);
+
+        $this->View()->assign($result);
+        $this->View()->assign('success', true);
+    }
+
+    /**
+     * Get one country
+     *
+     * GET /api/countries/{id}
+     */
+    public function getAction()
+    {
+        $id = $this->Request()->getParam('id');
+
+        $country = $this->resource->getOne($id);
+
+        $this->View()->assign('data', $country);
+        $this->View()->assign('success', true);
+    }
+
+    /**
+     * Create country
+     *
+     * POST /api/countries
+     */
+    public function postAction()
+    {
+        $params = $this->Request()->getPost();
+
+        $country = $this->resource->create($params);
+
+        $location = $this->apiBaseUrl . 'countries/' . $country->getId();
+        $data = [
+            'id' => $country->getId(),
+            'location' => $location
+        ];
+
+        $this->View()->assign('data', $data);
+        $this->View()->assign('success', true);
+    }
+
+    /**
+     * Update country
+     *
+     * PUT /api/countries/{id}
+     */
+    public function putAction()
+    {
+        $id = $this->Request()->getParam('id');
+        $params = $this->Request()->getPost();
+
+        $country = $this->resource->update($id, $params);
+
+        $location = $this->apiBaseUrl . 'countries/' . $country->getId();
+        $data = [
+            'id' => $country->getId(),
+            'location' => $location
+        ];
+
+        $this->View()->assign('data', $data);
+        $this->View()->assign('success', true);
+    }
+
+    /**
+     * Delete country
+     *
+     * DELETE /api/countries/{id}
+     */
+    public function deleteAction()
+    {
+        $id = $this->Request()->getParam('id');
+
+        $this->resource->delete($id);
+
+        $this->View()->assign('success', true);
+    }
+}

--- a/engine/Shopware/Models/Country/Country.php
+++ b/engine/Shopware/Models/Country/Country.php
@@ -139,14 +139,14 @@ class Country extends ModelEntity
     *
     * @ORM\Column(name="display_state_in_registration", type="boolean", nullable=false)
     */
-    private $displayStateInRegistration;
+    private $displayStateInRegistration = false;
 
     /**
     * @var integer $forceStateInRegistration
     *
     * @ORM\Column(name="force_state_in_registration", type="boolean", nullable=false)
     */
-    private $forceStateInRegistration;
+    private $forceStateInRegistration = false;
 
     /**
      * @var \Doctrine\Common\Collections\ArrayCollection
@@ -194,8 +194,6 @@ class Country extends ModelEntity
 
     public function __construct()
     {
-        $this->displayStateInRegistration = false;
-        $this->forceStateInRegistration = false;
         $this->payments = new ArrayCollection();
         $this->states = new ArrayCollection();
     }

--- a/engine/Shopware/Models/Country/Country.php
+++ b/engine/Shopware/Models/Country/Country.php
@@ -26,6 +26,7 @@ namespace   Shopware\Models\Country;
 
 use Shopware\Components\Model\ModelEntity;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  *
@@ -190,6 +191,14 @@ class Country extends ModelEntity
      * @ORM\Column(name="areaID", type="integer", nullable=false)
      */
     private $areaId;
+
+    public function __construct()
+    {
+        $this->displayStateInRegistration = false;
+        $this->forceStateInRegistration = false;
+        $this->payments = new ArrayCollection();
+        $this->states = new ArrayCollection();
+    }
 
     /**
      * Get id

--- a/engine/Shopware/Models/Country/Repository.php
+++ b/engine/Shopware/Models/Country/Repository.php
@@ -91,6 +91,33 @@ class Repository extends ModelRepository
     }
 
     /**
+     * @param array|null $filter
+     * @param array|null $order
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    public function getCountriesWithStatesQueryBuilder($filter = null, $order = null)
+    {
+        $builder = $this->getEntityManager()->createQueryBuilder();
+
+        $builder->select(
+            'countries',
+            'states'
+        );
+        $builder->from('Shopware\Models\Country\Country', 'countries')
+        ->leftJoin('countries.states', 'states');
+
+        if ($filter !== null) {
+            $builder->addFilter($filter);
+        }
+
+        if ($order !== null) {
+            $builder->addOrderBy($order);
+        }
+
+        return $builder;
+    }
+
+    /**
      * Returns an instance of \Doctrine\ORM\Query object which selects a
      * list of countries for the passed area id.
      * @param $areaId

--- a/tests/Functional/Components/Api/CountryTest.php
+++ b/tests/Functional/Components/Api/CountryTest.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Components\Api;
+
+use Shopware\Components\Api\Resource\Country;
+use Shopware\Models\Country\State;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Tests
+ * @copyright Copyright (c) 2013, shopware AG (http://www.shopware.de)
+ */
+class CountryTest extends TestCase
+{
+    /**
+     * @var \Shopware\Components\Api\Resource\Country
+     */
+    protected $resource;
+
+    /**
+     * @var array
+     */
+    private static $existingCountryIds = 0;
+
+    /**
+     * @var array
+     */
+    private static $existingStatesIds = 0;
+
+    /**
+     * @return \Shopware\Components\Api\Resource\Country
+     */
+    public function createResource()
+    {
+        return new Country();
+    }
+
+    /**
+     * Saves the IDs of currently existing countries and states.
+     */
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        static::$existingCountryIds = Shopware()->Db()->fetchCol(
+           'SELECT id
+            FROM s_core_countries'
+        );
+        static::$existingStatesIds = Shopware()->Db()->fetchCol(
+           'SELECT id
+            FROM s_core_countries_states'
+        );
+    }
+
+    /**
+     * Restores the state of the 's_core_countries' and 's_core_countries_states' tables
+     * by deleting all entries added by this class.
+     */
+    public static function tearDownAfterClass()
+    {
+        parent::setUpBeforeClass();
+
+        Shopware()->Db()->query(
+           'DELETE FROM s_core_countries
+            WHERE id NOT IN (' . implode(',', static::$existingCountryIds) . ')'
+        );
+        Shopware()->Db()->query(
+           'DELETE FROM s_core_countries_states
+            WHERE id NOT IN (' . implode(',', static::$existingStatesIds) . ')'
+        );
+    }
+
+    /**
+     * @return \Shopware\Models\Country\Country
+     */
+    public function testCreate()
+    {
+        $area = $this->getArea();
+        $data = [
+            'name' => 'Test Country',
+            'iso' => 'TC',
+            'iso3' => 'TCY',
+            'isoName' => 'TEST COUNTRY',
+            'areaId' => $area->getId()
+        ];
+
+        $country = $this->resource->create($data);
+
+        $this->assertEquals($country->getName(), $data['name']);
+        $this->assertEquals($country->getIso(), $data['iso']);
+        $this->assertEquals($country->getIso3(), $data['iso3']);
+        $this->assertEquals($country->getIsoName(), $data['isoName']);
+
+        $this->assertNotNull($country->getArea());
+        $this->assertEquals($country->getArea()->getId(), $area->getId());
+
+        return $country;
+    }
+
+    /**
+     * @return \Shopware\Models\Country\Country
+     */
+    public function testCreateWithState()
+    {
+        $state = new State();
+        $state->fromArray([
+            'name' => 'Test State',
+            'shortCode' => 'TS'
+        ]);
+        Shopware()->Models()->persist($state);
+        Shopware()->Models()->flush($state);
+
+        $area = $this->getArea();
+        $data = [
+            'name' => 'Test Country 2',
+            'iso' => 'T2',
+            'iso3' => 'TC2',
+            'isoName' => 'TEST COUNTRY 2',
+            'areaId' => $area->getId(),
+            'states' => [
+                [
+                    'id' => $state->getId(),
+                    'name' => 'New State Name',
+                    'shortCode' => 'NSC'
+                ]
+            ]
+        ];
+
+        $country = $this->resource->create($data);
+
+        $this->assertEquals($country->getName(), $data['name']);
+        $this->assertEquals($country->getIso(), $data['iso']);
+        $this->assertEquals($country->getIso3(), $data['iso3']);
+        $this->assertEquals($country->getIsoName(), $data['isoName']);
+
+        $this->assertNotNull($country->getArea());
+        $this->assertEquals($country->getArea()->getId(), $area->getId());
+
+        $this->assertEquals($country->getStates()->count(), 1);
+        $assignedState = $country->getStates()->first();
+        $this->assertEquals($assignedState->getId(), $data['states'][0]['id']);
+        $this->assertEquals($assignedState->getName(), $data['states'][0]['name']);
+        $this->assertEquals($assignedState->getShortCode(), $data['states'][0]['shortCode']);
+
+        return $country;
+    }
+
+    /**
+     * @depends testCreateWithState
+     *
+     * @param \Shopware\Models\Country\Country $country
+     * @return \Shopware\Models\Country\Country
+     */
+    public function testGetOne(\Shopware\Models\Country\Country $country)
+    {
+        $countryData = $this->resource->getOne($country->getId());
+
+        $this->assertEquals($countryData['id'], $country->getId());
+        $this->assertEquals($countryData['name'], $country->getName());
+        $this->assertEquals($countryData['iso'], $country->getIso());
+        $this->assertEquals($countryData['iso3'], $country->getIso3());
+        $this->assertEquals($countryData['isoName'], $country->getIsoName());
+        $this->assertEquals($countryData['areaId'], $country->getArea()->getId());
+
+        $this->assertArrayHasKey('states', $countryData);
+        $this->assertCount(1, $countryData['states']);
+        $firstState = $country->getStates()->first();
+        $this->assertEquals($countryData['states'][0]['id'], $firstState->getId());
+        $this->assertEquals($countryData['states'][0]['name'], $firstState->getName());
+        $this->assertEquals($countryData['states'][0]['shortCode'], $firstState->getShortCode());
+        $this->assertEquals($countryData['states'][0]['countryId'], $country->getId());
+
+        return $country;
+    }
+
+    /**
+     * @depends testGetOne
+     *
+     * @param \Shopware\Models\Country\Country $country
+     * @return \Shopware\Models\Country\Country
+     */
+    public function testUpdate(\Shopware\Models\Country\Country $country)
+    {
+        $oldState = $country->getStates()->first();
+        $state = new State();
+        $state->fromArray([
+            'name' => 'Test State 2',
+            'shortCode' => 'TS2'
+        ]);
+        Shopware()->Models()->persist($state);
+        Shopware()->Models()->flush($state);
+
+        $area = $this->getArea(1);
+        $data = [
+            'name' => 'New Country Name',
+            'iso' => 'NC',
+            'iso3' => 'NCN',
+            'isoName' => 'NEW COUNTRY',
+            'areaId' => $area->getId(),
+            'states' => [
+                [
+                    'id' => $oldState->getId()
+                ],
+                [
+                    'id' => $state->getId(),
+                    'name' => 'New State 2 Name',
+                    'shortCode' => 'NSC2'
+                ]
+            ]
+        ];
+
+        $country = $this->resource->update($country->getId(), $data);
+
+        $this->assertEquals($country->getName(), $data['name']);
+        $this->assertEquals($country->getIso(), $data['iso']);
+        $this->assertEquals($country->getIso3(), $data['iso3']);
+        $this->assertEquals($country->getIsoName(), $data['isoName']);
+
+        $this->assertNotNull($country->getArea());
+        $this->assertEquals($country->getArea()->getId(), $area->getId());
+
+        $this->assertEquals($country->getStates()->count(), 2);
+        $oldAssignedState = $country->getStates()->first();
+        $this->assertEquals($oldAssignedState->getId(), $data['states'][0]['id']);
+        $this->assertEquals($oldAssignedState->getName(), $oldState->getName());
+        $this->assertEquals($oldAssignedState->getShortCode(), $oldState->getShortCode());
+        $newAssignedState = $country->getStates()->last();
+        $this->assertEquals($newAssignedState->getId(), $data['states'][1]['id']);
+        $this->assertEquals($newAssignedState->getName(), $data['states'][1]['name']);
+        $this->assertEquals($newAssignedState->getShortCode(), $data['states'][1]['shortCode']);
+
+        return $country;
+    }
+
+    /**
+     * @depends testUpdate
+     *
+     * @param \Shopware\Models\Country\Country $country
+     * @return \Shopware\Models\Country\Country
+     */
+    public function testGetList(\Shopware\Models\Country\Country $country)
+    {
+        $countryData = $this->resource->getList(0, 1000);
+
+        $this->assertArrayHasKey('data', $countryData);
+        $this->assertArrayHasKey('total', $countryData);
+        $this->assertCount((2 + count(static::$existingCountryIds)), $countryData['data']);
+        $this->assertEquals($countryData['total'], (2 + count(static::$existingCountryIds)));
+
+        return $country;
+    }
+
+    /**
+     * @depends testGetList
+     *
+     * @param \Shopware\Models\Country\Country $country
+     */
+    public function testDelete(\Shopware\Models\Country\Country $country)
+    {
+        $deletedCountry = $this->resource->delete($country->getId());
+
+        $this->assertInstanceOf('\Shopware\Models\Country\Country', $deletedCountry);
+        $this->assertNull($deletedCountry->getId());
+    }
+
+    /**
+     * @param int $index
+     * @return \Shopware\Models\Country\Area
+     */
+    private function getArea($index = 0)
+    {
+        $areas = Shopware()->Models()->getRepository('Shopware\Models\Country\Area')->findAll();
+
+        return $areas[$index];
+    }
+}


### PR DESCRIPTION
This PR adds a new API resource `Country` that allows fetching, creating, updating and deleting instances of `Shopware\Models\Country\Country`. Furthermore it adds an API controller, which uses the new resource to provide all its operations via the REST API.

This PR does not introduce any breaking changes.
