### PR TITLE
API-Bug: mp3-files are imported as mpga

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Media.php
+++ b/engine/Shopware/Components/Api/Resource/Media.php
@@ -29,6 +29,7 @@ use Shopware\Components\Thumbnail\Manager;
 use Shopware\Models\Media\Album;
 use Shopware\Models\Media\Media as MediaModel;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
  * Media API Resource
@@ -290,7 +291,14 @@ class Media extends Resource
         $name = pathinfo($link, PATHINFO_FILENAME);
         $path = $this->load($link, $name);
         $name = pathinfo($path, PATHINFO_FILENAME);
-        $file = new File($path);
+        $ext = pathinfo($link, PATHINFO_EXTENSION);
+        if($ext == 'mp3'){
+            $full = $path.'.'.$ext;
+            $file = new UploadedFile($path, $full);
+        }
+        else{
+            $file = new File($path);
+        }
 
         $media = new MediaModel();
 

--- a/engine/Shopware/Components/Api/Resource/Media.php
+++ b/engine/Shopware/Components/Api/Resource/Media.php
@@ -291,7 +291,7 @@ class Media extends Resource
         $name = pathinfo($link, PATHINFO_FILENAME);
         $path = $this->load($link, $name);
         $name = pathinfo($path, PATHINFO_FILENAME);
-        $ext = pathinfo($link, PATHINFO_EXTENSION);
+        $ext = strtolower(pathinfo($link, PATHINFO_EXTENSION));
         if($ext == 'mp3'){
             $full = $path.'.'.$ext;
             $file = new UploadedFile($path, $full);


### PR DESCRIPTION
We noticed that the API uses the "File" class to guess the file extension. This guesser method fails on mp3 files. Jpgs and pdfs guessed correctly. There's also an class called "UploadedFile" which works properly on mp3, pdf,... but not for jpgs. So we need to check if the file extension is mp3 and use there the proper File class.

May you can provide a better workaround?
