### PR TITLE
[Papercut][SW-16040] filterable properties on detail pages as links to filtered l…

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -786,6 +786,13 @@ class LegacyStructConverter
                 /**@var $option StoreFrontBundle\Struct\Property\Option */
                 $values[$option->getId()] = $option->getName();
             }
+            
+            $keyValues = array_map(
+                function (StoreFrontBundle\Struct\Property\Option $option) {
+                    return ['id' => $option->getId(), 'name' => $option->getName()];
+                },
+                $group->getOptions()
+            );
 
             $mediaValues = array();
             foreach ($group->getOptions() as $option) {
@@ -803,6 +810,8 @@ class LegacyStructConverter
                 'groupName' => $set->getName(),
                 'value'     => implode(', ', $values),
                 'values'    => $values,
+                'isFilter'  => $group->isFilterable(),
+                'keyValues' => $keyValues,
                 'media'     => $mediaValues,
                 'attributes' => $group->getAttributes(),
             ];

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -787,12 +787,7 @@ class LegacyStructConverter
                 $values[$option->getId()] = $option->getName();
             }
             
-            $keyValues = array_map(
-                function (StoreFrontBundle\Struct\Property\Option $option) {
-                    return ['id' => $option->getId(), 'name' => $option->getName()];
-                },
-                $group->getOptions()
-            );
+            $propertyOptions = array_map([$this, 'convertPropertyOptionStruct'], $group->getOptions());
 
             $mediaValues = array();
             foreach ($group->getOptions() as $option) {
@@ -810,8 +805,8 @@ class LegacyStructConverter
                 'groupName' => $set->getName(),
                 'value'     => implode(', ', $values),
                 'values'    => $values,
-                'isFilter'  => $group->isFilterable(),
-                'keyValues' => $keyValues,
+                'isFilterable' => $group->isFilterable(),
+                'options'   => $propertyOptions,
                 'media'     => $mediaValues,
                 'attributes' => $group->getAttributes(),
             ];

--- a/themes/Frontend/Bare/frontend/detail/tabs/description.tpl
+++ b/themes/Frontend/Bare/frontend/detail/tabs/description.tpl
@@ -43,18 +43,7 @@
 
 							{* Property content *}
 							{block name='frontend_detail_description_properties_content'}
-								<td class="product--properties-value">
-                                    {if $sProperty.isFilter}
-                                        {$sBreadcrumbEnd = $sBreadcrumb|@end}
-                                        {foreach $sProperty.keyValues as $sPropertyValue}
-                                            <a href="{url controller='cat' sCategory=$sBreadcrumbEnd['id']}?n={$sProperty.groupID}&f={$sPropertyValue.id}" 
-                                               title="{s namespace='frontend/listing/filter_properties' name='FilterHeadlineCategory'}{/s}">
-                                                {$sPropertyValue.name|escape}</a>{if !$sPropertyValue@last}, {/if}
-                                        {/foreach}
-                                    {else}
-                                        {$sProperty.value|escape}
-                                    {/if}
-                                </td>
+								<td class="product--properties-value">{$sProperty.value|escape}</td>
 							{/block}
 						</tr>
 					{/foreach}

--- a/themes/Frontend/Bare/frontend/detail/tabs/description.tpl
+++ b/themes/Frontend/Bare/frontend/detail/tabs/description.tpl
@@ -43,7 +43,18 @@
 
 							{* Property content *}
 							{block name='frontend_detail_description_properties_content'}
-								<td class="product--properties-value">{$sProperty.value|escape}</td>
+								<td class="product--properties-value">
+                                    {if $sProperty.isFilter}
+                                        {$sBreadcrumbEnd = $sBreadcrumb|@end}
+                                        {foreach $sProperty.keyValues as $sPropertyValue}
+                                            <a href="{url controller='cat' sCategory=$sBreadcrumbEnd['id']}?n={$sProperty.groupID}&f={$sPropertyValue.id}" 
+                                               title="{s namespace='frontend/listing/filter_properties' name='FilterHeadlineCategory'}{/s}">
+                                                {$sPropertyValue.name|escape}</a>{if !$sPropertyValue@last}, {/if}
+                                        {/foreach}
+                                    {else}
+                                        {$sProperty.value|escape}
+                                    {/if}
+                                </td>
 							{/block}
 						</tr>
 					{/foreach}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? filter articles by clicking on a property in product description
- What does it improve? properties of filterable property groups on detail page will link to the pre-filtered category with their respective filter values. the category in question is the one at the very end of the current breadcrumb.
- Does it have side effects? none so far

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-16040 |
| How to test? | detail/index on articles with associated properties |
