### PR TITLE
translate replacement of '&' in SEO URLs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -366,6 +366,7 @@ In this document you will find a changelog of the important changes related to t
 * Removed unused controller endpoints `ajax_login` and `ajax_logout` in `themes/Frontend/Bare/frontend/index/index.tpl`
 * \Shopware\Bundle\SearchBundleES\ConditionHandler\ProductAttributeConditionHandler requires now the \Shopware\Bundle\AttributeBundle\Service\CrudService as constructor dependency
 * Merged \Shopware\Bundle\AttributeBundle\Service\CrudService create and update function
+* translate replacement of "&" in SEO URLs
 
 ## 5.1.6
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.

--- a/engine/Shopware/Core/sRewriteTable.php
+++ b/engine/Shopware/Core/sRewriteTable.php
@@ -1237,6 +1237,10 @@ class sRewriteTable
             $part = str_replace($params['separator'], '', $part);
         }
         $parts = implode($params['separator'], $parts);
+
+        $ampReplace = Shopware()->Snippets()->getNamespace('core/rewrite/seo')->get('ampersandReplace');
+        $parts = str_replace('&', $ampReplace, $parts);
+
         return $parts;
     }
 

--- a/snippets/core/rewrite/seo.ini
+++ b/snippets/core/rewrite/seo.ini
@@ -1,0 +1,5 @@
+[en_GB]
+ampersandReplace = "and"
+
+[de_DE]
+ampersandReplace = "und"


### PR DESCRIPTION
If you have a non-german shop with categories like "Foo & Bar" then the seo url looks like "/foo-und-bar". With this request you can translate the replacement of the ampersand for each shop, so the url for an english shop would look like "/foo-and-bar".

Feel free to change the namespace of the snippet if you are not happy with it.

There is also a ticket in your issue tracker: https://issues.shopware.com/#/issues/SW-14378
