### PR TITLE
Register controllers automatically

### DIFF
--- a/engine/Shopware/Bundle/ControllerBundle/DependencyInjection/Compiler/RegisterControllerCompilerPass.php
+++ b/engine/Shopware/Bundle/ControllerBundle/DependencyInjection/Compiler/RegisterControllerCompilerPass.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Shopware\Bundle\ControllerBundle\DependencyInjection\Compiler;
+
+use Shopware\Bundle\ControllerBundle\Finder\ControllerFinder;
+use Shopware\Bundle\ControllerBundle\Listener\ControllerPathListener;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class RegisterControllerCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @param string $path
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     *
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $finder = new ControllerFinder();
+        $controllers = $finder->getControllers($this->path);
+
+        if (count($controllers) === 0) {
+            return;
+        }
+
+        $listener = new Definition(ControllerPathListener::class);
+
+        foreach ($controllers as $controller) {
+            $listener
+                ->addTag(
+                    'shopware.event_listener',
+                    [
+                        'event'  => $controller->getEvent(),
+                        'method' => 'getControllerPath',
+                    ]
+                )
+                ->addMethodCall('addController', [$controller->getEvent(), $controller->getPath()]);
+        }
+
+        $container->setDefinition('shopware.generic_controller_listener.' . uniqid(), $listener);
+    }
+}

--- a/engine/Shopware/Bundle/ControllerBundle/Finder/ControllerFinder.php
+++ b/engine/Shopware/Bundle/ControllerBundle/Finder/ControllerFinder.php
@@ -3,10 +3,12 @@
 namespace Shopware\Bundle\ControllerBundle\Finder;
 
 use Shopware\Bundle\ControllerBundle\Struct\ControllerStruct;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class ControllerFinder
 {
-    const MODULES = ['Backend', 'Frontend', 'Widgets'];
+    const MODULES = ['Backend', 'Frontend', 'Widgets', 'Api'];
 
     /**
      * @param string $path
@@ -16,17 +18,23 @@ class ControllerFinder
     public function getControllers($path)
     {
         $controllers = [];
+        $finder = new Finder();
+        $finder
+            ->in($path)
+            ->files()
+            ->name('*.php');
 
         foreach (self::MODULES as $module) {
-            $files = glob(sprintf('%s/%s/*.php', rtrim($path, '/'), $module));
+            $finder->path($module);
+        }
 
-            if ($files === false) {
-                continue;
-            }
-
-            foreach ($files as $file) {
-                $controllers[] = new ControllerStruct($module, rtrim(basename($file), '.php'), $file);
-            }
+        foreach ($finder as $file) {
+            /** @var $file SplFileInfo */
+            $controllers[] = new ControllerStruct(
+                $file->getPathInfo()->getBasename(),
+                $file->getBasename('.php'),
+                $file->getPathname()
+            );
         }
 
         return $controllers;

--- a/engine/Shopware/Bundle/ControllerBundle/Finder/ControllerFinder.php
+++ b/engine/Shopware/Bundle/ControllerBundle/Finder/ControllerFinder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Shopware\Bundle\ControllerBundle\Finder;
+
+use Shopware\Bundle\ControllerBundle\Struct\ControllerStruct;
+
+class ControllerFinder
+{
+    const MODULES = ['Backend', 'Frontend', 'Widgets'];
+
+    /**
+     * @param string $path
+     *
+     * @return ControllerStruct[]
+     */
+    public function getControllers($path)
+    {
+        $controllers = [];
+
+        foreach (self::MODULES as $module) {
+            $files = glob(sprintf('%s/%s/*.php', rtrim($path, '/'), $module));
+
+            if ($files === false) {
+                continue;
+            }
+
+            foreach ($files as $file) {
+                $controllers[] = new ControllerStruct($module, rtrim(basename($file), '.php'), $file);
+            }
+        }
+
+        return $controllers;
+    }
+}

