### PR TITLE
[Papercut][SW-15897] make possible to use html mails in status mails

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1065,7 +1065,13 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
         $mail = clone Shopware()->Container()->get('mail');
         $mail->clearRecipients();
         $mail->setSubject($this->Request()->getParam('subject', ''));
-        $mail->setBodyText($this->Request()->getParam('content', ''));
+
+        if ($this->Request()->getParam('isHtml')) {
+            $mail->setBodyHtml($this->Request()->getParam('contentHtml', ''));
+        } else {
+            $mail->setBodyText($this->Request()->getParam('content', ''));
+        }
+
         $mail->setFrom($this->Request()->getParam('fromMail', ''), $this->Request()->getParam('fromName', ''));
         $mail->addTo($this->Request()->getParam('to', ''));
 
@@ -1434,11 +1440,13 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
                 'data' => array(
                     'error' => false,
                     'content' => $mail->getPlainBodyText(),
+                    'contentHtml' => $mail->getPlainBody(),
                     'subject' => $mail->getPlainSubject(),
                     'to' => implode(', ', $mail->getTo()),
                     'fromMail' => $mail->getFrom(),
                     'fromName' => $mail->getFromName(),
                     'sent' => false,
+                    'isHtml' => !empty($mail->getPlainBody()),
                     'orderId' => $orderId
                 )
             );

--- a/themes/Backend/ExtJs/backend/order/model/mail.js
+++ b/themes/Backend/ExtJs/backend/order/model/mail.js
@@ -49,11 +49,13 @@ Ext.define('Shopware.apps.Order.model.Mail', {
 		//{block name="backend/order/model/mail/fields"}{/block}
         { name: 'orderId', type:'int' },
         { name: 'content', type:'string' },
+        { name: 'contentHtml', type:'string' },
         { name: 'subject', type:'string' },
         { name: 'to', type:'string' },
         { name: 'fromMail', type:'string' },
         { name: 'fromName', type:'string' },
-        { name: 'sent', type:'boolean' }
+        { name: 'sent', type:'boolean' },
+        { name: 'isHtml', type:'boolean' }
     ],
 
     /**

--- a/themes/Backend/ExtJs/backend/order/view/mail/form.js
+++ b/themes/Backend/ExtJs/backend/order/view/mail/form.js
@@ -157,7 +157,7 @@ Ext.define('Shopware.apps.Order.view.mail.Form', {
     getFormItems: function() {
         var me = this;
 
-        return [
+        var fields = [
             {
                 xtype: 'textfield',
                 name: 'to',
@@ -167,14 +167,26 @@ Ext.define('Shopware.apps.Order.view.mail.Form', {
                 xtype: 'textfield',
                 name: 'subject',
                 fieldLabel: me.snippets.subject
-            },
-            {
+            }
+        ];
+
+        if (me.mail.get('isHtml')) {
+            fields.push({
+                xtype: 'tinymcefield',
+                name: 'contentHtml',
+                minHeight: 90,
+                flex: 1
+            });
+        } else {
+            fields.push({
                 xtype: 'textarea',
                 name: 'content',
                 minHeight: 90,
                 flex: 1
-            }
-        ];
+            });
+        }
+
+        return fields;
     }
 
 });

--- a/themes/Backend/ExtJs/backend/order/view/mail/window.js
+++ b/themes/Backend/ExtJs/backend/order/view/mail/window.js
@@ -61,7 +61,7 @@ Ext.define('Shopware.apps.Order.view.mail.Window', {
      *
      * @type { Number }
      */
-    width: 600,
+    width: 700,
 
     /**
      * Define window height
@@ -102,7 +102,9 @@ Ext.define('Shopware.apps.Order.view.mail.Window', {
     initComponent: function () {
         var me = this;
 
-        me.form = Ext.create('Shopware.apps.Order.view.mail.Form');
+        me.form = Ext.create('Shopware.apps.Order.view.mail.Form', {
+            mail: me.mail
+        });
 
         me.items = me.form;
 


### PR DESCRIPTION
## Description

Please describe your pull request:
It makes possible to use html mails in status mails

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | [SW-15897](https://issues.shopware.com/#/issues/SW-15897) |
| How to test? | Write to a status mail a html content and change a order to that status |
