### PR TITLE
[Papercut][SW-12430] - Fixes an issue were changedate wont update in Sitemap.xml

### DIFF
--- a/engine/Shopware/Controllers/Backend/Category.php
+++ b/engine/Shopware/Controllers/Backend/Category.php
@@ -679,6 +679,7 @@ class Shopware_Controllers_Backend_Category extends Shopware_Controllers_Backend
             $params['template'] = null;
         }
 
+        $params['changed'] = new \DateTime();
         $categoryModel->fromArray($params);
         Shopware()->Models()->flush();
 


### PR DESCRIPTION
This PR fixes an issue were the changedate for categories wont update in the Databasetable and therefore the changedate in the sitemap.xml is always the old one when it is created.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-12430 |
| How to test? | Open sitmap.xml and then change something in a category. Checks if the lastmod (chageDate) is updated. |
