### PR TITLE
[Papercut][SW-14526] add numeric prices to product export

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -951,7 +951,9 @@ class sExport
                 a.configurator_set_id as configurator,
 
                 ROUND(CAST(IFNULL($grouppricefield, $pricefield)*(100-IF(pd.discount,pd.discount,0)-{$this->sCustomergroup["discount"]})/100*{$this->sCurrency["factor"]} AS DECIMAL(10,3)),2) as netprice,
+                IFNULL($grouppricefield, $pricefield)*(100-IF(pd.discount,pd.discount,0)-{$this->sCustomergroup["discount"]})/100*{$this->sCurrency["factor"]} as netprice_numeric,
                 ROUND(CAST(IFNULL($grouppricefield, $pricefield)*(100+t.tax)/100*(100-IF(pd.discount,pd.discount,0)-{$this->sCustomergroup["discount"]})/100*{$this->sCurrency["factor"]} AS DECIMAL(10,3)),2) as price,
+                IFNULL($grouppricefield, $pricefield)*(100+t.tax)/100*(100-IF(pd.discount,pd.discount,0)-{$this->sCustomergroup["discount"]})/100*{$this->sCurrency["factor"]} as price_numeric,
                 pd.discount,
                 ROUND(CAST($pseudoprice*{$this->sCurrency["factor"]} AS DECIMAL(10,3)),2) as netpseudoprice,
                 ROUND(CAST($pseudoprice*(100+t.tax)*{$this->sCurrency["factor"]}/100 AS DECIMAL(10,3)),2) as pseudoprice,


### PR DESCRIPTION
## Description
- Why is it necessary?
  - -
- What does it improve?
  - add numeric prices without rounding to product export
- Does it have side effects?
  - no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | [Issue](https://issues.shopware.com/#/issues/SW-14526) |
| How to test? | edit some product export template and add {$sArticle.netprice_numeric} and / or {$sArticle.price_numeric} . start product export. the new numbers should be available |
