### PR TITLE
Add support for integer and array values to 'sw:plugin:config:set' cli command

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,9 @@
 # Shopware Upgrade Information
 In this document you will find a changelog of the important changes related to the code base of Shopware.
 
+## 5.2.1 DEV
+* Add support for integer and array values to the `sw:plugin:config:set` cli command
+
 ## 5.2.0
 * Increased minimum required PHP version to PHP >= 5.6.4.
 * Added CSRF protection to frontend and backend which is enabled by default.

--- a/engine/Shopware/Commands/PluginConfigSetCommand.php
+++ b/engine/Shopware/Commands/PluginConfigSetCommand.php
@@ -110,6 +110,15 @@ class PluginConfigSetCommand extends ShopwareCommand
         if ($value === "true") {
             $value = true;
         }
+        if (preg_match('/^\d+$/', $value)) {
+            $value = intval($value);
+        }
+        if (preg_match('/^\[(.+,?)*\]$/', $value, $matches) && count($matches) == 2) {
+            $value = explode(',', $matches[1]);
+            $value = array_map(function ($val) {
+                return (preg_match('/^\d+$/', $val)) ? intval($val) : $val;
+            }, $value);
+        }
 
         $pluginManager->saveConfigElement($plugin, $input->getArgument('key'), $value, $shop);
         $output->writeln(sprintf("Plugin configuration for Plugin %s saved.", $pluginName));


### PR DESCRIPTION
Previously it was not possible to set an integer or array value when using the cli command `sw:plugin:config:set`. However, since it is possible to create plugin config elements e.g. for selecting one or multiple dispatch methods, which are saved as their ID (integer) or an array of their IDs (integers) respectively, it is desirable to be able to set the same config value using the cli tools. This PR adds an extra check on the config value passed to `Shopware\Commands\PluginConfigSetCommand::execute()`, which matches integers and arrays of e.g. the form `[val1,val2,val3]` and converts them to PHP arrays. Furthermore, if a value contained in the matched array contains only digits, it is converted to an integer.

This PR does not introduce any breaking changes.
