### PR TITLE
 [Papercut][SW-14482] Fix description in basicsettings Seo-Router

### DIFF
--- a/_sql/migrations/788-change-Seo-Router-description.php
+++ b/_sql/migrations/788-change-Seo-Router-description.php
@@ -1,0 +1,41 @@
+<?php
+
+class Migrations_Migration788 extends Shopware\Components\Migrations\AbstractMigration
+{
+    /**
+     * @param string $modus
+     * @return void
+     */
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+           UPDATE `s_core_config_elements` SET `label` = 'prev/next-Tag auf paginierten Seiten benutzen' 
+           WHERE `s_core_config_elements`.`name` = 'seoIndexPaginationLinks';
+EOD;
+        $this->addSql($sql);
+
+
+        $sql = <<<'EOD'
+           UPDATE `s_core_config_elements` SET `description` = 'Wenn aktiv, wird auf paginierten Seiten anstatt des Canoncial-Tags der prev/next-Tag benutzt.' 
+           WHERE `s_core_config_elements`.`name` = 'seoIndexPaginationLinks';
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+           SET @elementId = (SELECT id FROM `s_core_config_elements` WHERE `name` = 'seoIndexPaginationLinks' LIMIT 1);
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+           UPDATE `s_core_config_element_translations` SET `label` = 'Use prev/next-tag on paginated sites' 
+           WHERE `element_id` = @elementId;
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+           UPDATE `s_core_config_element_translations` SET `description` = 'If active, use prev/next-tag instead of the Canoncial-tag on paginated sites' 
+           WHERE `element_id` = @elementId;
+EOD;
+        $this->addSql($sql);
+    }
+}

--- a/_sql/migrations/788-change-Seo-Router-description.php
+++ b/_sql/migrations/788-change-Seo-Router-description.php
@@ -9,14 +9,8 @@ class Migrations_Migration788 extends Shopware\Components\Migrations\AbstractMig
     public function up($modus)
     {
         $sql = <<<'EOD'
-           UPDATE `s_core_config_elements` SET `label` = 'prev/next-Tag auf paginierten Seiten benutzen' 
-           WHERE `s_core_config_elements`.`name` = 'seoIndexPaginationLinks';
-EOD;
-        $this->addSql($sql);
-
-
-        $sql = <<<'EOD'
-           UPDATE `s_core_config_elements` SET `description` = 'Wenn aktiv, wird auf paginierten Seiten anstatt des Canoncial-Tags der prev/next-Tag benutzt.' 
+           UPDATE `s_core_config_elements` SET `label` = 'prev/next-Tag auf paginierten Seiten benutzen',
+           `description` = 'Wenn aktiv, wird auf paginierten Seiten anstatt des Canoncial-Tags der prev/next-Tag benutzt.'
            WHERE `s_core_config_elements`.`name` = 'seoIndexPaginationLinks';
 EOD;
         $this->addSql($sql);
@@ -27,13 +21,8 @@ EOD;
         $this->addSql($sql);
 
         $sql = <<<'EOD'
-           UPDATE `s_core_config_element_translations` SET `label` = 'Use prev/next-tag on paginated sites' 
-           WHERE `element_id` = @elementId;
-EOD;
-        $this->addSql($sql);
-
-        $sql = <<<'EOD'
-           UPDATE `s_core_config_element_translations` SET `description` = 'If active, use prev/next-tag instead of the Canoncial-tag on paginated sites' 
+           UPDATE `s_core_config_element_translations` SET `label` = 'Use prev/next-tag on paginated sites',
+           `description` = 'If active, use prev/next-tag instead of the Canoncial-tag on paginated sites'
            WHERE `element_id` = @elementId;
 EOD;
         $this->addSql($sql);


### PR DESCRIPTION
This PR is a migration which changes the label and description for the entry seoIndexPaginationLinks in the table config_elements and its translation.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-14482 |
| How to test? | Make an ant build-unit for the migration to apply. Check if the changes in basic settings -> frontend -> seo/ router settings are applied in german and english |
