### PR TITLE
Hide big menu if parent ist hidden (SW-15795)

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/advanced_menu/index.tpl
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/advanced_menu/index.tpl
@@ -7,7 +7,7 @@
     <ul class="menu--list menu--level-{$level} columns--{$columnCount}"{if $level === 0} style="width: {$menuSizePercentage}%;"{/if}>
         {block name="frontend_plugins_advanced_menu_list"}
             {foreach $categories as $category}
-                {if $category.hidetop}
+                {if $category.hideTop}
                     {continue}
                 {/if}
 
@@ -33,7 +33,7 @@
 <div class="advanced-menu" data-advanced-menu="true" data-hoverDelay="{$hoverDelay}">
     {block name="frontend_plugins_advanced_menu"}
         {foreach $sAdvancedMenu as $mainCategory}
-            {if !$mainCategory.active || $mainCategory.hidetop}
+            {if !$mainCategory.active || $mainCategory.hideTop}
                 {continue}
             {/if}
 


### PR DESCRIPTION
If a menu element is selected for hiding in main menu, then the big menu is still created. When hovering a main menu element the wrong big menu gets displayed. The template variable for hiding in main navigation is hideTop not hidetop.
