### PR TITLE
[BUGFIX] Load basket products with sArticles::sGetArticleById()

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2085,7 +2085,7 @@ class sBasket
 
             // Get additional basket meta data for each product
             if ($getArticles[$key]["modus"] == 0) {
-                $tempArticle = $this->moduleManager->Articles()->sGetProductByOrdernumber($getArticles[$key]['ordernumber']);
+                $tempArticle = $this->moduleManager->Articles()->sGetArticleById(0, null, $getArticles[$key]['ordernumber']);
 
                 if (empty($tempArticle)) {
                     $getArticles[$key]["additional_details"] = array("properties" => array());


### PR DESCRIPTION
Load basket products with sArticles::sGetArticleById() instead of sArticles::sGetProductByOrdernumber() in sBasket::getBasketArticlesUncached(). This loads the products using the ProductService instead of the ListProductsService. This fixes a problem that the data in the "additional_data" field has always been loaded from the main variant even if you have a specific variant in the cart.
