### PR TITLE
Allow usage of 'base' stores in config combo boxes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -206,6 +206,7 @@ In this document you will find a changelog of the important changes related to t
 * Removed `sAdmin::sUpdateAccount()`
 * Removed `saveAccount()` in `Controllers/Frontend/Account.php`
 * Moved field `birthday` from billing address to customer
+* Added support for loading stores by ID in the base combo box `Shopware.apps.Base.view.element.Select`
 
 ## 5.1.5
 * The smarty variable `sCategoryInfo` in Listing and Blog controllers is now deprecated and will be removed soon. Use `sCategoryContent` instead, it's a drop in replacement. 


### PR DESCRIPTION
This commits improves the base combo box `Shopware.apps.Base.view.element.Select`, which is used e.g. for the plugin configuration forms, to allow passing a store ID as the `store` parameter. This is escpecially usefull when providing selections of e.g. payment methods (`base.Payment`) or dispatch methods (`base.Dispatch`). In order to avoid side effects of other backend modules using the same store instance (and e.g. setting filters on it), the combo box does not use the instance that is registered by the passed store ID, but creates and uses a copy of that store instead. This copy uses the same model, URL and proxy settings, but has its own ID and its solely purpose is to be used as a store for base combo boxes.

This commit does not introduce any breaking changes.
