### PR TITLE
[Papercut][SW-15981] Fix album collapse behaviour on reload

### DIFF
--- a/engine/Shopware/Controllers/Backend/MediaManager.php
+++ b/engine/Shopware/Controllers/Backend/MediaManager.php
@@ -640,7 +640,7 @@ class Shopware_Controllers_Backend_MediaManager extends Shopware_Controllers_Bac
                 \Doctrine\ORM\AbstractQuery::HYDRATE_OBJECT
             );
             if (!$album) {
-                $this->View()->assign(array('success' => false, 'message' => 'Invalid album id passed'));
+                $this->View()->assign(['success' => false, 'message' => 'Invalid album id passed']);
                 return false;
             }
         } else {
@@ -655,9 +655,9 @@ class Shopware_Controllers_Backend_MediaManager extends Shopware_Controllers_Bac
             $this->getManager()->flush($album);
             $this->getManager()->flush($album->getSettings());
 
-            $this->View()->assign(array('success' => true));
+            $this->View()->assign(['success' => true, 'data' => ['id' => $album->getId()]]);
         } catch (Exception $e) {
-            $this->View()->assign(array('success' => false, 'message' => $e->getMessage()));
+            $this->View()->assign(['success' => false, 'message' => $e->getMessage()]);
         }
     }
 

--- a/themes/Backend/ExtJs/backend/media_manager/controller/media.js
+++ b/themes/Backend/ExtJs/backend/media_manager/controller/media.js
@@ -342,8 +342,7 @@ Ext.define('Shopware.apps.MediaManager.controller.Media', {
                 mediaView.setLoading(false);
                 store.load({
                     callback: function() {
-                        rootNode.removeAll(false);
-                        treeStore.load();
+                        tree.fireEvent('refresh', tree);
                         mediaView.deleteBtn.setDisabled(true);
                     }
                 });

--- a/themes/Backend/ExtJs/backend/media_manager/view/album/add.js
+++ b/themes/Backend/ExtJs/backend/media_manager/view/album/add.js
@@ -85,6 +85,11 @@ Ext.define('Shopware.apps.MediaManager.view.album.Add', {
            cls: 'shopware-toolbar',
            items: me.createActionButtons()
         }];
+
+        me.on('show', function() {
+            me.nameField.focus(false, 200);
+        });
+
         me.callParent(arguments);
     },
 

--- a/themes/Backend/ExtJs/backend/media_manager/view/album/tree.js
+++ b/themes/Backend/ExtJs/backend/media_manager/view/album/tree.js
@@ -88,6 +88,7 @@ Ext.define('Shopware.apps.MediaManager.view.album.Tree', {
         // Set column model and selection model
         me.columns = me.createColumns();
         me.selModel = Ext.create('Ext.selection.RowModel', {
+            allowDeselect: true,
             listeners: {
                 scope: me,
                 select: me.onUnlockDeleteBtn
@@ -113,6 +114,7 @@ Ext.define('Shopware.apps.MediaManager.view.album.Tree', {
             'editSettings',
             'addAlbum',
             'reload',
+            'refresh',
             'emptyTrash'
         );
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? Fixes very disturbing issue when working with media albums
- What does it improve? Collapsing behavior after tree reload
- Does it have side effects? No

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-15981 |
| How to test? | Go to media manager - open album - drag image to expanded album or from expanded album - after tree reload album should stay expanded |
