### PR TITLE
Add unsubscribeEvent() method for plugins

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -316,6 +316,7 @@ In this document you will find a changelog of the important changes related to t
 * Include the departments, salutations, cities and countries in the address comparison of the backend order details
 * Display the departments in the backend order details overview
 * Added new API resource 'Country' and respective REST API controller 'countries'
+* Add a new `unsubscribeEvent` method to `Enlight_Plugin_Bootstrap_Config` for removing existing event subscriptions
 
 ## 5.1.6
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.

--- a/engine/Library/Enlight/Plugin/Bootstrap/Config.php
+++ b/engine/Library/Enlight/Plugin/Bootstrap/Config.php
@@ -92,6 +92,32 @@ class Enlight_Plugin_Bootstrap_Config extends Enlight_Plugin_Bootstrap
     }
 
     /**
+     * Removes an existing plugin event.
+     *
+     * First all subscribed listeners are looped to find the one, which matches the given
+     * event and listener names and also the name of this plugin. Finally the matching listener
+     * is removed from the namespace subscriber.
+     *
+     * @param string|Enlight_Event_Handler $event The name of the event or the event itself, which shall be removed.
+     * @param string $listener The name of the listener, which shall be removed.
+     * @return Enlight_Plugin_Bootstrap_Config This instance.
+     */
+    public function unsubscribeEvent($event, $listener)
+    {
+        // Find the listener instance matching the plugin, event and listener names
+        $subscriber = $this->Collection()->Subscriber();
+        foreach ($subscriber->getListeners() as $handler) {
+            if ($handler->toArray()['plugin'] === $this->getName() && $handler->getName() === $event
+                    && $handler->getListener() === $listener) {
+                // Remove the matching handler
+                $subscriber->removeListener($handler);
+                break;
+            }
+        }
+        return $this;
+    }
+
+    /**
      * This function installs the plugin.
      *
      * @return bool

--- a/engine/Shopware/Components/Plugin/Bootstrap.php
+++ b/engine/Shopware/Components/Plugin/Bootstrap.php
@@ -497,6 +497,27 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
     }
 
     /**
+     * Unsubscribes a plugin event.
+     *
+     * {@inheritDoc}
+     *
+     * @param string|Enlight_Event_Handler $event
+     * @param string $listener
+     *
+     * @return Enlight_Plugin_Bootstrap_Config
+     */
+    public function unsubscribeEvent($event, $listener = null)
+    {
+        if ($listener === null) {
+            $this->Collection()->Subscriber()->removeListener($event);
+        } else {
+            parent::unsubscribeEvent($event, $listener);
+        }
+
+        return $this;
+    }
+
+    /**
      * Helper function to register a plugin controller.
      *
      * If the default event listener is used for the registration of a plugin controller, the following requirements must be fulfilled:

--- a/engine/Shopware/Components/Plugin/Namespace.php
+++ b/engine/Shopware/Components/Plugin/Namespace.php
@@ -378,7 +378,7 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
             $plugin->setInstalled(new DateTime());
             $plugin->setUpdated(new DateTime());
             $em->flush($plugin);
-            $this->write();
+            $this->write($bootstrap);
 
             $em->flush();
 
@@ -685,7 +685,7 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
             $this->registerPlugin($plugin);
 
             // Save events / Hooks
-            $this->write();
+            $this->write($plugin);
 
             $form = $plugin->Form();
             if ($form->hasElements()) {
@@ -706,15 +706,32 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
     }
 
     /**
-     * Writes all registered plugins into the storage.
-     * The subscriber and the registered plugins are converted to an array.
+     * Synchronizes the plugin subscribes with the storage.
+     * All remaining subscribes are inserted or updated in the storage. If the optional bootstrap
+     * parameter is given, all subscribes of that plugin are loaded and compared to the
+     * given subscribes. Finally the subscribes, which were removed from the list,
+     * are also removed from the storage.
      *
+     * @param Shopware_Components_Plugin_Bootstrap $bootstrap
      * @return  Enlight_Plugin_Namespace_Config
      */
