### PR TITLE
Disable loading of widgets of deactivated plugins

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -27,6 +27,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
     * `frontend_detail_images_image_slider_item`
 * Updated `ongr/elasticsearch-dsl` to version 2.0.2
 * Updated `phpunit/phpunit` to version 5.5
+* Disable loading of widgets of deactivated plugins
 
 ## 5.2.5
 

--- a/engine/Shopware/Controllers/Backend/Widgets.php
+++ b/engine/Shopware/Controllers/Backend/Widgets.php
@@ -48,10 +48,12 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
         $userID = (int)$identity->id;
 
         $builder = Shopware()->Container()->get('models')->createQueryBuilder();
-        $builder->select(array('widget', 'view'))
+        $builder->select(array('widget', 'view', 'plugin'))
             ->from('Shopware\Models\Widget\Widget', 'widget')
             ->leftJoin('widget.views', 'view', 'WITH', 'view.authId = ?1')
+            ->leftJoin('widget.plugin', 'plugin')
             ->orderBy('view.position')
+            ->where('widget.plugin IS NULL OR plugin.active = 1')
             ->setParameter(1, $userID);
 
         $data = $builder->getQuery()->getArrayResult();


### PR DESCRIPTION
Widgets of deactivated plugins should neither be loaded nor be able to be added to the widget list, since they cause a JS error and crash the widget panel.
This fix ensures that only Shopware widgets or widgets of active plugins are loaded. This also ensures they are not shown in the widget list (therefore cannot be added to the widget panel)

This PR does not introduce any breaking changes.
