### PR TITLE
normalized the return value of Album/Settings getThumbnailSize

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -40,6 +40,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
     * `Theme_Compiler_Collect_Javascript_Files_FilterResult`
 * Removed synchronizing of plugin information column `changes`
 * Allow root menu elements for plugins. Added attribute `isRootMenu` in `menu.xml` Example: `<entry isRootMenu="true">`
+* Normalized the return value of `Album\Settings` getThumbnailSize to return a empty array instead of a array with an empty string when no size is active
 
 ## 5.2.3
 

--- a/engine/Shopware/Models/Media/Settings.php
+++ b/engine/Shopware/Models/Media/Settings.php
@@ -184,6 +184,10 @@ class Settings extends ModelEntity
      */
     public function getThumbnailSize()
     {
+        if (empty($this->thumbnailSize)) {
+            return [];
+        }
+
         return explode(';', $this->thumbnailSize);
     }
 

--- a/tests/Functional/Models/Album/SettingsTest.php
+++ b/tests/Functional/Models/Album/SettingsTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Tests
+ * @copyright Copyright (c) 2014, shopware AG (http://www.shopware.de)
+ */
+class Shopware_Tests_Models_Album_SettingsTest extends Enlight_Components_Test_TestCase
+{
+    public function testGetThumbnailSizeReturnValue()
+    {
+        $settings = new \Shopware\Models\Media\Settings();
+        $settings->setThumbnailSize([]);
+
+        $size = $settings->getThumbnailSize();
+
+        $this->assertEquals([], $size);
+        $this->assertNotEquals([0 => ''], $size);
+    }
+}

--- a/tests/Unit/Model/Album/SettingsTest.php
+++ b/tests/Unit/Model/Album/SettingsTest.php
@@ -37,6 +37,5 @@ class Shopware_Tests_Models_Album_SettingsTest extends Enlight_Components_Test_T
         $size = $settings->getThumbnailSize();
 
         $this->assertEquals([], $size);
-        $this->assertNotEquals([0 => ''], $size);
     }
 }

--- a/tests/Unit/Model/Album/SettingsTest.php
+++ b/tests/Unit/Model/Album/SettingsTest.php
@@ -25,7 +25,7 @@
 /**
  * @category  Shopware
  * @package   Shopware\Tests
- * @copyright Copyright (c) 2014, shopware AG (http://www.shopware.de)
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
 class Shopware_Tests_Models_Album_SettingsTest extends Enlight_Components_Test_TestCase
 {

--- a/tests/Unit/Model/Album/SettingsTest.php
+++ b/tests/Unit/Model/Album/SettingsTest.php
@@ -27,7 +27,7 @@
  * @package   Shopware\Tests
  * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
-class Shopware_Tests_Models_Album_SettingsTest extends Enlight_Components_Test_TestCase
+class Shopware_Tests_Models_Album_SettingsTest extends PHPUnit_Framework_TestCase
 {
     public function testGetThumbnailSizeReturnValue()
     {


### PR DESCRIPTION
**Why:**

When no settings are present, the current behaviour will return a array with an empty value instead of an empty array. This makes it difficult to check if there are sizes as the array needs to be analysed.

if (empty($sizes) vs if (empty($sizes[0]))

**What:**

Changed the return value to return a empty array if its empty.

**Breaking something?**

Anything that relies on the old format might break
