### PR TITLE
fix error in unifiedToSQL()

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -9,6 +9,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
     * The default implementation delegates to [`cocur/slugify`](https://github.com/cocur/slugify)
     * SEO url generation now uses this new service to rewrite urls
 * Added new media file type for 3D model files. Supporting following files in the media manager: .dae, .obj, .fbx, .spx, .3ds, .3mf, .blend, .awd, .ply, .pcd, .stl, .skp
+* `\Shopware\Bundle\AttributeBundle\CrudService::unifiedToSql()` now returns SQL type mapped to `string` if a given type is not mapped
 
 ## 5.2.3
 

--- a/engine/Shopware/Bundle/AttributeBundle/Service/TypeMapping.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/TypeMapping.php
@@ -228,7 +228,7 @@ class TypeMapping
     {
         $type = strtolower($type);
         if (!isset($this->types[$type])) {
-            return 'string';
+            return $this->types['string']['sql'];
         }
         $mapping = $this->types[$type];
         return $mapping['sql'];


### PR DESCRIPTION
If the `unifiedToSQL()` function doesn't recognize a given type, it returns `'string'`. I assume this is done to make string the default type in case a type is not recognized. Simply returning `'string'` however leads to a confusing SQL error message. Instead it should return the SQL value that is mapped to `'string'`. The function is also used in `CrudService::getList` to set the field `sqlType` but it doesn't make much sense here either because `'string'` is not an actual SQL type.

I don't think this should break anything, because it doesn't work right now.
