### PR TITLE
[BUGFIX] No files as plugin

### DIFF
--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -312,7 +312,7 @@ class Kernel implements HttpKernelInterface
 
         $pluginRoot = $this->getRootDir().'/custom/plugins';
         foreach (new \DirectoryIterator($pluginRoot) as $pluginDir) {
-            if ($pluginDir->isDot()) {
+            if ($pluginDir->isDot() || $pluginDir->isFile()) {
                 continue;
             }
 


### PR DESCRIPTION
Don't allow files like .gitkeep to be tested as plugin. isDir and isLink should be OK

Avoid errors like

``` php
Warning: is_file(): open_basedir restriction in effect. File(/var/www/plugins/.gitkeep/.gitkeep.php) is not within the allowed path(s): (/var/www:[MORE]) in /var/www/engine/Shopware/Kernel.php on line 311
```
