### PR TITLE
Throw exception if plugin's class not found

### DIFF
--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -329,6 +329,10 @@ class Kernel implements HttpKernelInterface
 
             $isActive = in_array($pluginName, $activePlugins);
 
+            if (!class_exists($className)) {
+                throw new \Exception("Class {$className} for plugin {$pluginName} not found.");
+            }
+
             /** @var Plugin $plugin */
             $plugin = new $className($isActive);
             $this->plugins[$plugin->getName()] = $plugin;


### PR DESCRIPTION
Otherwise PHP tries to instanciate a non existing class.
