### PR TITLE
[Papercut][SW-12741] - Fix currency selection display

### DIFF
--- a/themes/Frontend/Bare/widgets/index/shop_menu.tpl
+++ b/themes/Frontend/Bare/widgets/index/shop_menu.tpl
@@ -42,7 +42,7 @@
                             <select name="__currency" class="currency--select" data-auto-submit="true">
                                 {foreach $currencies as $currency}
                                     <option value="{$currency->getId()}"{if $currency->getId() === $shop->getCurrency()->getId()} selected="selected"{/if}>
-                                        {$currency->getSymbol()} {$currency->getCurrency()}
+                                        {if $currency->getSymbol() != $currency->getCurrency()}{$currency->getSymbol()} {/if}{$currency->getCurrency()}
                                     </option>
                                 {/foreach}
                             </select>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? Currencies without symbol 
- What does it improve? look & feel
- Does it have side effects? no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-12741 |
| How to test? | Add a currency like CHF with no symbol and add it to shop. Shows CHF CHF |
