### PR TITLE
add order attributes join to order api resource

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Order.php
+++ b/engine/Shopware/Components/Api/Resource/Order.php
@@ -123,7 +123,9 @@ class Order extends Resource
     {
         $this->checkPrivilege('read');
 
-        $builder = $this->getRepository()->createQueryBuilder('orders');
+        $builder = $this->getRepository()->createQueryBuilder('orders')
+            ->addSelect(['attribute'])
+            ->leftJoin('orders.attribute', 'attribute');
 
         $builder->addFilter($criteria);
         $builder->addOrderBy($orderBy);


### PR DESCRIPTION
This commit adds the order attributes to the order query builder to allow filtering of order attributes e.g.
`/api/orders/?filter[0][property]=attribute.attribute1&filter[0][value]=foo`
(such as in the article resource).
