### PR TITLE
Fix Javascript error when opening an order without a shipping address

### DIFF
--- a/themes/Backend/ExtJs/backend/order/controller/main.js
+++ b/themes/Backend/ExtJs/backend/order/controller/main.js
@@ -151,7 +151,7 @@ Ext.define('Shopware.apps.Order.controller.Main', {
                     me.documentTypesStore = storeData.getDocumentTypes();
 
                     billingStore = record.getBilling();
-                    if(!billingStore == null){
+                    if (billingStore != null) {
                         if (billingStore.getCount() === 0) {
                             billing = Ext.create('Shopware.apps.Order.model.Billing', {
                                 orderId: record.get('id'),


### PR DESCRIPTION
It was not possible before to open an order in the Shopware backend if it was missing its shipping address, because a Javascript error came up. The cause is that the condition (!billingStore == null) never resolves to true because !billingStore is either true or false, but never null.

![selection_100](https://cloud.githubusercontent.com/assets/105166/15023629/820c7300-1231-11e6-933b-3f07f08d9628.png)
