### PR TITLE
[BUGFIX] Don't add condition as post_filter

### DIFF
--- a/engine/Shopware/Components/ProductStream/Repository.php
+++ b/engine/Shopware/Components/ProductStream/Repository.php
@@ -93,7 +93,7 @@ class Repository implements RepositoryInterface
     {
         $ordernumbers = $this->getOrdernumbers($productStream['id']);
 
-        $criteria->addCondition(new OrdernumberCondition($ordernumbers));
+        $criteria->addBaseCondition(new OrdernumberCondition($ordernumbers));
 
         $sortings = $criteria->getSortings();
         if (empty($sortings)) {


### PR DESCRIPTION
When displaying product streams with a custom selected set of articles, always all available filters show up in frontend, not only the matching for the current result.

The ES documentation says about post_filters:
"The post_filter is applied to the search hits at the very end of a search request, after aggregations have already been calculated" 

When the ProductStream Query is build, the CategoryId gets overwritten by the shop root category. In this case the Query can result all articles of the current shop. To only show selected articles in productstream the post_filter was added with the selected set of article numbers.

So ists better here to add the condition as "base condition" and not as "normal" condition.
