### PR TITLE
Skip stats folder on update

### DIFF
--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/FileSystem.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/FileSystem.php
@@ -67,6 +67,9 @@ class FileSystem
 
         /** @var $fileInfo \DirectoryIterator */
         foreach (new \DirectoryIterator($directory) as $fileInfo) {
+            
+            if (preg_match("/stats/", $fileInfo->getPathname())) continue;
+            
             if ($fileInfo->isDot()) {
                 continue;
             }


### PR DESCRIPTION
In ISPConfig there is always a `stats` folder. Because this folder does not belong to Shopware, Shopware is blocking Updates everytime, so you have to change this line manually in the Core file.

It would be good to merge this pull request to skip this folder in future updates.
