### PR TITLE
Allow applying custom filters on base combobox element

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -2,6 +2,26 @@
 
 This changelog references changes done in Shopware 5.2 patch versions.
 
+## 5.2.7
+
+[View all changes from v5.2.6...v5.2.7](https://github.com/shopware/shopware/compare/v5.2.6...v5.2.7)
+
+* Added optional `filter` option to `Shopware.apps.Base.view.element.Select`
+* Set `remoteFilter` to `true` in several *base* stores:
+    * `Shopware.apps.Base.store.Country`
+    * `Shopware.apps.Base.store.CountryArea`
+    * `Shopware.apps.Base.store.CountryState`
+    * `Shopware.apps.Base.store.Currency`
+    * `Shopware.apps.Base.store.CustomerGroup`
+    * `Shopware.apps.Base.store.Dispatch`
+    * `Shopware.apps.Base.store.Locale`
+    * `Shopware.apps.Base.store.OrderStatus`
+    * `Shopware.apps.Base.store.Payment`
+    * `Shopware.apps.Base.store.PaymentStatus`
+    * `Shopware.apps.Base.store.PositionStatus`
+    * `Shopware.apps.Base.store.Tax`
+* Replaced the default filter on `dispatches.active` added in `Shopware_Controllers_Backend_Base::getDispatchesAction()` by a default filter on `active` added in `Shopware.apps.Base.store.Dispatch`
+
 ## 5.2.6
 
 [View all changes from v5.2.5...v5.2.6](https://github.com/shopware/shopware/compare/v5.2.5...v5.2.6)

--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -268,11 +268,9 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
         //load shop repository
         $repository = Shopware()->Models()->getRepository('Shopware\Models\Dispatch\Dispatch');
 
-        $filters = $this->Request()->getParam('filter', array());
-        $filters[] = array('property' => 'dispatches.active', 'value' => 1);
         $query = $repository->getDispatchesQuery(
-            $filters,
-            $this->Request()->getParam('sort', array()),
+            $this->prefixKeys($this->Request()->getParam('filter', array()), 'dispatches'),
+            $this->prefixKeys($this->Request()->getParam('sort', array()), 'dispatches'),
             $this->Request()->getParam('start'),
             $this->Request()->getParam('limit')
         );
@@ -1097,5 +1095,21 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
         }
         $value = array_unique(array_filter($value));
         return $value;
+    }
+
+    /**
+     * @param array $elements
+     * @param string $prefix
+     * @return array
+     */
+    private function prefixKeys(array $elements, $prefix)
+    {
+        return array_map(function ($element) use ($prefix) {
+            if (isset($element['property']) && strpos($element['property'], ($prefix . '.')) !== 0) {
+                $element['property'] = $prefix . '.' . $element['property'];
+            }
+
+            return $element;
+        }, $elements);
     }
 }

