### PR TITLE
[Papercut][SW-15915] - Optimize theme compiling with shop selection

### DIFF
--- a/snippets/backend/index/view/theme_cache.ini
+++ b/snippets/backend/index/view/theme_cache.ini
@@ -6,7 +6,8 @@ progress/progress_bar_text = "0 theme shop(s) found"
 progress/progress_bar_single_text = "Compile theme files for shop \"[0]\""
 progress/progress_bar_loading = "Loading..."
 fieldset/information/title = "Information"
-fieldset/information/detail = "If you have made changes to your theme or its configuration, the theme must be compiled. The process is called automatically, in the first frontend request, if no compiled theme file exist. If you choose not to do this, changes in theme configuration maybe not applied."
+fieldset/information/detail = "If you have made changes to your theme or its configuration, the theme must be compiled. The process is called automatically, in the first frontend request, if no compiled theme file exist. If you choose not to do this, changes in theme configuration maybe not applied.<br><br>When selecting one or more shops only these get compiled. Otherwise all."
+fieldset/information/shopselection = "Shop selection"
 window/title = "Theme compiling"
 
 [de_DE]
@@ -17,6 +18,7 @@ progress/progress_bar_text = "0 Theme Shop(s) gefunden"
 progress/progress_bar_single_text = "Kompiliere Theme für Shop \"[0]\""
 progress/progress_bar_loading = "Lade..."
 fieldset/information/title = "Information"
-fieldset/information/detail = "Die Theme Dateien müssen kompiliert werden. Dies ist nur nötig, wenn Sie grundlegende Änderungen am Theme vorgenommen haben. Falls die Themes nicht manuell kompiliert werden, werden Änderungen an Themes nicht im Frontend übernommen. Sollten keine kompilierten Dateien beim Aufruf des Frontends vorliegen, wird der Prozess automatisch angestoßen"
+fieldset/information/detail = "Die Theme Dateien müssen kompiliert werden. Dies ist nur nötig, wenn Sie grundlegende Änderungen am Theme vorgenommen haben. Falls die Themes nicht manuell kompiliert werden, werden Änderungen an Themes nicht im Frontend übernommen. Sollten keine kompilierten Dateien beim Aufruf des Frontends vorliegen, wird der Prozess automatisch angestoßen.<br><br>Bei Auswahl eines oder mehrerer Shops werden nur diese kompiliert. Ansonsten alle."
+fieldset/information/shopselection = "Shopwauswahl"
 window/title = "Theme Kompilierung"
 

--- a/themes/Backend/ExtJs/backend/index/controller/theme_cache_warm_up.js
+++ b/themes/Backend/ExtJs/backend/index/controller/theme_cache_warm_up.js
@@ -71,6 +71,7 @@ Ext.define('Shopware.apps.Index.controller.ThemeCacheWarmUp', {
                 me.shopStore.getProxy().extraParams.shopId = shopId;
 
                 me.window.setSingleShopId(shopId);
+                me.window.shopSelector.hide();
             }
 
             me.shopStore.load({
@@ -79,6 +80,9 @@ Ext.define('Shopware.apps.Index.controller.ThemeCacheWarmUp', {
                         me.window.close();
                     } else {
                         me.window.setShops(records);
+                        if (me.window.shopSelector.isVisible()) {
+                            me.window.shopSelector.bindStore(me.shopStore);
+                        }
                         me.window.show();
                     }
                 }

--- a/themes/Backend/ExtJs/backend/index/view/theme_cache/theme_cache_warm_up.js
+++ b/themes/Backend/ExtJs/backend/index/view/theme_cache/theme_cache_warm_up.js
@@ -61,7 +61,7 @@ Ext.define('Shopware.apps.Index.view.themeCache.ThemeCacheWarmUp', {
      * Define window height
      * @integer
      */
-    height: 300,
+    height: 360,
 
     /**
      * Set vbox layout and stretch align to display the toolbar on top and the button container
@@ -152,6 +152,7 @@ Ext.define('Shopware.apps.Index.view.themeCache.ThemeCacheWarmUp', {
         var me = this;
 
         me.progressBar = me.createProgressBar();
+        me.shopSelector = me.createShopSelector();
 
         return [
             {
@@ -165,6 +166,7 @@ Ext.define('Shopware.apps.Index.view.themeCache.ThemeCacheWarmUp', {
                     })
                 ]
             },
+            me.shopSelector,
             me.progressBar,
             me.createButtons()
         ];
@@ -185,6 +187,25 @@ Ext.define('Shopware.apps.Index.view.themeCache.ThemeCacheWarmUp', {
         });
     },
 
+    createShopSelector: function() {
+        var me = this;
+
+        return Ext.create('Ext.form.field.ComboBox', {
+            displayField: 'name',
+            valueField: 'id',
+            forceSelection: true,
+            multiSelect: true,
+            editable: false,
+            emptyText: '{s name=fieldset/information/shopselection}Shop selection{/s}',
+            listeners: {
+                scope: me,
+                select: function(combo, records) {
+                    me.setShops(records);
+                }
+            }
+        });
+    },
+
     /**
      * Sets the shops and changes view accordingly
      * @param records
@@ -192,7 +213,7 @@ Ext.define('Shopware.apps.Index.view.themeCache.ThemeCacheWarmUp', {
     setShops: function(records) {
         var me = this;
 
-        if (Ext.isEmpty(me.singleShopId)) {
+        if (Ext.isEmpty(me.singleShopId) && records.length > 1) {
             me.progressBar.updateProgress(
                 0, me.snippets.progressBar.replace('0', records.length)
             );
@@ -249,8 +270,25 @@ Ext.define('Shopware.apps.Index.view.themeCache.ThemeCacheWarmUp', {
                     this.disable();
                 }
                 me.closeButton.disable();
+                me.filterThemes();
                 me.fireEvent('themeCacheWarmUpStartProcess');
             }
+        });
+    },
+
+    /**
+     * Filter shop store with selected shops before starting
+     * warumup process.
+     */
+    filterThemes: function() {
+        var me = this,
+            selectedShops = me.shopSelector.getValue();
+        if (Ext.isEmpty(selectedShops)) {
+            return;
+        }
+
+        me.shopSelector.getStore().filterBy(function(record, id) {
+            return Ext.Array.contains(selectedShops, id);
         });
     },
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? Optimized performance for theme compiling
- What does it improve? A selection of subshop for theme compiling is possible
- Does it have side effects? No.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-15915 |
| How to test? | In backend go to Settings / Cache and performance / Recompile themes. Now you can select a subshop if you want. Without selection default behaviour stays the same. All shop themes get compiled. |
