### PR TITLE
Check Customergroup before setting default group

### DIFF
--- a/engine/Shopware/Bundle/AccountBundle/Service/RegisterService.php
+++ b/engine/Shopware/Bundle/AccountBundle/Service/RegisterService.php
@@ -196,10 +196,12 @@ class RegisterService implements RegisterServiceInterface
         $customer->setLanguageSubShop(
             $this->modelManager->find('Shopware\Models\Shop\Shop', $shop->getId())
         );
-
-        $customer->setGroup(
-            $this->modelManager->find('Shopware\Models\Customer\Group', $shop->getCustomerGroup()->getId())
-        );
+        
+        if (is_null($customer->getGroup())) {
+            $customer->setGroup(
+                $this->modelManager->find('Shopware\Models\Customer\Group', $shop->getCustomerGroup()->getId())
+            );
+        }
 
         if ($customer->getAffiliate()) {
             $customer->setAffiliate((int) $this->getPartnerId($customer));


### PR DESCRIPTION
As stated here https://forum.shopware.com/discussion/39854/customer-api-kundengruppe-wird-ignoriert and here https://forum.shopware.com/discussion/39808/sw-5-2-3-api-customers-groupkey/p1 the RegisterService does not work correctly in combination with creating users via API.
I added a simple check whether the customer already has a group (which is the case when it is given via API) before setting the default group defined in the shop settings.
