### PR TITLE
SW-12898 Fix sites-navigation target attribute is not set

### DIFF
--- a/themes/Frontend/Bare/frontend/index/sites-navigation.tpl
+++ b/themes/Frontend/Bare/frontend/index/sites-navigation.tpl
@@ -12,7 +12,7 @@
                            title="{$page.description|escape}"
                            data-categoryId="{$page.id}"
                            data-fetchUrl="{url module=widgets controller=listing action=getCustomPage pageId={$page.id}}"
-                           {if $page.target}target="{$page.page}"{/if}>
+                           {if $page.target}target="{$page.target}"{/if}>
                             {$page.description}
 
                             {if $page.childrenCount}


### PR DESCRIPTION
If the link-target is set for the sites-navigation in the frontend the target attribute is empty.
Its because a wrong Smarty-variable is used in the template.
