### PR TITLE
Ensure usage of unique store instance in config combo boxes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -371,6 +371,7 @@ In this document you will find a changelog of the important changes related to t
 * Removed wrong parameter usage of `Shopware\Models\Menu\Repository::findOneBy`, which allows to provide two strings as criteria instead of array.
 * Updated composer dependency elasticsearch/elasticsearch to version 2.2.0
 * Changed default labelWidth for emotion component fields in `Shopware.apps.Emotion.view.components.Base` to 170 pixels
+* Added support for loading a new store instance by ID in the config combo box `Shopware.apps.Config.view.element.Select`
 
 ## 5.1.6
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.

--- a/themes/Backend/ExtJs/backend/config/view/element/select.js
+++ b/themes/Backend/ExtJs/backend/config/view/element/select.js
@@ -62,6 +62,8 @@ Ext.define('Shopware.apps.Config.view.element.Select', {
             eval('me.store = ' + me.store + ';');
             // Remove value field for reasons of compatibility
             me.valueField = me.displayField;
+        } else if (typeof(me.store) === 'string' && me.store.substring(0, 5) !== 'base.') {
+            me.store = me.getStoreById(me.store);
         }
 
         me.callParent(arguments);
@@ -85,5 +87,35 @@ Ext.define('Shopware.apps.Config.view.element.Select', {
         }
 
         me.callParent(arguments);
+    },
+
+    /**
+     * plugin example usage:
+     * public function install()
+     * {
+     *     $form = $this->Form();
+     *
+     *     $form->setElement("select", "test123", [
+     *         "valueField" => "id",
+     *         "displayField" => "name",
+     *         "queryMode" => "remote",
+     *         "store" => "Shopware.apps.Base.store.Country"
+     *     ]);
+     *
+     *     return true;
+     * }
+     *
+     * @param storeId string
+     * @return Ext.data.Store|null
+     */
+    getStoreById: function(storeId) {
+        try {
+            return Ext.create(storeId, {
+                pageSize: 1000,
+                autoLoad: true
+            });
+        } catch (e) {
+            return null;
+        }
     }
 });


### PR DESCRIPTION
This PR improves the base combo box `Shopware.apps.Config.view.element.Select`, which is used e.g. when viewing plugin configuration forms via the settings module, to allow passing a store ID as the `store` parameter. This is escpecially usefull when providing selections of e.g. payment methods (`Shopware.apps.Base.store.Payment`) or dispatch methods (`Shopware.apps.Base.store.Dispatch`). In order to avoid side effects of other backend modules using the same store instance (and e.g. setting filters on it), the combo box does not use the instance that is registered by the passed store ID, but creates and uses a new instance of that store instead.

See also PR #525 for the original change of the `base` combo box, which is used when viewing plugin config forms in the plugin manager. This PR fixes the viewing of the same plugin config forms in the settings module. Furthermore it already includes the latest fix to support old storeIDs (22f5cacc17358161d7d0109de679973cba2c8906).

This PR does not introduce any breaking changes.
