### PR TITLE
[BUGFIX] Update ongr/elasticsearch-dsl to a new stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "guzzlehttp/guzzle": "5.3.1",
         "egulias/email-validator": "1.2.12",
         "elasticsearch/elasticsearch": "2.2.0",
-        "ongr/elasticsearch-dsl": "2.0.1",
+        "ongr/elasticsearch-dsl": "2.0.2",
         "league/flysystem": "1.0.22",
         "paragonie/random_compat": "1.4.1",
         "cocur/slugify": "2.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9d22a41d7ad67237428e0187e982c211",
-    "content-hash": "df51231312f9ab55942f7a107a73df4f",
+    "hash": "e87244c1d9a0b040c50f106ae7e8ce25",
+    "content-hash": "e59580beb7c25ab113a63ee5c1231fc5",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1145,21 +1145,20 @@
         },
         {
             "name": "ongr/elasticsearch-dsl",
-            "version": "v2.0.1",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ongr-io/ElasticsearchDSL.git",
-                "reference": "7cd0ab4b2a8b1d7c9f265954ce5d69feb4b19069"
+                "reference": "dc569d219a8fed08192cf8dacdb69c48c54f7b80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ongr-io/ElasticsearchDSL/zipball/7cd0ab4b2a8b1d7c9f265954ce5d69feb4b19069",
-                "reference": "7cd0ab4b2a8b1d7c9f265954ce5d69feb4b19069",
+                "url": "https://api.github.com/repos/ongr-io/ElasticsearchDSL/zipball/dc569d219a8fed08192cf8dacdb69c48c54f7b80",
+                "reference": "dc569d219a8fed08192cf8dacdb69c48c54f7b80",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "symfony/options-resolver": "~2.7|~3.0",
                 "symfony/serializer": "~2.7|~3.0"
             },
             "require-dev": {
@@ -1190,7 +1189,7 @@
             ],
             "description": "Elasticsearch DSL library",
             "homepage": "http://ongr.io",
-            "time": "2016-05-03 01:24:48"
+            "time": "2016-07-11 08:15:59"
         },
         {
             "name": "oyejorge/less.php",


### PR DESCRIPTION
In our projects we are using some FunctionScoreQuery Features of Elasticsearch.  In the last version there are some bugs around this feature. The new version 2.0.2 fixes those problems.

I am pointing to: "Fixed function score query #122"

For more details: https://github.com/ongr-io/ElasticsearchDSL/pull/122
