### PR TITLE
Fix skipping opt out fields

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
@@ -645,8 +645,8 @@
             var me = this,
                 isError,
                 errorMessages = [],
-                skipEmailConfirmationError = me.$targetElement.attr('name') == me.$personalEmailConfirmation.attr('name') && me.$personalEmailConfirmation.val().length === 0,
-                skipPasswordConfirmationError = me.$targetElement.attr('name') == me.$personalPasswordConfirmation.attr('name') && me.$personalPasswordConfirmation.val().length === 0;
+                skipEmailConfirmationError = me.$targetElement.attr('name') == me.$personalEmailConfirmation.attr('name') && me.$personalEmailConfirmation.val() === undefined,
+                skipPasswordConfirmationError = me.$targetElement.attr('name') == me.$personalPasswordConfirmation.attr('name') && me.$personalPasswordConfirmation.val() === undefined;
 
             $('#' + action + '--message').remove();
 


### PR DESCRIPTION
if validation of $personalEmailConfirmation and $personalPasswordConfirmation should be skipped the fields won't be selected by jquery hence there is no .length which results in an error.
