### PR TITLE
[FEATURE] Set "snippet_resource" service to public

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -23,8 +23,7 @@
         </service>
 
         <service id="snippet_resource"
-                 class="Enlight_Components_Snippet_Resource"
-                 public="false">
+                 class="Enlight_Components_Snippet_Resource">
             <argument type="service" id="snippets"/>
             <argument>%shopware.snippet.showSnippetPlaceholder%</argument>
         </service>


### PR DESCRIPTION
As discussed with Martin Weinmayr (CEO dasistweb GmbH) with and agreed by Elke Klein-Ridder it is necessary to remove the public="false" property in the "snippet_resource" service definition to create the opportunity to override the Snippet Manager for special needs.
