### PR TITLE
SW-14601 - close detail window after blog article is saved

### DIFF
--- a/themes/Backend/ExtJs/backend/blog/controller/blog.js
+++ b/themes/Backend/ExtJs/backend/blog/controller/blog.js
@@ -445,6 +445,8 @@ Ext.define('Shopware.apps.Blog.controller.Blog', {
                     listStore.load();
                     //to remove all red flags
                     Shopware.Notification.createGrowlMessage('',me.snippets.onSaveChangesSuccess, me.snippets.growlMessage);
+
+                    me.getDetailWindow().close();
                 } else {
                     Shopware.Notification.createGrowlMessage('',me.snippets.onSaveChangesError, me.snippets.growlMessage);
                 }


### PR DESCRIPTION
If you added content to the attribute fields of a new blog entry and save it twice without closing the detail window the connection between the attribute fields and the blog entry gets lost. The blog_id in s_blog_attributes will be null.

This commit closes the detail window of the blog entry when you save it to get rid of this behaviour
