### PR TITLE
change smarty-block for paymentframe-js

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/payment.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/payment.tpl
@@ -7,13 +7,10 @@
 {/block}
 
 {* Javascript *}
-{block name="frontend_index_header_javascript" append}
+{block name="frontend_index_header_javascript_jquery" append}
 <script type="text/javascript">
 //<![CDATA[
 	jQuery(document).ready(function($) {
-		
-		//$('#payment').removeClass('grid_18').removeClass('push_1');
-		//$('#payment').addClass('grid_14').addClass('push_3');
 		$('#payment_frame').css('display', 'none');
 		$('#payment_loader').css('display', 'block');
 		


### PR DESCRIPTION
Actually this JS is appended to the "frontend_index_header_javascript"-block.
But it requires jQuery, which is initialised later. So this must be moved to another block.
