### PR TITLE
Fix dumb snippet for search-breadcrumbs

### DIFF
--- a/snippets/frontend/search/fuzzy.ini
+++ b/snippets/frontend/search/fuzzy.ini
@@ -3,10 +3,11 @@ SearchFuzzyHeadlineNoResult = "No products matching your search"
 SearchFuzzyInfoShortTerm = "The entered search term is too short."
 SearchHeadline = "The following products have been found matching your search \"{$sRequests.sSearch}\":  {$sSearchResults.sArticlesCount} "
 SearchResultsFor = "Search results for {$sRequests.sSearch}"
+SearchResultsEmpty = "Search results"
 
 [de_DE]
 SearchFuzzyHeadlineNoResult = "Leider wurden zu Ihrer Suchanfrage keine Artikel gefunden"
 SearchFuzzyInfoShortTerm = "Der eingegebene Suchbegriff ist leider zu kurz."
 SearchHeadline = "Zu \"{$sRequests.sSearch}\" wurden {$sSearchResults.sArticlesCount} Artikel gefunden!"
 SearchResultsFor = "Suchergebnis für {$sRequests.sSearch}"
-
+SearchResultsEmpty = "Suchergebnisse"

--- a/themes/Frontend/Bare/frontend/search/fuzzy.tpl
+++ b/themes/Frontend/Bare/frontend/search/fuzzy.tpl
@@ -2,7 +2,11 @@
 
 {* Breadcrumb *}
 {block name='frontend_index_start' prepend}
-	{$sBreadcrumb = [['name'=>"{s name="SearchResultsFor"}{/s}"]]}
+	{if $sRequests.sSearchOrginal}
+		{$sBreadcrumb = [['name' => "{s name="SearchResultsFor"}{/s}"]]}
+	{else}
+		{$sBreadcrumb = [['name' => "{s name="SearchResultsEmpty"}{/s}"]]}
+	{/if}
 {/block}
 
 {* Main content *}


### PR DESCRIPTION
When using the search, the breadcrumb gets set to `Search results for Foobar`.

The problem is, when the User didn't enter a search and instead just pressed enter, so the breadcrumb will now be `Search results for` when instead it should be just `Search results`.

This PR fixes this issue. It also provides a German & English Text for the new Snippet `SearchResultsEmpty`.
