### PR TITLE
fixed the sites-navigation link-target value being empty

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -9,6 +9,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 * Add support for third party post messages in the backend
 * getOne function of customer api resource contains now the country and state data for billing and shipping address
 * Changed `jquery.search::onKeyboardNavigation()` method to provide more extension possibilities.
+* Fixed the sites-navigation link-target value being empty
 
 ## 5.2.6
 

--- a/themes/Frontend/Bare/frontend/index/sites-navigation.tpl
+++ b/themes/Frontend/Bare/frontend/index/sites-navigation.tpl
@@ -12,7 +12,7 @@
                            title="{$page.description|escape}"
                            data-categoryId="{$page.id}"
                            data-fetchUrl="{url module=widgets controller=listing action=getCustomPage pageId={$page.id}}"
-                           {if $page.target}target="{$page.page}"{/if}>
+                           {if $page.target}target="{$page.target}"{/if}>
                             {$page.description}
 
                             {if $page.childrenCount}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- This fixes the link target being empty (`target=""`) if a target is set (which is also invalid HTML)

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | SW-12898 |
| How to test? | Create a custom link in your sites' navigation with any target. Now look at the source code of your page -> `target` is empty. This PR fixes this. |
