### PR TITLE
[Papercut][SW-16008] - Smarty function to get a custom page's content

### DIFF
--- a/engine/Library/Enlight/Template/Plugins/function.getPageContent.php
+++ b/engine/Library/Enlight/Template/Plugins/function.getPageContent.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Returns a custom page's content either as HTML or plain text
+ *
+ * @param $params
+ * @param $smarty
+ * @return string
+ */
+function smarty_function_getPageContent($params, $smarty)
+{
+    $shopId = Shopware()->Container()->get('shopware_storefront.context_service')->getShopContext()->getShop()->getId();
+    $staticPage = Shopware()->Modules()->Cms()->sGetStaticPage($params["id"], $shopId);
+    if (!empty($staticPage['html']))
+    {
+        if (empty($params["plain"]))
+        {
+            return $staticPage['html'];
+        }
+        else
+        {
+            $html = $staticPage['html'];
+            $search =  [
+                          "/\r/", 
+                          "/[\n\t]+/", 
+                          "/<head\b[^>]*>.*?<\/head>/i", 
+                          "/<script\b[^>]*>.*?<\/script>/i", 
+                          "/<style\b[^>]*>.*?<\/style>/i", 
+                          "/(<ul\b[^>]*>|<\/ul>)/i", 
+                          "/(<ol\b[^>]*>|<\/ol>)/i", 
+                          "/(<dl\b[^>]*>|<\/dl>)/i", 
+                          "/<li\b[^>]*>(.*?)<\/li>/i", 
+                          "/<dd\b[^>]*>(.*?)<\/dd>/i", 
+                          "/<dt\b[^>]*>(.*?)<\/dt>/i", 
+                          "/<li\b[^>]*>/i", 
+                          "/<hr\b[^>]*>/i", 
+                          "/<div\b[^>]*>/i", 
+                          "/<p\b[^>]*>/i", 
+                          "/<br\b[^>]*>/i", 
+                          "/<h[123456]+\b[^>]*>/i", 
+                          "/(<table\b[^>]*>|<\/table>)/i", 
+                          "/(<tr\b[^>]*>|<\/tr>)/i", 
+                          "/<td\b[^>]*>(.*?)<\/td>/i"
+                       ];
+            $replace = [
+                          "", 
+                          " ", 
+                          "", 
+                          "", 
+                          "", 
+                          "\n\n", 
+                          "\n\n", 
+                          "\n\n", 
+                          "\t* \\1\n", 
+                          " \\1\n", 
+                          "\t* \\1", 
+                          "\n\t* ", 
+                          "\n-------------------------\n", 
+                          "\n\n", 
+                          "\n\n", 
+                          "\n\n", 
+                          "\n\n", 
+                          "\n\n", 
+                          "\n", 
+                          "\t\t\\1\n"
+                       ];
+            $text = strip_tags(preg_replace($search, $replace, html_entity_decode($html)));
+            return $text;
+        }
+    }
+}

--- a/engine/Library/Enlight/Template/Plugins/function.getPageContent.php
+++ b/engine/Library/Enlight/Template/Plugins/function.getPageContent.php
@@ -10,57 +10,53 @@ function smarty_function_getPageContent($params, $smarty)
 {
     $shopId = Shopware()->Container()->get('shopware_storefront.context_service')->getShopContext()->getShop()->getId();
     $staticPage = Shopware()->Modules()->Cms()->sGetStaticPage($params["id"], $shopId);
-    if (!empty($staticPage['html']))
-    {
-        if (empty($params["plain"]))
-        {
+    if (!empty($staticPage['html'])) {
+        if (empty($params["plain"])) {
             return $staticPage['html'];
-        }
-        else
-        {
+        } else {
             $html = $staticPage['html'];
             $search =  [
-                          "/\r/", 
-                          "/[\n\t]+/", 
-                          "/<head\b[^>]*>.*?<\/head>/i", 
-                          "/<script\b[^>]*>.*?<\/script>/i", 
-                          "/<style\b[^>]*>.*?<\/style>/i", 
-                          "/(<ul\b[^>]*>|<\/ul>)/i", 
-                          "/(<ol\b[^>]*>|<\/ol>)/i", 
-                          "/(<dl\b[^>]*>|<\/dl>)/i", 
-                          "/<li\b[^>]*>(.*?)<\/li>/i", 
-                          "/<dd\b[^>]*>(.*?)<\/dd>/i", 
-                          "/<dt\b[^>]*>(.*?)<\/dt>/i", 
-                          "/<li\b[^>]*>/i", 
-                          "/<hr\b[^>]*>/i", 
-                          "/<div\b[^>]*>/i", 
-                          "/<p\b[^>]*>/i", 
-                          "/<br\b[^>]*>/i", 
-                          "/<h[123456]+\b[^>]*>/i", 
-                          "/(<table\b[^>]*>|<\/table>)/i", 
-                          "/(<tr\b[^>]*>|<\/tr>)/i", 
+                          "/\r/",
+                          "/[\n\t]+/",
+                          "/<head\b[^>]*>.*?<\/head>/i",
+                          "/<script\b[^>]*>.*?<\/script>/i",
+                          "/<style\b[^>]*>.*?<\/style>/i",
+                          "/(<ul\b[^>]*>|<\/ul>)/i",
+                          "/(<ol\b[^>]*>|<\/ol>)/i",
+                          "/(<dl\b[^>]*>|<\/dl>)/i",
+                          "/<li\b[^>]*>(.*?)<\/li>/i",
+                          "/<dd\b[^>]*>(.*?)<\/dd>/i",
+                          "/<dt\b[^>]*>(.*?)<\/dt>/i",
+                          "/<li\b[^>]*>/i",
+                          "/<hr\b[^>]*>/i",
+                          "/<div\b[^>]*>/i",
+                          "/<p\b[^>]*>/i",
+                          "/<br\b[^>]*>/i",
+                          "/<h[123456]+\b[^>]*>/i",
+                          "/(<table\b[^>]*>|<\/table>)/i",
+                          "/(<tr\b[^>]*>|<\/tr>)/i",
                           "/<td\b[^>]*>(.*?)<\/td>/i"
                        ];
             $replace = [
-                          "", 
-                          " ", 
-                          "", 
-                          "", 
-                          "", 
-                          "\n\n", 
-                          "\n\n", 
-                          "\n\n", 
-                          "\t* \\1\n", 
-                          " \\1\n", 
-                          "\t* \\1", 
-                          "\n\t* ", 
-                          "\n-------------------------\n", 
-                          "\n\n", 
-                          "\n\n", 
-                          "\n\n", 
-                          "\n\n", 
-                          "\n\n", 
-                          "\n", 
+                          "",
+                          " ",
+                          "",
+                          "",
+                          "",
+                          "\n\n",
+                          "\n\n",
+                          "\n\n",
+                          "\t* \\1\n",
+                          " \\1\n",
+                          "\t* \\1",
+                          "\n\t* ",
+                          "\n-------------------------\n",
+                          "\n\n",
+                          "\n\n",
+                          "\n\n",
+                          "\n\n",
+                          "\n\n",
+                          "\n",
                           "\t\t\\1\n"
                        ];
             $text = strip_tags(preg_replace($search, $replace, html_entity_decode($html)));


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary?
  Papercut SW-16008
- What does it improve?
  It makes a smarty function available in templates (especially inteded for mail templates) to get the content from custom pages (terms of service etc.):
  {getPageContent id=?} for HTML
  {getPageContent id=? plain=1} for plain text version
- Does it have side effects?
  No - if the function is not used, it is completely silent

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-16008 |
| How to test? | Use {getPageContent id=?} in any template |
