### PR TITLE
Add block for advanced menu teaser.

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/advanced_menu/index.tpl
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/advanced_menu/index.tpl
@@ -71,27 +71,29 @@
                             {/if}
 
                             {if $hasTeaser}
-                                {if $hasCategories}
-                                    <div class="menu--delimiter" style="right: {$columnAmount * 25}%;"></div>
-                                {/if}
-                                <div class="menu--teaser"{if $hasCategories} style="width: {$columnAmount * 25}%;"{else} style="width: 100%;"{/if}>
-                                    {if !empty($mainCategory.media)}
-                                        <a href="{$link|escapeHtml}" title="{s name="toCategoryBtn" namespace="frontend/plugins/advanced_menu/advanced_menu"}{/s}{$mainCategory.name|escape:'html'}" class="teaser--image" style="background-image: url({link file={$mainCategory.media.path}});"></a>
+                                {block name="frontend_plugins_advanced_menu_teaser"}
+                                    {if $hasCategories}
+                                        <div class="menu--delimiter" style="right: {$columnAmount * 25}%;"></div>
                                     {/if}
+                                    <div class="menu--teaser"{if $hasCategories} style="width: {$columnAmount * 25}%;"{else} style="width: 100%;"{/if}>
+                                        {if !empty($mainCategory.media)}
+                                            <a href="{$link|escapeHtml}" title="{s name="toCategoryBtn" namespace="frontend/plugins/advanced_menu/advanced_menu"}{/s}{$mainCategory.name|escape:'html'}" class="teaser--image" style="background-image: url({link file={$mainCategory.media.path}});"></a>
+                                        {/if}
 
-                                    {if !empty($mainCategory.cmsHeadline)}
-                                        <div class="teaser--headline">{$mainCategory.cmsHeadline}</div>
-                                    {/if}
+                                        {if !empty($mainCategory.cmsHeadline)}
+                                            <div class="teaser--headline">{$mainCategory.cmsHeadline}</div>
+                                        {/if}
 
-                                    {if !empty($mainCategory.cmsText)}
-                                        <div class="teaser--text">
-                                            {$mainCategory.cmsText|strip_tags|truncate:250:"..."}
-                                            <a class="teaser--text-link" href="{$link|escapeHtml}" title="{s name="learnMoreLink" namespace="frontend/plugins/advanced_menu/advanced_menu"}mehr erfahren{/s}">
-                                                {s name="learnMoreLink" namespace="frontend/plugins/advanced_menu/advanced_menu"}mehr erfahren{/s}
-                                            </a>
-                                        </div>
-                                    {/if}
-                                </div>
+                                        {if !empty($mainCategory.cmsText)}
+                                            <div class="teaser--text">
+                                                {$mainCategory.cmsText|strip_tags|truncate:250:"..."}
+                                                <a class="teaser--text-link" href="{$link|escapeHtml}" title="{s name="learnMoreLink" namespace="frontend/plugins/advanced_menu/advanced_menu"}mehr erfahren{/s}">
+                                                    {s name="learnMoreLink" namespace="frontend/plugins/advanced_menu/advanced_menu"}mehr erfahren{/s}
+                                                </a>
+                                            </div>
+                                        {/if}
+                                    </div>
+                                {/block}
                             {/if}
                         </div>
                     {/if}


### PR DESCRIPTION
When you try to change the teaser appearance in AdvancedMenu there's no block available and one has to change the whole menu container. This PR simply adds a block just for the teaser. :-)

This should not break anything as far as I can tell.
