### PR TITLE
making sure the elasticsearch index we are operating on is green

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/ShopIndexer.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/ShopIndexer.php
@@ -137,7 +137,7 @@ class ShopIndexer implements ShopIndexerInterface
      */
     private function updateSettings(ShopIndex $index)
     {
-        $this->client->cluster()->health(['wait_for_status' => 'yellow']);
+        $this->client->cluster()->health(['index' => $index->getName(), 'wait_for_status' => 'green']);
         $this->client->indices()->close(['index' => $index->getName()]);
 
         foreach ($this->settings as $setting) {
@@ -154,7 +154,7 @@ class ShopIndexer implements ShopIndexerInterface
 
         $this->client->indices()->open(['index' => $index->getName()]);
         $this->client->indices()->refresh(['index' => $index->getName()]);
-        $this->client->cluster()->health(['wait_for_status' => 'yellow']);
+        $this->client->cluster()->health(['index' => $index->getName(), 'wait_for_status' => 'green']);
     }
 
     /**


### PR DESCRIPTION
It is not safe to close and open an index in yellow state and actually broke indexing for us with a high number of replicas being initialised and left the cluster in a red state. Fortunately we can check whether a single index is green, preventing us to wait forever on a yellow cluster and generally fixes indexing for us.
