### PR TITLE
Make order billing and shipping addresses searchable

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -276,9 +276,11 @@ class Repository extends ModelRepository
                 ->leftJoin('orders.paymentStatus', 'paymentStatus')
                 ->leftJoin('orders.orderStatus', 'orderStatus')
                 ->leftJoin('orders.billing', 'billing')
+                ->leftJoin('orders.shipping', 'shipping')
                 ->leftJoin('orders.customer', 'customer')
                 ->leftJoin('billing.country', 'billingCountry')
                 ->leftJoin('billing.state', 'billingState')
+                ->leftJoin('shipping.country', 'shippingCountry')
                 ->leftJoin('orders.shop', 'shop')
                 ->leftJoin('orders.dispatch', 'dispatch');
 
@@ -450,9 +452,23 @@ class Repository extends ModelRepository
                                 $expr->like('orders.invoiceAmount', '?1'),
                                 $expr->like('orders.transactionId', '?1'),
                                 $expr->like('billing.company', '?3'),
+                                $expr->like('shipping.company', '?3'),
+                                $expr->like('billing.department', '?3'),
+                                $expr->like('shipping.department', '?3'),
+                                $expr->like('billing.street', '?3'),
+                                $expr->like('shipping.street', '?3'),
+                                $expr->like('billing.zipCode', '?1'),
+                                $expr->like('shipping.zipCode', '?1'),
+                                $expr->like('billing.city', '?3'),
+                                $expr->like('shipping.city', '?3'),
+                                $expr->like('billingCountry.name', '?3'),
+                                $expr->like('shippingCountry.name', '?3'),
                                 $expr->like('customer.email', '?3'),
                                 $expr->like('billing.lastName', '?3'),
+                                $expr->like('shipping.lastName', '?3'),
                                 $expr->like('billing.firstName', '?3'),
+                                $expr->like('shipping.firstName', '?3'),
+                                $expr->like('shop.name', '?3'),
                                 $expr->like('orders.comment', '?3'),
                                 $expr->like('orders.customerComment', '?3'),
                                 $expr->like('orders.internalComment', '?3')


### PR DESCRIPTION
Re-created [PR 224](https://github.com/shopware/shopware/pull/244) for a rebase on top of 5.2.

Original PR text:

> This makes it possible to search for orders with a specific address (street, city, country etc.) in the order dialog.

This patch adds joins to `orders.shipping` and `shipping.country`. In the original PR, potential performance issues [were raised](https://github.com/shopware/shopware/pull/244#issuecomment-78919892). However, the proposed changes, i.e. not joining `orders.details`, are orthogonal to this commit, which does not touch anything `orders.details` related. While the actually added additional joins may incur a performance cost, I propose to deal with performance improvements in a separate issue and rather add this functionality for now.
