### PR TITLE
shortcut for configuring cache clear on Plugin operations

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -2,6 +2,12 @@
 
 This changelog references changes done in Shopware 5.2 patch versions.
 
+## 5.2.7
+
+[View all changes from v5.2.6...v5.2.7](https://github.com/shopware/shopware/compare/v5.2.6...v5.2.7)
+
+* added protected field `Shopware\Components\Plugin::$cachesToClear`, override this in your Plugin main class (YourPluginName.php) to more easily control Cache behavior across update, activate, deactivate, uninstall
+
 ## 5.2.6
 
 [View all changes from v5.2.5...v5.2.6](https://github.com/shopware/shopware/compare/v5.2.5...v5.2.6)

--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -60,6 +60,14 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
     private $isActive;
 
     /**
+     * override this in your plugin to change the default cache clear behavior across update, activate, deactivate,
+     * uninstall
+     *
+     * @var array
+     */
+    protected $cachesToClear = InstallContext::CACHE_LIST_DEFAULT;
+
+    /**
      * @inheritdoc
      */
     public static function getSubscribedEvents()
@@ -106,7 +114,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
      */
     public function update(UpdateContext $context)
     {
-        $context->scheduleClearCache(InstallContext::CACHE_LIST_DEFAULT);
+        $context->scheduleClearCache($this->cachesToClear);
     }
 
     /**
@@ -115,7 +123,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
      */
     public function activate(ActivateContext $context)
     {
-        $context->scheduleClearCache(InstallContext::CACHE_LIST_DEFAULT);
+        $context->scheduleClearCache($this->cachesToClear);
     }
 
     /**
@@ -124,7 +132,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
      */
     public function deactivate(DeactivateContext $context)
     {
-        $context->scheduleClearCache(InstallContext::CACHE_LIST_DEFAULT);
+        $context->scheduleClearCache($this->cachesToClear);
     }
 
     /**
@@ -133,7 +141,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
      */
     public function uninstall(UninstallContext $context)
     {
-        $context->scheduleClearCache(InstallContext::CACHE_LIST_DEFAULT);
+        $context->scheduleClearCache($this->cachesToClear);
     }
 
     /**


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | successfully tested manually |
| Related tickets? | none found |
| How to test? | Override the field in a plugin controller class and activate/deactivate. |
## Description

With the current way of clearing the cache, if you have a plugin that extends the theme you would need to override at least the activate, deactivate, and uninstall methods in order to correctly clear the cache and recompile the theme, which felt like a lot of redundant code. 

We figured that, if we add a field to the Plugin Abstract class and get the cache clear flag from there, we would only have to override the field in order to clear the desired caches.
