### PR TITLE
Disable xdebug for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ cache:
    directories:
      - $HOME/.composer/cache/files
 
+before_script:
+    - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+
 script:
     - ant -f build/build.xml -Ddb.user=travis -Ddb.host=127.0.0.1 -Ddb.name=shopware build-continuous static-lint
 


### PR DESCRIPTION
see https://docs.travis-ci.com/user/languages/php#Disabling-preinstalled-PHP-extensions and https://getcomposer.org/doc/articles/troubleshooting.md#xdebug-impact-on-composer

> Compared to a cli command run with "xdebug" enabled a speed improvement by a factor of up to 3 is not uncommon.
