### PR TITLE
Fix für SW-15610

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Media.php
+++ b/engine/Shopware/Components/Api/Resource/Media.php
@@ -288,6 +288,8 @@ class Media extends Resource
     public function internalCreateMediaByFileLink($link, $albumId = -1)
     {
         $name = pathinfo($link, PATHINFO_FILENAME);
+        $ext = pathinfo($link, PATHINFO_EXTENSION);
+        $name = $name.'.'.$ext;
         $path = $this->load($link, $name);
         $name = pathinfo($path, PATHINFO_FILENAME);
         $file = new File($path);


### PR DESCRIPTION
Beim Import von Dateien wird die Endung entfernt. Durch erneutes aufrufen von pathinfo wird dann alles nach dem letzten Punkt im Namen abgeschnitten. Dadurch entstehen Medieneinträge mit doppelten Namen.

Da die Thumbnails auf Basis des Mediennamen erstellt werden, haben einige Dateien die gleichen Thumbs. 
