### PR TITLE
[Papercut][SW-15035] Backend orders list: use company/name instead of customerId for sorting by customer

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -369,11 +369,11 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
                     array_splice($sort, 1, 0, [
                         [
                             'property' => 'billing.lastName',
-                            'direction' => $orderBy[0]['direction']
+                            'direction' => $sort[0]['direction']
                         ],
                         [
                             'property' => 'billing.firstName',
-                            'direction' => $orderBy[0]['direction']
+                            'direction' => $sort[0]['direction']
                         ]
                     ]);
                     break;

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -364,6 +364,19 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
                 case 'customerEmail':
                     $sort[0]['property'] = 'customer.email';
                     break;
+                case 'customerId':
+                    $sort[0]['property'] = 'billing.company';
+                    array_splice($sort, 1, 0, [
+                        [
+                            'property' => 'billing.lastName',
+                            'direction' => $orderBy[0]['direction']
+                        ],
+                        [
+                            'property' => 'billing.firstName',
+                            'direction' => $orderBy[0]['direction']
+                        ]
+                    ]);
+                    break;
                 default:
                     $sort[0]['property'] = 'orders.' . $sort[0]['property'];
                     break;

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -364,7 +364,7 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
                 case 'customerEmail':
                     $sort[0]['property'] = 'customer.email';
                     break;
-                case 'customerId':
+                case 'customerName':
                     $sort[0]['property'] = 'billing.company';
                     array_splice($sort, 1, 0, [
                         [

--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -288,7 +288,7 @@ class Repository extends ModelRepository
         $builder->andWhere('orders.number IS NOT NULL');
 
         if (!empty($orderBy)) {
-            //order by path of company, lastName and firstName instead of customerId 
+            //order by path of company, lastName and firstName instead of customerId
             if(isset($orderBy[0]['property']) && $orderBy[0]['property'] === 'orders.customerId'){
                 $orderBy[0] = [
                     'property' => 'billing.company',

--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -288,7 +288,7 @@ class Repository extends ModelRepository
         $builder->andWhere('orders.number IS NOT NULL');
 
         if (!empty($orderBy)) {
-            //order by path of company, lastName and firstName instead of customerId
+            //order by path of company, lastName and firstName instead of customerId 
             if(isset($orderBy[0]['property']) && $orderBy[0]['property'] === 'orders.customerId'){
                 $orderBy[0] = [
                     'property' => 'billing.company',

--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -288,23 +288,6 @@ class Repository extends ModelRepository
         $builder->andWhere('orders.number IS NOT NULL');
 
         if (!empty($orderBy)) {
-            //order by path of company, lastName and firstName instead of customerId
-            if(isset($orderBy[0]['property']) && $orderBy[0]['property'] === 'orders.customerId'){
-                $orderBy[0] = [
-                    'property' => 'billing.company',
-                    'direction' => $orderBy[0]['direction']
-                ];
-                array_splice($orderBy, 1, 0, [
-                    [
-                        'property' => 'billing.lastName',
-                        'direction' => $orderBy[0]['direction']
-                    ],
-                    [
-                        'property' => 'billing.firstName',
-                        'direction' => $orderBy[0]['direction']
-                    ]
-                ]);
-            }
             //add order by path
             $builder->addOrderBy($orderBy);
         }

--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -288,6 +288,23 @@ class Repository extends ModelRepository
         $builder->andWhere('orders.number IS NOT NULL');
 
         if (!empty($orderBy)) {
+            //order by path of company, lastName and firstName instead of customerId
+            if(isset($orderBy[0]['property']) && $orderBy[0]['property'] === 'orders.customerId'){
+                $orderBy[0] = [
+                    'property' => 'billing.company',
+                    'direction' => $orderBy[0]['direction']
+                ];
+                array_splice($orderBy, 1, 0, [
+                    [
+                        'property' => 'billing.lastName',
+                        'direction' => $orderBy[0]['direction']
+                    ],
+                    [
+                        'property' => 'billing.firstName',
+                        'direction' => $orderBy[0]['direction']
+                    ]
+                ]);
+            }
             //add order by path
             $builder->addOrderBy($orderBy);
         }

--- a/themes/Backend/ExtJs/backend/order/view/list/list.js
+++ b/themes/Backend/ExtJs/backend/order/view/list/list.js
@@ -319,7 +319,10 @@ Ext.define('Shopware.apps.Order.view.list.List', {
                 header: me.snippets.columns.customer,
                 dataIndex: 'customerId',
                 flex:2,
-                renderer: me.customerColumn
+                renderer: me.customerColumn,
+                getSortParam: function() {
+                    return 'customerName';
+                }
             },
             {
                 header: me.snippets.columns.customerEmail,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
Sorting by customer in backend orders list will order by customer id. The user
expects the list to be ordered alphabetically by company name or last name/ first name.
This pull request changes the order queue to company, firstName, lastName when the
sorting property is customerId.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-15035 |
| How to test? | Order by customer in backend order list |
