### PR TITLE
inconsistent net and gross amounts in basket for modus = 4

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2198,7 +2198,7 @@ class sBasket
                         $discount += ($getArticles[$key]["amountWithTax"] / 100 * ($this->sSYSTEM->sUSERGROUPDATA["basketdiscount"]));
                     }
                 } elseif ($getArticles[$key]["modus"] == 4 || $getArticles[$key]["modus"] == 10) {
-                    $getArticles[$key]["amountWithTax"] = round(1 * ($price / 100 * (100 + $tax)), 2);
+                    $getArticles[$key]["amountWithTax"] = round($quantity * ($price / 100 * (100 + $tax)), 2);
                     if ($this->sSYSTEM->sUSERGROUPDATA["basketdiscount"] && $this->sCheckForDiscount()) {
                         $discount += ($getArticles[$key]["amountWithTax"] / 100 * $this->sSYSTEM->sUSERGROUPDATA["basketdiscount"]);
                     }


### PR DESCRIPTION
our use case:
In a shop with net mode, we need quantified shipping surcharges which we add via a plugin (i.e. we add basket items with modus = 4 and quantities > 1).
Net and gross amount calculations for such positions differ:
net amount is correct: quantity \* single net price
but gross amount is always 1 \* single net price \* tax_factor.

This is inconsistent.
Either quantity should be ignored for net and gross or quantity should be respected for both (which I would prefer ;-)

Corresponding lines in sBasket.php: 2201 (gross amount calculation) and 2208 (net amount calculation)
