### PR TITLE
Strip content of style and script tags in for long description

### DIFF
--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -1468,6 +1468,7 @@ class sArticles
     public function sOptimizeText($text)
     {
         $text = html_entity_decode($text, ENT_NOQUOTES, 'UTF-8');
+        $text = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $text);
         $text = preg_replace('!<[^>]*?>!u', ' ', $text);
         $text = preg_replace('/\s\s+/u', ' ', $text);
         $text = trim($text);


### PR DESCRIPTION
Replace <script> and <style> Tags with content. This is important for nice shortdescriptions in listing controller.

Code: $text = preg_replace('@<(script|style)[^>]_?>._?</\1>@si', '', $text);
