### PR TITLE
Fix parsing of JSON posted to the REST API

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -2,6 +2,12 @@
 
 This changelog references changes done in Shopware 5.2 patch versions.
 
+## 5.2.7
+
+[View all changes from v5.2.6...v5.2.7](https://github.com/shopware/shopware/compare/v5.2.6...v5.2.7)
+
+* Fixed parsing of JSON `POST`ed to the REST API to not remove top-level `NULL` values
+
 ## 5.2.6
 
 [View all changes from v5.2.5...v5.2.6](https://github.com/shopware/shopware/compare/v5.2.5...v5.2.6)

--- a/engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
@@ -158,10 +158,10 @@ class Shopware_Plugins_Core_RestApi_Bootstrap extends Shopware_Components_Plugin
             return;
         }
 
+        // Save the posted data directly in the $_POST global, because 'Enlight_Controller_Request_RequestHttp::setPost()'
+        // filters out NULL values, which is undesireable when working with JSON
         foreach ((array) $input as $key => $value) {
-            if ($value !== null) {
-                $request->setPost($key, $value);
-            }
+            $_POST[$key] = $value;
         }
     }
 


### PR DESCRIPTION
## Description
### Why is it necessary?

When `POST`ing a simple JSON of the form `{"key": null}` to the REST API, currently no data is returned when calling `Enlight_Controller_Request_RequestHttp::getPost()`. This is due to the fact that `Shopware_Plugins_Core_RestApi_Bootstrap::onFrontPreDispatch()` parses the `POST`ed JSON, but [filters out all top-level `NULL` values, before calling `Enlight_Controller_Request_RequestHttp::setPost()`](https://github.com/shopware/shopware/blob/a6888373a4b99f6b19b904b0a712b86193a9a2dc/engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php#L162-L164). This is necessary though, because [`Zend_Controller_Request_Http::setPost()` will throw a `Zend_Controller_Exception`, if `setPost()` is called with a non-`array` `$key` and a `NULL` `$value`](https://github.com/shopware/shopware/blob/a6888373a4b99f6b19b904b0a712b86193a9a2dc/engine/Library/Zend/Controller/Request/Http.php#L293-L296). However, this behaviour makes no sense in the context of a JSON REST API, because it must be possible to set a field to `NULL`, if the changed entity allows it. Furthermore the current behaviour is inconsistent, because only top-level `NULL` values are removed from the `POST` body, but not any `NULL` values nested in the JSON.
### What does it improve?

This PR fixes the described behaviour by changing `Shopware_Plugins_Core_RestApi_Bootstrap::onFrontPreDispatch()` to neither filter `NULL` values nor use `Enlight_Controller_Request_RequestHttp::setPost()` to save the values, but save the values directly in the global `$_POST` variable. After all, [this is exactly what `Zend_Controller_Request_Http::setPost()` does](https://github.com/shopware/shopware/blob/a6888373a4b99f6b19b904b0a712b86193a9a2dc/engine/Library/Zend/Controller/Request/Http.php#L303), without all the validations and special treatment, which is not required in this case.
### Does it have side effects?

I don't assume this PR to be breaking anything. However, if exising implementations use the REST API in a wrong way and e.g. set `NULL` values to fields, which cannot be `NULL` in the database, the called API resource will throw a `Shopware\Components\Api\Exception\ValidationException`.

**EDIT:** I didn't add a test case, because the API test cases are not part of the CI test suite. Please let me know, if I should add a test case anyway.

| Questions | Answers |
| --- | --- |
| BC breaks? | only if REST API is used in wrong way |
| Tests pass? | yes |
| Related tickets? |  |
| How to test? | <ol><li>Send a `PUT` request to `<SHOP_URL>/api/variants/<ANY_ARTICLE_DETAIL_ID>` with the content `{"ean": "TEST"}`</li><li>Send a `PUT` request to `<SHOP_URL>/api/variants/<ANY_ARTICLE_DETAIL_ID>` with the content `{"ean": null}`</li></ol><br>The `ean` field of the changed article detail should be `NULL` after the second request. |
