### PR TITLE
Support for combo store values in plugin config.xml

### DIFF
--- a/engine/Shopware/Components/Plugin/XmlConfigDefinitionReader.php
+++ b/engine/Shopware/Components/Plugin/XmlConfigDefinitionReader.php
@@ -129,7 +129,16 @@ class XmlConfigDefinitionReader
         }
 
         if ($position = $this->getChildren($entry, 'store')) {
-            $element['store'] = $position[0]->nodeValue;
+            $options = $this->getChildren($position[0], 'option');
+
+            if (!empty($options)) {
+                $element['store'] = [];
+                foreach ($options as $item) {
+                    $element['store'][] = [$item->getAttribute('value'), $item->nodeValue];
+                }
+            } else {
+                $element['store'] = $position[0]->nodeValue;
+            }
         }
 
         if ($position = $this->getChildren($entry, 'value')) {

--- a/engine/Shopware/Components/Plugin/schema/config.xsd
+++ b/engine/Shopware/Components/Plugin/schema/config.xsd
@@ -57,16 +57,23 @@
         </xsd:restriction>
     </xsd:simpleType>
 
+    <xsd:complexType name="store" mixed="true">
+        <xsd:sequence>
+            <xsd:element type="storeOption" name="option" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+        <xsd:attribute type="storeType" name="storeType" use="optional"/>
+    </xsd:complexType>
+
     <xsd:simpleType name="storeType">
         <xsd:restriction base="xsd:string">
             <xsd:enumeration value="php"/>
         </xsd:restriction>
     </xsd:simpleType>
 
-    <xsd:complexType name="store">
+    <xsd:complexType name="storeOption">
         <xsd:simpleContent>
             <xsd:extension base="xsd:string">
-                <xsd:attribute name="type" type="storeType" default="php"/>
+                <xsd:attribute type="xsd:string" name="value"/>
             </xsd:extension>
         </xsd:simpleContent>
     </xsd:complexType>

--- a/tests/Unit/Components/Plugin/XmlConfigDefinitionReaderTest.php
+++ b/tests/Unit/Components/Plugin/XmlConfigDefinitionReaderTest.php
@@ -27,4 +27,19 @@ class XmlConfigDefinitionReaderTest extends TestCase
         $result = $this->SUT->read(__DIR__.'/examples/config.xml');
         $this->assertInternalType('array', $result);
     }
+
+    public function testCanReadStores()
+    {
+        $form = $this->SUT->read(__DIR__.'/examples/config_store.xml');
+        $this->assertInternalType('array', $form);
+
+        $expected = [
+            ['1', 'Test 1'],
+            ['2', 'Test 2'],
+            ['3', 'Test 3'],
+        ];
+
+        $this->assertEquals($expected, $form['elements'][0]['store']);
+        $this->assertEquals('Shopware.apps.Base.store.Category', $form['elements'][1]['store']);
+    }
 }

--- a/tests/Unit/Components/Plugin/examples/config_store.xml
+++ b/tests/Unit/Components/Plugin/examples/config_store.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../engine/Shopware/Components/Plugin/schema/config.xsd">
+    <elements>
+        <element type="select">
+            <name>selectArray</name>
+            <label>XML Store</label>
+            <store>
+                <option value="1">Test 1</option>
+                <option value="2">Test 2</option>
+                <option value="3">Test 3</option>
+            </store>
+        </element>
+        <element type="select">
+            <name>selectExtjsStore</name>
+            <label>Extjs Store</label>
+            <store>Shopware.apps.Base.store.Category</store>
+        </element>
+    </elements>
+</config>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | Nope |
| How to test? | Example config.xml => https://dpaste.de/gnGL |
## Description

Please describe your pull request:
this PR allows the plugin developer to define the store values in the config file. Currently we must set the combo values in the plugin install (getting form model set new store saving....), that is not so pretty and easy like the other fields :)
