### PR TITLE
Check relations before translation them in article resource

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -2075,23 +2075,29 @@ class Article extends Resource implements BatchInterface
             );
         }
 
-        $data['related'] = $this->translateAssociation(
-            $data['related'],
-            $shop,
-            'article'
-        );
+        if(isset($data['related'])) {
+            $data['related'] = $this->translateAssociation(
+                $data['related'],
+                $shop,
+                'article'
+            );
+        }
 
-        $data['similar'] = $this->translateAssociation(
-            $data['similar'],
-            $shop,
-            'article'
-        );
+        if(isset($data['similar'])) {
+            $data['similar'] = $this->translateAssociation(
+                $data['similar'],
+                $shop,
+                'article'
+            );
+        }
 
-        $data['images'] = $this->translateAssociation(
-            $data['images'],
-            $shop,
-            'articleimage'
-        );
+        if (isset($data['images'])) {
+            $data['images'] = $this->translateAssociation(
+                $data['images'],
+                $shop,
+                'articleimage'
+            );
+        }
 
         return $data;
     }


### PR DESCRIPTION
Following error occurs using article resource with translation option, because article relation array are not fully validated.

```
            $article = \Shopware\Components\Api\Manager::getResource('Article')
                ->getOneByNumber($id, ['language' => 2]);
```

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Shopware\Components\Api\Resource\Article::translateAssociation() must be of the type array, null given
```
