### PR TITLE
[TASK] Use identical operator in config writer

### DIFF
--- a/engine/Shopware/Components/Plugin/ConfigWriter.php
+++ b/engine/Shopware/Components/Plugin/ConfigWriter.php
@@ -105,7 +105,7 @@ class ConfigWriter
         $valueModel = $this->valueRepository->findOneBy(['shop' => $shop, 'element' => $element]);
 
         if (!$valueModel) {
-            if ($value == $defaultValue || $value === null) {
+            if ($value === $defaultValue || $value === null) {
                 return;
             }
 


### PR DESCRIPTION
Hey folks,
I just came accross this issue. I wanted to set some configs with the value `0`. This didnt work because my config field does not have a default value, so its `null`.

`null == 0` is true, so the method returns here. Using the identical operator solves this issue.

Regards,
Thomas
