### PR TITLE
Removed pseudo second argument on Shopware\Models\Menu\Repository::fi…

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -212,9 +212,12 @@ In this document you will find a changelog of the important changes related to t
     * `sAdmin::assignCustomerNumber()`
     * `sOrder::sGetOrderNumber()`
     * `Shopware_Components_Document::saveDocument()`
+* Removed pseudo second argument on `Shopware\Models\Menu\Repository::findOneBy()` and deprecated methodes:
+    * `addItem`
+    * `save`
 
 ## 5.1.5
-* The smarty variable `sCategoryInfo` in Listing and Blog controllers is now deprecated and will be removed soon. Use `sCategoryContent` instead, it's a drop in replacement. 
+* The smarty variable `sCategoryInfo` in Listing and Blog controllers is now deprecated and will be removed soon. Use `sCategoryContent` instead, it's a drop in replacement.
 
 ## 5.1.4
 * Customer logout will now regenerate the session id and clear the customers basket.

--- a/engine/Shopware/Models/Menu/Repository.php
+++ b/engine/Shopware/Models/Menu/Repository.php
@@ -28,33 +28,4 @@ use Shopware\Components\Model\ModelRepository;
 
 /**
  */
-class Repository extends ModelRepository
-{
-    /**
-     * @deprecated Will be executed automatically.
-     */
-    public function save()
-    {
-    }
-
-    /**
-     * @deprecated Will be executed automatically.
-     * @param $item
-     */
-    public function addItem($item)
-    {
-    }
-
-    /**
-     * @param   array $criteria
-     * @return  object|\Shopware\Models\Menu\Menu
-     */
-    public function findOneBy(array $criteria)
-    {
-        if (func_num_args() === 2) {
-            return parent::findOneBy(array(func_get_arg(0) => func_get_arg(1)));
-        } else {
-            return parent::findOneBy($criteria);
-        }
-    }
-}
+class Repository extends ModelRepository {}


### PR DESCRIPTION
On PHP 7 is impossible to use the second argument, because the typehinting will throw a exception.
Example:  ->findOneBy('name', 'Einstellungen')
