### PR TITLE
MultiEdit and BestitItscope compatibility

### DIFF
--- a/engine/Shopware/Components/MultiEdit/Resource/Product/BatchProcess.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/BatchProcess.php
@@ -133,6 +133,7 @@ class BatchProcess
 
             switch ($type) {
                 case 'integer':
+                case 'bigint':
                 case 'decimal':
                 case 'float':
                     $attributes[$attribute] = array('set', 'add', 'subtract', 'devide', 'multiply');


### PR DESCRIPTION
Our Plugin BestitItscope adds an bigint article attribute. With need to add bigint to the configured column types so that we can edit the Itscope articles with the MultiEdit
