### PR TITLE
[Papercut][SW-14292] move hardcoded star for price to snippet

### DIFF
--- a/snippets/frontend/checkout/ajax_cart.ini
+++ b/snippets/frontend/checkout/ajax_cart.ini
@@ -8,6 +8,7 @@ AjaxCartContinueShopping = "Continue shopping"
 AjaxCartTotalAmount = "Subtotal amount"
 AjaxCartRemoveArticle = "Remove product"
 AjaxCartSuccessText = "The product was successfully added to your shopping cart"
+Star = "*"
 
 [de_DE]
 AjaxCartInfoBundle = "BUNDLE RABATT"
@@ -19,4 +20,4 @@ AjaxCartContinueShopping = "Weiter einkaufen"
 AjaxCartTotalAmount = "Zwischensumme"
 AjaxCartRemoveArticle = "Artikel entfernen"
 AjaxCartSuccessText = "Der Artikel wurde erfolgreich in den Warenkorb gelegt"
-
+Star = "*"

--- a/themes/Frontend/Bare/frontend/checkout/ajax_cart_item.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/ajax_cart_item.tpl
@@ -1,3 +1,5 @@
+{namespace name="frontend/checkout/ajax_cart"}
+
 {* Constants for the different basket item types *}
 {$IS_PRODUCT = 0}
 {$IS_PREMIUM_PRODUCT = 1}
@@ -13,8 +15,8 @@
 
 <div class="cart--item{if $basketItem.modus == 1} is--premium-article{elseif $basketItem.modus == 10} is--bundle-article{/if}">
     {* Article image *}
-	{block name='frontend_checkout_ajax_cart_articleimage'}
-		<div class="thumbnail--container{if $basketItem.image.thumbnails[0]} has--image{/if}">
+    {block name='frontend_checkout_ajax_cart_articleimage'}
+        <div class="thumbnail--container{if $basketItem.image.thumbnails[0]} has--image{/if}">
 
             {* Real product *}
             {block name='frontend_checkout_ajax_cart_articleimage_product'}
@@ -24,10 +26,9 @@
                         {if $basketItem.additional_details.image.description}
                             {$desc = $basketItem.additional_details.image.description|escape}
                         {/if}
-                        <img srcset="{$basketItem.additional_details.image.thumbnails[0].sourceSet}" alt="{$desc}" title="{$desc|truncate:25:""}" class="thumbnail--image" />
-
+                        <img srcset="{$basketItem.additional_details.image.thumbnails[0].sourceSet}" alt="{$desc}" title="{$desc|truncate:25:""}" class="thumbnail--image"/>
                     {elseif $basketItem.image.src.0}
-                        <img src="{$basketItem.image.src.0}" alt="{$desc}" title="{$desc|truncate:25:""}" class="thumbnail--image" />
+                        <img src="{$basketItem.image.src.0}" alt="{$desc}" title="{$desc|truncate:25:""}" class="thumbnail--image"/>
                     {/if}
                 {/if}
             {/block}
@@ -36,7 +37,7 @@
             {block name='frontend_checkout_ajax_cart_articleimage_badge_premium'}
                 {if $basketItem.modus == $IS_PREMIUM_PRODUCT}
                     <span class="cart--badge">
-                        <span class="badge--free">{s name='AjaxCartInfoFree' namespace="frontend/checkout/ajax_cart"}{/s}</span>
+                        <span class="badge--free">{s name='AjaxCartInfoFree'}{/s}</span>
                     </span>
                 {/if}
             {/block}
@@ -75,8 +76,8 @@
                     </div>
                 {/if}
             {/block}
-		</div>
-	{/block}
+        </div>
+    {/block}
 
     {* Article actions *}
     {block name='frontend_checkout_ajax_cart_actions'}
@@ -89,7 +90,7 @@
 
             {if $basketItem.modus != 4}
                 <form action="{$deleteUrl}" method="post">
-                    <button type="submit" class="btn is--small action--remove" title="{s name="AjaxCartRemoveArticle" namespace="frontend/checkout/ajax_cart"}{/s}">
+                    <button type="submit" class="btn is--small action--remove" title="{s name="AjaxCartRemoveArticle"}{/s}">
                         <i class="icon--cross"></i>
                     </button>
                 </form>
@@ -100,34 +101,34 @@
     {* Article name *}
     {block name='frontend_checkout_ajax_cart_articlename'}
         {$useAnchor = ($basketItem.modus != 4 && $basketItem.modus != 2)}
-		{if $useAnchor}
-        	<a class="item--link" href="{$detailLink}" title="{$basketItem.articlename|escape}">
-		{else}
-			<div class="item--link">
-		{/if}
+        {if $useAnchor}
+            <a class="item--link" href="{$detailLink}" title="{$basketItem.articlename|escape}">
+        {else}
+            <div class="item--link">
+        {/if}
             {block name="frontend_checkout_ajax_cart_articlename_quantity"}
-				<span class="item--quantity">{$basketItem.quantity}x</span>
-			{/block}
-			{block name="frontend_checkout_ajax_cart_articlename_name"}
-				<span class="item--name">
-					{if $basketItem.modus == 10}
-						{s name='AjaxCartInfoBundle' namespace="frontend/checkout/ajax_cart"}{/s}
-					{else}
-						{if $theme.offcanvasCart}
-							{$basketItem.articlename}
-						{else}
-							{$basketItem.articlename|truncate:28:"...":true}
-						{/if}
-					{/if}
-				</span>
-			{/block}
-			{block name="frontend_checkout_ajax_cart_articlename_price"}
-				<span class="item--price">{if $basketItem.amount}{$basketItem.amount|currency}{else}{s name="AjaxCartInfoFree" namespace="frontend/checkout/ajax_cart"}{/s}{/if}*</span>
-			{/block}
-		{if $useAnchor}
-			</a>
-		{else}
-			</div>
-		{/if}
+                <span class="item--quantity">{$basketItem.quantity}x</span>
+            {/block}
+            {block name="frontend_checkout_ajax_cart_articlename_name"}
+                <span class="item--name">
+                    {if $basketItem.modus == 10}
+                        {s name='AjaxCartInfoBundle'}{/s}
+                    {else}
+                        {if $theme.offcanvasCart}
+                            {$basketItem.articlename}
+                        {else}
+                            {$basketItem.articlename|truncate:28:"...":true}
+                        {/if}
+                    {/if}
+                </span>
+            {/block}
+            {block name="frontend_checkout_ajax_cart_articlename_price"}
+                <span class="item--price">{if $basketItem.amount}{$basketItem.amount|currency}{else}{s name="AjaxCartInfoFree"}{/s}{/if}{s name="Star"}{/s}</span>
+            {/block}
+        {if $useAnchor}
+            </a>
+        {else}
+            </div>
+        {/if}
     {/block}
 </div>


### PR DESCRIPTION
## Description

Please describe your pull request:
- Why is it necessary?
  - to change the \* character in ajax cart
- What does it improve?
  - editing the star via snippet
- Does it have side effects?
  - no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | [Issue](https://issues.shopware.com/#/issues/SW-14292) |
| How to test? | change snippet frontend/checkout/ajax_cart/Star and have a look in the ajax cart, when putting product to cart |
