### PR TITLE
Add backticks in SELECT statement of BE-Controller ImportExport.php

### DIFF
--- a/engine/Shopware/Controllers/Backend/ImportExport.php
+++ b/engine/Shopware/Controllers/Backend/ImportExport.php
@@ -421,9 +421,9 @@ class Shopware_Controllers_Backend_ImportExport extends Shopware_Controllers_Bac
 
                 $joinStatements[] = "
                     LEFT JOIN `s_articles_prices` p{$cg['id']}
-                    ON p{$cg['id']}.articledetailsID=d.id
-                    AND p{$cg['id']}.pricegroup='{$cg['groupkey']}'
-                    AND p{$cg['id']}.`from`=1
+                    ON `p{$cg['id']}.articledetailsID`=d.id
+                    AND `p{$cg['id']}.pricegroup`='{$cg['groupkey']}'
+                    AND `p{$cg['id']}.from`=1
                 ";
 
                 if (empty($cg['taxinput'])) {


### PR DESCRIPTION
When a customer group contains special characters, especially a minus "-" this query will break due to invalid syntax. The backticks should prevent this from happening.
