### PR TITLE
[Papercut][SW-16047] Add missing translation in config > basic settings 

### DIFF
--- a/_sql/migrations/786-add-missing-translation-basicsettings-login-and-registration.php
+++ b/_sql/migrations/786-add-missing-translation-basicsettings-login-and-registration.php
@@ -1,0 +1,18 @@
+<?php
+
+class Migrations_Migration786 extends Shopware\Components\Migrations\AbstractMigration
+{
+    /**
+     * @param string $modus
+     * @return void
+     */
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+        SET @elementId = (SELECT id FROM `s_core_config_elements` WHERE `name` = 'displayprofiletitle' LIMIT 1);
+        INSERT IGNORE INTO `s_core_config_element_translations` (`element_id`, `locale_id`, `label`, `description`)
+        VALUES (@elementId, 2, 'Show title field', NULL);
+EOD;
+        $this->addSql($sql);
+    }
+}

--- a/_sql/migrations/787-add-missing-translation-basicsettings-login-and-registration.php
+++ b/_sql/migrations/787-add-missing-translation-basicsettings-login-and-registration.php
@@ -1,6 +1,6 @@
 <?php
 
-class Migrations_Migration786 extends Shopware\Components\Migrations\AbstractMigration
+class Migrations_Migration787 extends Shopware\Components\Migrations\AbstractMigration
 {
     /**
      * @param string $modus
@@ -10,6 +10,10 @@ class Migrations_Migration786 extends Shopware\Components\Migrations\AbstractMig
     {
         $sql = <<<'EOD'
         SET @elementId = (SELECT id FROM `s_core_config_elements` WHERE `name` = 'displayprofiletitle' LIMIT 1);
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
         INSERT IGNORE INTO `s_core_config_element_translations` (`element_id`, `locale_id`, `label`, `description`)
         VALUES (@elementId, 2, 'Show title field', NULL);
 EOD;


### PR DESCRIPTION
This PR adds a migration which adds a translation for the element 'displayprofiletitle' (label: Titel Feld anzeigen) in the table s_core_config_element_translations. The translation is then located in config > basic settings > frontend > login/registration.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-16047 |
| How to test? | Make an ant build-unit for the migration to apply. Then open the backend in english. Open config > basic settings > frontend > login/registration and check if there is a field called 'Show title field' instead of 'Titel Feld anzeigen'. |
