### PR TITLE
[Papercut] SW-14598 - remove duplicate meta tag and set the right attribute

### DIFF
--- a/themes/Frontend/Bare/frontend/index/header.tpl
+++ b/themes/Frontend/Bare/frontend/index/header.tpl
@@ -40,13 +40,12 @@
 		<meta name="mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-title" content="{if $theme.appleWebAppTitle != ""}{$theme.appleWebAppTitle|escapeHtml}{else}{{config name=sShopname}|escapeHtml}{/if}">
 		<meta name="apple-mobile-web-app-capable" content="yes">
-		<meta name="apple-mobile-web-app-status-bar-style" content="black">
+		<meta name="apple-mobile-web-app-status-bar-style" content="default">
 	{/block}
 {/block}
 
 {* Set favicons and touch icons for all different sizes *}
 {block name="frontend_index_header_favicons"}
-    <meta name="apple-mobile-web-app-status-bar-style" content="none">
     <link rel="apple-touch-icon{if $theme.setPrecomposed}-precomposed{/if}" href="{link file=$theme.appleTouchIcon}">
 	<link rel="shortcut icon" href="{link file=$theme.favicon}">
 {/block}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary?  
  meta tag was duplicate and wrong. there is no option "content= none". furthermore is this meta tag not working atm. Apple bug.
- What does it improve?  
- Does it have side effects?  
  no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-14598 |
| How to test? |  |
