### PR TITLE
[Papercut][Sw-13901] Fix error message in cancel_order by sort for comment

### DIFF
--- a/themes/Backend/ExtJs/backend/canceled_order/view/tabs/order/orders.js
+++ b/themes/Backend/ExtJs/backend/canceled_order/view/tabs/order/orders.js
@@ -123,7 +123,8 @@ Ext.define('Shopware.apps.CanceledOrder.view.tabs.order.Orders', {
             },
             {
                 header: me.snippets.columns.contact,
-                dataIndex: 'comment',
+                dataIndex: 'orders.comment',
+                renderer: me.commentRenderer,
                 flex: 2
             },
             {
@@ -152,7 +153,20 @@ Ext.define('Shopware.apps.CanceledOrder.view.tabs.order.Orders', {
         ];
     },
 
-
+    /**
+     * Returns the transactionId from a record
+     *
+     * @param value
+     * @param metaDate
+     * @param record
+     * @return string
+     */
+    commentRenderer: function (value, metaDate, record) {
+        if (!record) {
+            return '-';
+        }
+        return record.get('comment');
+    },
 
     /**
      * Returns the transactionId from a record


### PR DESCRIPTION
This Request fixes an error_message that occurs when you sort in the canceled orders by comment (German: Kontakt). It also now make that field visible.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-13901 |
| How to test? | Create some cancelled Orders with Comments. Then open the canceld orders in the backend and sort them by Comment. |
