### PR TITLE
[Papercut][SW-16122] Fix thumbnails--arrow in image-gallery

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
@@ -462,6 +462,7 @@
                 $el.replaceWith(img);
             });
 
+            me._$thumbContainerClone.find('a.thumbnails--arrow').remove();
             me._$imageContainerClone.find('.arrow').remove();
 
             $template = $('<div>', {


### PR DESCRIPTION
This PR seraches in the thumbcontainer from the productdetail for thumbnails--arrows and removes them from the Container.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-16122 https://issues.shopware.com/#/issues/SW-15177 |
| How to test? | Open a Product in the Frontend with more than 15 images. Open the image-gallery and check if the right thumbnail--arrows are shown. |
