### PR TITLE
Fix missing word wrap for item names in documents

### DIFF
--- a/themes/Frontend/Bare/documents/index.tpl
+++ b/themes/Frontend/Bare/documents/index.tpl
@@ -200,7 +200,7 @@ td.head  {
 			{if $position.name == 'Versandkosten'}
 				{s name="DocumentIndexPositionNameShippingCosts"}{$position.name}{/s}
 			{else}
-				{s name="DocumentIndexPositionNameDefault"}{$position.name|nl2br}{/s}
+				{s name="DocumentIndexPositionNameDefault"}{$position.name|nl2br|wordwrap:65:"<br />\n"}{/s}
 			{/if}
 			</td>
 		{/block}


### PR DESCRIPTION
Currently long item names will be displayed in one line. The PDF engine will reduce the font size until the item name will fit in the line. This fix will add a word wrap to the pdf-documents to prevent this. In older shopware-versions you can change the snippet "DocumentIndexPositionNameDefault" to `{$position.name|nl2br|wordwrap:65:"<br />\n"}.`

without word wrap:
[20002-1.pdf](https://github.com/shopware/shopware/files/313401/20002-1.pdf)

with word wrap:
[mpdf.pdf](https://github.com/shopware/shopware/files/313403/mpdf.pdf)
