### PR TITLE
[Papercut][SW-15761] Fix address type detection when changing exisiting addresses

### DIFF
--- a/themes/Frontend/Bare/frontend/address/form.tpl
+++ b/themes/Frontend/Bare/frontend/address/form.tpl
@@ -30,7 +30,7 @@
                     {else}
                         {block name="frontend_address_form_fieldset_customer_type_input"}
                             {* Always register as a private customer*}
-                            <input type="hidden" name="{$inputPrefix}[additional][customer_type]" value="private" />
+                            <input type="hidden" name="{$inputPrefix}[additional][customer_type]" value="{if $formData.company}business{else}private{/if}" />
                         {/block}
                     {/if}
                 </div>

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
@@ -52,7 +52,7 @@
              * @property typeFieldSelector
              * @type {String}
              */
-            typeFieldSelector: '.register--customertype select,.address--customertype select',
+            typeFieldSelector: '.register--customertype select,.address--customertype select,.address--customertype input',
 
             /**
              * Type name for a company selection.


### PR DESCRIPTION
## Description
- Why is it necessary?
  - You can't edit private addresses in your account.
- What does it improve?
  - It extends the customer type selector of `jquery.register.js` which handles the visibility of fields related to business addresses. In addition, the field now represents the correct customer type for existing addresses. (there was private only)
- Does it have side effects?
  - Nope, sir.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-15761 |
| How to test? | Register an account with a private address. Disable the customer type selection. Try to edit an existing non-business address in your account. In addition, existing business addresses should be updateable as business addresses too. |
