### PR TITLE
[Papercut][Sw-13189] Fix-sorting-from-blogcomments

### DIFF
--- a/engine/Shopware/Controllers/Backend/Blog.php
+++ b/engine/Shopware/Controllers/Backend/Blog.php
@@ -318,6 +318,9 @@ class Shopware_Controllers_Backend_Blog extends Shopware_Controllers_Backend_Ext
         //order data
         $order = (array) $this->Request()->getParam('sort', array());
 
+        if (empty($order)) {
+            $order = array(array('property' => 'creationDate', 'direction' => 'DESC'));
+        }
         /** @var $filter array */
         $filter = $this->Request()->getParam('filter', array());
         $blogId = intval($this->Request()->blogId);

--- a/themes/Backend/ExtJs/backend/blog/store/comment.js
+++ b/themes/Backend/ExtJs/backend/blog/store/comment.js
@@ -58,12 +58,17 @@ Ext.define('Shopware.apps.Blog.store.Comment', {
      */
     remoteSort: true,
 
-    remoteFilter : true,
+    remoteFilter: true,
+
+    sorters: [{
+        property: 'creationDate',
+        direction: 'DESC'
+    }],
     /**
      * Amount of data loaded at once
      * @integer
      */
-    pageSize:30,
+    pageSize: 30,
     /**
      * Define the used model for this store
      * @string


### PR DESCRIPTION
This Requests sets a sort by default, so when you open blogartical->comments it is sort by Date form new to old and not put in the table without sorting

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-13189 |
| How to test? | create a few blogcomments and the open blog article comments and check if they are sorted by Date from new to old. |
