### PR TITLE
Set order number in order details upon converting a cancelled order

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -6,6 +6,8 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 [View all changes from v5.2.4...v5.2.5](https://github.com/shopware/shopware/compare/v5.2.4...v5.2.5)
 
+* Added missing update of the order details' order number, when converting a cancelled order to a *normal* order in `Shopware_Controllers_Backend_CanceledOrder::convertOrderAction()`
+
 ## 5.2.4
 
 [View all changes from v5.2.3...v5.2.4](https://github.com/shopware/shopware/compare/v5.2.3...v5.2.4)

--- a/engine/Shopware/Controllers/Backend/CanceledOrder.php
+++ b/engine/Shopware/Controllers/Backend/CanceledOrder.php
@@ -97,9 +97,12 @@ class Shopware_Controllers_Backend_CanceledOrder extends Shopware_Controllers_Ba
         // Set new ordernumber
         $numberModel->setNumber($newOrderNumber);
 
-        // set new ordernumber to the order
+        // Set new ordernumber to the order and its details
         $orderModel = Shopware()->Models()->find('Shopware\Models\Order\Order', $orderId);
         $orderModel->setNumber($newOrderNumber);
+        foreach ($orderModel->getDetails() as $detailModel) {
+            $detailModel->setNumber($newOrderNumber);
+        }
 
         // refreshes the in stock correctly for this order if the user confirmed it
         if ((bool) $this->Request()->getParam('refreshInStock')) {


### PR DESCRIPTION
When converting a cancelled order to a _normal_ order, the newly determined order number is currently not set in the order details. This behaviour diverges from the order creation during the checkout process. This PR fixes this behaviour by setting the new order number in all order details too.

This PR does not introduce any breaking changes.