--- a/engine/Shopware/Bundle/ControllerBundle/Listener/ControllerPathListener.php
+++ b/engine/Shopware/Bundle/ControllerBundle/Listener/ControllerPathListener.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Shopware\Bundle\ControllerBundle\Listener;
+
+use Enlight_Event_EventArgs;
+
+class ControllerPathListener
+{
+    /**
+     * @var string[]
+     */
+    private $controllers = [];
+
+    /**
+     * @param string $event
+     * @param string $path
+     *
+     * @return void
+     */
+    public function addController($event, $path)
+    {
+        $this->controllers[$event] = $path;
+    }
+
+    /**
+     * @param Enlight_Event_EventArgs $args
+     *
+     * @return string
+     */
+    public function getControllerPath(Enlight_Event_EventArgs $args)
+    {
+        if (isset($this->controllers[$args->getName()])) {
+            return $this->controllers[$args->getName()];
+        }
+
+        return null;
+    }
+}

--- a/engine/Shopware/Bundle/ControllerBundle/Struct/ControllerStruct.php
+++ b/engine/Shopware/Bundle/ControllerBundle/Struct/ControllerStruct.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Shopware\Bundle\ControllerBundle\Struct;
+
+class ControllerStruct
+{
+    /**
+     * @var string
+     */
+    private $module;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @param string $module
+     * @param string $name
+     * @param string $path
+     */
+    public function __construct($module, $name, $path)
+    {
+        $this->module = $module;
+        $this->name = $name;
+        $this->path = $path;
+    }
+
+    /**
+     * @return string
+     */
+    public function getModule()
+    {
+        return $this->module;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEvent()
+    {
+        return sprintf(
+            'Enlight_Controller_Dispatcher_ControllerPath_%s_%s',
+            $this->module,
+            $this->name
+        );
+    }
+}

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -25,6 +25,7 @@
 namespace Shopware;
 
 use Shopware\Bundle\AttributeBundle\DependencyInjection\Compiler\SearchRepositoryCompilerPass;
+use Shopware\Bundle\ControllerBundle\DependencyInjection\Compiler\RegisterControllerCompilerPass;
 use Shopware\Bundle\ESIndexingBundle\DependencyInjection\CompilerPass\SettingsCompilerPass;
 use Shopware\Bundle\ESIndexingBundle\DependencyInjection\CompilerPass\SynchronizerCompilerPass;
 use Shopware\Bundle\ESIndexingBundle\DependencyInjection\CompilerPass\DataIndexerCompilerPass;
@@ -764,7 +765,21 @@ class Kernel implements HttpKernelInterface
             }
 
             $container->addObjectResource($plugin);
+            $this->addControllerCompilerPass($plugin, $container);
             $plugin->build($container);
+        }
+    }
+
+    /**
+     * @param Plugin           $plugin
+     * @param ContainerBuilder $container
+     */
+    private function addControllerCompilerPass(Plugin $plugin, ContainerBuilder $container)
+    {
+        $path = $plugin->getPath() . '/Controllers';
+
+        if (is_dir($path)) {
+            $container->addCompilerPass(new RegisterControllerCompilerPass($path));
         }
     }
 }


### PR DESCRIPTION
Hi,
i'm really in love with the new plugin implementation. It works like a charm!
While nearly everything is configured by convention, the controllers have to be registered in the old way.

I tried to improve this by scanning the plugin directory for controller files. The next step will be to add a CompilerPass to the `ContainerBuilder`. It creates a new listener definition and adds the ControllerPath event (Enlight_Controller_Dispatcher_ControllerPath_X_Y) to a new `shopware.event_listener` tag for each found controller. In an additional array, the listener will store all ControllerPath events and their matching controller paths.

While running at build time, there should be no performance issues. The great advantage is the registration of controllers without any additional configuration, just by adding them to the filesystem.

I look forward to your feedback!
