### PR TITLE
Avoid potential conflicts in parseQueryString

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.infinite-scrolling.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.infinite-scrolling.js
@@ -9,25 +9,25 @@
      * @returns {{}} Object with all extracted parameters
      */
     var parseQueryString = function(url) {
-	    var qparams = {},
-		    parts = (url || '').split('?'),
-		    qparts, qpart;
+        var qparams = {},
+            parts = (url || '').split('?'),
+            qparts, qpart;
 
-	    if (parts.length <= 1) {
-		    return qparams;
-	    }
+        if (parts.length <= 1) {
+            return qparams;
+        }
 
-	    qparts = parts[1].split('&');
-	    for (var i = 0, len = qparts.length; i < len; i++) {
-		    var key, value;
+        qparts = parts[1].split('&');
+        for (var i = 0, len = qparts.length; i < len; i++) {
+            var key, value;
 
-		    qpart = qparts[i].split('=');
-		    key = decodeURIComponent(qpart[0]);
-		    value = decodeURIComponent(qpart[1] || '');
-		    qparams[key] = ($.isNumeric(value) ? parseFloat(value, 10) : value);
-	    }
+            qpart = qparts[i].split('=');
+            key = decodeURIComponent(qpart[0]);
+            value = decodeURIComponent(qpart[1] || '');
+            qparams[key] = ($.isNumeric(value) ? parseFloat(value, 10) : value);
+        }
 
-	    return qparams;
+        return qparams;
     };
 
     $.plugin('swInfiniteScrolling', {

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.infinite-scrolling.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.infinite-scrolling.js
@@ -9,26 +9,25 @@
      * @returns {{}} Object with all extracted parameters
      */
     var parseQueryString = function(url) {
-        var qparams = {},
-            parts = (url || '').split('?'),
-            qparts, qpart,
-            i=0;
+	    var qparams = {},
+		    parts = (url || '').split('?'),
+		    qparts, qpart;
 
-        if(parts.length <= 1){
-            return qparams;
-        }
+	    if (parts.length <= 1) {
+		    return qparams;
+	    }
 
-        qparts = parts[1].split('&');
-        for (i in qparts) {
-            var key, value;
+	    qparts = parts[1].split('&');
+	    for (var i = 0, len = qparts.length; i < len; i++) {
+		    var key, value;
 
-            qpart = qparts[i].split('=');
-            key = decodeURIComponent(qpart[0])
-            value = decodeURIComponent(qpart[1] || '');
-            qparams[key] = ($.isNumeric(value) ? parseFloat(value, 10) : value);
-        }
+		    qpart = qparts[i].split('=');
+		    key = decodeURIComponent(qpart[0]);
+		    value = decodeURIComponent(qpart[1] || '');
+		    qparams[key] = ($.isNumeric(value) ? parseFloat(value, 10) : value);
+	    }
 
-        return qparams;
+	    return qparams;
     };
 
     $.plugin('swInfiniteScrolling', {


### PR DESCRIPTION
The `for...in` loop shouldn't be used to iterate over arrays because `Array.prototype` could have been extended by 3rd-party libraries. This would break this function.
