### PR TITLE
[Papercut][SW-12795] Fix search with uri related chars

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Search.php
+++ b/engine/Shopware/Controllers/Frontend/Search.php
@@ -23,7 +23,7 @@
  */
 use Shopware\Bundle\SearchBundle\ProductSearchResult;
 use Shopware\Bundle\SearchBundle\SearchTermPreProcessorInterface;
-use Shopware\Bundle\StoreFrontBundle\Struct\ProductContextInterface;
+use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 
 /**
  * @category  Shopware
@@ -53,7 +53,7 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
 
         $term = $this->getSearchTerm();
 
-        // Check if we have a one to one match for ordernumber, then redirect
+        // Check if we have a one to one match for order number, then redirect
         $location = $this->searchFuzzyCheck($term);
         if (!empty($location)) {
             return $this->redirect($location);
@@ -66,14 +66,14 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
             return;
         }
 
-        /**@var $context ProductContextInterface*/
-        $context  = $this->get('shopware_storefront.context_service')->getShopContext();
+        /**@var $context ShopContextInterface */
+        $context = $this->get('shopware_storefront.context_service')->getShopContext();
 
         $criteria = Shopware()->Container()->get('shopware_search.store_front_criteria_factory')
             ->createSearchCriteria($this->Request(), $context);
 
-        /**@var $result ProductSearchResult*/
-        $result   = $this->get('shopware_search.product_search')->search($criteria, $context);
+        /**@var $result ProductSearchResult */
+        $result = $this->get('shopware_search.product_search')->search($criteria, $context);
         $articles = $this->convertProducts($result);
 
         if ($this->get('config')->get('traceSearch', true)) {
@@ -92,7 +92,7 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
         /** @var $mapper \Shopware\Components\QueryAliasMapper */
         $mapper = $this->get('query_alias_mapper');
 
-        $this->View()->assign(array(
+        $this->View()->assign([
             'term' => $term,
             'criteria' => $criteria,
             'facets' => $result->getFacets(),
@@ -104,12 +104,12 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
             'shortParameters' => $mapper->getQueryAliases(),
             'pageSizes' => array_values(explode("|", $pageCounts)),
             'ajaxCountUrlParams' => ['sCategory' => $context->getShop()->getCategory()->getId()],
-            'sSearchResults' => array(
+            'sSearchResults' => [
                 'sArticles' => $articles,
                 'sArticlesCount' => $result->getTotalCount()
-            ),
+            ],
             'productBoxLayout' => $this->get('config')->get('searchProductBoxLayout')
-        ));
+        ]);
     }
 
     /**
@@ -118,11 +118,9 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
      */
     private function convertProducts(ProductSearchResult $result)
     {
-        $articles = array();
+        $articles = [];
         foreach ($result->getProducts() as $product) {
-            $article = $this->get('legacy_struct_converter')->convertListProductStruct(
-                $product
-            );
+            $article = $this->get('legacy_struct_converter')->convertListProductStruct($product);
 
             $articles[] = $article;
         }
@@ -130,6 +128,7 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
         if (empty($articles)) {
             return null;
         }
+
         return $articles;
     }
 
@@ -142,6 +141,7 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
 
         /** @var SearchTermPreProcessorInterface $processor */
         $processor = $this->get('shopware_search.search_term_pre_processor');
+
         return $processor->process($term);
     }
 
@@ -171,7 +171,7 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
                 GROUP BY articleID
                 LIMIT 2
             ';
-            $articles = $this->get('db')->fetchAll($sql, array($search));
+            $articles = $this->get('db')->fetchAll($sql, [$search]);
             if ($articles[0]['configurator_set_id']) {
                 $number = $articles[0]['ordernumber'];
             }
@@ -187,7 +187,7 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
                     GROUP BY articleID
                     LIMIT 2
                 ";
