### PR TITLE
Use ID auf authenticated user as fallback 'userId' when creating media using REST API

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -399,6 +399,7 @@ In this document you will find a changelog of the important changes related to t
     * `\Shopware\Bundle\StoreFrontBundle\Struct\LocationContextInterface`
     * `\Shopware\Bundle\StoreFrontBundle\Struct\ProductContextInterface`
 * Added support for loading a new store instance by ID in the config combo box `Shopware.apps.Config.view.element.Select`
+* Use the ID of the authenticated user as the fallback `userId` when `POST`ing media using the REST API
 
 ## 5.1.6
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.

--- a/engine/Shopware/Controllers/Api/Media.php
+++ b/engine/Shopware/Controllers/Api/Media.php
@@ -74,7 +74,14 @@ class Shopware_Controllers_Api_Media extends Shopware_Controllers_Api_Rest
      */
     public function postAction()
     {
-        $media = $this->resource->create($this->Request()->getPost());
+        $params = $this->Request()->getPost();
+
+        // Use the ID of the authenticated user as a fallback 'userId'
+        if (!isset($params['userId']) || empty($params['userId'])) {
+            $params['userId'] = $this->get('auth')->getIdentity()->id;
+        }
+
+        $media = $this->resource->create($params);
 
         $location = $this->apiBaseUrl . 'media/' . $media->getId();
         $data = array(

--- a/tests/Api/MediaTest.php
+++ b/tests/Api/MediaTest.php
@@ -192,6 +192,10 @@ class Shopware_Tests_Api_MediaTest extends PHPUnit_Framework_TestCase
 
         $this->assertGreaterThan(0, $identifier);
 
+        // Check userId
+        $media = Shopware()->Models()->find('Shopware\Models\Media\Media', $identifier);
+        $this->assertGreaterThan(0, $media->getUserId());
+
         return $identifier;
     }
 


### PR DESCRIPTION
Previously, creating a new `Media` instance using the REST API required a parameter `userId` containing a valid ID of an existing `Shopware\Models\User\User`. This constraint is added by using the `Media` resource, which would otherwise fall back to using `0` as the `userID`. However, when using the REST API, the user mostly only knows their username and API key, but not their internal `ID`. To overcome this, this PR adds a check for a given `userId` to the `Media` API controller and, if not present, sets the `ID` of the currently authenticated user as the `userId` in the parameters.

This PR  does not introduce any breaking changes.
