### PR TITLE
Uninstall and Cache Invalidation Options for new plugin system

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
@@ -81,7 +81,10 @@ class PluginInstaller implements PluginInstallerInterface
             $this->em->flush($plugin);
         });
 
-        return true;
+        return [
+            'success' => true,
+            'invalidateCache' => $this->getCacheActions($pluginBootstrap, 'install')
+        ];
     }
 
     /**
@@ -129,7 +132,13 @@ class PluginInstaller implements PluginInstallerInterface
         $this->removeFormsAndElements($pluginId);
         $this->removeEmotionComponents($pluginId);
 
-        return $this->getPluginByName($plugin->getName())->uninstall();
+        $pluginBootstrap = $this->getPluginByName($plugin->getName());
+        $pluginBootstrap->uninstall();
+
+        return [
+            'success' => true,
+            'invalidateCache' => $this->getCacheActions($pluginBootstrap, 'uninstall')
+        ];
     }
 
     /**
@@ -160,6 +169,11 @@ class PluginInstaller implements PluginInstallerInterface
 
             $this->em->flush($plugin);
         });
+
+        return [
+            'success' => true,
+            'invalidateCache' => $this->getCacheActions($pluginBootstrap, 'update')
+        ];
     }
 
     /**
@@ -170,7 +184,12 @@ class PluginInstaller implements PluginInstallerInterface
         $plugin->setActive(true);
         $this->em->flush($plugin);
 
-        return true;
+        $pluginBootstrap = $this->getPluginByName($plugin->getName());
+
+        return [
+            'success' => true,
+            'invalidateCache' => $this->getCacheActions($pluginBootstrap, 'activate')
+        ];
     }
 
     /**
@@ -181,7 +200,12 @@ class PluginInstaller implements PluginInstallerInterface
         $plugin->setActive(false);
         $this->em->flush($plugin);
 
-        return true;
+        $pluginBootstrap = $this->getPluginByName($plugin->getName());
+
+        return [
+            'success' => true,
+            'invalidateCache' => $this->getCacheActions($pluginBootstrap, 'deactivate')
+        ];
     }
 
     /**
@@ -276,17 +300,33 @@ class PluginInstaller implements PluginInstallerInterface
      */
     public function getPluginPath(Plugin $plugin)
     {
-        /** @var Kernel $kernel */
         $pluginBootstrap = $this->getPluginByName($plugin->getName());
 
         return $pluginBootstrap->getPath();
+    }
+
+    public function getCacheActions(\Shopware\Components\Plugin $plugin, $action = 'install')
+    {
+        $xmlPluginInfo = new XmlPluginInfoReader();
+
+        if (file_exists($plugin->getPath() . '/plugin.xml')) {
+            $info = $xmlPluginInfo->read($plugin->getPath() . '/plugin.xml');
+        } else {
+            return null;
+        }
+
+        if (isset($info['cache-invalidation']) && isset($info['cache-invalidation'][$action])) {
+            return $info['cache-invalidation'][$action];
+        } else {
+            return null;
+        }
     }
 
     /**
      * @param string $pluginName
      * @return \Shopware\Components\Plugin
      */
-    private function getPluginByName($pluginName)
+    public function getPluginByName($pluginName)
     {
         /** @var Kernel $kernel */
         $kernel = Shopware()->Container()->get('kernel');

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
@@ -128,6 +128,8 @@ class PluginInstaller implements PluginInstallerInterface
         $this->removeTemplates($pluginId);
         $this->removeFormsAndElements($pluginId);
         $this->removeEmotionComponents($pluginId);
+
+        return $this->getPluginByName($plugin->getName())->uninstall();
     }
 
     /**

--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -96,6 +96,13 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
 
     /**
      * This method can be overridden
+     */
+    public function uninstall()
+    {
+    }
+
+    /**
+     * This method can be overridden
      * @param string $oldVersion
      * @param string $currentVersion
      */

