### PR TITLE
Update testing info in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,13 +71,14 @@ For most tests a configured database connection is required.
 
 ## Running the tests
 The tests are located in the `tests/Shopware/` directory
+The tests are located in the `tests/` directory
 You can run the entire test suite with the following command:
 
-    vendor/bin/phpunit -c tests/Shopware
+    vendor/bin/phpunit -c tests
 
 If you want to test a single component, add its path after the phpunit command, e.g.:
 
-    vendor/bin/phpunit -c tests/Shopware tests/Shopware/Tests/Components/Api/
+    vendor/bin/phpunit -c tests tests/Functional/Components/Api/
 
 # Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ If you want to test a single component, add its path after the phpunit command, 
 # Documentation
 
 Developer documentation for Shopware is available [here](https://developers.shopware.com/). You can also contribute to the documentation project by submitting your pull requests to our [Devdocs Github project](https://github.com/shopware/devdocs)
- 
+
 # Translations
 
-Shopware translations are done by the community and can be installed from the plugin store. If you wish to improve Shopware's translations, you can do so in our [Crowdin project page](https://crowdin.com/project/shopware). 
+Shopware translations are done by the community and can be installed from the plugin store. If you wish to improve Shopware's translations, you can do so in our [Crowdin project page](https://crowdin.com/project/shopware).


### PR DESCRIPTION
Adapt `CONTRIBUTING.md` to new Shopware 5.2 test architecture (introduced in 90c2f2fbe55772d6a2cf24a86434f83aa76dab16).
