### PR TITLE
[Papercut][SW-12745] Fix voucher wrong enddate

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -458,12 +458,12 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
 
         // Check if voucher is available
         $sqlVoucher = "SELECT s_emarketing_voucher_codes.id AS id, code, description, value, percental FROM s_emarketing_vouchers, s_emarketing_voucher_codes
-         WHERE  modus = 1 AND (valid_to >= now() OR valid_to IS NULL)
+         WHERE  modus = 1 AND (valid_to >= CURDATE() OR valid_to IS NULL)
          AND s_emarketing_voucher_codes.voucherID = s_emarketing_vouchers.id
          AND s_emarketing_voucher_codes.userID IS NULL
          AND s_emarketing_voucher_codes.cashed = 0
          AND s_emarketing_vouchers.id=?
-         GROUP BY s_emarketing_voucher_codes.voucherID
+         Limit 1
          ";
 
         $getVoucher = Shopware()->Db()->fetchRow($sqlVoucher, array($id));

--- a/engine/Shopware/Controllers/Backend/CanceledOrder.php
+++ b/engine/Shopware/Controllers/Backend/CanceledOrder.php
@@ -253,8 +253,8 @@ class Shopware_Controllers_Backend_CanceledOrder extends Shopware_Controllers_Ba
 
         $sql = "SELECT s_emarketing_vouchers.id, s_emarketing_vouchers.description, s_emarketing_vouchers.value
             FROM s_emarketing_vouchers
-            WHERE  s_emarketing_vouchers.modus = 1 AND (s_emarketing_vouchers.valid_to >= now() OR s_emarketing_vouchers.valid_to is NULL)
-            AND (s_emarketing_vouchers.valid_from <= now() OR s_emarketing_vouchers.valid_from is NULL)
+            WHERE  s_emarketing_vouchers.modus = 1 AND (s_emarketing_vouchers.valid_to >= CURDATE() OR s_emarketing_vouchers.valid_to is NULL)
+            AND (s_emarketing_vouchers.valid_from <= CURDATE() OR s_emarketing_vouchers.valid_from is NULL)
             AND (
                 SELECT s_emarketing_voucher_codes.id
                 FROM s_emarketing_voucher_codes
@@ -286,7 +286,7 @@ class Shopware_Controllers_Backend_CanceledOrder extends Shopware_Controllers_Ba
                 ->leftJoin('voucher.codes', 'voucherCodes')
                 ->where('voucher.modus = ?1')
                 ->andWhere('voucher.id = :voucherId')
-                ->andWhere('voucher.validTo >= CURRENT_TIMESTAMP() OR voucher.validTo is NULL')
+                ->andWhere('voucher.validTo >= CURRENT_DATE() OR voucher.validTo is NULL')
                 ->andWhere('voucherCodes.customerId is NULL')
                 ->andWhere('voucherCodes.cashed = 0')
                 ->setParameter(1, 1)

--- a/engine/Shopware/Controllers/Backend/Newsletter.php
+++ b/engine/Shopware/Controllers/Backend/Newsletter.php
@@ -520,8 +520,8 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
         $sql = "
             SELECT ev.*, 'VOUCHER123' as code
             FROM s_emarketing_vouchers ev
-            WHERE  ev.modus = 1 AND (ev.valid_to >= NOW() OR ev.valid_to IS NULL)
-            AND (ev.valid_from <= NOW() OR ev.valid_from IS NULL)
+            WHERE  ev.modus = 1 AND (ev.valid_to >= CURDATE() OR ev.valid_to IS NULL)
+            AND (ev.valid_from <= CURDATE() OR ev.valid_from IS NULL)
             AND ev.id=?
         ";
         $voucher = Shopware()->Db()->fetchRow($sql, array($voucherID));

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -629,7 +629,7 @@ class sBasket
               WHERE modus != 1
               AND LOWER(vouchercode) = ?
               AND (
-                (valid_to >= now() AND valid_from <= now())
+                (valid_to >= CURDATE() AND valid_from <= CURDATE())
                 OR valid_to IS NULL
               )',
             array($voucherCode)
@@ -667,8 +667,8 @@ class sBasket
                     minimumcharge, shippingfree, bindtosupplier, taxconfig, valid_from,
                     valid_to, ordercode, modus, percental, strict, subshopID
                     FROM s_emarketing_vouchers WHERE modus = 1 AND id = ? AND (
-                      (valid_to >= now()
-                          AND valid_from <= now()
+                      (valid_to >= CURDATE()
+                          AND valid_from <= CURDATE()
                       )
                       OR valid_to is NULL
                 ) LIMIT 1',

--- a/engine/Shopware/Plugins/Default/Core/CronBirthday/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/CronBirthday/Bootstrap.php
@@ -86,7 +86,7 @@ class Shopware_Plugins_Core_CronBirthday_Bootstrap extends Shopware_Components_P
         $sql = '
             SELECT evc.voucherID
             FROM s_emarketing_vouchers ev, s_emarketing_voucher_codes evc
-            WHERE  modus = 1 AND (valid_to >= now() OR valid_to IS NULL)
+            WHERE  modus = 1 AND (valid_to >= CURDATE() OR valid_to IS NULL)
             AND evc.voucherID = ev.id
             AND evc.userID IS NULL
             AND evc.cashed = 0


### PR DESCRIPTION
This PR now compares the voucher validdate with the Date instad of the datetime from today so that the last day is now included to the days that you can use the voucher.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-12745 https://issues.shopware.com/#/issues/SW-15604 |
| How to test? | Set the valid_from date to something and the valit_to time of a voucher to the current date and check if you can use the voucher in the frontend. You should also make a check if its available on the next date at 0:00 . |
