### PR TITLE
Ensure composer autoloader optimization to prevent incomplete classmap.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,12 @@
         "classmap": [
             "engine/Shopware/Core/"
         ],
-        "files": ["engine/Shopware/Application.php"]
+        "files": ["engine/Shopware/Application.php"],
+        "exclude-from-classmap": [
+            "engine/Shopware/Plugins/Community/",
+            "engine/Shopware/Plugins/Local/",
+            "custom/plugins/"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
     },
     "config": {
         "autoloader-suffix": "Shopware",
+        "optimize-autoloader": true,
         "platform": {
             "php": "5.4"
         }


### PR DESCRIPTION
With composer 1.1.2 and 1.1.3 an additional `composer install` on the current release results in an incomplete classmap in `autoload_static.php`. One possible fix is `composer install -o`, another one is to force the optimization in `composer.json`, which is what I've done in this pull request.

This fixes errors like `Doctrine\Common\Proxy\Exception\OutOfBoundsException: Missing value for primary key id on Shopware\Models\Customer\Group`.
