### PR TITLE
[TASK] htmlencode snippet translation emptyText

### DIFF
--- a/themes/Backend/ExtJs/backend/snippet/view/main/translate_form.js
+++ b/themes/Backend/ExtJs/backend/snippet/view/main/translate_form.js
@@ -103,8 +103,9 @@ Ext.define('Shopware.apps.Snippet.view.main.TranslateForm', {
             fieldSetItems.push({
                 fieldLabel: locale.get('displayName'),
                 name: translation.internalId,
-                emptyText: translation.get('defaultValue'),
-                value: translation.get('value')
+                emptyText: Ext.String.htmlEncode(translation.get('defaultValue')),
+                value: translation.get('value'),
+                fieldStyle: 'line-height: normal;'
             });
         });
 


### PR DESCRIPTION
Hey folks,
having some HTML as a Snippet value breaks the translations in the backend.
See Screenshot:

![snippettranslationbroken](https://cloud.githubusercontent.com/assets/5468191/15926280/74993e12-2e3b-11e6-938f-49685cc1ea19.jpg)

This is because the value `<strong>bold example text</strong>` is used as the emptyText of the translations Textarea, which will become the placeholder attribute of the element. HTML in the placeholder attributes breaks the DOM. Encoding the value solves this issue.

Unfortunally there is a bug when you focus in and out a textarea the raw html-entities will be displayed. I think this is an ExtJs Bug as this behavior is reproducible in a Sencha Fiddle even with the newest ExtJs Version. But anyway a broken placeholder is way better than a broken value.

By the way the fieldStyle property fixes a chrome bug which would resize the textareas on focus.

Regards,
Thomas
