### PR TITLE
Fix exception in account bundle register service

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -406,6 +406,7 @@ In this document you will find a changelog of the important changes related to t
     * `Enlight_Controller_Request_Request::setAttribute()`
     * `Enlight_Controller_Request_Request::unsetAttribute()`
 * Fixed tax free for company configuration. If the delivery country contains the flag `taxfree_ustid`, the vat id of the shipping address is checked.
+* Fixed exception in `\Shopware\Bundle\AccountBundle\ServiceRegisterService`, caused by using the `\Shopware\Components\NumberRangeIncrementer` within a transaction
 
 # 5.1.7
 * Update elasticsearch/elasticsearch library to 2.2.0


### PR DESCRIPTION
This commit fixes a `PDOException` inside the `RegisterService` of the `AccountBundle`, which is raised because of creating a nested transaction. The source of the exception is the `number range incrementer`, which I introduced in PR #517 for shopware 5.2. The incrementer uses a transaction to ensure a safe increment of the numbers. However, the `RegisterService` starts a transaction itself and then uses the `number range incrementer` within this transaction.

This commit fixes the exception by moving the check, whether a customer number must be created, as well as the increment of the number just before starting the transaction and then passing the number to the `saveCustomer()` method.

This commit does not introduce any breaking changes.
