### PR TITLE
Updated add product to compare click event target

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-add.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-add.js
@@ -39,7 +39,7 @@
          */
         onAddArticleCompare: function (event) {
             var me = this,
-                $target = $(event.target),
+                $target = $(event.currentTarget),
                 addArticleUrl = $target.attr('href');
 
             event.preventDefault();


### PR DESCRIPTION
I've run into an issue where adding article to compare list doesnt work when parent dom with data-product-compare-add="true" has some children dom elements. In your demo page this is observable when clicking icon, not the text of compare button.
This simple change checks for attribute on the event source, instead of clicked children
