### PR TITLE
[Papercut][SW-14270] fix risk management rule ORDERPOSITIONSMORE

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -708,14 +708,14 @@ class sAdmin
 
         $addScopeSql = "";
         if ($this->scopedRegistration == true) {
-            $addScopeSql = $this->db->quoteInto(' AND subshopID = ? ',  $this->subshopId);
+            $addScopeSql = $this->db->quoteInto(' AND subshopID = ? ', $this->subshopId);
         }
 
         // When working with a prehashed password, we need to limit the getUser query by password,
         // as there might be multiple users with the same mail address (accountmode = 1).
         $preHashedSql = '';
         if ($isPreHashed) {
-            $preHashedSql = $this->db->quoteInto(' AND password = ? ',  $password);
+            $preHashedSql = $this->db->quoteInto(' AND password = ? ', $password);
         }
 
         if ($ignoreAccountMode) {
@@ -1963,7 +1963,7 @@ SQL;
     public function sRiskORDERPOSITIONSMORE($user, $order, $value)
     {
         return (
-            (is_array($order["content"]) ? count($order["content"]) : $order["content"] >= $value)
+            (is_array($order["content"]) ? count($order["content"]) : $order["content"] < $value)
         );
     }
 

--- a/tests/Functional/Core/sAdminTest.php
+++ b/tests/Functional/Core/sAdminTest.php
@@ -1694,8 +1694,8 @@ class sAdminTest extends PHPUnit_Framework_TestCase
                 'value1' => '2'
             )
         );
-        $this->assertFalse($this->module->sManageRisks(2, $basket, $user));
-        Shopware()->Db()->delete('s_core_rulesets', 'id >= '.$firstTestRuleId);
+        $this->assertTrue($this->module->sManageRisks(2, $basket, $user));
+        Shopware()->Db()->delete('s_core_rulesets', 'id >= ' . $firstTestRuleId);
 
         $this->module->sSYSTEM->sSESSION_ID = uniqid(rand());
         $this->session->offsetSet('sessionId', $this->module->sSYSTEM->sSESSION_ID);


### PR DESCRIPTION
## Description
- Why is it necessary?
  - risk management ORDERPOSITIONSMORE does not behave as expected
- What does it improve?
  - correct behaviour of ORDERPOSITIONSMORE
- Does it have side effects?
  - maybe some settings will break, which rely on this false behaviour

| Questions | Answers |
| --- | --- |
| BC breaks? | maybe |
| Tests pass? | no -> test had to be fixed |
| Related tickets? | [Issue](https://issues.shopware.com/#/issues/SW-14270) |
| How to test? | create new risk management for "Nachnahme" with "Bestellpositionen >=" 2. put one product to cart. "Nachnahme" should not be available. put another product to cart -> "Nachnahme" is available |
