### PR TITLE
Fix address comparison in order details

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -312,6 +312,8 @@ In this document you will find a changelog of the important changes related to t
 * Removed s_categories.noviewselect
 * Removed \Shopware\Models\Category\Category::$noViewSelect
 * Removed \Shopware\Bundle\StoreFrontBundle\Struct\Category::$allowViewSelect
+* Include the departments, salutations, cities and countries in the address comparison of the backend order details
+* Display the departments in the backend order details overview
 
 ## 5.1.6
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.

--- a/themes/Backend/ExtJs/backend/order/view/detail/overview.js
+++ b/themes/Backend/ExtJs/backend/order/view/detail/overview.js
@@ -320,64 +320,11 @@ Ext.define('Shopware.apps.Order.view.detail.Overview', {
             items: [
                 {
                     xtype: 'container',
-                    renderTpl: me.createBillingTemplate(),
+                    renderTpl: me.createAddressTemplate(),
                     renderData: billing.raw
                 }
             ]
         });
-    },
-
-    /**
-     * Creates the XTemplate for the billing information panel
-     *
-     * @return [Ext.XTemplate] generated Ext.XTemplate
-     */
-    createBillingTemplate:function () {
-        return new Ext.XTemplate(
-            '{literal}<tpl for=".">',
-                '<div class="customeer-info-pnl">',
-                    '<div class="base-info">',
-                        '<p>',
-                            '<span>{company}</span>',
-                        '</p>',
-                        '<p>',
-                            '<span>{salutationSnippet}</span>&nbsp;',
-                            '<tpl if="title"><span>{title}</span><br /></tpl>',
-                            '<span>{firstName}</span>&nbsp;',
-                            '<span>{lastName}</span>',
-                        '</p>',
-                        '<p>',
-                            '<span>{street}</span>',
-                        '</p>',
-                        '<tpl if="additionalAddressLine1">',
-                            '<p>',
-                                '<span>{additionalAddressLine1}</span>',
-                            '</p>',
-                        '</tpl>',
-                        '<tpl if="additionalAddressLine2">',
-                            '<p>',
-                                '<span>{additionalAddressLine2}</span>',
-                            '</p>',
-                        '</tpl>',
-                        '<p>',
-                            '<span>{zipCode}</span>&nbsp;',
-                            '<span>{city}</span>',
-                        '</p>',
-                        '<tpl for="state">',
-                            '<p>',
-                                '<span>{name}</span>',
-                            '</p>',
-                        '</tpl>',
-                        '<tpl for="country">',
-                            '<p>',
-                                '<span>{name}</span>',
-                            '</p>',
-                        '</tpl>',
-                    '</div>',
-                '</div>',
-
-            '</tpl>{/literal}'
-        );
     },
 
     /**
@@ -405,7 +352,7 @@ Ext.define('Shopware.apps.Order.view.detail.Overview', {
             items: [
                 {
                     xtype: 'container',
-                    renderTpl: me.createShippingTemplate(),
+                    renderTpl: me.createAddressTemplate(),
                     renderData:shipping.raw
                 }
             ]
@@ -414,8 +361,8 @@ Ext.define('Shopware.apps.Order.view.detail.Overview', {
 
 
     /**
-     * Checks if the shipping and billing address is different. If this is the case the panel title
-     * if colored red and an icon will be displayed on the right side.
+     * Checks if the shipping and billing address is different by comparing all their fields, except for the ids.
+     * If this is the case, the panel title is colored red and an icon will be displayed to its right.
      * @return string
      */
     getShippingPanelTitle: function() {
@@ -429,12 +376,19 @@ Ext.define('Shopware.apps.Order.view.detail.Overview', {
 
         billing = billing.first();
 
-        //if the shipping and billing address is different, an exclamation icon will be displayed.
+        // Compare ALL fields of the two addresses and if they differ, display an exclamation icon in the title of the box
         if (shipping.get('company') != billing.get('company') ||
+            shipping.get('department') != billing.get('department') ||
+            shipping.get('salutationSnippet') != billing.get('salutationSnippet') ||
             shipping.get('firstName') != billing.get('firstName') ||
             shipping.get('lastName') != billing.get('lastName') ||
             shipping.get('street') != billing.get('street') ||
-            shipping.get('zipCode') != billing.get('zipCode')) {
+            shipping.get('additionalAddressLine1') != billing.get('additionalAddressLine1') ||
+            shipping.get('additionalAddressLine2') != billing.get('additionalAddressLine2') ||
+            shipping.get('zipCode') != billing.get('zipCode') ||
+            shipping.get('city') != billing.get('city') ||
+            shipping.get('stateId') != billing.get('stateId') ||
+            shipping.get('countryId') != billing.get('countryId')) {
 
             var helper = new Ext.dom.Helper;
             var iconSpec = {
@@ -455,17 +409,20 @@ Ext.define('Shopware.apps.Order.view.detail.Overview', {
     },
 
     /**
-     * Creates the XTemplate for the billing information panel
+     * Creates the XTemplate for an address information panel, including department and salutation.
      *
      * @return [Ext.XTemplate] generated Ext.XTemplate
      */
-    createShippingTemplate:function () {
+    createAddressTemplate: function() {
         return new Ext.XTemplate(
             '{literal}<tpl for=".">',
                 '<div class="customer-info-pnl">',
                     '<div class="base-info">',
                         '<p>',
                             '<span>{company}</span>',
+                        '</p>',
+                        '<p>',
+                            '<span>{department}</span>',
                         '</p>',
                         '<p>',
                             '<span>{salutationSnippet}</span>&nbsp;',


### PR DESCRIPTION
Re-created and adapted PR #188 as a merge for the 5.2 branch.

Original PR text:

> Currently, the address comparison in the backend order details does not include the countries of the billing and shipping addresses. However, since some customers change the country to get around certain country restrictions, it is important to compare the countries, too. This PR adds this check, by comparing the countryIds of the two addresses.
> Because this fix is located in the ExtJS backend order app, I didn't include test cases.
> 
> I updated my commit to include also department, salutation and city in the address comparison. Additionally I also made department and salutation visible in the addresses in the backend order overview. This will make the applied comparison comprehensible to the user.
