### PR TITLE
Fix 'countries' REST API response data and header

### DIFF
--- a/engine/Shopware/Controllers/Api/Countries.php
+++ b/engine/Shopware/Controllers/Api/Countries.php
@@ -48,7 +48,7 @@ class Shopware_Controllers_Api_Countries extends Shopware_Controllers_Api_Rest
 
         $result = $this->resource->getList($offset, $limit, $filter, $sort);
 
-        $this->View()->assign('data', $result);
+        $this->View()->assign($result);
         $this->View()->assign('success', true);
     }
 
@@ -86,6 +86,7 @@ class Shopware_Controllers_Api_Countries extends Shopware_Controllers_Api_Rest
 
         $this->View()->assign('data', $data);
         $this->View()->assign('success', true);
+        $this->Response()->setHeader('Location', $location);
     }
 
     /**


### PR DESCRIPTION
This PR fixes two problems in the `countries` REST API:
1. The structure of the response data of `GET /api/countries` previously contained a nested `data` field inside the top-level `data` field. This PR fixes the structure to contain the country data directly in the top-level `data` field.
2. When sending a `POST` request to `/api/countries` the response was previously missing the `Location` header, which should be set according to REST best practices. This PR adds the missing header with the correct location.

This PR does not introduce any breaking changes, since the REST API `countries` endpoint is only introduced in shopware 5.2. It was added via PR #524. Therefore I think this PR must be merged before the final release of shopware 5.2.

Pinging @janbuecker since he merged the original PR.
