### PR TITLE
Ability to clear the cache, after plugin config save

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -207,7 +207,7 @@ In this document you will find a changelog of the important changes related to t
 * Removed `saveAccount()` in `Controllers/Frontend/Account.php`
 * Moved field `birthday` from billing address to customer
 * Added validation of order number to `Shopware\Components\Api\Resource\Variant::prepareData()` to respond with meaningful error message for duplicate order numbers
-
+* Added `saveConfig` method to `Shopware_Components_Plugin_Bootstrap` to handle clearing caches, after plugin form submit
 
 ## 5.1.5
 * The smarty variable `sCategoryInfo` in Listing and Blog controllers is now deprecated and will be removed soon. Use `sCategoryContent` instead, it's a drop in replacement. 

--- a/engine/Shopware/Components/Plugin/Bootstrap.php
+++ b/engine/Shopware/Components/Plugin/Bootstrap.php
@@ -188,6 +188,17 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
     }
 
     /**
+     * Save plugin config method
+     *
+     * @param array $elements
+     *
+     * @return bool|bool
+     */
+    public function saveConfig($elements) {
+        return true;
+    }
+
+    /**
      * Enable plugin method
      *
      * @return bool

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
@@ -147,8 +147,8 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
     saveConfiguration: function(plugin, form) {
         var me = this;
 
-        form.onSaveForm(form, false, function() {
-
+        form.onSaveForm(form, false, function(form, records, operation) {
+            me.handleCrudResponse(records.proxy.getReader().jsonData, plugin);
         });
     },
 

--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.PluginPanel.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.PluginPanel.js
@@ -400,7 +400,7 @@ Ext.define('Shopware.form.PluginPanel',
                     win.destroy();
                 }
                 if(callback) {
-                    callback.apply(me, records, operation);
+                    callback(me, records, operation);
                 }
             },
             failure:function (records, operation) {


### PR DESCRIPTION
We should give the plugin developer the choice, to clear the cache, after plugin config saves.
The reasons could be like less variables in the plugin config etc.
