### PR TITLE
Add missing order attributes and order detail attributes upon creating a temporary order

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -6,6 +6,8 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 [View all changes from v5.2.4...v5.2.5](https://github.com/shopware/shopware/compare/v5.2.4...v5.2.5)
 
+* Added missing creation of `Shopware\Models\Attribute\Order` and `Shopware\Models\Attribute\OrderDetail` instances in `sOrder::sCreateTemporaryOrder()`
+
 ## 5.2.4
 
 [View all changes from v5.2.3...v5.2.4](https://github.com/shopware/shopware/compare/v5.2.3...v5.2.4)

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -466,6 +466,18 @@ class sOrder
             throw new Enlight_Exception("##sOrder-sTemporaryOrder-#01: No rows affected or no order id saved", 0);
         }
 
+        // Create order attributes
+        $attributeData = [
+            'attribute1' => $this->o_attr_1,
+            'attribute2' => $this->o_attr_2,
+            'attribute3' => $this->o_attr_3,
+            'attribute4' => $this->o_attr_4,
+            'attribute5' => $this->o_attr_5,
+            'attribute6' => $this->o_attr_6,
+        ];
+        $attributeData = array_merge($attributeData, $this->orderAttributes);
+        $this->attributePersister->persist($attributeData, 's_order_attributes', $orderID);
+
         $position = 0;
         foreach ($this->sBasketData["content"] as $basketRow) {
             $position++;
@@ -510,9 +522,14 @@ class sOrder
 
             try {
                 $this->db->insert('s_order_details', $data);
+                $orderDetailId = $this->db->lastInsertId();
             } catch (Exception $e) {
                 throw new Enlight_Exception("##sOrder-sTemporaryOrder-Position-#02:" . $e->getMessage(), 0, $e);
             }
+
+            // Create order detail attributes
+            $attributeData = $this->attributeLoader->load('s_order_basket_attributes', $basketRow['id']);
+            $this->attributePersister->persist($attributeData, 's_order_details_attributes', $orderDetailId);
         } // For every article in basket
         return;
     }

--- a/tests/Functional/Core/sOrderTest.php
+++ b/tests/Functional/Core/sOrderTest.php
@@ -397,19 +397,17 @@ class sOrderTest extends PHPUnit_Framework_TestCase
 
         $this->module->sCreateTemporaryOrder();
 
-        $order = Shopware()->Models()->createQueryBuilder()
-            ->select(array('orders'))
-            ->from('Shopware\Models\Order\Order', 'orders')
-            ->where('orders.temporaryId = :orderId')
-            ->setParameter('orderId', self::$sessionId)
-            ->setFirstResult(0)
-            ->setMaxResults(1)
-            ->getQuery()
-            ->getOneOrNullResult(\Doctrine\ORM\AbstractQuery::HYDRATE_ARRAY);
+        $order = Shopware()->Models()->getRepository('Shopware\Models\Order\Order')->findOneBy(['temporaryId' => self::$sessionId]);
 
-        $this->assertEquals('1113', $order['invoiceAmount']);
-        $this->assertEquals('1113', $order['invoiceAmountNet']);
-        $this->assertEquals('0', $order['number']);
+        $this->assertNotNull($order);
+        $this->assertNotNull($order->getAttribute());
+        $this->assertEquals('1113', $order->getInvoiceAmount());
+        $this->assertEquals('1113', $order->getInvoiceAmountNet());
+        $this->assertEquals('0', $order->getNumber());
+
+        foreach ($order->getDetails() as $orderDetail) {
+            $this->assertNotNull($orderDetail->getAttribute());
+        }
     }
 
     /**


### PR DESCRIPTION
Currently `sOrder::sCreateTemporaryOrder()` only creates rows in `s_order` and `s_order_details`, but not their attribute rows in `s_order_attributes` and `s_order_details_attributes` respectively. As a result, when later converting a cancelled order to a _normal_ order, both the order and their details are still missing their attributes. This might lead to problems, if a plugin relies on order attributes and/or order detail attributes being present. This PR adds the creation of both order attributes and order detail attributes to `sOrder::sCreateTemporaryOrder()`, which leads to a consistent database even before converting a cancelled order to a _normal_ order.

This PR does not introduce any breaking changes.
