### PR TITLE
Added filter events to all convert functions in LegacyStructConverter

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -321,6 +321,7 @@ In this document you will find a changelog of the important changes related to t
 * Removed method `\Shopware_Controllers_Frontend_Account::resetPassword()`
 * Changed structure of `billing` and `shipping` to `\Shopware\Models\Customer\Address` in `\Shopware\Components\Api\Resource\Customer`
 * Added filter events to all convert functions in `LegacyStructConverter`
+* Added interface `LegacyStructConverterInterface` to `LegacyStructConverter`
 
 ## 5.1.6
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -320,6 +320,7 @@ In this document you will find a changelog of the important changes related to t
 * Removed method `\Shopware_Controllers_Frontend_Account::validatePasswordResetForm()`
 * Removed method `\Shopware_Controllers_Frontend_Account::resetPassword()`
 * Changed structure of `billing` and `shipping` to `\Shopware\Models\Customer\Address` in `\Shopware\Components\Api\Resource\Customer`
+* Added filter events to all convert functions in `LegacyStructConverter`
 
 ## 5.1.6
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -110,7 +110,9 @@ class LegacyStructConverter
             $data['states'] = $this->convertStateStructList($country->getStates());
         }
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Country', $data, [
+            'country' => $country
+        ]);
     }
 
     /**
@@ -130,7 +132,10 @@ class LegacyStructConverter
     {
         $data = json_decode(json_encode($state), true);
         $data += ['shortcode' => $state->getCode()];
-        return $data;
+
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_State', $data, [
+            'state' => $state
+        ]);
     }
 
     /**
@@ -141,7 +146,7 @@ class LegacyStructConverter
      */
     public function convertConfiguratorGroupStruct(StoreFrontBundle\Struct\Configurator\Group $group)
     {
-        return array(
+        $data = array(
             'groupID' => $group->getId(),
             'groupname' => $group->getName(),
             'groupdescription' => $group->getDescription(),
@@ -149,6 +154,10 @@ class LegacyStructConverter
             'selected' => $group->isSelected(),
             'user_selected' => $group->isSelected()
         );
+
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Configurator_Group', $data, [
+            'configurator_group' => $group
+        ]);
     }
 
     /**
@@ -168,7 +177,7 @@ class LegacyStructConverter
             $attribute = $category->getAttribute('core')->toArray();
         }
 
-        return [
+        $data = [
             'id' => $category->getId(),
             'parentId' => $category->getParentId(),
             'name' => $category->getName(),
@@ -192,6 +201,10 @@ class LegacyStructConverter
             'media' => $media,
             'link' => $this->getCategoryLink($category)
         ];
+
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Category', $data, [
+            'category' => $category
+        ]);
     }
 
     /**
@@ -331,7 +344,9 @@ class LegacyStructConverter
         $promotion["linkDetails"] = $this->config->get('baseFile') .
             "?sViewport=detail&sArticle=" . $promotion["articleID"];
 
-        return $promotion;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_List_Product', $promotion, [
+            'product' => $product
+        ]);
     }
 
     /**
@@ -346,12 +361,16 @@ class LegacyStructConverter
             return array();
         }
 
-        return [
+        $data = [
             'id' => $productStream->getId(),
             'name' => $productStream->getName(),
             'description' => $productStream->getDescription(),
             'type' => $productStream->getType()
         ];
+
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Related_Product_Stream', $data, [
+            'product_stream' => $productStream
+        ]);
     }
 
     /**
@@ -510,7 +529,9 @@ class LegacyStructConverter
             $data['relatedProductStreams'][] = $this->convertRelatedProductStreamStruct($relatedProductStream);
         }
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Product', $data, [
+            'product' => $product
+        ]);
     }
 
     /**
@@ -527,7 +548,9 @@ class LegacyStructConverter
 
         $data['attributes'] = $average->getAttributes();
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Vote_Average', $data, [
+            'average' => $average
+        ]);
     }
 
     /**
@@ -559,7 +582,9 @@ class LegacyStructConverter
 
         $data['attributes'] = $vote->getAttributes();
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Vote', $data, [
+            'vote' => $vote
+        ]);
     }
 
     /**
@@ -580,7 +605,9 @@ class LegacyStructConverter
 
         $data['attributes'] = $price->getAttributes();
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Price', $data, [
+            'price' => $price
+        ]);
     }
 
     private function getSourceSet($thumbnail)
@@ -663,7 +690,9 @@ class LegacyStructConverter
 
         $data['unit_attributes'] = $unit->getAttributes();
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Unit', $data, [
+            'unit' => $unit
+        ]);
     }
 
     /**
@@ -739,7 +768,9 @@ class LegacyStructConverter
             ];
         }
 
-        return $result;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Property_Set', $result, [
+            'property_set' => $set
+        ]);
     }
 
     /**
@@ -764,7 +795,9 @@ class LegacyStructConverter
             $data['options'][] = $this->convertPropertyOptionStruct($option);
         }
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Property_Group', $data, [
+            'property_group' => $group
+        ]);
     }
 
     /**
@@ -783,7 +816,9 @@ class LegacyStructConverter
             $data['attributes'][$key] = $attribute->toArray();
         }
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Property_Option', $data, [
+            'property_option' => $option
+        ]);
     }
 
     /**
@@ -811,7 +846,9 @@ class LegacyStructConverter
             );
         }
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Manufacturer', $data, [
+            'manufacturer' => $manufacturer
+        ]);
     }
 
     /**
@@ -853,7 +890,10 @@ class LegacyStructConverter
             'isSelectionSpecified' => $set->isSelectionSpecified()
         );
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Configurator_Set', $data, [
+            'configurator_set' => $set,
+            'product' => $product
+        ]);
     }
 
     /**
@@ -891,7 +931,10 @@ class LegacyStructConverter
 
         $data['sBlockPrices'] = [];
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Configurator_Price', $data, [
+            'configurator_set' => $set,
+            'product' => $product
+        ]);
     }
 
     /**
@@ -923,7 +966,10 @@ class LegacyStructConverter
             $settings["template"] = "article_config_upprice.tpl";
         }
 
-        return $settings;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Configurator_Settings', $settings, [
+            'configurator_set' => $set,
+            'product' => $product
+        ]);
     }
 
     /**
@@ -950,7 +996,10 @@ class LegacyStructConverter
             $data['media'] = $this->convertMediaStruct($option->getMedia());
         }
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Configurator_Option', $data, [
+            'configurator_group' => $group,
+            'configurator_options' => $option
+        ]);
     }
 
     /**
@@ -1095,7 +1144,9 @@ class LegacyStructConverter
             $data['sReleasedate'] = $product->getReleaseDate()->format('Y-m-d');
         }
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_List_Product_data', $data, [
+            'product' => $product,
+        ]);
     }
 
     /**

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -34,7 +34,7 @@ use Shopware\Bundle\StoreFrontBundle\Service\Core\ContextService;
  * @package   Shopware\Components\Compatibility
  * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
-class LegacyStructConverter
+class LegacyStructConverter implements LegacyStructConverterInterface
 {
     /**
      * @var \Shopware_Components_Config
@@ -75,8 +75,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Country[] $countries
-     * @return array
+     * @inheritdoc
      */
     public function convertCountryStructList($countries)
     {
@@ -84,8 +83,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Country $country
-     * @return array
+     * @inheritdoc
      */
     public function convertCountryStruct(StoreFrontBundle\Struct\Country $country)
     {
@@ -116,8 +114,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Country\State[] $states
-     * @return array
+     * @inheritdoc
      */
     public function convertStateStructList($states)
     {
@@ -125,8 +122,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Country\State $state
-     * @return array
+     * @inheritdoc
      */
     public function convertStateStruct(StoreFrontBundle\Struct\Country\State $state)
     {
@@ -139,10 +135,7 @@ class LegacyStructConverter
     }
 
     /**
-     * Converts a configurator group struct which used for default or selection configurators.
-     *
-     * @param StoreFrontBundle\Struct\Configurator\Group $group
-     * @return array
+     * @inheritdoc
      */
     public function convertConfiguratorGroupStruct(StoreFrontBundle\Struct\Configurator\Group $group)
     {
@@ -161,9 +154,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Category $category
-     * @return array
-     * @throws \Exception
+     * @inheritdoc
      */
     public function convertCategoryStruct(StoreFrontBundle\Struct\Category $category)
     {
@@ -224,8 +215,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\ListProduct[] $products
-     * @return array
+     * @inheritdoc
      */
     public function convertListProductStructList(array $products)
     {
@@ -233,10 +223,7 @@ class LegacyStructConverter
     }
 
     /**
-     * Converts the passed ListProduct struct to a shopware 3-4 array structure.
-     *
-     * @param StoreFrontBundle\Struct\ListProduct $product
-     * @return array
+     * @inheritdoc
      */
     public function convertListProductStruct(StoreFrontBundle\Struct\ListProduct $product)
     {
@@ -350,10 +337,7 @@ class LegacyStructConverter
     }
 
     /**
-     * Converts the passed ProductStream struct to an array structure.
-     *
-     * @param StoreFrontBundle\Struct\ProductStream $productStream
-     * @return array
+     * @inheritdoc
      */
     public function convertRelatedProductStreamStruct(StoreFrontBundle\Struct\ProductStream $productStream)
     {
@@ -374,8 +358,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Product $product
-     * @return array
+     * @inheritdoc
      */
     public function convertProductStruct(StoreFrontBundle\Struct\Product $product)
     {
@@ -535,8 +518,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Product\VoteAverage $average
-     * @return array
+     * @inheritdoc
      */
     public function convertVoteAverageStruct(StoreFrontBundle\Struct\Product\VoteAverage $average)
     {
@@ -554,8 +536,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Product\Vote $vote
-     * @return array
+     * @inheritdoc
      */
     public function convertVoteStruct(StoreFrontBundle\Struct\Product\Vote $vote)
     {
@@ -588,8 +569,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Product\Price $price
-     * @return array
+     * @inheritdoc
      */
     public function convertPriceStruct(StoreFrontBundle\Struct\Product\Price $price)
     {
@@ -620,8 +600,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Media $media
-     * @return array
+     * @inheritdoc
      */
     public function convertMediaStruct(StoreFrontBundle\Struct\Media $media)
     {
@@ -669,8 +648,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Product\Unit $unit
-     * @return array
+     * @inheritdoc
      */
     public function convertUnitStruct(StoreFrontBundle\Struct\Product\Unit $unit)
     {
@@ -705,37 +683,7 @@ class LegacyStructConverter
     }
 
     /**
-     * Example:
-     *
-     * return [
-     *     9 => [
-     *         'id' => 9,
-     *         'optionID' => 9,
-     *         'name' => 'Farbe',
-     *         'groupID' => 1,
-     *         'groupName' => 'Edelbrände',
-     *         'value' => 'goldig',
-     *         'values' => [
-     *             53 => 'goldig',
-     *         ],
-     *     ],
-     *     2 => [
-     *         'id' => 2,
-     *         'optionID' => 2,
-     *         'name' => 'Flaschengröße',
-     *         'groupID' => 1,
-     *         'groupName' => 'Edelbrände',
-     *         'value' => '0,5 Liter, 0,7 Liter, 1,0 Liter',
-     *         'values' => [
-     *             23 => '0,5 Liter',
-     *             24 => '0,7 Liter',
-     *             25 => '1,0 Liter',
-     *         ],
-     *     ],
-     * ];
-     *
-     * @param StoreFrontBundle\Struct\Property\Set $set
-     * @return array
+     * @inheritdoc
      */
     public function convertPropertySetStruct(StoreFrontBundle\Struct\Property\Set $set)
     {
@@ -774,8 +722,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Property\Group $group
-     * @return array
+     * @inheritdoc
      */
     public function convertPropertyGroupStruct(StoreFrontBundle\Struct\Property\Group $group)
     {
@@ -801,8 +748,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Property\Option $option
-     * @return array
+     * @inheritdoc
      */
     public function convertPropertyOptionStruct(StoreFrontBundle\Struct\Property\Option $option)
     {
@@ -822,8 +768,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Product\Manufacturer $manufacturer
-     * @return array
+     * @inheritdoc
      */
     public function convertManufacturerStruct(StoreFrontBundle\Struct\Product\Manufacturer $manufacturer)
     {
@@ -852,9 +797,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\ListProduct $product
-     * @param StoreFrontBundle\Struct\Configurator\Set $set
-     * @return array
+     * @inheritdoc
      */
     public function convertConfiguratorStruct(
         StoreFrontBundle\Struct\ListProduct $product,
@@ -897,9 +840,7 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\ListProduct $product
-     * @param StoreFrontBundle\Struct\Configurator\Set $set
-     * @return array
+     * @inheritdoc
      */
     public function convertConfiguratorPrice(
         StoreFrontBundle\Struct\ListProduct $product,
@@ -973,11 +914,7 @@ class LegacyStructConverter
     }
 
     /**
-     * Converts a configurator option struct which used for default or selection configurators.
-     *
-     * @param StoreFrontBundle\Struct\Configurator\Group $group
-     * @param StoreFrontBundle\Struct\Configurator\Option $option
-     * @return array
+     * @inheritdoc
      */
     public function convertConfiguratorOptionStruct(
         StoreFrontBundle\Struct\Configurator\Group $group,

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverterInterface.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverterInterface.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Compatibility;
+
+use Shopware\Bundle\StoreFrontBundle;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Components\Compatibility
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+interface LegacyStructConverterInterface
+{
+    /**
+     * @param StoreFrontBundle\Struct\Country[] $countries
+     * @return array
+     */
+    public function convertCountryStructList($countries);
+
+    /**
+     * @param StoreFrontBundle\Struct\Country $country
+     * @return array
+     */
+    public function convertCountryStruct(StoreFrontBundle\Struct\Country $country);
+
+    /**
+     * @param StoreFrontBundle\Struct\Country\State[] $states
+     * @return array
+     */
+    public function convertStateStructList($states);
+
+    /**
+     * @param StoreFrontBundle\Struct\Country\State $state
+     * @return array
+     */
+    public function convertStateStruct(StoreFrontBundle\Struct\Country\State $state);
+
+    /**
+     * Converts a configurator group struct which used for default or selection configurators.
+     *
+     * @param StoreFrontBundle\Struct\Configurator\Group $group
+     * @return array
+     */
+    public function convertConfiguratorGroupStruct(StoreFrontBundle\Struct\Configurator\Group $group);
+
+    /**
+     * @param StoreFrontBundle\Struct\Category $category
+     * @return array
+     * @throws \Exception
+     */
+    public function convertCategoryStruct(StoreFrontBundle\Struct\Category $category);
+
+    /**
+     * @param StoreFrontBundle\Struct\ListProduct[] $products
+     * @return array
+     */
+    public function convertListProductStructList(array $products);
+
+    /**
+     * Converts the passed ListProduct struct to a shopware 3-4 array structure.
+     *
+     * @param StoreFrontBundle\Struct\ListProduct $product
+     * @return array
+     */
+    public function convertListProductStruct(StoreFrontBundle\Struct\ListProduct $product);
+
+    /**
+     * Converts the passed ProductStream struct to an array structure.
+     *
+     * @param StoreFrontBundle\Struct\ProductStream $productStream
+     * @return array
+     */
+    public function convertRelatedProductStreamStruct(StoreFrontBundle\Struct\ProductStream $productStream);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product $product
+     * @return array
+     */
+    public function convertProductStruct(StoreFrontBundle\Struct\Product $product);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\VoteAverage $average
+     * @return array
+     */
+    public function convertVoteAverageStruct(StoreFrontBundle\Struct\Product\VoteAverage $average);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\Vote $vote
+     * @return array
+     */
+    public function convertVoteStruct(StoreFrontBundle\Struct\Product\Vote $vote);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\Price $price
+     * @return array
+     */
+    public function convertPriceStruct(StoreFrontBundle\Struct\Product\Price $price);
+
+    /**
+     * @param StoreFrontBundle\Struct\Media $media
+     * @return array
+     */
+    public function convertMediaStruct(StoreFrontBundle\Struct\Media $media);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\Unit $unit
+     * @return array
+     */
+    public function convertUnitStruct(StoreFrontBundle\Struct\Product\Unit $unit);
+    
+
+    /**
+     * Example:
+     *
+     * return [
+     *     9 => [
+     *         'id' => 9,
+     *         'optionID' => 9,
+     *         'name' => 'Farbe',
+     *         'groupID' => 1,
+     *         'groupName' => 'Edelbrände',
+     *         'value' => 'goldig',
+     *         'values' => [
+     *             53 => 'goldig',
+     *         ],
+     *     ],
+     *     2 => [
+     *         'id' => 2,
+     *         'optionID' => 2,
+     *         'name' => 'Flaschengröße',
+     *         'groupID' => 1,
+     *         'groupName' => 'Edelbrände',
+     *         'value' => '0,5 Liter, 0,7 Liter, 1,0 Liter',
+     *         'values' => [
+     *             23 => '0,5 Liter',
+     *             24 => '0,7 Liter',
+     *             25 => '1,0 Liter',
+     *         ],
+     *     ],
+     * ];
+     *
+     * @param StoreFrontBundle\Struct\Property\Set $set
+     * @return array
+     */
+    public function convertPropertySetStruct(StoreFrontBundle\Struct\Property\Set $set);
+
+    /**
+     * @param StoreFrontBundle\Struct\Property\Group $group
+     * @return array
+     */
+    public function convertPropertyGroupStruct(StoreFrontBundle\Struct\Property\Group $group);
+
+    /**
+     * @param StoreFrontBundle\Struct\Property\Option $option
+     * @return array
+     */
+    public function convertPropertyOptionStruct(StoreFrontBundle\Struct\Property\Option $option);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\Manufacturer $manufacturer
+     * @return array
+     */
+    public function convertManufacturerStruct(StoreFrontBundle\Struct\Product\Manufacturer $manufacturer);
+
+    /**
+     * @param StoreFrontBundle\Struct\ListProduct $product
+     * @param StoreFrontBundle\Struct\Configurator\Set $set
+     * @return array
+     */
+    public function convertConfiguratorStruct(
+        StoreFrontBundle\Struct\ListProduct $product,
+        StoreFrontBundle\Struct\Configurator\Set $set
+    );
+
+    /**
+     * @param StoreFrontBundle\Struct\ListProduct $product
+     * @param StoreFrontBundle\Struct\Configurator\Set $set
+     * @return array
+     */
+    public function convertConfiguratorPrice(
+        StoreFrontBundle\Struct\ListProduct $product,
+        StoreFrontBundle\Struct\Configurator\Set $set
+    );
+
+    /**
+     * Converts a configurator option struct which used for default or selection configurators.
+     *
+     * @param StoreFrontBundle\Struct\Configurator\Group $group
+     * @param StoreFrontBundle\Struct\Configurator\Option $option
+     * @return array
+     */
+    public function convertConfiguratorOptionStruct(
+        StoreFrontBundle\Struct\Configurator\Group $group,
+        StoreFrontBundle\Struct\Configurator\Option $option
+    );
+}

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -128,7 +128,7 @@ class sArticles
     private $db;
 
     /**
-     * @var \Shopware\Components\Compatibility\LegacyStructConverter
+     * @var \Shopware\Components\Compatibility\LegacyStructConverterInterface
      */
     private $legacyStructConverter;
 


### PR DESCRIPTION
This is needed to be able to convert the attributes you can add in the decorated services to the struct objects. The new events are consistent to the event `Legacy_Struct_Converter_Convert_Media` that was already present in the code. This also creates the ability to edit the storefront data in one central place.
