### PR TITLE
[PAPERCUT] SW-14306 - Increase label width of base components to 155px

### DIFF
--- a/themes/Backend/ExtJs/backend/base/application/Shopware.model.Container.js
+++ b/themes/Backend/ExtJs/backend/base/application/Shopware.model.Container.js
@@ -887,7 +887,7 @@ Ext.define('Shopware.model.Container', {
         formField.xtype = 'displayfield';
         formField.anchor = '100%';
         formField.margin = '0 3 7 0';
-        formField.labelWidth = 130;
+        formField.labelWidth = 155;
         formField.name = field.name;
 
         //if an alias was passed, the form field name will be surround with square bracket


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary?
  - Unify label width of backend components with backend modules
- What does it improve?
  - Unified label width for all modules with this components 
- Does it have side effects?
  - Existing fields without own defined label width are increased by 25px 

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-14306 |
| How to test? | Download one of the backend tutorial plugins and check label width of detail view |
