### PR TITLE
[PAPERCUT][SW-14335] Fix php plugin notice for cli commands

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Struct/StructHydrator.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Struct/StructHydrator.php
@@ -504,10 +504,13 @@ class StructHydrator
 
         $producer->setId($data['id']);
         $producer->setName($data['name']);
-        $producer->setDescription($data['description']);
         $producer->setPrefix($data['prefix']);
         $producer->setWebsite($data['website']);
         $producer->setIconPath($data['iconPath']);
+
+        if (!empty($data['description'])) {
+            $producer->setDescription($data['description']);
+        }
 
         return $producer;
     }


### PR DESCRIPTION
## Description
- Why is it necessary?
  - Every time a plugin pulls data from the store api, the data will be used for hydrating structs. Currently, the api doesn't provide `producer.description`.
- What does it improve?
  - It now checks, if `producer.description` is not empty which catches the notice.
- Does it have side effects?
  - Nope, sir.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-14335 |
| How to test? | Download a plugin via cli. f.e. `bin/console sw:store:download SwagDemoDataDE` and no (error) notice should appear. |
