### PR TITLE
Added stock and purchase related information to order items in account

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -4370,6 +4370,18 @@ class sAdmin
                     $getOrderDetails[$orderDetailsKey]['referenceprice'] = $tmpArticle['referenceprice'];
                 }
 
+                if (!empty($tmpArticle['minpurchase'])) {
+                    $getOrderDetails[$orderDetailsKey]['minpurchase'] = $tmpArticle['minpurchase'];
+                }
+
+                if (!empty($tmpArticle['maxpurchase'])) {
+                    $getOrderDetails[$orderDetailsKey]['maxpurchase'] = $tmpArticle['maxpurchase'];
+                }
+
+                if (!empty($tmpArticle['purchasesteps'])) {
+                    $getOrderDetails[$orderDetailsKey]['purchasesteps'] = $tmpArticle['purchasesteps'];
+                }
+
                 if (!empty($tmpArticle['sUnit']) && is_array($tmpArticle['sUnit'])) {
                     $getOrderDetails[$orderDetailsKey]['sUnit'] = $tmpArticle['sUnit'];
                 }
@@ -4380,6 +4392,14 @@ class sAdmin
 
                 if (!empty($tmpArticle['pseudoprice'])) {
                     $getOrderDetails[$orderDetailsKey]['currentPseudoprice'] = $tmpArticle['pseudoprice'];
+                }
+
+                if (!empty($tmpArticle['laststock'])) {
+                    $getOrderDetails[$orderDetailsKey]['laststock'] = $tmpArticle['laststock'];
+                }
+
+                if (!empty($tmpArticle['instock'])) {
+                    $getOrderDetails[$orderDetailsKey]['instock'] = $tmpArticle['instock'];
                 }
 
                 $getOrderDetails[$orderDetailsKey]['currentHas_pseudoprice'] = $tmpArticle['has_pseudoprice'];


### PR DESCRIPTION
This missing infos are needed if you want to add a "Add to cart" button on each order item in the account order history without reloading the product structs. Since other information like `purchaseunit` are already copied from the product to, this PR should be easy to merge.
