### PR TITLE
Fix PluginBase._off removing all events

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
@@ -211,7 +211,7 @@
                     return typeof obj !== 'undefined' && pluginEvent === obj.event && $element[0] === obj.el[0];
                 });
 
-            $.each(filteredEvents, function (event) {
+            $.each(filteredEvents, function (i, event) {
                 $element.off.call($element, event.event);
             });
 


### PR DESCRIPTION
The method `PluginBase._off` falsely removes all events from an element.

This issue is caused by the wrong usage of `$.each` in _jquery.plugin-base.js:214_.
`$.each` expects a callback of type `Function(Integer indexInArray, Object value)`, in this case `Function(Object value)` is given.
