### PR TITLE
Fix adding article to note listing dont send sUniqueID cookie on non existing session id

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1149,10 +1149,9 @@ class sBasket
      */
     public function sAddNote($articleID, $articleName, $articleOrderNumber)
     {
-        $cookieData = $this->front->Request()->getCookie();
         $uniqueId = $this->front->Request()->getCookie('sUniqueID');
 
-        if (!empty($cookieData) && empty($uniqueId)) {
+        if (empty($uniqueId)) {
             $uniqueId = md5(uniqid(rand()));
             $this->front->Response()->setCookie('sUniqueID', $uniqueId, Time()+(86400*360), '/');
         }


### PR DESCRIPTION
We are adding article to note list via api request. But initial sAddNote call dont sends `sUniqueID` because we have not yet a session. Only after calling the page again session is set and and we get the Set-Cookie header. See guzzle testing which pipes to sAddNote:

``` php
        // force session error ;)
        $guzzle->get('/');

        $guzzle->post('shop-api/note', ['body' => json_encode([
            'action' => 'addLineItem',
            'productId' => 'SW10043',
        ])]);

        $response = $guzzle->post('shop-api/note', ['body' => json_encode([
            'action' => 'addLineItem',
            'productId' => 'SW10150.5',
        ])])->json();
```
