### PR TITLE
Fix category attributes frontend format regression

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -34,6 +34,7 @@ use Shopware\Bundle\StoreFrontBundle\Struct\Product\Price;
 use Shopware\Components\DependencyInjection\Container;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Emotion\Emotion;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 
 /**
  * @category  Shopware
@@ -215,6 +216,13 @@ class LegacyStructConverter
         $attribute = [];
         if ($category->hasAttribute('core')) {
             $attribute = $category->getAttribute('core')->toArray();
+            $converter = new CamelCaseToSnakeCaseNameConverter();
+
+            // Attribute names were in lowerCamelCase format in < 5.2
+            foreach ($attribute as $key => $value) {
+                $snakeKey = $converter->denormalize($key);
+                $attribute[$snakeKey] = $value;
+            }
         }
 
         $productStream = null;


### PR DESCRIPTION
In Shopware < 5.2 the keys of category attribute had the lowerCamelCase format since they where given to the frontend throught `sCategories::sGetCategoryContent()` which didn't use the `LegacyStructConverter` but a doctrine query builder (https://github.com/shopware/shopware/blob/5.1/engine/Shopware/Core/sCategories.php#L529 and https://github.com/shopware/shopware/blob/5.1/engine/Shopware/Core/sCategories.php#L657).

After upgrading our customer's shop to 5.2 we had to change all listing templates because of this regression. This PR offers and approach to remain backwards compatible.
