### PR TITLE
[Papercut][SW-12180] - Fix currency character position

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -1290,7 +1290,7 @@ class sAdmin
         $limitEnd = Shopware()->Db()->quote($perPage);
 
         $sql = "
-            SELECT SQL_CALC_FOUND_ROWS o.*, cu.templatechar as currency_html, DATE_FORMAT(ordertime, '%d.%m.%Y %H:%i') AS datum
+            SELECT SQL_CALC_FOUND_ROWS o.*, cu.templatechar as currency_html, cu.symbol_position as currency_position, DATE_FORMAT(ordertime, '%d.%m.%Y %H:%i') AS datum
             FROM s_order o
             LEFT JOIN s_core_currencies as cu
             ON o.currency = cu.currency

--- a/themes/Frontend/Bare/frontend/account/order_item_details.tpl
+++ b/themes/Frontend/Bare/frontend/account/order_item_details.tpl
@@ -147,7 +147,11 @@
 							{block name='frontend_account_order_item_price_value'}
 								<div class="column--value">
 									{if $article.price}
-										{$article.price} {$offerPosition.currency_html} *
+                                        {if $offerPosition.currency_position == "32"}
+											{$offerPosition.currency_html} {$article.price} *
+										{else}
+											{$article.price} {$offerPosition.currency_html} *
+										{/if}
 									{else}
 										{s name="OrderItemInfoFree"}{/s}
 									{/if}
@@ -167,7 +171,11 @@
 							{block name='frontend_account_order_item_amount_value'}
 								<div class="column--value">
 									{if $article.amount}
-										{$article.amount} {$offerPosition.currency_html} *
+                                        {if $offerPosition.currency_position == "32"}
+                                            {$offerPosition.currency_html} {$article.amount}  *
+                                        {else}
+                                            {$article.amount} {$offerPosition.currency_html} *
+                                        {/if}
 									{else}
 										{s name="OrderItemInfoFree"}{/s}
 									{/if}
@@ -267,14 +275,32 @@
 
 				{* Shopping costs *}
 				{block name="frontend_account_order_item_shippingamount"}
-					<p class="is--strong">{$offerPosition.invoice_shipping} {$offerPosition.currency_html}</p>
+                    <p class="is--strong">
+                        {if $offerPosition.currency_position == "32"}
+                            {$offerPosition.currency_html} {$offerPosition.invoice_shipping}
+                        {else}
+                            {$offerPosition.invoice_shipping} {$offerPosition.currency_html}
+                        {/if}
+                    </p>
 				{/block}
 
 				{block name="frontend_acccount_order_item_amount"}
 					{if $offerPosition.taxfree}
-						<p class="is--bold">{$offerPosition.invoice_amount_net} {$offerPosition.currency_html}</p>
+                        <p class="is--bold">
+                            {if $offerPosition.currency_position == "32"}
+                                {$offerPosition.currency_html} {$offerPosition.invoice_amount_net}
+                            {else}
+                                {$offerPosition.invoice_amount_net} {$offerPosition.currency_html}
+                            {/if}
+                        </p>
 					{else}
-						<p class="is--bold">{$offerPosition.invoice_amount} {$offerPosition.currency_html}</p>
+                        <p class="is--bold">
+                            {if $offerPosition.currency_position == "32"}
+                                {$offerPosition.currency_html} {$offerPosition.invoice_amount}
+                            {else}
+                                {$offerPosition.invoice_amount} {$offerPosition.currency_html}
+                            {/if}
+                        </p>
 					{/if}
 				{/block}
 			</div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? No recognition of config settings in account orders view
- What does it improve? Recognizes currency config
- Does it have side effects? No

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-12180 |
| How to test? | Set your currency settings to show left. Go to Frontend - My Account - Orders - All currency signs should be positioned to the left. |
