### PR TITLE
Add missing article translations in listing

### DIFF
--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -2244,7 +2244,7 @@ class sArticles
                 $article["description_long"] = $article['description'];
             }
             $article['description_long'] = $this->sOptimizeText($article['description_long']);
-
+            $article = $this->sGetTranslation($article, $article['id'], 'article');
             $articles[$article['ordernumber']] = $article;
         }
 


### PR DESCRIPTION
We need this fix to translate for example the pack unit.
