### PR TITLE
Remove plugin manager timeouts

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -316,6 +316,7 @@ In this document you will find a changelog of the important changes related to t
 * Include the departments, salutations, cities and countries in the address comparison of the backend order details
 * Display the departments in the backend order details overview
 * Added new API resource 'Country' and respective REST API controller 'countries'
+* Remove timeouts from install/update/(secure) uninstall operations in plugin manager
 
 ## 5.1.6
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Controllers/Backend/PluginInstaller.php
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Controllers/Backend/PluginInstaller.php
@@ -53,6 +53,8 @@ class Shopware_Controllers_Backend_PluginInstaller extends Shopware_Controllers_
 
     public function installPluginAction()
     {
+        @set_time_limit(0);
+
         $plugin = $this->getPluginModel($this->Request()->getParam('technicalName'));
 
         if (!$plugin instanceof Plugin) {
@@ -82,6 +84,8 @@ class Shopware_Controllers_Backend_PluginInstaller extends Shopware_Controllers_
 
     public function updateAction()
     {
+        @set_time_limit(0);
+
         $technicalName = $this->Request()->getParam('technicalName');
 
         $plugin = $this->getPluginModel($technicalName);
@@ -121,6 +125,8 @@ class Shopware_Controllers_Backend_PluginInstaller extends Shopware_Controllers_
 
     public function uninstallPluginAction()
     {
+        @set_time_limit(0);
+
         $plugin = $this->getPluginModel($this->Request()->getParam('technicalName'));
 
         try {
@@ -137,6 +143,8 @@ class Shopware_Controllers_Backend_PluginInstaller extends Shopware_Controllers_
 
     public function secureUninstallPluginAction()
     {
+        @set_time_limit(0);
+
         $plugin = $this->getPluginModel($this->Request()->getParam('technicalName'));
 
         try {

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
@@ -157,7 +157,7 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
 
         me.authenticateForUpdate(plugin, function() {
             me.startPluginDownload(plugin, function() {
-                me.displayLoadingMask(plugin, '{s name=execute_update}Plugin is being updated{/s}');
+                me.displayLoadingMask(plugin, '{s name=execute_update}Plugin is being updated{/s}', false);
                 me.executePluginUpdate(plugin, function() {
 
                     Shopware.app.Application.fireEvent('load-update-listing', function() {
@@ -434,7 +434,7 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
 
     authenticateForUpdate: function(plugin, callback) {
         var me = this;
-        
+
         if (plugin.flaggedAsDummyPlugin()) {
             callback();
         } else {
@@ -450,10 +450,10 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
             { technicalName: plugin.get('technicalName') },
             function(response) {
                 me.handleCrudResponse(response, plugin);
-                if (typeof callback == 'function') {
-                    callback(response);
-                }
-            }
+                callback(response);
+            },
+            null,
+            300000
         );
     },
 
@@ -642,7 +642,7 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
     installPlugin: function(plugin, callback) {
         var me = this;
 
-        me.displayLoadingMask(plugin, '{s name="plugin_is_being_installed"}Plugin is being installed{/s}');
+        me.displayLoadingMask(plugin, '{s name="plugin_is_being_installed"}Plugin is being installed{/s}', false);
 
         me.sendAjaxRequest(
             '{url controller=PluginInstaller action=installPlugin}',
@@ -650,7 +650,9 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
             function(response) {
                 me.handleCrudResponse(response, plugin);
                 callback(response);
-            }
+            },
+            null,
+            300000
         );
     },
 
@@ -677,7 +679,7 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
     doUninstall: function(plugin, callback) {
         var me = this;
 
-        me.displayLoadingMask(plugin, '{s name="plugin_is_being_uninstalled"}Plugin is being uninstalled{/s}');
+        me.displayLoadingMask(plugin, '{s name="plugin_is_being_uninstalled"}Plugin is being uninstalled{/s}', false);
 
         me.sendAjaxRequest(
             '{url controller=PluginInstaller action=uninstallPlugin}',
@@ -685,7 +687,9 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
             function(response) {
                 me.handleCrudResponse(response, plugin);
                 callback(response);
-            }
+            },
+            null,
+            300000
         );
     },
 
@@ -707,7 +711,7 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
     secureUninstallPlugin: function(plugin, callback) {
         var me = this;
 
-        me.displayLoadingMask(plugin, '{s name="plugin_is_being_uninstalled"}Plugin is being uninstalled{/s}');
+        me.displayLoadingMask(plugin, '{s name="plugin_is_being_uninstalled"}Plugin is being uninstalled{/s}', false);
 
         me.sendAjaxRequest(
             '{url controller=PluginInstaller action=secureUninstallPlugin}',
@@ -715,7 +719,9 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
             function(response) {
                 me.handleCrudResponse(response, plugin);
                 callback(response);
-            }
+            },
+            null,
+            300000
         );
     },
 

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/plugin_helper.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/plugin_helper.js
@@ -249,13 +249,14 @@ Ext.define('Shopware.apps.PluginManager.view.PluginHelper', {
         );
     },
 
-    sendAjaxRequest: function(url, params, callback, errorCallback) {
+    sendAjaxRequest: function(url, params, callback, errorCallback, timeout) {
         var me = this;
 
         Ext.Ajax.request({
             url: url,
             method: 'POST',
             params: params,
+            timeout: Ext.isNumber(timeout) ? timeout : 30000,
             success: function(operation, opts) {
                 var response = Ext.decode(operation.responseText);
 


### PR DESCRIPTION
Re-created PR #360 for a rebase on top of the 5.2 branch.

Original PR text:

> Currently the plugin manager uses the default timeout settings when installing/updating/uninstalling plugins. That is, the default PHP timeout (e.g. 30 seconds) for the operation itself, the Ext JS default timeout for AJAX requests (30 seconds) as well as the default timeout of 15 seconds for hiding the loading animation. When running e.g. a plugin installation/update/uninstallation with a duration of > 30 seconds, currently the following happens:
> - After 15 seconds: the loading animation disappears, although the request is still pending.
> - After 30 seconds: The AJAX requests gets cancelled, although the operation on the server is still running.
> - After PHPs timeout: The operation gets cancelled.
> 
> This behaviour is not desirable for several reasons:
> - The user thinks e.g. the plugin installation is finished, as soon as the loading mask is hidden (after max. 15 seconds). However, the plugin is still marked as not installed. Clicking the install button again might cause problems because of two concurrent installation operations.
> - Success messages are not displayed, because the AJAX request is cancelled.
> - Cancelling the install operation itself might result in e.g. a corrupt database.
> 
> This PR fixes the described behaviour by
> - Removing the timeouts of PHP operations for the respective actions
> - Disabling the autoTimeout of the loading mask
> - Seting the timeout of the respective AJAX request to a reasonable long time of 5 minutes