--- a/engine/Shopware/Components/Plugin/schema/plugin.xsd
+++ b/engine/Shopware/Components/Plugin/schema/plugin.xsd
@@ -2,51 +2,92 @@
 
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 
-    <xsd:element name="plugin" type="pluginType"/>
+    <xsd:element name="plugin" type="pluginType" />
 
     <xsd:complexType name="pluginType">
         <xsd:sequence>
-            <xsd:element name="label" type="translatableString" minOccurs="0" maxOccurs="unbounded"/>
-            <xsd:element name="version" type="xsd:string"/>
-            <xsd:element name="copyright" type="xsd:string" minOccurs="0"/>
-            <xsd:element name="license" type="xsd:string" minOccurs="0"/>
-            <xsd:element name="link" type="xsd:anyURI" minOccurs="0"/>
-            <xsd:element name="author" type="xsd:string" minOccurs="0"/>
-            <xsd:element name="description" type="translatableString" minOccurs="0" maxOccurs="unbounded"/>
-            <xsd:element name="changelog" type="changelogLog" minOccurs="0" maxOccurs="unbounded"/>
-            <xsd:element name="compatibility" type="compatibilityType" minOccurs="0"/>
+            <xsd:element name="label" type="translatableString" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="version" type="xsd:string" />
+            <xsd:element name="copyright" type="xsd:string" minOccurs="0" />
+            <xsd:element name="license" type="xsd:string" minOccurs="0" />
+            <xsd:element name="link" type="xsd:anyURI" minOccurs="0" />
+            <xsd:element name="author" type="xsd:string" minOccurs="0" />
+            <xsd:element name="description" type="translatableString" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="changelog" type="changelogLog" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="compatibility" type="compatibilityType" minOccurs="0" />
+            <xsd:element name="cache-invalidation" type="cacheInvalidateType" minOccurs="0" />
             <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 
     <xsd:complexType name="compatibilityType">
         <xsd:sequence>
-            <xsd:element name="blacklist" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="blacklist" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
-        <xsd:attribute name="minVersion" type="xsd:string"/>
-        <xsd:attribute name="maxVersion" type="xsd:string"/>
+        <xsd:attribute name="minVersion" type="xsd:string" />
+        <xsd:attribute name="maxVersion" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="changelogLog">
         <xsd:sequence>
-            <xsd:element name="changes" type="translatableString" maxOccurs="unbounded"/>
+            <xsd:element name="changes" type="translatableString" maxOccurs="unbounded" />
         </xsd:sequence>
-        <xsd:attribute name="version" type="xsd:string"/>
+        <xsd:attribute name="version" type="xsd:string" />
     </xsd:complexType>
+
+    <xsd:complexType name="cacheInvalidateType">
+        <xsd:sequence>
+            <xsd:element name="invalidate" type="pluginCacheType" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="cacheInvalidateAttribute">
+        <xsd:attribute name="on" type="pluginMethodType" use="required" />
+    </xsd:complexType>
+
+    <xsd:simpleType name="pluginMethodType">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="install" />
+            <xsd:enumeration value="uninstall" />
+            <xsd:enumeration value="update" />
+            <xsd:enumeration value="activate" />
+            <xsd:enumeration value="deactivate" />
+            <xsd:enumeration value="saveConfig" />
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="pluginCacheType">
+        <xsd:sequence>
+            <xsd:element name="cache" type="pluginCacheTypes" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="on" type="pluginMethodType" use="required" />
+    </xsd:complexType>
+
+    <xsd:simpleType name="pluginCacheTypes">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="config" />
+            <xsd:enumeration value="theme" />
+            <xsd:enumeration value="frontend" />
+            <xsd:enumeration value="proxy" />
+            <xsd:enumeration value="cache" />
+            <xsd:enumeration value="http" />
+            <xsd:enumeration value="search" />
+            <xsd:enumeration value="router" />
+        </xsd:restriction>
+    </xsd:simpleType>
 
     <xsd:simpleType name="scope">
         <xsd:restriction base="xsd:string">
