### PR TITLE
[Papercut][SW-13189] Fix sorting from blogcomments in the frontend

### DIFF
--- a/engine/Shopware/Models/Blog/Repository.php
+++ b/engine/Shopware/Models/Blog/Repository.php
@@ -380,6 +380,7 @@ class Repository extends ModelRepository
                 ->leftJoin('blog.comments', 'comments', \Doctrine\ORM\Query\Expr\Join::WITH, 'comments.active = 1')
                 ->leftJoin('mappingMedia.media', 'media')
                 ->where("blog.id = :blogArticleId")
+                ->addOrderBy('comments.creationDate', 'ASC')
                 ->setParameter("blogArticleId", $blogArticleId);
 
         return $builder;


### PR DESCRIPTION
This PR always sorts the blogcomments chronologically for the creationDate in the frontend.
https://github.com/shopware/shopware/pull/710 this does it only for the backend.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-13189 |
| How to test? | Create different Blogcomments with different createDates and check if they are sorted |

chronologically.
