### PR TITLE
Fix bug in price group management by automatically preselect first customer group

### DIFF
--- a/themes/Backend/ExtJs/backend/config/view/price_group/discount.js
+++ b/themes/Backend/ExtJs/backend/config/view/price_group/discount.js
@@ -54,7 +54,15 @@ Ext.define('Shopware.apps.Config.view.priceGroup.Discount', {
             editable: false,
             name: 'customerGroupId',
             store: 'base.CustomerGroup',
-            emptyText: '{s name=price_group/table/customer_group_empty_text}Please select...{/s}'
+            emptyText: '{s name=price_group/table/customer_group_empty_text}Please select...{/s}',
+            listeners: {
+                enable: function() {
+                    // Preselect first item
+                    if(this.store.getAt('0')) {
+                        this.setValue(this.store.getAt('0').get('id'));
+                    }
+                }
+            }
         });
         return topBar;
     }


### PR DESCRIPTION
Re-created PR #127 for rebase on top of 5.2.

Orignal PR text:

> Currently discounts, which are associated to a price group, are lazy-loaded, when the user selects a customer group. Since the save action for price groups simply overwrites the data stored in the database with the data received from the client, this behavior leads to the deletion of associated discounts, if the user only alters the name of a price group without "lazy-loading" the discounts before he clicks the save button. The automatic preselection of the first customer group ensures, that the discounts are always been loaded, when the user triggers the save action.
