### PR TITLE
added an initialize method which is called whenever a plugin is initi…

### DIFF
--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -137,6 +137,14 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
     }
 
     /**
+     * This method is called during initialization of the plugin
+     */
+    public function initialize()
+    {
+
+    }
+
+    /**
      * Builds the Plugin.
      *
      * It is only ever called once when the cache is empty.

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -331,6 +331,8 @@ class Kernel implements HttpKernelInterface
 
             /** @var Plugin $plugin */
             $plugin = new $className($isActive);
+            $plugin->initialize();
+
             $this->plugins[$plugin->getName()] = $plugin;
         }
 


### PR DESCRIPTION
**Why:**

currently its not possible to autoload dependencies during container building except the dependencies which can be autoloaded with psr4 from the plugin root directory. In my case, i wanted to include the viison/address-splitter and use it for my services definied in my Resources/services.xml. When the Container is built, i am able to include my own autoloaded. If the Cntainer is already built, this is not possible.

What:

Added a small initialize function

Breaking something?

No.
