### PR TITLE
[Papercut][Sw-14787] fix voucher select in cancel orders

### DIFF
--- a/engine/Shopware/Controllers/Backend/CanceledOrder.php
+++ b/engine/Shopware/Controllers/Backend/CanceledOrder.php
@@ -251,7 +251,7 @@ class Shopware_Controllers_Backend_CanceledOrder extends Shopware_Controllers_Ba
     {
         $orderId = $this->Request()->getParam('id', null);
 
-        $sql = "SELECT s_emarketing_vouchers.id, s_emarketing_vouchers.description, s_emarketing_vouchers.value
+        $sql = "SELECT s_emarketing_vouchers.id, s_emarketing_vouchers.description, s_emarketing_vouchers.value, s_emarketing_vouchers.percental
             FROM s_emarketing_vouchers
             WHERE  s_emarketing_vouchers.modus = 1 AND (s_emarketing_vouchers.valid_to >= now() OR s_emarketing_vouchers.valid_to is NULL)
             AND (s_emarketing_vouchers.valid_from <= now() OR s_emarketing_vouchers.valid_from is NULL)

--- a/snippets/backend/canceled_order/model/voucher.ini
+++ b/snippets/backend/canceled_order/model/voucher.ini
@@ -1,6 +1,7 @@
 [en_GB]
-sendVoucherWorth = "Send voucher worth {literal}{0}{/literal}"
+sendVoucherWorth = "Send voucher worth {literal}{0}{/literal} vouchername: {literal}{1}{/literal}"
+sendVoucherWorthPercent = "Send voucher worth {literal}{0}{/literal}% vouchername: {literal}{1}{/literal}"
 
 [de_DE]
-sendVoucherWorth = "Gutschein im Wert von {literal}{0}{/literal}€ verschicken"
-
+sendVoucherWorth = "Gutschein im Wert von {literal}{0}{/literal}€ Gutscheinname: {literal}{1}{/literal}"
+sendVoucherWorthPercent = "Gutschein im Wert von {literal}{0}{/literal}% Gutscheinname: {literal}{1}{/literal}"

--- a/snippets/backend/canceled_order/model/voucher.ini
+++ b/snippets/backend/canceled_order/model/voucher.ini
@@ -1,7 +1,7 @@
 [en_GB]
-sendVoucherWorth = "Send voucher worth {literal}{0}{/literal} vouchername: {literal}{1}{/literal}"
-sendVoucherWorthPercent = "Send voucher worth {literal}{0}{/literal}% vouchername: {literal}{1}{/literal}"
+sendVoucherWorth = "Send voucher worth [0] vouchername: [1]"
+sendVoucherWorthPercent = "Send voucher worth [0]% vouchername: [1]"
 
 [de_DE]
-sendVoucherWorth = "Gutschein im Wert von {literal}{0}{/literal}€ Gutscheinname: {literal}{1}{/literal}"
-sendVoucherWorthPercent = "Gutschein im Wert von {literal}{0}{/literal}% Gutscheinname: {literal}{1}{/literal}"
+sendVoucherWorth = "Gutschein im Wert von [0]€ Gutscheinname: [1]"
+sendVoucherWorthPercent = "Gutschein im Wert von [0]% Gutscheinname: [1]"

--- a/themes/Backend/ExtJs/backend/canceled_order/model/voucher.js
+++ b/themes/Backend/ExtJs/backend/canceled_order/model/voucher.js
@@ -60,10 +60,10 @@ Ext.define('Shopware.apps.CanceledOrder.model.Voucher', {
                     return value;
                 }
                 if ( record.get('percental') == 1 ) {
-                    return Ext.String.format("{s name=sendVoucherWorthPercent}Send voucher worth {literal}{0}{/literal}% vouchername: {literal}{1}{/literal}{/s}", value, record.get('description'));
+                    return Ext.String.format("{s name=sendVoucherWorthPercent}Send voucher worth [0]% vouchername: [1]{/s}", value, record.get('description'));
                 }
                 else {
-                    return Ext.String.format("{s name=sendVoucherWorth}Send voucher worth {literal}{0}{/literal} vouchername: {literal}{1}{/literal}{/s}", value, record.get('description'));
+                    return Ext.String.format("{s name=sendVoucherWorth}Send voucher worth [0] vouchername: [1]{/s}", value, record.get('description'));
                 }
             }
         }

--- a/themes/Backend/ExtJs/backend/canceled_order/model/voucher.js
+++ b/themes/Backend/ExtJs/backend/canceled_order/model/voucher.js
@@ -47,6 +47,7 @@ Ext.define('Shopware.apps.CanceledOrder.model.Voucher', {
 		//{block name="backend/canceled_order/model/voucher/fields"}{/block}
         { name: 'id', type:'int' },
         { name: 'description', type:'string' },
+        { name: 'percental', type: 'int' },
         {
             name: 'value',
             type: 'string',
@@ -58,8 +59,12 @@ Ext.define('Shopware.apps.CanceledOrder.model.Voucher', {
                 if(record && record.get('id') == -1) {
                     return value;
                 }
-                return Ext.String.format("{s name=sendVoucherWorth}Send voucher worth {literal}{0}{/literal}{/s}", value);
-
+                if ( record.get('percental') == 1 ) {
+                    return Ext.String.format("{s name=sendVoucherWorthPercent}Send voucher worth {literal}{0}{/literal}% vouchername: {literal}{1}{/literal}{/s}", value, record.get('description'));
+                }
+                else {
+                    return Ext.String.format("{s name=sendVoucherWorth}Send voucher worth {literal}{0}{/literal} vouchername: {literal}{1}{/literal}{/s}", value, record.get('description'));
+                }
             }
         }
     ]

--- a/themes/Backend/ExtJs/backend/canceled_order/model/voucher.js
+++ b/themes/Backend/ExtJs/backend/canceled_order/model/voucher.js
@@ -59,10 +59,9 @@ Ext.define('Shopware.apps.CanceledOrder.model.Voucher', {
                 if(record && record.get('id') == -1) {
                     return value;
                 }
-                if ( record.get('percental') == 1 ) {
+                if (record.get('percental') == 1) {
                     return Ext.String.format("{s name=sendVoucherWorthPercent}Send voucher worth [0]% vouchername: [1]{/s}", value, record.get('description'));
-                }
-                else {
+                } else {
                     return Ext.String.format("{s name=sendVoucherWorth}Send voucher worth [0] vouchername: [1]{/s}", value, record.get('description'));
                 }
             }


### PR DESCRIPTION
In the cancelled order the voucher selection now shows % if percental and a symbol if absolute. The voucher Description is also added to tell which one is which.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-14787 |
| How to test? | Reload the snippet database. Create a percental and an absolute voucher. Open the cancelled order window. Select an Element where no voucher is already send. Open the Customer feedback and select a voucher. (Must be tested for eng and ger because of the snippets) |
