### PR TITLE
add "console.command" tag support which registers commands in a more Symfony way

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -308,6 +308,7 @@ In this document you will find a changelog of the important changes related to t
 * Moved s_user_billingaddress.customernumber to s_user table
 * Removed \Shopware\Models\Customer\Billing::number property
 * Removed method `Shopware\Bundle\PluginInstallerBundle\Service\InstallerService::getPluginBootstrap()`
+* Add support for Symfony `console.command` service tag to register commands directly inside service container
 
 ## 5.1.6
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.

--- a/engine/Shopware/Components/Console/Application.php
+++ b/engine/Shopware/Components/Console/Application.php
@@ -150,6 +150,7 @@ class Application extends BaseApplication
         }
 
         $this->registerFilesystemCommands();
+        $this->registerTaggedServiceIds();
     }
 
     protected function registerFilesystemCommands()
@@ -190,6 +191,20 @@ class Application extends BaseApplication
         foreach ($collection as $command) {
             if ($command instanceof Command) {
                 $this->add($command);
+            }
+        }
+    }
+
+    /**
+     * Register tagged commands in Symfony style
+     *
+     * @see Shopware\Components\DependencyInjection\Compiler\AddConsoleCommandPass
+     */
+    protected function registerTaggedServiceIds()
+    {
+        if ($this->kernel->getContainer()->hasParameter('console.command.ids')) {
+            foreach ($this->kernel->getContainer()->getParameter('console.command.ids') as $id) {
+                $this->add($this->kernel->getContainer()->get($id));
             }
         }
     }

--- a/engine/Shopware/Components/DependencyInjection/Compiler/AddConsoleCommandPass.php
+++ b/engine/Shopware/Components/DependencyInjection/Compiler/AddConsoleCommandPass.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Shopware\Components\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @see Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConsoleCommandPass
+ */
+class AddConsoleCommandPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $commandServices = $container->findTaggedServiceIds('console.command');
+        $serviceIds = [];
+
+        foreach ($commandServices as $id => $tags) {
+            $definition = $container->getDefinition($id);
+
+            if ($definition->isAbstract()) {
+                throw new \InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must not be abstract.', $id));
+            }
+
+            $class = $container->getParameterBag()->resolveValue($definition->getClass());
+            if (!is_subclass_of($class, 'Symfony\\Component\\Console\\Command\\Command')) {
+                throw new \InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must be a subclass of "Symfony\\Component\\Console\\Command\\Command".', $id));
+            }
+
+            $container->setAlias($serviceId = 'console.command.' . strtolower(str_replace('\\', '_', $class)), $id);
+            $serviceIds[] = $serviceId;
+        }
+
+        $container->setParameter('console.command.ids', $serviceIds);
+    }
+}

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -35,6 +35,7 @@ use Shopware\Bundle\SearchBundle\DependencyInjection\Compiler\CriteriaRequestHan
 use Shopware\Bundle\SearchBundleDBAL\DependencyInjection\Compiler\DBALCompilerPass;
 use Shopware\Bundle\SearchBundleES\DependencyInjection\CompilerPass\SearchHandlerCompilerPass;
 use Shopware\Bundle\FormBundle\DependencyInjection\CompilerPass\AddConstraintValidatorsPass;
+use Shopware\Components\DependencyInjection\Compiler\AddConsoleCommandPass;
 use Shopware\Components\DependencyInjection\Compiler\DoctrineEventSubscriberCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EventListenerCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EventSubscriberCompilerPass;
@@ -597,6 +598,7 @@ class Kernel implements HttpKernelInterface
         $container->addCompilerPass(new FormPass());
         $container->addCompilerPass(new AddConstraintValidatorsPass());
         $container->addCompilerPass(new SearchRepositoryCompilerPass());
+        $container->addCompilerPass(new AddConsoleCommandPass());
 
         if ($this->isElasticSearchEnabled()) {
             $container->addCompilerPass(new SearchHandlerCompilerPass());


### PR DESCRIPTION
see http://symfony.com/doc/current/cookbook/console/commands_as_services.html
