### PR TITLE
Fix rounding error in basket amount if a discount is applied in net mode

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2575,7 +2575,7 @@ class sBasket
             ($this->config->get('sARTICLESOUTPUTNETTO') && !$this->sSYSTEM->sUSERGROUPDATA["tax"])
             || (!$this->sSYSTEM->sUSERGROUPDATA["tax"] && $this->sSYSTEM->sUSERGROUPDATA["id"])
         ) {
-            $netPrice = round($grossPrice, 2);
+            $netPrice = $grossPrice;
         } else {
             // Round to right value, if no purchase unit is set
             if ($queryAdditionalInfo["purchaseunit"] == 1) {


### PR DESCRIPTION
Re-created for rebase against 5.2.

Please see the original pull request for more information: https://github.com/shopware/shopware/pull/217

Original PR text:

> It is currently possible that the basket amount does not equal the sum of the basket items:
> selection_304
> 
> ![7366d37a-8a12-11e4-8a3a-70040fa5b567](https://cloud.githubusercontent.com/assets/4528060/15643061/8325bb7e-264b-11e6-8b2d-f14a53adb80e.png)
> 
> Furthermore, at least if Payone is used as the payment provider, the customer will not be able to complete his purchase because of this (they check if the sum of the items equals the basket amount).
> 
> The cause of this error lies in the getTaxesForUpdateArticle() function. Without this fix, it is possible that $netPrice and $grossPrice differ at the end of the getTaxesForUpdateArticle() function in net mode (13.22 vs 13.21 in this concrete case), which should not happen. By passing the exact same price for both $netPrice and $grossPrice to sGetPricegroupDiscount(), we can make sure that no rounding errors can occur.
> 
> I will follow up with the concrete article and customer details for which we encountered this problem.
> 
> The normal price of the 'Bordbuch für Motorflug' article in this example is 18.50 € (19% VAT included). Due to his customer group, the active customer gets a 15% discount.
> 
> So let's do the math. Shopware first calculates the net price without a discount:
> 18.5 / 1.19 = 15.546218487
> 
> This price gets rounded to 3 decimal places, so $netPrice = 15.546.
> 
> When we apply the 15% directly to this, we get the correct price:
> 15.546 \* .85 = 13.2141
> 
> However, before this fix, 15.546 was rounded to 15.55, leading to the wrong price of 13.22:
> 15.55 \* .85 = 13.2175

@bcremer has already [reproduced the issue](https://github.com/shopware/shopware/pull/217#issuecomment-68852172).
