### PR TITLE
[TASK] Use container to create FormType classes

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -26,6 +26,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 * Added `Shopware\Components\Emotion\ComponentInstaller` class to install emotion components in plugins.
 * Added `\Shopware\Components\Emotion\EmotionComponentViewSubscriber` to register emotion widget templates 
 * Added `plugin_dir` and `plugin_name` container parameter for each plugin. Parameters are prefixed by `\Shopware\Components\Plugin::getContainerPrefix`
+* Creating Forms in Registration or AddressController use classes from container now
 
 
 ## 5.2.9

--- a/engine/Shopware/Controllers/Backend/Address.php
+++ b/engine/Shopware/Controllers/Backend/Address.php
@@ -139,7 +139,10 @@ class Shopware_Controllers_Backend_Address extends Shopware_Controllers_Backend_
         $data['state'] = $data['state_id'];
 
         /** @var \Symfony\Component\Form\FormInterface $form */
-        $form = $this->get('shopware.form.factory')->create(AddressFormType::class, $model);
+        $form = $this->get('shopware.form.factory')->create(
+            get_class($this->container->get('shopware_account.form.addressform')),
+            $model
+        );
         $form->submit($data);
 
         if (!$form->isValid()) {

--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -496,7 +496,7 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
             return;
         }
 
-        $form = $this->createForm(ResetPasswordFormType::class, $customer);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.resetpasswordform')), $customer);
         $form->handleRequest($this->Request());
 
         if (!$form->isValid()) {
@@ -606,7 +606,7 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
         /** @var Customer $customer */
         $customer = $this->get('models')->find(Customer::class, $userId);
 
-        $form = $this->createForm(ProfileUpdateFormType::class, $customer);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.profile_update_form')), $customer);
         $form->handleRequest($this->Request());
 
         if ($form->isValid()) {
@@ -628,7 +628,7 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
         /** @var Customer $customer */
         $customer = $this->get('models')->find(Customer::class, $userId);
 
-        $form = $this->createForm(EmailUpdateFormType::class, $customer);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.emailupdateform')), $customer);
         $form->handleRequest($this->Request());
 
         if ($form->isValid()) {
@@ -651,7 +651,7 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
         /** @var Customer $customer */
         $customer = $this->get('models')->find(Customer::class, $userId);
 
-        $form = $this->createForm(PasswordUpdateFormType::class, $customer);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.passwordupdateform')), $customer);
         $form->handleRequest($this->Request());
 
         if ($form->isValid()) {

--- a/engine/Shopware/Controllers/Frontend/Address.php
+++ b/engine/Shopware/Controllers/Frontend/Address.php
@@ -87,7 +87,7 @@ class Shopware_Controllers_Frontend_Address extends Enlight_Controller_Action
     public function createAction()
     {
         $address = new Address();
-        $form = $this->createForm(AddressFormType::class, $address);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.addressform')), $address);
         $form->handleRequest($this->Request());
 
         if ($form->isValid()) {
@@ -130,7 +130,7 @@ class Shopware_Controllers_Frontend_Address extends Enlight_Controller_Action
         $addressId = $this->Request()->getParam('id', null);
         $address = $this->addressRepository->getOneByUser($addressId, $userId);
 
-        $form = $this->createForm(AddressFormType::class, $address);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.addressform')), $address);
         $form->handleRequest($this->Request());
 
         if ($form->isValid()) {
@@ -310,7 +310,7 @@ class Shopware_Controllers_Frontend_Address extends Enlight_Controller_Action
             $address = new Address();
         }
 
-        $form = $this->createForm(AddressFormType::class, $address);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.addressform')), $address);
         $this->View()->assign($this->getFormViewData($form));
     }
 
@@ -335,7 +335,7 @@ class Shopware_Controllers_Frontend_Address extends Enlight_Controller_Action
             $address = new Address();
         }
 
-        $form = $this->createForm(AddressFormType::class, $address);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.addressform')), $address);
         $form->handleRequest($this->Request());
         
         if ($form->isValid()) {

--- a/engine/Shopware/Controllers/Frontend/Register.php
+++ b/engine/Shopware/Controllers/Frontend/Register.php
@@ -409,7 +409,7 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
     private function createCustomerForm(array $data)
     {
         $customer = new Customer();
-        $form = $this->createForm(PersonalFormType::class, $customer);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.personalform')), $customer);
         $form->submit($data);
         return $form;
     }
@@ -421,7 +421,7 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
     private function createBillingForm(array $data)
     {
         $address = new Address();
-        $form = $this->createForm(AddressFormType::class, $address);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.addressform')), $address);
         $form->submit($data);
         return $form;
     }
@@ -433,7 +433,7 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
     private function createShippingForm(array $data)
     {
         $address = new Address();
-        $form = $this->createForm(AddressFormType::class, $address);
+        $form = $this->createForm(get_class($this->container->get('shopware_account.form.addressform')), $address);
         $form->submit($data);
         return $form;
     }


### PR DESCRIPTION
Hey folks,
as discussed in IRC here is my PR which allows decorating/replacing of the formtypes.

This brings a lot of flexibility. In my case I wanted to use symfony validation_groups which could not be obtained without decorating the forms.

This change does not break anything.

Regards,
Thomas
