### PR TITLE
[PAPERCUT] SW-16063 - Move media files to manufacturer media album when uploaded…

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Manufacturer.php
+++ b/engine/Shopware/Components/Api/Resource/Manufacturer.php
@@ -26,6 +26,7 @@ namespace Shopware\Components\Api\Resource;
 
 use Shopware\Components\Api\Exception as ApiException;
 use Shopware\Models\Article\Supplier as ManufacturerModel;
+use Shopware\Models\Media\Album;
 use Shopware\Models\Media\Media as MediaModel;
 
 /**
@@ -232,10 +233,9 @@ class Manufacturer extends Resource
         $media = null;
 
         if (isset($data['image']['link'])) {
-            /**@var $media MediaModel */
-            $media = $this->getResource('media')->internalCreateMediaByFileLink(
-                $data['image']['link']
-            );
+            /** @var Media $resource */
+            $resource = $this->getResource('media');
+            $media = $resource->internalCreateMediaByFileLink($data['image']['link'], Album::ALBUM_SUPPLIER);
         } elseif (!empty($data['image']['mediaId'])) {
             $media = $this->getManager()->find(
                 'Shopware\Models\Media\Media',

--- a/tests/Functional/Components/Api/ManufacturerTest.php
+++ b/tests/Functional/Components/Api/ManufacturerTest.php
@@ -22,9 +22,14 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Tests\Functional\Components\Api;
+namespace Shopware\tests\Functional\Components\Api;
 
+use Doctrine\ORM\AbstractQuery;
 use Shopware\Components\Api\Resource\Manufacturer;
+use Shopware\Components\Api\Resource\Resource;
+use Shopware\Components\Model\ModelRepository;
+use Shopware\Models\Media\Album;
+use Shopware\Models\Media\Media;
 
 class ManufacturerTest extends TestCase
 {
@@ -156,5 +161,50 @@ class ManufacturerTest extends TestCase
     public function testDeleteWithMissingIdShouldThrowParameterMissingException()
     {
         $this->resource->delete('');
+    }
+
+    public function testMediaUploadOnCreate()
+    {
+        $manufacturer = $this->resource->create([
+            'name' => 'foo',
+            'image' => [
+                'link' => 'file://' . __DIR__ . '/fixtures/test-bild.jpg'
+            ]
+        ]);
+
+        $this->assertNotEmpty($manufacturer->getImage());
+
+        /** @var ModelRepository $repo */
+        $repo = Shopware()->Container()->get('models')->getRepository(Media::class);
+        /** @var Media $media */
+        $media = $repo->findOneBy(['path' => $manufacturer->getImage()]);
+
+        $this->assertEquals($media->getAlbumId(), Album::ALBUM_SUPPLIER);
+    }
+
+    public function testMediaUploadOnUpdate()
+    {
+        $manufacturer = $this->resource->create([
+            'name' => 'bar'
+        ]);
+
+        $this->resource->update($manufacturer->getId(), [
+            'name' => 'bar',
+            'image' => [
+                'link' => 'file://' . __DIR__ . '/fixtures/test-bild.jpg'
+            ]
+        ]);
+
+        $this->resource->setResultMode(Resource::HYDRATE_OBJECT);
+        $manufacturer = $this->resource->getOne($manufacturer->getId());
+        $this->assertNotEmpty($manufacturer->getImage());
+
+        /** @var ModelRepository $repo */
+        $repo = Shopware()->Container()->get('models')->getRepository(Media::class);
+
+        /** @var Media $media */
+        $media = $repo->findOneBy(['path' => $manufacturer->getImage()]);
+
+        $this->assertEquals($media->getAlbumId(), Album::ALBUM_SUPPLIER);
     }
 }

--- a/tests/Functional/Components/Api/ManufacturerTest.php
+++ b/tests/Functional/Components/Api/ManufacturerTest.php
@@ -22,9 +22,8 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\tests\Functional\Components\Api;
+namespace Shopware\Tests\Functional\Components\Api;
 
-use Doctrine\ORM\AbstractQuery;
 use Shopware\Components\Api\Resource\Manufacturer;
 use Shopware\Components\Api\Resource\Resource;
 use Shopware\Components\Model\ModelRepository;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary?
  - Customers would expect manufacturer media files in the corresponding album
- What does it improve? 
  - Media files are now stored in the correct album
- Does it have side effects? 
  - Existing API behavior changed

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-16063 |
| How to test? | Upload an media over the manufacturer rest api resource (example see implemented tests) |