-            <xsd:enumeration value="local"/>
-            <xsd:enumeration value="shop"/>
+            <xsd:enumeration value="local" />
+            <xsd:enumeration value="shop" />
         </xsd:restriction>
     </xsd:simpleType>
 
     <xsd:complexType name="translatableString">
         <xsd:simpleContent>
             <xsd:extension base="xsd:string">
-                <xsd:attribute name="lang" type="xsd:language" default="en"/>
+                <xsd:attribute name="lang" type="xsd:language" default="en" />
             </xsd:extension>
         </xsd:simpleContent>
     </xsd:complexType>
-
 </xsd:schema>

--- a/engine/Shopware/Controllers/Backend/Config.php
+++ b/engine/Shopware/Controllers/Backend/Config.php
@@ -277,7 +277,21 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
             ));
         }
 
-        $this->View()->assign(array('success' => true));
+        if ($this->Request()->has('id')) {
+            $technicalName = Shopware()->Container()->get('dbal_connection')->fetchColumn('SELECT `name` FROM s_core_plugins WHERE `id` = (SELECT `plugin_id` FROM s_core_config_forms WHERE `id` = ?) and `namespace` = "ShopwarePlugins"', [$this->Request()->getParam('id')]);
+
+            try {
+                $pluginBootstrap = Shopware()->Container()->get('shopware_plugininstaller.plugin_installer')->getPluginByName($technicalName);
+                $this->View()->assign([
+                    'success' => true,
+                    'invalidateCache' => Shopware()->Container()->get('shopware_plugininstaller.plugin_installer')->getCacheActions($pluginBootstrap, 'saveConfig')
+                ]);
+            } catch (Exception $e) {
+                $this->View()->assign(['success' => true]);
+            }
+        } else {
+            $this->View()->assign(['success' => true]);
+        }
     }
 
     /**

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
@@ -147,8 +147,8 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
     saveConfiguration: function(plugin, form) {
         var me = this;
 
-        form.onSaveForm(form, false, function() {
-
+        form.onSaveForm(form, false, function(form, records, operation) {
+            me.handleCrudResponse(records.proxy.getReader().jsonData, plugin);
         });
     },
 
@@ -434,7 +434,7 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
 
     authenticateForUpdate: function(plugin, callback) {
         var me = this;
-        
+
         if (plugin.flaggedAsDummyPlugin()) {
             callback();
         } else {
@@ -778,7 +778,7 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
             }
         }
 
-        if (response.hasOwnProperty('invalidateCache')) {
+        if (response.hasOwnProperty('invalidateCache') && response.invalidateCache != null) {
             this.clearCache(response.invalidateCache, plugin);
         }
     },

--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.PluginPanel.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.PluginPanel.js
@@ -400,7 +400,7 @@ Ext.define('Shopware.form.PluginPanel',
                     win.destroy();
                 }
                 if(callback) {
-                    callback.apply(me, records, operation);
+                    callback(me, records, operation);
                 }
             },
             failure:function (records, operation) {


### PR DESCRIPTION
I added in this Pull Request a new method uninstall in the plugin class. This is needed in some requirements like drop tables on uninstall, mail templates etc...

My second point was to add a cache invalidation in the plugin.xml.
Example:

``` xml
<cache-invalidation>
        <invalidate on="install">
            <cache>config</cache>
            <cache>proxy</cache>
        </invalidate>
        <invalidate on="activate">
            <cache>theme</cache>
        </invalidate>
        <invalidate on="uninstall">
            <cache>config</cache>
            <cache>proxy</cache>
        </invalidate>
        <invalidate on="saveConfig">
            <cache>config</cache>
        </invalidate>
    </cache-invalidation>
```

Special Thanks to @t2oh4e which helps me with xsd.......
