### PR TITLE
[Papercut][SW-13998] - Fix image position attribute

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/MediaHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/MediaHydrator.php
@@ -94,6 +94,10 @@ class MediaHydrator extends Hydrator
             $media->setDescription($data['__media_description']);
         }
 
+        if (isset($data['__image_position'])) {
+            $media->setPosition($data['__image_position']);
+        }
+
         if (isset($data['__media_type'])) {
             $media->setType($data['__media_type']);
         }

--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/Media.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/Media.php
@@ -50,6 +50,11 @@ class Media extends Extendable implements \JsonSerializable
     protected $description;
 
     /**
+     * @var int
+     */
+    protected $position;
+
+    /**
      * @var boolean
      */
     protected $preview;
@@ -163,6 +168,22 @@ class Media extends Extendable implements \JsonSerializable
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    /**
+     * @param int $position
+     */
+    public function setPosition($position)
+    {
+        $this->position = $position;
     }
 
     /**

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -683,7 +683,7 @@ class LegacyStructConverter
 
         $data = array(
             'id' => $media->getId(),
-            'position' => 1,
+            'position' => $media->getPosition(),
             'source' => $media->getFile(),
             'description' => $media->getName(),
             'extension' => $media->getExtension(),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary?  
  The image position attribute can now be used by plugins / extensions. Before all images got "position = 1" and not the value from the database  
- What does it improve?  
  it now sets the right position from the database  
- Does it have side effects?  
  no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-13998 |
| How to test? | outprint $sArticel.images in template /bare/frontend/detail/images.tpl and see the right position attribute |
