### PR TITLE
Don't require matching countries for tax-free company orders

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -771,7 +771,6 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action
             } elseif (
                 !empty($userData['additional']['countryShipping']['taxfree_ustid'])
                 && !empty($userData['billingaddress']['ustid'])
-                && $userData['additional']['country']['id'] == $userData['additional']['countryShipping']['id']
             ) {
                 $sTaxFree = true;
             }


### PR DESCRIPTION
Re-created PR #187 for rebase on top of 5.2.

Original PR text:

> When shipping to companies in a tax-free country (should be EU, since non-EU/ROW countries are completly tax-free anyways) it does not matter where the invoice is adressed to, just shipping it to a destination outside Germany (respectivly the country where the shop is run from) makes it tax-free.
> 
> For reference see the German law § 6a Abs. 1 UStG:
> 
> > Eine innergemeinschaftliche Lieferung [...] liegt vor, wenn [...] Der Unternehmer oder der Abnehmer hat den Gegenstand der Lieferung in das übrige Gemeinschaftsgebiet befördert oder versendet;