-                $articles = $this->get('db')->fetchCol($sql, array($search, $search));
+                $articles = $this->get('db')->fetchCol($sql, [$search, $search]);
             }
         }
         if (!empty($articles) && count($articles) == 1) {
@@ -202,10 +202,10 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
                 LIMIT 1
             ';
 
-            $articles = $this->get('db')->fetchCol($sql, array(
+            $articles = $this->get('db')->fetchCol($sql, [
                 $this->get('shop')->get('parentID'),
                 $articles[0]
-            ));
+            ]);
         }
         if (!empty($articles) && count($articles) == 1) {
             $assembleParams = [

--- a/tests/Mink/features/bootstrap/Element/Paging.php
+++ b/tests/Mink/features/bootstrap/Element/Paging.php
@@ -25,8 +25,8 @@ class Paging extends Element implements \Shopware\Tests\Mink\HelperSelectorInter
     public function getCssSelectors()
     {
         return [
-            'previous' => 'a.pagination--link.paging--prev',
-            'next' => 'a.pagination--link.paging--next'
+            'previous' => 'a.paging--link.paging--prev',
+            'next' => 'a.paging--link.paging--next'
         ];
     }
 
@@ -48,11 +48,7 @@ class Paging extends Element implements \Shopware\Tests\Mink\HelperSelectorInter
         $elements = Helper::findElements($this, $locator);
 
         for ($i = 0; $i < $steps; $i++) {
-            $result = Helper::countElements($this, $direction, 1);
-
-            if ($result !== true) {
-                $result = Helper::countElements($this, $direction, 2);
-            }
+            $result = Helper::countElements($this, $direction, 4);
 
             if ($result !== true) {
                 Helper::throwException(

--- a/tests/Mink/features/search.feature
+++ b/tests/Mink/features/search.feature
@@ -22,6 +22,15 @@ Feature: Search things
         Then I should see "Zu \"str\" wurden 13 Artikel gefunden!"
         But  I should see 12 elements of type "ArticleBox"
 
+    @javascript
+    Scenario: Search with special uri characters
+        When I search for "20% alle"
+        Then I should see "Zu \"20% alle\" wurden 14 Artikel gefunden!"
+        But  I should see 12 elements of type "ArticleBox"
+        When I browse to next page
+        Then I should see 2 elements of type "ArticleBox"
+        But  I should see "Zu \"20% alle\" wurden 14 Artikel gefunden!"
+
     Scenario: Search with no hits
         When I search for "foo"
         Then I should see the no results message for keyword "foo"

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.listing-actions.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.listing-actions.js
@@ -488,9 +488,9 @@
          *
          * @returns {*}
          */
-        setCategoryParamsFromTopLocation: function() {
+        setCategoryParamsFromTopLocation: function () {
             var me = this,
-                urlParams = decodeURI(window.location.search).substr(1),
+                urlParams = window.location.search.substr(1),
                 categoryParams = me.setCategoryParamsFromUrlParams(urlParams);
 
             $.publish('plugin/swListingActions/onSetCategoryParamsFromData', [ me, categoryParams ]);
@@ -504,7 +504,7 @@
          * @param urlParamString
          * @returns {{}|*}
          */
-        setCategoryParamsFromUrlParams: function(urlParamString) {
+        setCategoryParamsFromUrlParams: function (urlParamString) {
             var me = this,
                 categoryParams,
                 params;
@@ -520,10 +520,13 @@
             categoryParams = me.categoryParams;
             params = urlParamString.split('&');
 
-            $.each(params, function(index, item) {
+            $.each(params, function (index, item) {
                 var param = item.split('=');
 
-                param = $.map(param, function(val) { return decodeURIComponent(val); });
+                param = $.map(param, function (val) {
+                    val = val.replace(/\+/g, '%20');
+                    return decodeURIComponent(val);
+                });
 
                 if (param[1] == 'reset') {
                     delete categoryParams[param[0]];
@@ -531,7 +534,7 @@
                 } else if (me.propertyFieldNames.indexOf(param[0]) != -1) {
                     var properties = param[1].split('|');
 
-                    $.each(properties, function(index, property) {
+                    $.each(properties, function (index, property) {
                         categoryParams[me.opts.propertyPrefixChar + param[0] + me.opts.propertyPrefixChar + property] = property;
                     });
 


### PR DESCRIPTION
## Description
- Why is it necessary?
  - if searching with URI related characters the filter panel will break. you also can't go to page 2
- What does it improve?
  - improve encoding and decoding of the search string, so the filter panel and pagination won't break anymore. also I cleaned up the search controllers. This fixes also an issue if you search with two terms and you go to page 2 or use the filter. example: initial search "all art" -> go to page 2, search term is "all+art"
- Does it have side effects?
  - nope

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | [Issue](https://issues.shopware.com/#/issues/SW-12795) |
| How to test? | Search for "20% alle" or "20+ alle" switch pages or use the filters. result must be correct now |
