### PR TITLE
Hide big menu if parent ist hidden (SW-15795)

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
@@ -350,6 +350,7 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
             if (!empty($category->getExternalLink())) {
                 $data['link'] = $category->getExternalLink();
             }
+            $data['hidetop'] = $data['hideTop'];
             return $data;
         }, $categories);
     }


### PR DESCRIPTION
If a menu element is selected for hiding in main menu, then the big menu is still created. When hovering a main menu element the wrong big menu gets displayed. The template variable for hiding in main navigation is hideTop not hidetop.