--- a/themes/Backend/ExtJs/backend/base/component/element/select.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/select.js
@@ -49,6 +49,7 @@ Ext.define('Shopware.apps.Base.view.element.Select', {
             me.store = new Ext.data.Store({
                 url:'{url controller=index}/' + me.controller + '/' + me.action,
                 autoLoad:true,
+                remoteFilter: true,
                 reader:new Ext.data.JsonReader({
                     root:me.root || 'data',
                     totalProperty:me.count || 'total',
@@ -66,6 +67,12 @@ Ext.define('Shopware.apps.Base.view.element.Select', {
             me.valueField = me.displayField;
         } else if (typeof(me.store) === 'string' && me.store.substring(0, 5) !== 'base.') {
             me.store = me.getStoreById(me.store);
+        }
+
+        if (me.store instanceof Ext.data.Store && me.filter) {
+            // Apply the filter on the store
+            me.store.clearFilter(true);
+            me.store.filter(me.filter);
         }
 
         me.callParent(arguments);

--- a/themes/Backend/ExtJs/backend/base/store/country.js
+++ b/themes/Backend/ExtJs/backend/base/store/country.js
@@ -39,6 +39,7 @@ Ext.define('Shopware.apps.Base.store.Country', {
     storeId: 'base.Country',
     model : 'Shopware.apps.Base.model.Country',
     pageSize: 1000,
+    remoteFilter: true,
 
     proxy:{
         type:'ajax',

--- a/themes/Backend/ExtJs/backend/base/store/country_area.js
+++ b/themes/Backend/ExtJs/backend/base/store/country_area.js
@@ -39,6 +39,7 @@ Ext.define('Shopware.apps.Base.store.CountryArea', {
     storeId: 'base.CountryArea',
     model : 'Shopware.apps.Base.model.CountryArea',
     pageSize: 1000,
+    remoteFilter: true,
 
     proxy:{
         type:'ajax',

--- a/themes/Backend/ExtJs/backend/base/store/country_state.js
+++ b/themes/Backend/ExtJs/backend/base/store/country_state.js
@@ -39,6 +39,7 @@ Ext.define('Shopware.apps.Base.store.CountryState', {
     storeId: 'base.CountryState',
     model : 'Shopware.apps.Base.model.CountryState',
     pageSize: 1000,
+    remoteFilter: true,
 
     proxy:{
         type:'ajax',

--- a/themes/Backend/ExtJs/backend/base/store/currency.js
+++ b/themes/Backend/ExtJs/backend/base/store/currency.js
@@ -41,6 +41,7 @@ Ext.define('Shopware.apps.Base.store.Currency', {
     storeId: 'base.Currency',
     model : 'Shopware.apps.Base.model.Currency',
     pageSize: 1000,
+    remoteFilter: true,
 
     proxy: {
         type: 'ajax',

--- a/themes/Backend/ExtJs/backend/base/store/customer_group.js
+++ b/themes/Backend/ExtJs/backend/base/store/customer_group.js
@@ -39,6 +39,7 @@ Ext.define('Shopware.apps.Base.store.CustomerGroup', {
     storeId: 'base.CustomerGroup',
     model : 'Shopware.apps.Base.model.CustomerGroup',
     pageSize: 1000,
+    remoteFilter: true,
 
     proxy:{
         type:'ajax',

--- a/themes/Backend/ExtJs/backend/base/store/dispatch.js
+++ b/themes/Backend/ExtJs/backend/base/store/dispatch.js
@@ -39,6 +39,11 @@ Ext.define('Shopware.apps.Base.store.Dispatch', {
     storeId: 'base.Dispatch',
     model : 'Shopware.apps.Base.model.Dispatch',
     pageSize: 1000,
+    remoteFilter: true,
+    filters: [{
+        property: 'active',
+        value: true
+    }],
 
     proxy: {
         type: 'ajax',

--- a/themes/Backend/ExtJs/backend/base/store/locale.js
+++ b/themes/Backend/ExtJs/backend/base/store/locale.js
@@ -43,6 +43,7 @@ Ext.define('Shopware.apps.Base.store.Locale', {
     storeId: 'base.Locale',
     model : 'Shopware.apps.Base.model.Locale',
     pageSize: 1000,
+    remoteFilter: true,
 
     proxy: {
         type: 'ajax',

--- a/themes/Backend/ExtJs/backend/base/store/order_status.js
+++ b/themes/Backend/ExtJs/backend/base/store/order_status.js
@@ -40,6 +40,7 @@ Ext.define('Shopware.apps.Base.store.OrderStatus', {
     model : 'Shopware.apps.Base.model.OrderStatus',
     pageSize: 1000,
     autoLoad: false,
+    remoteFilter: true,
     proxy:{
         type:'ajax',
         url:'{url action="getOrderStatus"}',

--- a/themes/Backend/ExtJs/backend/base/store/payment.js
+++ b/themes/Backend/ExtJs/backend/base/store/payment.js
@@ -39,6 +39,7 @@ Ext.define('Shopware.apps.Base.store.Payment', {
     storeId: 'base.Payment',
     model : 'Shopware.apps.Base.model.Payment',
     pageSize: 1000,
+    remoteFilter: true,
 
     proxy:{
         type:'ajax',

--- a/themes/Backend/ExtJs/backend/base/store/payment_status.js
+++ b/themes/Backend/ExtJs/backend/base/store/payment_status.js
@@ -40,6 +40,7 @@ Ext.define('Shopware.apps.Base.store.PaymentStatus', {
     model : 'Shopware.apps.Base.model.PaymentStatus',
     pageSize: 1000,
     autoLoad: false,
+    remoteFilter: true,
     proxy:{
         type:'ajax',
         url:'{url action="getPaymentStatus"}',

--- a/themes/Backend/ExtJs/backend/base/store/position_status.js
+++ b/themes/Backend/ExtJs/backend/base/store/position_status.js
@@ -52,6 +52,7 @@ Ext.define('Shopware.apps.Base.store.PositionStatus', {
     alternateClassName: 'Shopware.store.PositionStatus',
     storeId: 'base.PositionStatus',
     pageSize: 1000,
+    remoteFilter: true,
     /**
      * Configure the data communication
      * @object

--- a/themes/Backend/ExtJs/backend/base/store/tax.js
+++ b/themes/Backend/ExtJs/backend/base/store/tax.js
@@ -39,6 +39,7 @@ Ext.define('Shopware.apps.Base.store.Tax', {
     storeId: 'base.Tax',
     model : 'Shopware.apps.Base.model.Tax',
     pageSize: 1000,
+    remoteFilter: true,
 
     proxy:{
         type:'ajax',


### PR DESCRIPTION
## Description
### Why is it necessary?

Currently it is not possible to apply a filter on a `select` element, when adding one to the plugin config using the short store syntax (e.g. `'store' => 'Shopware.apps.Base.store.Dispatch'`). However, since e.g. the dispatch base store applies a filter on the `active` field by default, it is desirable to be able to override those default filters in a plugin config.
### What does it improve?

This PR changes the `Shopware.apps.Base.view.element.Select` element to check for an optional `filter` option and, if set, clears all filters from the store and applies the passed filters. Furthermore the `remoteFilter` property is set to `true` in all ExtJS base stores, whose corresponding controller actions allow passing a `filter` parameter. Finally, the  default filter on `dispatches.active` added in `Shopware_Controllers_Backend_Base::getDispatchesAction()` is removed and instead a filter on `active` is added to `Shopware.apps.Base.store.Dispatch`. This allows to override the filter and keeps backwards compatibility of the `Shopware.apps.Base.store.Dispatch` at the same time. However, it changes the default behaviour `Shopware_Controllers_Backend_Base::getDispatchesAction()` to respond all dispatch methods instead of only active ones.
### Does it have side effects?

The following base stores will use remote filtering by default:
- `Shopware.apps.Base.store.Country`
- `Shopware.apps.Base.store.CountryArea`
- `Shopware.apps.Base.store.CountryState`
- `Shopware.apps.Base.store.Currency`
- `Shopware.apps.Base.store.CustomerGroup`
- `Shopware.apps.Base.store.Dispatch`
- `Shopware.apps.Base.store.Locale`
- `Shopware.apps.Base.store.OrderStatus`
- `Shopware.apps.Base.store.Payment`
- `Shopware.apps.Base.store.PaymentStatus`
- `Shopware.apps.Base.store.PositionStatus`
- `Shopware.apps.Base.store.Tax`

Furthermore `Shopware_Controllers_Backend_Base::getDispatchesAction()` will now respond all dispatch methods, instead of only active ones.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? |  |
| How to test? | Create a plugin containing a config form `select` element with e.g. the `store` `Shopware.apps.Base.store.Language` and a  `filter` of `[['property' => 'name', 'value' => 'English']]`. The select element will only show the store named `English`. |
