### PR TITLE
Fix wrong IDs for Variant Radio Buttons

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/config_variant.tpl
+++ b/themes/Frontend/Bare/frontend/detail/config_variant.tpl
@@ -23,7 +23,7 @@
 											{block name='frontend_detail_configurator_variant_group_option_input'}
 												<input type="radio"
 													   class="option--input"
-													   id="group[{$option.groupID}]"
+													   id="group[{$option.groupID}][{$option.optionID}]"
 													   name="group[{$option.groupID}]"
 													   value="{$option.optionID}"
 													   title="{$option.optionname}"
@@ -33,7 +33,7 @@
 											{/block}
 
 											{block name='frontend_detail_configurator_variant_group_option_label'}
-												<label for="group[{$option.groupID}]" class="option--label{if !$option.selectable} is--disabled{/if}">
+												<label for="group[{$option.groupID}][{$option.optionID}]" class="option--label{if !$option.selectable} is--disabled{/if}">
 
 													{if $option.media}
 														{$media = $option.media}


### PR DESCRIPTION
This fixes the labels in the details, when using the "Image"-Config for variants. Before this all Radio-Buttons would have the same id and therefore, have been invalid. This Pull-Requests fixes this, by introducing a separate ID for each Radio-Button.
