### PR TITLE
fixArticleTranslation: Only check for existence in exists statement

### DIFF
--- a/engine/Shopware/Components/Translation.php
+++ b/engine/Shopware/Components/Translation.php
@@ -430,8 +430,8 @@ class Shopware_Components_Translation
         $existStmt = Shopware()->Container()->get('dbal_connection')->prepare(
             "SELECT EXISTS (SELECT 1
              FROM s_core_translations
-	     WHERE objectlanguage = :language
-	     LIMIT 1)"
+             WHERE objectlanguage = :language
+             LIMIT 1)"
         );
 
         $insertStmt = Shopware()->Container()->get('dbal_connection')->prepare("

--- a/engine/Shopware/Components/Translation.php
+++ b/engine/Shopware/Components/Translation.php
@@ -428,9 +428,10 @@ class Shopware_Components_Translation
         $ids = Shopware()->Db()->fetchCol($sql, array($languageId));
 
         $existStmt = Shopware()->Container()->get('dbal_connection')->prepare(
-            "SELECT id
+            "SELECT EXISTS (SELECT 1
              FROM s_core_translations
-             WHERE objectlanguage = :language"
+	     WHERE objectlanguage = :language
+	     LIMIT 1)"
         );
 
         $insertStmt = Shopware()->Container()->get('dbal_connection')->prepare("


### PR DESCRIPTION
The current `$existStmt` calls a query that selects every translation id of a specific language, resulting in long requests times on large tables (250000 entries ~ 700ms request). When pushing many articles with multiple translations this results in very long request times since this multiplicates.

This change turns the `$existStmt` in an actual exists statement, since we only check if the first column returns something anyway (see line 470). Way faster.
