### PR TITLE
CheapestPriceService getHighestQuantityDiscount() throws Exception if PriceGroup is null

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/CheapestPriceService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/CheapestPriceService.php
@@ -197,6 +197,11 @@ class CheapestPriceService implements Service\CheapestPriceServiceInterface
             return null;
         }
 
+        $checkPriceGroup = $product->getPriceGroup();
+        if (empty($checkPriceGroup)) {
+            return null;
+        }
+
         $id = $product->getPriceGroup()->getId();
         if (!isset($priceGroups[$id])) {
             return null;


### PR DESCRIPTION
After updating a shopware 4 version to shopware 5.1.5 we get an error while loading the product detail page (see attached Screenshot). 

While debugging this error we noticed that the method call $product->getPriceGroup() returns null. We fixed this problem by adding the following check:

```
$id = $product->getPriceGroup()->getId();
 if (!isset($priceGroups[$id])) {
     return null;
 } 
```

![error_detail_page](https://cloud.githubusercontent.com/assets/153074/16763739/983a9222-482a-11e6-97ce-d2c6497e7f84.png)
