### PR TITLE
[Papercut][SW-15443] Use snippet for language dropdown.

### DIFF
--- a/themes/Frontend/Bare/widgets/index/shop_menu.tpl
+++ b/themes/Frontend/Bare/widgets/index/shop_menu.tpl
@@ -14,7 +14,7 @@
                                     <select name="__shop" class="language--select" data-auto-submit="true">
                                         {foreach $languages as $language}
                                             <option value="{$language->getId()}" {if $language->getId() === $shop->getId()}selected="selected"{/if}>
-                                                {$language->getName()}
+                                                {"shopname"|snippet:"frontend_shopname_{$language->getId()}":"frontend"}
                                             </option>
                                         {/foreach}
                                     </select>

--- a/themes/Frontend/Bare/widgets/index/shop_menu.tpl
+++ b/themes/Frontend/Bare/widgets/index/shop_menu.tpl
@@ -14,7 +14,7 @@
                                     <select name="__shop" class="language--select" data-auto-submit="true">
                                         {foreach $languages as $language}
                                             <option value="{$language->getId()}" {if $language->getId() === $shop->getId()}selected="selected"{/if}>
-                                                {"shopname"|snippet:"frontend_shopname_{$language->getId()}":"frontend"}
+                                                {{$language->getName()}|snippet:"frontend_shopname_{$language->getId()}":"frontend"}
                                             </option>
                                         {/foreach}
                                     </select>

--- a/themes/Frontend/Bare/widgets/index/shop_menu.tpl
+++ b/themes/Frontend/Bare/widgets/index/shop_menu.tpl
@@ -14,7 +14,8 @@
                                     <select name="__shop" class="language--select" data-auto-submit="true">
                                         {foreach $languages as $language}
                                             <option value="{$language->getId()}" {if $language->getId() === $shop->getId()}selected="selected"{/if}>
-                                                {{$language->getName()}|snippet:"frontend_shopname_{$language->getId()}":"frontend"}
+                                                {assign var=languageId value=$language->getId()}
+                                                {$language->getName()|snippet:"frontend_shopname_$languageId":"frontend"}
                                             </option>
                                         {/foreach}
                                     </select>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? 
  Als Text für das Sprachdropdown wird der jeweilige Shopname verwendet. Dies ist unpassend wenn der Shop nicht nach der jeweiligen Sprache benannt werden soll. 
- What does it improve?
  Der Text für das Sprachdropdown kann jetzt über Textbausteine unabhängig vom Shopnamen gesetzt werden.
- Does it have side effects?
  Nein.

| Questions | Answers |
| --- | --- |
| BC breaks? | yes |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-15443 |
| How to test? | Zwei Shops anlegen, in Textbausteinen frontend_shopname_\* die Namen setzen, Sprachdropdown prüfen. |
