### PR TITLE
[BUGFIX] wrong usage of unitize mixin

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/footer.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/footer.less
@@ -43,8 +43,7 @@ The footer element sizes are defined with the unitize mixin.
         }
 
         &::after {
-            .unitize(4, margin-top);
-            .unitize(18, font-size);
+            .unitize(font-size, 18);
             font-family: 'shopware';
             color: @text-color;
             font-weight: 700;


### PR DESCRIPTION
This fixes wrong used .unitize() mixins.
Line 46 was obsolete as it had never an effect due to the wrong mixin usage.
Line 47 was refactored to be applied correctly now as it probably was intended.
