### PR TITLE
Add the possibility to make shop-independent sessions

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
@@ -53,11 +53,13 @@ class Session
             \Enlight_Components_Session::writeClose();
         }
 
-        /** @var $shop \Shopware\Models\Shop\Shop */
-        $shop = $container->get('Shop');
+        if (!isset($sessionOptions['name'])) {
+            /** @var $shop \Shopware\Models\Shop\Shop */
+            $shop = $container->get('Shop');
 
-        $name = 'session-' . $shop->getId();
-        $sessionOptions['name'] = $name;
+            $name = 'session-' . $shop->getId();
+            $sessionOptions['name'] = $name;
+        }
 
         if (!isset($sessionOptions['save_handler']) || $sessionOptions['save_handler'] == 'db') {
             $config_save_handler = array(

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -106,7 +106,6 @@ return array_replace_recursive([
         'cache_cookies' => ['shop', 'currency', 'x-cache-context-hash'],
     ],
     'session' => [
-        'name' => 'SHOPWARESID',
         'cookie_lifetime' => 0,
         //'cookie_httponly' => 1,
         'use_trans_sid' => false,


### PR DESCRIPTION
Hi,

this PR adds the possibility to make sessions independent of the selected (sub-) shop, just by adding a name parameter to Shopware's session configuration.

Before the change, it was always overwritten, so you had to completely override the Session-Factory class.

See support ticket #56586 for your reference.
