### PR TITLE
Update Forms.php

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Forms.php
+++ b/engine/Shopware/Controllers/Frontend/Forms.php
@@ -300,7 +300,7 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
 
         $mailBody = str_replace("{sIP}", $_SERVER['REMOTE_ADDR'], $mailBody);
         $mailBody = str_replace("{sDateTime}", date("d.m.Y h:i:s"), $mailBody);
-        $mailBody = str_replace('{$sShopname}', Shopware()->Config()->shopName, $mailBody);
+        $mailBody = str_replace("{sShopname}", Shopware()->Config()->shopName, $mailBody);
         $mailBody = strip_tags($mailBody);
 
         $mail->setFrom(Shopware()->Config()->Mail);


### PR DESCRIPTION
there was a typo in the following line:
old:
$mailBody = str_replace('{$sShopname}', Shopware()->Config()->shopName, $mailBody);
new:
$mailBody = str_replace("{sShopname}", Shopware()->Config()->shopName, $mailBody);
