### PR TITLE
[PAPERCUT] Sw 16036/5.2/extend local admins check

### DIFF
--- a/themes/Backend/ExtJs/backend/user_manager/view/roles/list.js
+++ b/themes/Backend/ExtJs/backend/user_manager/view/roles/list.js
@@ -70,14 +70,19 @@ Ext.define('Shopware.apps.UserManager.view.roles.List', {
                     }
                 },
                 beforeedit: function (editor, e) {
+                    var fields = me.getFieldsToLockForAdmin();
                     var form   = editor.getEditor().form;
-                    var field  = form.findField('name');
 
                     if (e.record.get('name') == 'local_admins') {
-                        field.disable();
-                    } else {
-                        field.enable();
+                        Ext.each(fields, function (field) {
+                            form.findField(field).disable();
+                        });
+                        return;
                     }
+
+                    Ext.each(fields, function(field) {
+                        form.findField(field).enable();
+                    });
                 }
             }
         });
@@ -163,6 +168,10 @@ Ext.define('Shopware.apps.UserManager.view.roles.List', {
 		this.dockedItems.push(this.toolbar);
 
 		this.callParent();
+    },
+
+    getFieldsToLockForAdmin: function() {
+        return ['name', 'admin', 'enabled'];
     },
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary?
  - You can deactivate the local admin group or mark it as none admin
- What does it improve?
  - Admin and active flag can only be reseted over database
- Does it have side effects?

| Questions | Answers |
| --- | --- |
| BC breaks? | yes/no |
| Tests pass? | yes/no |
| Related tickets? | If this PR fixes an existing [Issue](https://issues.shopware.com) ticket, please add its complete issue URL. |
| How to test? | Please describe how to best verify that this PR is correct. |
