### PR TITLE
Update box-shadow.less for browser compatibility.

### DIFF
--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/box-shadow.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/box-shadow.less
@@ -15,7 +15,9 @@ Please refer to <http://caniuse.com/css-boxshadow> to see the browser support ta
 */
 
 .box-shadow(@shadow: 0 0 5px 0 rgba(0, 0, 0, 0.2)) {
-	box-shadow: @shadow;
+	-webkit-box-shadow: @shadow;
+    -moz-box-shadow: @shadow;
+    box-shadow: @shadow;
 }
 
 .reset-box-shadow() {


### PR DESCRIPTION
I added to the .box-shadow mixing to have cross browser compatibility.
I was having cross browser issue for a client and I believe that this should be in the bare shopware code.
