### PR TITLE
Fix snippet content when name is given without quotes

### DIFF
--- a/engine/Library/Enlight/Components/Snippet/Resource.php
+++ b/engine/Library/Enlight/Components/Snippet/Resource.php
@@ -187,6 +187,7 @@ class Enlight_Components_Snippet_Resource extends Smarty_Internal_Resource_Exten
         while (preg_match($pattern, $source->content, $_block_match, PREG_OFFSET_CAPTURE)) {
             $_block_editable = !empty($_block_match[1][0]);
             $_block_args = $_block_match[2][0];
+            $_block_args = preg_replace('/name=([^\'" ]\S*)/', "name='$1'", $_block_args);
             $_block_default = $_block_match[3][0];
             list($_block_tag, $_block_start) = $_block_match[0];
             $_block_length = strlen($_block_tag);


### PR DESCRIPTION
A snippet definition {s name=foo/bar} without quotes around 'foo/bar' previously led to a PHP warning on runtime, because a division by zero occurs. This was due to the following faulty code being generated:

```
<?php $_smarty_tpl->smarty->_tag_stack[] = array('snippet', array('name'=>'foo'/'bar',
[...]
```

After this change, the following valid code is produced:

```
<?php $_smarty_tpl->smarty->_tag_stack[] = array('snippet', array('name'=>'foo/bar',
[...]
```