-    public function write()
+    public function write(Shopware_Components_Plugin_Bootstrap $bootstrap = null)
     {
-        $subscribes = $this->Subscriber()->toArray();
+        $obsoleteSubscribes = array();
+        if ($bootstrap !== null) {
+            // Fetch all existing subscribes of the given plugin
+            $pluginId = $this->getPluginId($bootstrap->getName());
+            $sql = '
+                SELECT `subscribe`, `listener`, `pluginID`
+                FROM `s_core_subscribes`
+                WHERE pluginID = ?
+            ';
+            $obsoleteSubscribes = $this->Application()->Db()->fetchAll($sql, array(
+                $pluginId
+            ));
+        }
 
+        $subscribes = $this->Subscriber()->toArray();
         foreach ($subscribes as $subscribe) {
             $subscribe['pluginID'] = $this->getInfo($subscribe['plugin'], 'id');
             if (!isset($subscribe['pluginID'])) {
@@ -743,6 +760,31 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
                 $subscribe['listener'],
                 $subscribe['position'],
                 $subscribe['pluginID'],
+            ));
+
+            if ($subscribe['pluginID'] === $pluginId) {
+                // Remove the subscribe from the list of obsolete subscribes
+                for ($i = 0; $i < count($obsoleteSubscribes); $i++) {
+                    if ($obsoleteSubscribes[$i]['subscribe'] === $subscribe['name'] && $obsoleteSubscribes[$i]['listener'] === $subscribe['listener']){
+                        array_splice($obsoleteSubscribes, $i, 1);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Delete all subscribes, that are left in obsoleteSubscribes
+        foreach ($obsoleteSubscribes as $subscribe) {
+            $sql = '
+                DELETE FROM `s_core_subscribes`
+                WHERE `subscribe` = ?
+                AND `listener` = ?
+                AND `pluginID` = ?
+            ';
+            $this->Application()->Db()->query($sql, array(
+                $subscribe['subscribe'],
+                $subscribe['listener'],
+                $subscribe['pluginID']
             ));
         }
 

--- a/tests/Shopware/Tests/Components/Event/PluginTest.php
+++ b/tests/Shopware/Tests/Components/Event/PluginTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Tests
+ * @copyright Copyright (c) 2012, shopware AG (http://www.shopware.de)
+ */
+class Shopware_Tests_Components_Event_PluginTest extends Enlight_Components_Test_Plugin_TestCase
+{
+    public function testSubscribeEvent()
+    {
+        // Use debug plugin (arbitrarily chosen)
+        $bootstrap = Shopware()->Plugins()->Core()->Debug();
+
+        // Subscribe
+        $bootstrap->subscribeEvent(
+			'event1',
+			'listener1'
+		);
+
+        $found = array_filter($bootstrap->Collection()->Subscriber()->getListeners(), function ($handler) {
+            return $handler->getName() == 'event1';
+        });
+
+        $this->assertCount(1, $found);
+        $this->assertEquals('listener1', array_values($found)[0]->getListener());
+    }
+
+    public function testUnsubscribeEvent()
+    {
+        // Use debug plugin (arbitrarily chosen)
+        $bootstrap = Shopware()->Plugins()->Core()->Debug();
+
+        // Subscribe two events
+        $bootstrap->subscribeEvent(
+			'event1',
+			'listener1'
+		);
+        $bootstrap->subscribeEvent(
+            'event1',
+            'listener2'
+        );
+
+        // Remove first
+        $bootstrap->unsubscribeEvent(
+            'event1',
+            'listener1'
+        );
+
+        $found = array_filter($bootstrap->Collection()->Subscriber()->getListeners(), function ($handler) {
+            return $handler->getName() == 'event1';
+        });
+
+        $this->assertCount(1, $found);
+        $this->assertEquals('listener2', array_values($found)[0]->getListener());
+    }
+}


### PR DESCRIPTION
Re-created PR #452 for rebase on top of the 5.2 branch.

Original PR text:

> In some plugin updates it is desirable to remove old event subscriptions, since they are no longer used. This commit adds a new method to Enlight_Plugin_Bootstrap_Config, from which all plugin bootstrap implementations inherit.
> 
> The new unsubscribeEvent() method requires only the event name and listener name to remove an existing subscription, just like subscribeEvent() requires those two parameters to add a subscription in the first place.
> 
> In order to make this work, it is also necessary to adapt the write() method of Shopware_Components_Plugin_Namespace, so that the removed subscribes are also removed from the database. Therefore it has now an optional parameter of type Shopware_Components_Plugin_Bootstrap. If it is present, that plugin's subscribes will be fully synced, meaning that its removed subscribes will be deleted from the database.
> 
> Please note, that unsubscribeEvent() relies on a properly working removeListener() method in Enlight_Event_Subscriber_Config which was fixed by #451. Until that is merged, the newly added test will fail!
> 
> This is an updated version of #175.
