### PR TITLE
[Papercut][SW-16359] Fix retrieval of image attribute 3

### DIFF
--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -1529,7 +1529,7 @@ class sArticles
             $imageData['attribute']['attribute2'] = $image['attribute2'];
         }
 
-        if (!empty($image['attribute1'])) {
+        if (!empty($image['attribute3'])) {
             $imageData['attribute']['attribute3'] = $image['attribute3'];
         }
 


### PR DESCRIPTION
Typo in `sArticles::getDataOfArticleImage()`.
