### PR TITLE
SW-15724 - Preise im Checkout werden vorm multiplizieren gerundet

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2234,7 +2234,7 @@ class sBasket
                 }
             }
 
-            $getArticles[$key]["amount"] = $quantity * round($price, 2);
+            $getArticles[$key]["amount"] = round($quantity * $price, 2);
 
             //reset purchaseunit and save the original value in purchaseunitTemp
             if ($getArticles[$key]["purchaseunit"] > 0) {


### PR DESCRIPTION
Dies führte dazu, dass Preise mit > 2 Nachkommastellen falsch gerundet, jedoch in Backend und auf Rechnungen wieder richtig angezeigt werden.
Siehe [SW-15724](https://issues.shopware.com/#/issues/SW-15724)
