### PR TITLE
Disable csrf-header for cors-ajax

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.csrf-protection.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.csrf-protection.js
@@ -131,13 +131,17 @@
         },
 
         /**
-         * Append X-CSRF-Token header to every request
+         * Append X-CSRF-Token header to every request, except CORS
          *
          * @param event
          * @param request
          * @private
          */
-        _ajaxBeforeSend: function(event, request) {
+        _ajaxBeforeSend: function(event, request, settings) {
+            if(settings.crossDomain){
+                return;
+            }
+
             request.setRequestHeader('X-CSRF-Token', this.getToken());
         },
 


### PR DESCRIPTION
The automatic CSRF-Header for AJAX-Requests has to be disabled for CORS-Requests, as those might not allow custom headers to be set / don't allow custom headers in preflight.

Without this fix all CORS-Requests **will fail**.

This change breaks nothing, as all regular AJAX-Requests still get an X-CSRF-Token Header added.
