### PR TITLE
[Papercut][SW-14466] - Delete emtyspace in the deleteButton in checkout

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/items/premium-product.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/items/premium-product.tpl
@@ -95,8 +95,10 @@
     {* Remove product from basket *}
     {block name='frontend_checkout_cart_item_premium_delete_article'}
         <div class="panel--td column--actions block">
-            <form action="{url action='deleteArticle' sDelete=$sBasketItem.id sTargetAction=$sTargetAction}" method="post">
-                <button type="submit" class="btn is--small column--actions-link" title="{"{s name='CartItemLinkDelete '}{/s}"|escape}">
+            <form action="{url action='deleteArticle' sDelete=$sBasketItem.id sTargetAction=$sTargetAction}"
+                  method="post">
+                <button type="submit" class="btn is--small column--actions-link"
+                        title="{"{s name='CartItemLinkDelete'}{/s}"|escape}">
                     <i class="icon--cross"></i>
                 </button>
             </form>

--- a/themes/Frontend/Bare/frontend/checkout/items/product.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/items/product.tpl
@@ -161,8 +161,10 @@
     {* Remove product from basket *}
     {block name='frontend_checkout_cart_item_delete_article'}
         <div class="panel--td column--actions">
-            <form action="{url action='deleteArticle' sDelete=$sBasketItem.id sTargetAction=$sTargetAction}" method="post">
-                <button type="submit" class="btn is--small column--actions-link" title="{"{s name='CartItemLinkDelete '}{/s}"|escape}">
+            <form action="{url action='deleteArticle' sDelete=$sBasketItem.id sTargetAction=$sTargetAction}"
+                  method="post">
+                <button type="submit" class="btn is--small column--actions-link"
+                        title="{"{s name='CartItemLinkDelete'}{/s}"|escape}">
                     <i class="icon--cross"></i>
                 </button>
             </form>

--- a/themes/Frontend/Bare/frontend/checkout/items/voucher.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/items/voucher.tpl
@@ -66,7 +66,8 @@
     {block name='frontend_checkout_cart_item_voucher_delete_article'}
         <div class="panel--td column--actions block">
             <form action="{url action='deleteArticle' sDelete=voucher sTargetAction=$sTargetAction}" method="post">
-                <button type="submit" class="btn is--small column--actions-link" title="{"{s name='CartItemLinkDelete '}{/s}"|escape}">
+                <button type="submit" class="btn is--small column--actions-link"
+                        title="{"{s name='CartItemLinkDelete'}{/s}"|escape}">
                     <i class="icon--cross"></i>
                 </button>
             </form>


### PR DESCRIPTION
This PR deletes an empty space at "{s name='CartItemLinkDelete '}{/s}" in premium-product.tpl product.tpl voucher.tpl and Reformat the block.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-14466 |
| How to test? | Load Bare Theme and check in Elements |
