### PR TITLE
Implementing __clone() method in ModelEntity

### DIFF
--- a/engine/Shopware/Components/Model/ModelEntity.php
+++ b/engine/Shopware/Components/Model/ModelEntity.php
@@ -33,6 +33,17 @@ namespace Shopware\Components\Model;
  */
 abstract class ModelEntity
 {
+    
+    /**
+     * Implementing the __clone interceptor method to set the entities id property 
+     * to null on using the clone method
+     */ 
+    public function __clone(){
+        if($this->id){
+            $this->id = null;
+        }
+    }
+    
     /**
      * Example:
      *


### PR DESCRIPTION
To allow cloning a model entity it's necessary to implement the abstract ModelEntity's __clone() interceptor method in which the clone's id property will be set to null
