### PR TITLE
new filter event for registration form validation

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -10,6 +10,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 * getOne function of customer api resource contains now the country and state data for billing and shipping address
 * Changed `jquery.search::onKeyboardNavigation()` method to provide more extension possibilities.
 * Deprecated the execution shopware.php via CLI. Please use the command line tool in `bin/console` instead.
+* Added filter event `Shopware_Modules_Admin_SaveRegister_FilterFormErrors` in `Shopware_Controllers_Frontend_Register` to filter form validation errors
 
 ## 5.2.6
 

--- a/engine/Shopware/Controllers/Frontend/Register.php
+++ b/engine/Shopware/Controllers/Frontend/Register.php
@@ -132,6 +132,15 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
             !empty($errors['billing'])
         );
 
+        $errors = $eventManager->filter(
+            'Shopware_Modules_Admin_SaveRegister_FilterFormErrors',
+            $errors,
+            [
+                'subject' => $this,
+                'postData' => $data
+            ]
+        );
+
         if ($errors['occurred']) {
             unset($data['register']['personal']['password']);
             unset($data['register']['personal']['passwordConfirmation']);


### PR DESCRIPTION
## Description

Please describe your pull request:
- Why is it necessary? Because there is currently no other possibility to validate custom registration form fields.
- What does it improve? The validation of the registration form.
- Does it have side effects? No

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | no ticket yet |
| How to test? | register an event listener and modify the $errors array |
