### PR TITLE
Fix error in article statistics due to mixup of article and voucher ids

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -3890,6 +3890,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
                 AND s_order.id = s_order_details.orderID
                 AND s_order.status != 4
                 AND s_order.status != -1
+                AND s_order_details.modus = 0
             GROUP BY groupdate
             ORDER BY groupdate ASC
             LIMIT %d
@@ -4162,6 +4163,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
             AND s_order.id = s_order_details.orderID
             AND s_order.status != 4
             AND s_order.status != -1
+            AND s_order_details.modus = 0
             AND TO_DAYS(ordertime) <= TO_DAYS(:endDate)
             AND TO_DAYS(ordertime) >= TO_DAYS(:startDate)
             GROUP BY TO_DAYS(ordertime)


### PR DESCRIPTION
Re-created for rebase against 5.2.

Please see the original PR for more information: https://github.com/shopware/shopware/pull/221#issue-54067005

Original PR text:

> We found that article statistics erroneously show redeemed vouchers that have nothing to do with the respective article:
> 
>  ![651d535a-9a77-11e4-85bc-79614ceeac49](https://cloud.githubusercontent.com/assets/4528060/15643185/28af6d7e-264c-11e6-8cef-e88ff5978e1a.png)
> 
> The problem arises in the statistics tab of the article that has the same id as the respective voucher.
> Technical details for the proposed fix:
> 
> The articleID column of the s_order_details table only represents a real article id when modus is 0. When modus is 2, for example, the articleID column contains a voucher id instead.
