### PR TITLE
SW-15039 fixing url builder replacement of ampersand to german 'und'-word

### DIFF
--- a/engine/Shopware/Core/sRewriteTable.php
+++ b/engine/Shopware/Core/sRewriteTable.php
@@ -541,7 +541,7 @@ class sRewriteTable
         'Ỷ' => 'Y',
         'Ỹ' => 'Y',
         // shopware rules
-        ' & ' => '-und-',
+        ' & ' => '-',
         ':' => '-',
         ',' => '-',
         "'" => '-',

--- a/tests/Shopware/Tests/Core/sRewriteTest.php
+++ b/tests/Shopware/Tests/Core/sRewriteTest.php
@@ -58,7 +58,7 @@ class sRewriteTest extends PHPUnit_Framework_TestCase
             array('Hello,World', 'Hello-World'),
             array('Hello;World', 'HelloWorld'),
             array('Hello&World', 'HelloWorld'),
-            array('Hello & World', 'Hello-und-World'),
+            array('Hello & World', 'Hello-World'),
             array('Nguyễn Đăng Khoa', 'Nguyen-Dang-Khoa'),
             array('Ä ä Ö ö Ü ü ß', 'AE-ae-OE-oe-UE-ue-ss'),
             array('Á À á à É È é è Ó Ò ó ò Ñ ñ Ú Ù ú ù', 'A-A-a-a-E-E-e-e-O-O-o-o-N-n-U-U-u-u'),


### PR DESCRIPTION
sReplaceTable will replace every "- & -" of a name of an entity with "-und-", which makes no sense on SEO-side and also will not fit to articles and categories of language sub shops other than german.

A category called "Home & Garden" will get the URL "home-und-garden". The word "und" is german and should be replaced with "and". But, from seo-side, this is a stop word and has no relevance on SEO-side. The recommendation of various SEO-experts is to use a hyphen instead of any translations.

With my commit the url would be "home-garden". From seo side these are two separate words, while underscore would be interpreted as a concatenated word. Some good source about this topic is [this one](http://www.ecreativeim.com/blog/2011/03/seo-basics-hyphen-or-underscore-for-seo-urls/).
