### PR TITLE
Add missing order detail attributes upon adding order position in backend

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -6,6 +6,8 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 [View all changes from v5.2.4...v5.2.5](https://github.com/shopware/shopware/compare/v5.2.4...v5.2.5)
 
+* Added creation of `Shopware\Models\Attribute\OrderDetail` upon adding a new order position via the backend
+
 ## 5.2.4
 
 [View all changes from v5.2.3...v5.2.4](https://github.com/shopware/shopware/compare/v5.2.3...v5.2.4)

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -710,6 +710,8 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
         //check if the passed position data is a new position or an existing position.
         if (empty($id)) {
             $position = new Detail();
+            $attribute = new Shopware\Models\Attribute\OrderDetail();
+            $position->setAttribute($attribute);
             Shopware()->Models()->persist($position);
         } else {
             $detailRepository = Shopware()->Models()->getRepository('Shopware\Models\Order\Detail');


### PR DESCRIPTION
When adding a new order position via the shopware backend, there are currently no attributes written to the database for that new position. This might lead to problems, if a plugin relies on order detail attributes (table `s_order_details_attributes`) being present. This PR adds the missing creation of a `Shopware\Models\Attribute\OrderDetail` instance, when adding a new order position.

This PR does not introduce any breaking changes.

**Edit:** We've always been wondering (for all shopware versions >= 4.0), why in some cases order details were missing their attributes, but now we are finally able to pin it on adding new positions via the backend. Throughout that time, we've also seen quite a few plugins using workarounds to ensure the existence of the attribute rows when needed.
