### PR TITLE
[Papercut][SW-15814] Fix sorting of filters in product stream categories

### DIFF
--- a/engine/Shopware/Components/ProductStream/FacetFilter.php
+++ b/engine/Shopware/Components/ProductStream/FacetFilter.php
@@ -65,28 +65,28 @@ class FacetFilter implements FacetFilterInterface
      */
     public function add(Criteria $criteria)
     {
-        if ($this->config->get('displayFiltersInListings')) {
-            $criteria->addFacet(new PropertyFacet());
-        }
-
-        if ($this->config->get('showPriceFacet')) {
-            $criteria->addFacet(new PriceFacet());
-        }
-
         if (!$criteria->hasBaseCondition('immediate_delivery') && $this->config->get('showImmediateDeliveryFacet')) {
             $criteria->addFacet(new ImmediateDeliveryFacet());
-        }
-
-        if (!$criteria->hasBaseCondition('manufacturer') && $this->config->get('showSupplierInCategories')) {
-            $criteria->addFacet(new ManufacturerFacet());
         }
 
         if (!$criteria->hasBaseCondition('shipping_free') && $this->config->get('showShippingFreeFacet')) {
             $criteria->addFacet(new ShippingFreeFacet());
         }
 
+        if ($this->config->get('showPriceFacet')) {
+            $criteria->addFacet(new PriceFacet());
+        }
+
         if (!$criteria->hasBaseCondition('vote_average') && $this->config->get('showVoteAverageFacet')) {
             $criteria->addFacet(new VoteAverageFacet());
+        }
+
+        if (!$criteria->hasBaseCondition('manufacturer') && $this->config->get('showSupplierInCategories')) {
+            $criteria->addFacet(new ManufacturerFacet());
+        }
+
+        if ($this->config->get('displayFiltersInListings')) {
+            $criteria->addFacet(new PropertyFacet());
         }
     }
 


### PR DESCRIPTION
## Description

Please describe your pull request:
- Why is it necessary?
  - different sortings of filters in product stream categories and normal categories
- What does it improve?
  - same sorting of filters
- Does it have side effects?
  - no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | [Issue](https://issues.shopware.com/#/issues/SW-15814) |
| How to test? | create a product stream. create a new category and add the product stream. open the new category in the storefront. compare with normal category |
