### PR TITLE
Revalidate Minimum Charge Voucher, after loading Record

### DIFF
--- a/themes/Backend/ExtJs/backend/voucher/view/voucher/base_configuration.js
+++ b/themes/Backend/ExtJs/backend/voucher/view/voucher/base_configuration.js
@@ -103,6 +103,9 @@ Ext.define('Shopware.apps.Voucher.view.voucher.BaseConfiguration', {
         if(me.record){
             me.loadRecord(me.record);
             me.attributeForm.loadAttribute(me.record.get('id'));
+
+            // revalidate minimumCharge after loading record
+            me.down('[name="minimumCharge"]').validateValue(me.down('[name="minimumCharge"]').getValue());
         }
     },
 


### PR DESCRIPTION
When the discountMode of the voucher is Percental and the minimum charge is less then discount charge it shows on opening the voucher detail a error. The error should be only shown in discountMode absolute. This pr fixes the error display, with revalidation the field after loading the record in the form.

Gif (before): http://i.imgur.com/VzhWnnw.gifv
Gif (after): http://i.imgur.com/JuNKCrp.gifv
