### PR TITLE
Fix wrong initial 'from' value at price model

### DIFF
--- a/engine/Shopware/Models/Article/Price.php
+++ b/engine/Shopware/Models/Article/Price.php
@@ -68,7 +68,7 @@ class Price extends LazyFetchModelEntity
      *
      * @ORM\Column(name="`from`", type="integer", nullable=false)
      */
-    private $from = 0;
+    private $from = 1;
 
     /**
      * @var integer $to


### PR DESCRIPTION
A default value of "0" causes problems at listing (price will not be shown). Initial value should be 1.
