### PR TITLE
BUGFIXING clear cache folders only if dir exists

### DIFF
--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -399,26 +399,28 @@ class CacheManager
      */
     private function clearDirectory($dir)
     {
-        if (file_exists($dir)) {
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
-                \RecursiveIteratorIterator::CHILD_FIRST
-            );
+        if (!file_exists($dir)) {
+            return;
+        }
+        
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
 
-            /** @var \SplFileInfo $path */
-            foreach ($iterator as $path) {
-                if ($path->getFilename() === '.gitkeep') {
+        /** @var \SplFileInfo $path */
+        foreach ($iterator as $path) {
+            if ($path->getFilename() === '.gitkeep') {
+                continue;
+            }
+
+            if ($path->isDir()) {
+                rmdir($path->__toString());
+            } else {
+                if (!$path->isFile()) {
                     continue;
                 }
-
-                if ($path->isDir()) {
-                    rmdir($path->__toString());
-                } else {
-                    if (!$path->isFile()) {
-                        continue;
-                    }
-                    unlink($path->__toString());
-                }
+                unlink($path->__toString());
             }
         }
     }

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -399,24 +399,26 @@ class CacheManager
      */
     private function clearDirectory($dir)
     {
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST
-        );
+        if (file_exists($dir)) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
 
-        /** @var \SplFileInfo $path */
-        foreach ($iterator as $path) {
-            if ($path->getFilename() === '.gitkeep') {
-                continue;
-            }
-
-            if ($path->isDir()) {
-                rmdir($path->__toString());
-            } else {
-                if (!$path->isFile()) {
+            /** @var \SplFileInfo $path */
+            foreach ($iterator as $path) {
+                if ($path->getFilename() === '.gitkeep') {
                     continue;
                 }
-                unlink($path->__toString());
+
+                if ($path->isDir()) {
+                    rmdir($path->__toString());
+                } else {
+                    if (!$path->isFile()) {
+                        continue;
+                    }
+                    unlink($path->__toString());
+                }
             }
         }
     }

--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -640,30 +640,33 @@ class Compiler
     private function clearDirectory($names = array())
     {
         $dir = $this->pathResolver->getCacheDirectory();
-        if (file_exists($dir)) {
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator(
-                    $dir,
-                    \RecursiveDirectoryIterator::SKIP_DOTS
-                ),
-                \RecursiveIteratorIterator::CHILD_FIRST
-            );
+        
+        if (!file_exists($dir)) {
+            return;
+        }
+        
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(
+                $dir,
+                \RecursiveDirectoryIterator::SKIP_DOTS
+            ),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
 
-            /** @var \SplFileInfo $path */
-            foreach ($iterator as $path) {
-                if ($path->getFilename() == '.gitkeep') {
-                    continue;
-                }
+        /** @var \SplFileInfo $path */
+        foreach ($iterator as $path) {
+            if ($path->getFilename() == '.gitkeep') {
+                continue;
+            }
 
-                if (!$this->fileNameMatch($path->getFilename(), $names)) {
-                    continue;
-                }
+            if (!$this->fileNameMatch($path->getFilename(), $names)) {
+                continue;
+            }
 
-                if ($path->isDir()) {
-                    rmdir($path->__toString());
-                } else {
-                    unlink($path->__toString());
-                }
+            if ($path->isDir()) {
+                rmdir($path->__toString());
+            } else {
+                unlink($path->__toString());
             }
         }
     }

--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -639,28 +639,31 @@ class Compiler
      */
     private function clearDirectory($names = array())
     {
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator(
-                $this->pathResolver->getCacheDirectory(),
-                \RecursiveDirectoryIterator::SKIP_DOTS
-            ),
-            \RecursiveIteratorIterator::CHILD_FIRST
-        );
+        $dir = $this->pathResolver->getCacheDirectory();
+        if (file_exists($dir)) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator(
+                    $dir,
+                    \RecursiveDirectoryIterator::SKIP_DOTS
+                ),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
 
-        /** @var \SplFileInfo $path */
-        foreach ($iterator as $path) {
-            if ($path->getFilename() == '.gitkeep') {
-                continue;
-            }
+            /** @var \SplFileInfo $path */
+            foreach ($iterator as $path) {
+                if ($path->getFilename() == '.gitkeep') {
+                    continue;
+                }
 
-            if (!$this->fileNameMatch($path->getFilename(), $names)) {
-                continue;
-            }
+                if (!$this->fileNameMatch($path->getFilename(), $names)) {
+                    continue;
+                }
 
-            if ($path->isDir()) {
-                rmdir($path->__toString());
-            } else {
-                unlink($path->__toString());
+                if ($path->isDir()) {
+                    rmdir($path->__toString());
+                } else {
+                    unlink($path->__toString());
+                }
             }
         }
     }


### PR DESCRIPTION
Wrapping the clearDirectory($dir) methods (in CacheManager and Compiler classes) logic in IF statement to only let the RecursiveDirectoryIterator delete the cache directories if the given directory already exists. This will fix a bug occuring when trying to regenerate the cache by console command. 

After calling `$ var/cache/clear_cache.sh` and `bin/console sw:theme:cache:generate` an exception will be thrown if the folder "cache/.../html" doesn't exist.
