### PR TITLE
[Papercut][SW-15997] Global Bcc Mail Option

### DIFF
--- a/_sql/migrations/786-add-bcc-mail-field.php
+++ b/_sql/migrations/786-add-bcc-mail-field.php
@@ -1,0 +1,12 @@
+<?php
+
+class Migrations_Migration786 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('SET @menu_id = (SELECT id FROM s_core_config_forms WHERE label=\'Stammdaten\');');
+        $this->addSql('INSERT INTO s_core_config_elements (form_id, name, value, label, description, type, required, scope) VALUES(@menu_id, "mailBcc", "s:0:\"\";", "Shopbetreiber BCC E-Mail", "Setzt bei jeder Mail einen BCC (Mehrere E-Mail Adressen können mit Komma getrennt werden)", "text", 0, 1);');
+        $this->addSql('SET @element_id = (SELECT id FROM s_core_config_elements WHERE name = "mailBcc");');
+        $this->addSql('INSERT INTO s_core_config_element_translations (element_id, locale_id, label, description) VALUES(@element_id, 2, "Show owner bcc mail", "Allows to set on any mail a bcc (multiple email addresses can be separated by commas)");');
+    }
+}

--- a/_sql/migrations/790-add-bcc-mail-field.php
+++ b/_sql/migrations/790-add-bcc-mail-field.php
@@ -1,6 +1,6 @@
 <?php
 
-class Migrations_Migration786 extends Shopware\Components\Migrations\AbstractMigration
+class Migrations_Migration790 extends Shopware\Components\Migrations\AbstractMigration
 {
     public function up($modus)
     {

--- a/engine/Shopware/Components/BccSubscriber.php
+++ b/engine/Shopware/Components/BccSubscriber.php
@@ -1,4 +1,27 @@
 <?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
 namespace Shopware\Components;
 
 use Enlight\Event\SubscriberInterface;
@@ -6,13 +29,22 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class BccSubscriber implements SubscriberInterface
 {
+    /**
+     * @var ContainerInterface
+     */
     private $container;
 
+    /**
+     * @param ContainerInterface $container
+     */
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }
 
+    /**
+     * @inheritdoc
+     */
     public static function getSubscribedEvents()
     {
         return [
@@ -20,6 +52,9 @@ class BccSubscriber implements SubscriberInterface
         ];
     }
 
+    /**
+     * @param \Enlight_Event_EventArgs $args
+     */
     public function onMailSend(\Enlight_Event_EventArgs $args)
     {
         /**

--- a/engine/Shopware/Components/BccSubscriber.php
+++ b/engine/Shopware/Components/BccSubscriber.php
@@ -1,0 +1,43 @@
+<?php
+namespace Shopware\Components;
+
+use Enlight\Event\SubscriberInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class BccSubscriber implements SubscriberInterface
+{
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            'Enlight_Components_Mail_Send' => 'onMailSend'
+        ];
+    }
+
+    public function onMailSend(\Enlight_Event_EventArgs $args)
+    {
+        /**
+         * Ignore if config is not initialized
+         */
+        if (!$this->container->has('config')) {
+            return;
+        }
+
+        $bccs = $this->container->get('config')->get('mailBcc');
+
+        /** @var \Enlight_Components_Mail $mail */
+        $mail = $args->get('mail');
+
+        if (!empty($bccs)) {
+            $bccs = array_map('trim', explode(',', $bccs));
+
+            $mail->addBcc($bccs);
+        }
+    }
+}

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -406,6 +406,11 @@
             <tag name="shopware.event_subscriber" />
         </service>
 
+        <service id="BccSubscriber" class="Shopware\Components\BccSubscriber">
+            <argument type="service" id="service_container" />
+            <tag name="shopware.event_subscriber" />
+        </service>
+
         <service id="config_writer" class="Shopware\Components\ConfigWriter">
             <argument type="service" id="dbal_connection" />
         </service>


### PR DESCRIPTION
## Description

Please describe your pull request:
It adds a global bcc mail fieldin the mail settings

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | [Issue](https://issues.shopware.com/#/issues/SW-15997) |
| How to test? | Go to Grundeinstellungen => Shopeinstellungen=> Stammdaten and insert a bcc mail and order a product :) |
