### PR TITLE
Fix jquery.tab-menu acknowledging whitespace-only tabs as having content

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.tab-menu.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.tab-menu.js
@@ -130,10 +130,10 @@
                 $container = $(el);
                 $tab = $(me.$tabs.get(i));
 
-                if ($container.find(opts.contentSelector).html().length) {
+                if ($.trim($container.find(opts.contentSelector).html()).length !== 0) {
                     $container.addClass(opts.hasContentClass);
                     $tab.addClass(opts.hasContentClass);
-                    
+
                     // When no start index is specified, we take the first tab with content.
                     if (opts.startIndex === -1) {
                         $tab.addClass(opts.activeTabClass);


### PR DESCRIPTION
If the Tab contains a tab which has only whitespace in it, the plugin thinks it has content and adds the class `.has--content` which leads to tabs being shown which have no content.
