### PR TITLE
add notifyUntil-event to sBasket::sInsertSurcharge

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,8 @@ In this document you will find a changelog of the important changes related to t
 
 # 5.1.7
 * Update elasticsearch/elasticsearch library to 2.2.0
+* Add notifyUntil-Event `Shopware_Modules_Basket_BeforeAddMinmumOrderSurcharge` to `\sBsket::sInsertSurcharge`,
+containing the surcharge. Use this to prevent sBasket from adding a surcharge to the basket.
 
 ## 5.1.6
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -874,22 +874,28 @@ class sBasket
                     ->getNamespace('backend/static/discounts_surcharges')
                     ->get('surcharge_name');
 
-                $this->db->insert(
-                    's_order_basket',
-                    $params = array(
-                        'sessionID'      => $this->session->get('sessionId'),
-                        'articlename'    => $surchargeName,
-                        'articleID'      => 0,
-                        'ordernumber'    => $name,
-                        'quantity'       => 1,
-                        'price'          => $surcharge,
-                        'netprice'       => $discountNet,
-                        'tax_rate'       => $tax,
-                        'datum'          => new Zend_Date(),
-                        'modus'          => 4,
-                        'currencyFactor' => $this->sSYSTEM->sCurrency["factor"]
-                    )
+                $params = array(
+                    'sessionID'      => $this->session->get('sessionId'),
+                    'articlename'    => $surchargeName,
+                    'articleID'      => 0,
+                    'ordernumber'    => $name,
+                    'quantity'       => 1,
+                    'price'          => $surcharge,
+                    'netprice'       => $discountNet,
+                    'tax_rate'       => $tax,
+                    'datum'          => new Zend_Date(),
+                    'modus'          => 4,
+                    'currencyFactor' => $this->sSYSTEM->sCurrency["factor"]
                 );
+
+                if (! $this->eventManager->notifyUntil(
+                    'Shopware_Modules_Basket_BeforeAddMinmumOrderSurcharge', array(
+                        'subject'   => $this,
+                        'surcharge' => $params
+                    )
+                )) {
+                    $this->db->insert('s_order_basket', $params);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds a notifyUntil-Event to the method `sBasket::sInsertSurcharge` to give Plugins the opportunity to stop Shopware adding the minimum order surcharge in certain circumstances. 

One of our Plugins has a feature to ignore the customer group minimum order value for orders when using certain vouchers. We discovered that if a minimum order surcharge is set our current solution doesn't work, and adding an event to allow us to stop Shopware from adding the surcharge is the least error-prone way and also carries the least performance penalty.

This PR should not introduce any breaking changes.
