### PR TITLE
[FEATURE] Use DI container to load API resources

### DIFF
--- a/engine/Shopware/Components/Api/Manager.php
+++ b/engine/Shopware/Components/Api/Manager.php
@@ -41,13 +41,10 @@ class Manager
      */
     public static function getResource($name)
     {
-        $name = ucfirst($name);
-        $class = __NAMESPACE__ . '\\Resource\\' . $name;
+        $container = Shopware()->Container();
 
         /** @var $resource Resource\Resource */
-        $resource = new $class();
-
-        $container = Shopware()->Container();
+        $resource = $container->get('shopware.api.' . strtolower($name));
 
         if ($resource instanceof ContainerAwareInterface) {
             $resource->setContainer($container);

--- a/engine/Shopware/Components/Api/Resource/Resource.php
+++ b/engine/Shopware/Components/Api/Resource/Resource.php
@@ -113,11 +113,8 @@ abstract class Resource
      */
     protected function getResource($name)
     {
-        $name = ucfirst($name);
-        $class = __NAMESPACE__ . '\\' . $name;
-
         /** @var $resource \Shopware\Components\Api\Resource\Resource */
-        $resource = new $class();
+        $resource = $this->getContainer()->get('shopware.api.' . strtolower($name));
         $resource->setManager($this->getManager());
 
         if ($this->getAcl()) {

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -475,5 +475,21 @@
             <argument>%kernel.root_dir%/engine/Shopware/Components/Check/Data/System.xml</argument>
             <argument type="service" id="db_connection"/>
         </service>
+
+        <service id="shopware.api.resource" class="Shopware\Components\Api\Resource\Resource" />
+        <service id="shopware.api.address" class="Shopware\Components\Api\Resource\Address" />
+        <service id="shopware.api.article" class="Shopware\Components\Api\Resource\Article" />
+        <service id="shopware.api.cache" class="Shopware\Components\Api\Resource\Cache" />
+        <service id="shopware.api.category" class="Shopware\Components\Api\Resource\Category" />
+        <service id="shopware.api.country" class="Shopware\Components\Api\Resource\Country" />
+        <service id="shopware.api.customer" class="Shopware\Components\Api\Resource\Customer" />
+        <service id="shopware.api.customergroup" class="Shopware\Components\Api\Resource\CustomerGroup" />
+        <service id="shopware.api.manufacturer" class="Shopware\Components\Api\Resource\Manufacturer" />
+        <service id="shopware.api.media" class="Shopware\Components\Api\Resource\Media" />
+        <service id="shopware.api.order" class="Shopware\Components\Api\Resource\Order" />
+        <service id="shopware.api.propertygroup" class="Shopware\Components\Api\Resource\PropertyGroup" />
+        <service id="shopware.api.shop" class="Shopware\Components\Api\Resource\Shop" />
+        <service id="shopware.api.translation" class="Shopware\Components\Api\Resource\Translation" />
+        <service id="shopware.api.variant" class="Shopware\Components\Api\Resource\Variant" />
     </services>
 </container>


### PR DESCRIPTION
Aktuell werden die API-Resourcen per `new` instanziert. Mit dieser Änderung werden sie über den DI-Container geladen, was nachträgliche Anpassungen in eigenen Plugins ermöglicht. Der Übersichtlichkeit halber habe ich in der Service-Definition den Namensraum `shopware.api.` genutzt.
