### PR TITLE
Add missing method setCookie() to enable testing cookies

### DIFF
--- a/engine/Library/Enlight/Controller/Response/ResponseTestCase.php
+++ b/engine/Library/Enlight/Controller/Response/ResponseTestCase.php
@@ -88,17 +88,6 @@ class Enlight_Controller_Response_ResponseTestCase
     {
         if (!empty($this->_cookies)) {
             $this->canSendHeaders(true);
-            foreach ($this->_cookies as $name => $cookie) {
-                setcookie(
-                    $name,
-                    $cookie['value'],
-                    $cookie['expire'],
-                    $cookie['path'],
-                    $cookie['domain'],
-                    $cookie['secure'],
-                    $cookie['httpOnly']
-                );
-            }
         }
         return $this;
     }

--- a/engine/Library/Enlight/Controller/Response/ResponseTestCase.php
+++ b/engine/Library/Enlight/Controller/Response/ResponseTestCase.php
@@ -80,6 +80,30 @@ class Enlight_Controller_Response_ResponseTestCase
     }
 
     /**
+     * Sends all cookies
+     *
+     * @return Enlight_Controller_Response_ResponseTestCase
+     */
+    public function sendCookies()
+    {
+        if (!empty($this->_cookies)) {
+            $this->canSendHeaders(true);
+            foreach ($this->_cookies as $name => $cookie) {
+                setcookie(
+                    $name,
+                    $cookie['value'],
+                    $cookie['expire'],
+                    $cookie['path'],
+                    $cookie['domain'],
+                    $cookie['secure'],
+                    $cookie['httpOnly']
+                );
+            }
+        }
+        return $this;
+    }
+
+    /**
      * Gets a cookie value
      *
      * @param string $name


### PR DESCRIPTION
The method is actually only available in Enlight_Controller_Response_ResponseHttp but it should exist in Enlight_Controller_Request_RequestTestCase, too.
