### PR TITLE
[Papercut] Fixing encoding on Ajax Search 'Alle Ergebnisse anzeigen'

### DIFF
--- a/themes/Frontend/Bare/frontend/search/ajax.tpl
+++ b/themes/Frontend/Bare/frontend/search/ajax.tpl
@@ -56,7 +56,7 @@
 
                     {* Link to the built-in search *}
                     {block name="search_ajax_all_results_link"}
-                        <a href="{url controller="search"}?sSearch={$sSearchRequest.sSearch}" class="search-result--link entry--all-results-link block">
+                        <a href="{url controller="search"}?sSearch={$sSearchRequest.sSearch|urlencode}" class="search-result--link entry--all-results-link block">
                             <i class="icon--arrow-right"></i>
                             {s name="SearchAjaxLinkAllResults"}{/s}
                         </a>


### PR DESCRIPTION
## Description

Fixing the missing encoding on the "Alle Ergebnisse anzeigen" Button in ajax search template.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-15823 |
| How to test? | Search for strings with space and look at the link on "Alle Ergebnisse zeigen". The correct encoding is/was missing. |
