### PR TITLE
Allow empty strings and booleans as attribute default values

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -203,6 +203,7 @@ In this document you will find a changelog of the important changes related to t
 * Moved `<form>` element in checkout confirm outside the agreement box to wrap around address and payment boxes
 * Removed smarty variable `sCategoryInfo` in listing and blog controllers. Use `sCategoryContent` instead. 
 * HttpCache: Added possibility to add multiple, comma separated proxy URLs
+* Allow using empty strings and booleans as default values when adding attribute fields using `Shopware\Components\Model\ModelManager::addAttribute()`
 
 ## 5.1.5
 * The smarty variable `sCategoryInfo` in Listing and Blog controllers is now deprecated and will be removed soon. Use `sCategoryContent` instead, it's a drop in replacement. 

--- a/engine/Shopware/Components/Model/ModelManager.php
+++ b/engine/Shopware/Components/Model/ModelManager.php
@@ -324,8 +324,10 @@ class ModelManager extends EntityManager
 
         $null = ($nullable) ? " NULL " : " NOT NULL ";
 
-        if (is_string($default) && strlen($default) > 0) {
+        if (is_string($default)) {
             $defaultValue = "'". $default ."'";
+        } elseif (is_bool($default)) {
+            $defaultValue = ($default) ? 1 : 0;
         } elseif (is_null($default)) {
             $defaultValue = " NULL ";
         } else {

--- a/tests/Functional/Components/Model/GeneratorTest.php
+++ b/tests/Functional/Components/Model/GeneratorTest.php
@@ -81,6 +81,15 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testDefaultInitializationEmptyString()
+    {
+        $this->addAndEvaluateInitialization(
+            'VARCHAR(255)',
+            '',
+            '""'
+        );
+    }
+
     public function testDefaultInitializationInteger()
     {
         $default = 123;
@@ -95,12 +104,30 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->addAndEvaluateInitialization(
             'TINYINT(1)',
-            1,
+            true,
             'true'
         );
     }
 
     public function testDefaultInitializationBooleanFalse()
+    {
+        $this->addAndEvaluateInitialization(
+            'TINYINT(1)',
+            false,
+            'false'
+        );
+    }
+
+    public function testDefaultInitializationBooleanTrueAsInt()
+    {
+        $this->addAndEvaluateInitialization(
+            'TINYINT(1)',
+            1,
+            'true'
+        );
+    }
+
+    public function testDefaultInitializationBooleanFalseAsInt()
     {
         $this->addAndEvaluateInitialization(
             'TINYINT(1)',


### PR DESCRIPTION
This PR changes the creation of custom attribute fields to allow default values such as empty strings or booleans. When previously passing an empty string as the default value of an attribute field it was replaced by `NULL`. However, it is perfectly valid to use an empty string as the default value for a table field and sometimes desirable. This commit removes the check for an empty string to allow using empty strings as default. Furthermore passing `false` as the default for a boolean (`tinyint`) attribute field previously resulted in an exception. Therefore this commit also adds a check of the passed `$default` for being a boolean type and translates it to `0` or `1` for `true` and `false` respectively.

This PR does not introduce any breaking changes.
