### PR TITLE
[Papercut][SW-14342] Use helper methode to get the IP of customer

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -604,7 +604,7 @@ class sOrder
             'currency'             => $this->sSYSTEM->sCurrency["currency"],
             'currencyFactor'       => $this->sSYSTEM->sCurrency["factor"],
             'subshopID'            => $mainShop->getId(),
-            'remote_addr'          => (string) $_SERVER['REMOTE_ADDR'],
+            'remote_addr'          => (string) Shopware()->Front()->Request()->getClientIp(true),
             'deviceType'           => $this->deviceType
         );
 


### PR DESCRIPTION
## Description

Please describe your pull request:
- Why is it necessary?
  - get correct IP if the shop uses proxies like varnish
- What does it improve?
  - gathering of IPs
- Does it have side effects?
  - no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Related tickets? | [Issue](https://issues.shopware.com/#/issues/SW-14342) |
| How to test? | have a look in s_order if `remote_addr` is still set correctly. if you want, set up varnish, etc and test with proxy |
