### PR TITLE
Add interfaces to additional core services

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -10,6 +10,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 * getOne function of customer api resource contains now the country and state data for billing and shipping address
 * Changed `jquery.search::onKeyboardNavigation()` method to provide more extension possibilities.
 * Deprecated the execution shopware.php via CLI. Please use the command line tool in `bin/console` instead.
+* Declared interfaces for`AttributeBundle` and `PluginInstallerBundle` services to allow for service decoration by plugins
 
 ## 5.2.6
 

--- a/engine/Shopware/Bundle/AccountBundle/Form/Account/AttributeFormType.php
+++ b/engine/Shopware/Bundle/AccountBundle/Form/Account/AttributeFormType.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Bundle\AccountBundle\Form\Account;
 
-use Shopware\Bundle\AttributeBundle\Service\CrudService;
+use Shopware\Bundle\AttributeBundle\Service\CrudServiceInterface;
 use Shopware\Components\Model\ModelManager;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,16 +38,17 @@ class AttributeFormType extends AbstractType
     private $entityManager;
 
     /**
-     * @var CrudService
+     * @var CrudServiceInterface
      */
     private $attributeService;
 
     /**
      * AttributeFormType constructor.
-     * @param ModelManager $entityManager
-     * @param CrudService $attributeService
+     *
+     * @param ModelManager         $entityManager
+     * @param CrudServiceInterface $attributeService
      */
-    public function __construct(ModelManager $entityManager, CrudService $attributeService)
+    public function __construct(ModelManager $entityManager, CrudServiceInterface $attributeService)
     {
         $this->entityManager = $entityManager;
         $this->attributeService = $attributeService;

--- a/engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/AttributeData.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/AttributeData.php
@@ -23,7 +23,9 @@
  */
 use Shopware\Bundle\AttributeBundle\Service\ConfigurationStruct;
 use Shopware\Bundle\AttributeBundle\Service\CrudService;
-use Shopware\Bundle\AttributeBundle\Service\DataLoader;
+use Shopware\Bundle\AttributeBundle\Service\CrudServiceInterface;
+use Shopware\Bundle\AttributeBundle\Service\DataLoaderInterface;
+use Shopware\Bundle\AttributeBundle\Service\DataPersisterInterface;
 
 /**
  * @category  Shopware
@@ -34,7 +36,7 @@ class Shopware_Controllers_Backend_AttributeData extends Shopware_Controllers_Ba
 {
     public function loadDataAction()
     {
-        /** @var DataLoader $dataLoader */
+        /** @var DataLoaderInterface $dataLoader */
         $dataLoader = $this->get('shopware_attribute.data_loader');
 
         try {
@@ -62,7 +64,7 @@ class Shopware_Controllers_Backend_AttributeData extends Shopware_Controllers_Ba
 
     public function saveDataAction()
     {
-        /** @var \Shopware\Bundle\AttributeBundle\Service\DataPersister $dataPersister */
+        /** @var DataPersisterInterface $dataPersister */
         $dataPersister = $this->get('shopware_attribute.data_persister');
 
         $data = [];
@@ -86,7 +88,7 @@ class Shopware_Controllers_Backend_AttributeData extends Shopware_Controllers_Ba
 
     public function listAction()
     {
-        /** @var CrudService $crudService */
+        /** @var CrudServiceInterface $crudService */
         $crudService = $this->get('shopware_attribute.crud_service');
         $columns = $crudService->getList(
             $this->Request()->getParam('table')

--- a/engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/Attributes.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/Attributes.php
@@ -22,10 +22,10 @@
  * our trademarks remain entirely with us.
  */
 
-use Shopware\Bundle\AttributeBundle\Service\CrudService;
-use Shopware\Bundle\AttributeBundle\Service\SchemaOperator;
-use Shopware\Bundle\AttributeBundle\Service\TableMapping;
-use Shopware\Bundle\AttributeBundle\Service\TypeMapping;
+use Shopware\Bundle\AttributeBundle\Service\CrudServiceInterface;
+use Shopware\Bundle\AttributeBundle\Service\SchemaOperatorInterface;
+use Shopware\Bundle\AttributeBundle\Service\TableMappingInterface;
+use Shopware\Bundle\AttributeBundle\Service\TypeMappingInterface;
 use Shopware\Components\Model\ModelManager;
 
 /**
@@ -46,7 +46,7 @@ class Shopware_Controllers_Backend_Attributes extends Shopware_Controllers_Backe
 
     public function getTablesAction()
     {
-        /** @var TableMapping $mapping */
+        /** @var TableMappingInterface $mapping */
         $mapping = $this->get('shopware_attribute.table_mapping');
         $tables = $mapping->getAttributeTables();
 
@@ -59,7 +59,7 @@ class Shopware_Controllers_Backend_Attributes extends Shopware_Controllers_Backe
 
     public function getTypesAction()
     {
-        /** @var TypeMapping $mapping */
+        /** @var TypeMappingInterface $mapping */
         $mapping = $this->get('shopware_attribute.type_mapping');
 
         $this->View()->assign([
@@ -70,7 +70,7 @@ class Shopware_Controllers_Backend_Attributes extends Shopware_Controllers_Backe
 
     public function getEntitiesAction()
     {
-        /** @var TypeMapping $mapping */
+        /** @var TypeMappingInterface $mapping */
         $mapping = $this->get('shopware_attribute.type_mapping');
 
         $this->View()->assign([
@@ -88,7 +88,7 @@ class Shopware_Controllers_Backend_Attributes extends Shopware_Controllers_Backe
             throw new Exception("Required parameter not found");
         }
 
-        /** @var SchemaOperator $schemaOperator */
+        /** @var SchemaOperatorInterface $schemaOperator */
         $schemaOperator = $this->get('shopware_attribute.schema_operator');
 
         try {
@@ -102,7 +102,7 @@ class Shopware_Controllers_Backend_Attributes extends Shopware_Controllers_Backe
 
     public function getColumnAction()
     {
-        /** @var CrudService $crudService */
+        /** @var CrudServiceInterface $crudService */
         $crudService = $this->get('shopware_attribute.crud_service');
         $columnName = $this->Request()->getParam('columnName');
 
@@ -124,7 +124,7 @@ class Shopware_Controllers_Backend_Attributes extends Shopware_Controllers_Backe
         $data = $this->Request()->getParams();
         $data['custom'] = true;
 
-        /** @var CrudService $service */
+        /** @var CrudServiceInterface $service */
         $service = $this->get('shopware_attribute.crud_service');
 
         try {
@@ -144,7 +144,7 @@ class Shopware_Controllers_Backend_Attributes extends Shopware_Controllers_Backe
 
     public function deleteAction()
     {
-        /** @var CrudService $service */
+        /** @var CrudServiceInterface $service */
         $service = $this->get('shopware_attribute.crud_service');
 
         try {
@@ -164,7 +164,7 @@ class Shopware_Controllers_Backend_Attributes extends Shopware_Controllers_Backe
     {
         $data = $this->Request()->getParams();
 
-        /** @var CrudService $service */
+        /** @var CrudServiceInterface $service */
         $service = $this->get('shopware_attribute.crud_service');
 
         try {
@@ -189,7 +189,7 @@ class Shopware_Controllers_Backend_Attributes extends Shopware_Controllers_Backe
     {
         $table = $this->Request()->getParam('tableName');
 
-        /** @var TableMapping $mapping */
+        /** @var TableMappingInterface $mapping */
         $mapping = $this->get('shopware_attribute.table_mapping');
 
         if (!$mapping->isAttributeTable($table) || !$table) {

--- a/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
@@ -32,7 +32,7 @@ use Shopware\Models\Attribute\Configuration;
  * @package   Shopware\Bundle\AttributeBundle\Service
  * @copyright Copyright (c) shopware AG (http://www.shopware.com)
  */
-class CrudService
+class CrudService implements CrudServiceInterface
 {
     const EXT_JS_PREFIX = '__attribute_';
     const NULL_STRING = 'NULL';
@@ -43,32 +43,33 @@ class CrudService
     private $entityManager;
 
     /**
-     * @var SchemaOperator
+     * @var SchemaOperatorInterface
      */
     private $schemaOperator;
 
     /**
-     * @var TableMapping
+     * @var TableMappingInterface
      */
     private $tableMapping;
 
     /**
-     * @var TypeMapping
+     * @var TypeMappingInterface
      */
     private $typeMapping;
 
     /**
      * CrudService constructor.
-     * @param ModelManager $entityManager
-     * @param SchemaOperator $schemaOperator
-     * @param TableMapping $tableMapping
-     * @param TypeMapping $typeMapping
+     *
+     * @param ModelManager            $entityManager
+     * @param SchemaOperatorInterface $schemaOperator
+     * @param TableMappingInterface   $tableMapping
+     * @param TypeMappingInterface    $typeMapping
      */
     public function __construct(
         ModelManager $entityManager,
-        SchemaOperator $schemaOperator,
-        TableMapping $tableMapping,
-        TypeMapping $typeMapping
+        SchemaOperatorInterface $schemaOperator,
+        TableMappingInterface $tableMapping,
+        TypeMappingInterface $typeMapping
     ) {
         $this->entityManager = $entityManager;
         $this->schemaOperator = $schemaOperator;

--- a/engine/Shopware/Bundle/AttributeBundle/Service/CrudServiceInterface.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/CrudServiceInterface.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\AttributeBundle\Service;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Bundle\AttributeBundle\Service
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+interface CrudServiceInterface
+{
+    /**
+     * @param string $table
+     * @param string $column
+     * @param bool   $updateDependingTables
+     *
+     * @throws \Exception
+     */
+    public function delete($table, $column, $updateDependingTables = false);
+
+    /**
+     * @param string                $table
+     * @param string                $columnName
+     * @param string                $unifiedType
+     * @param array                 $data
+     * @param null                  $newColumnName
+     * @param bool                  $updateDependingTables
+     * @param null|string|int|float $defaultValue
+     *
+     * @throws \Exception
+     */
+    public function update(
+        $table,
+        $columnName,
+        $unifiedType,
+        array $data = [],
+        $newColumnName = null,
+        $updateDependingTables = false,
+        $defaultValue = null
+    );
+
+    /**
+     * @param string $table
+     * @param string $columnName
+     *
+     * @return ConfigurationStruct|null
+     */
+    public function get($table, $columnName);
+
+    /**
+     * @param string $table
+     *
+     * @return ConfigurationStruct[]
+     */
+    public function getList($table);
+}

--- a/engine/Shopware/Bundle/AttributeBundle/Service/DataLoader.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/DataLoader.php
@@ -31,7 +31,7 @@ use Doctrine\DBAL\Connection;
  * @package   Shopware\Bundle\AttributeBundle\Service
  * @copyright Copyright (c) shopware AG (http://www.shopware.com)
  */
-class DataLoader
+class DataLoader implements DataLoaderInterface
 {
     /**
      * @var Connection
@@ -39,15 +39,15 @@ class DataLoader
     private $connection;
 
     /**
-     * @var TableMapping
+     * @var TableMappingInterface
      */
     private $mapping;
 
     /**
-     * @param Connection $connection
-     * @param TableMapping $mapping
+     * @param Connection            $connection
+     * @param TableMappingInterface $mapping
      */
-    public function __construct(Connection $connection, TableMapping $mapping)
+    public function __construct(Connection $connection, TableMappingInterface $mapping)
     {
         $this->connection = $connection;
         $this->mapping = $mapping;
@@ -69,7 +69,7 @@ class DataLoader
             throw new \Exception("No foreign key provided");
         }
 
-        /** @var TableMapping $mapping */
+        /** @var TableMappingInterface $mapping */
         $foreignKeyColumn = $this->mapping->getTableForeignKey($table);
 
         $query = $this->connection->createQueryBuilder();

--- a/engine/Shopware/Bundle/AttributeBundle/Service/DataLoaderInterface.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/DataLoaderInterface.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\AttributeBundle\Service;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Bundle\AttributeBundle\Service
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+interface DataLoaderInterface
+{
+    /**
+     * @param string $table
+     * @param string $foreignKey
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function load($table, $foreignKey);
+
+    /**
+     * @param string $table
+     * @param int    $foreignKey
+     *
+     * @return array[]
+     * @throws \Exception
+     */
+    public function loadTranslations($table, $foreignKey);
+}

--- a/engine/Shopware/Bundle/AttributeBundle/Service/DataPersister.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/DataPersister.php
@@ -34,7 +34,7 @@ use Shopware\Components\Model\DBAL\Types\DateTimeStringType;
  * @package   Shopware\Bundle\AttributeBundle\Service
  * @copyright Copyright (c) shopware AG (http://www.shopware.com)
  */
-class DataPersister
+class DataPersister implements DataPersisterInterface
 {
     /**
      * @var Connection
@@ -42,22 +42,23 @@ class DataPersister
     private $connection;
 
     /**
-     * @var TableMapping
+     * @var TableMappingInterface
      */
     private $mapping;
 
     /**
-     * @var DataLoader
+     * @var DataLoaderInterface
      */
     private $dataLoader;
 
     /**
      * DataPersister constructor.
-     * @param Connection $connection
-     * @param TableMapping $mapping
-     * @param DataLoader $dataLoader
+     *
+     * @param Connection            $connection
+     * @param TableMappingInterface $mapping
+     * @param DataLoaderInterface   $dataLoader
      */
-    public function __construct(Connection $connection, TableMapping $mapping, DataLoader $dataLoader)
+    public function __construct(Connection $connection, TableMappingInterface $mapping, DataLoaderInterface $dataLoader)
     {
         $this->connection = $connection;
         $this->mapping = $mapping;
@@ -155,7 +156,7 @@ class DataPersister
             $query->setValue($key, ':' . $key);
             $query->setParameter(':' . $key, $value);
         }
-        
+
         $query->execute();
     }
 
@@ -206,7 +207,7 @@ class DataPersister
      */
     private function filter($table, $data)
     {
-        /** @var TableMapping $mapping */
+        /** @var TableMappingInterface $mapping */
         $columns = $this->mapping->getTableColumns($table);
 
         $result = [];

--- a/engine/Shopware/Bundle/AttributeBundle/Service/DataPersisterInterface.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/DataPersisterInterface.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\AttributeBundle\Service;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Bundle\AttributeBundle\Service
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+interface DataPersisterInterface
+{
+    /**
+     * Persists the provided data into the provided attribute table.
+     * Only attribute tables supported.
+     *
+     * @param string     $table
+     * @param array      $data
+     * @param int|string $foreignKey
+     *
+     * @throws \Exception
+     */
+    public function persist($data, $table, $foreignKey);
+
+    /**
+     * @param string $table
+     * @param int    $sourceForeignKey
+     * @param int    $targetForeignKey
+     *
+     * @throws \Exception
+     */
+    public function cloneAttribute($table, $sourceForeignKey, $targetForeignKey);
+
+    /**
+     * @param string $table
+     * @param int    $sourceForeignKey
+     * @param int    $targetForeignKey
+     *
+     * @throws \Exception
+     */
+    public function cloneAttributeTranslations($table, $sourceForeignKey, $targetForeignKey);
+}

--- a/engine/Shopware/Bundle/AttributeBundle/Service/SchemaOperator.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/SchemaOperator.php
@@ -31,7 +31,7 @@ use Doctrine\DBAL\Connection;
  * @package   Shopware\Bundle\AttributeBundle\Service
  * @copyright Copyright (c) shopware AG (http://www.shopware.com)
  */
-class SchemaOperator
+class SchemaOperator implements SchemaOperatorInterface
 {
     /**
      * @var Connection
@@ -39,7 +39,7 @@ class SchemaOperator
     private $connection;
 
     /**
-     * @var TableMapping
+     * @var TableMappingInterface
      */
     private $tableMapping;
 
@@ -50,10 +50,11 @@ class SchemaOperator
 
     /**
      * SchemaOperator constructor.
-     * @param Connection $connection
-     * @param TableMapping $tableMapping
+     *
+     * @param Connection            $connection
+     * @param TableMappingInterface $tableMapping
      */
-    public function __construct(Connection $connection, TableMapping $tableMapping)
+    public function __construct(Connection $connection, TableMappingInterface $tableMapping)
     {
         $this->connection = $connection;
         $this->tableMapping = $tableMapping;

--- a/engine/Shopware/Bundle/AttributeBundle/Service/SchemaOperatorInterface.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/SchemaOperatorInterface.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\AttributeBundle\Service;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Bundle\AttributeBundle\Service
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+interface SchemaOperatorInterface
+{
+    /**
+     * @param string                $table
+     * @param string                $column
+     * @param string                $type
+     * @param null|string|int|float $defaultValue
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Exception
+     */
+    public function createColumn($table, $column, $type, $defaultValue = null);
+
+    /**
+     * @param string                $table
+     * @param string                $originalName
+     * @param string                $newName
+     * @param string                $type
+     * @param null|string|int|float $defaultValue
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Exception
+     */
+    public function changeColumn($table, $originalName, $newName, $type, $defaultValue = null);
+
+    /**
+     * @param string $table
+     * @param string $column
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Exception
+     */
+    public function dropColumn($table, $column);
+
+    /**
+     * Updates the provided column data to sql NULL value
+     *
+     * @param string $table
+     * @param string $column
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Exception
+     */
+    public function resetColumn($table, $column);
+}

--- a/engine/Shopware/Bundle/AttributeBundle/Service/TableMapping.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/TableMapping.php
@@ -32,7 +32,7 @@ use Doctrine\DBAL\Schema\Column;
  * @package   Shopware\Bundle\AttributeBundle\Service
  * @copyright Copyright (c) shopware AG (http://www.shopware.com)
  */
-class TableMapping
+class TableMapping implements TableMappingInterface
 {
     /**
      * @var Connection

--- a/engine/Shopware/Bundle/AttributeBundle/Service/TableMappingInterface.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/TableMappingInterface.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\AttributeBundle\Service;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Bundle\AttributeBundle\Service
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+interface TableMappingInterface
+{
+    /**
+     * @param string $table
+     * @param string $name
+     *
+     * @return bool
+     * @throws \Exception
+     */
+    public function isIdentifierColumn($table, $name);
+
+    /**
+     * @param string $table
+     * @param string $name
+     *
+     * @return bool
+     * @throws \Exception
+     */
+    public function isCoreColumn($table, $name);
+
+    /**
+     * @param $table
+     *
+     * @return null|string
+     */
+    public function getTableModel($table);
+
+    /**
+     * @return string[]
+     */
+    public function getAttributeTables();
+
+    /**
+     * @param $table
+     *
+     * @return string
+     */
+    public function getTableForeignKey($table);
+
+    /**
+     * @param string $table
+     *
+     * @return bool
+     */
+    public function isAttributeTable($table);
+
+    /**
+     * @param string $table
+     * @param string $column
+     *
+     * @return bool
+     */
+    public function isTableColumn($table, $column);
+
+    /**
+     * @param string $table
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function getDependingTables($table);
+
+    /**
+     * @param string $table
+     *
+     * @return \Doctrine\DBAL\Schema\Column[]
+     */
+    public function getTableColumns($table);
+}

--- a/engine/Shopware/Bundle/AttributeBundle/Service/TypeMapping.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/TypeMapping.php
@@ -31,7 +31,7 @@ use Doctrine\DBAL\Types\Type;
  * @package   Shopware\Bundle\AttributeBundle\Service
  * @copyright Copyright (c) shopware AG (http://www.shopware.com)
  */
-class TypeMapping
+class TypeMapping implements TypeMappingInterface
 {
     const TYPE_STRING = 'string';
     const TYPE_TEXT = 'text';

--- a/engine/Shopware/Bundle/AttributeBundle/Service/TypeMappingInterface.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/TypeMappingInterface.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\AttributeBundle\Service;
+
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Bundle\AttributeBundle\Service
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+interface TypeMappingInterface
+{
+    /**
+     * @return array
+     */
+    public function getTypes();
+
+    /**
+     * @return string[]
+     */
+    public function getEntities();
+
+    /**
+     * @param Type $type
+     *
+     * @return string
+     */
+    public function dbalToUnified(Type $type);
+
+    /**
+     * @param string $type
+     *
+     * @return string
+     */
+    public function unifiedToSQL($type);
+
+    /**
+     * @param string $unified
+     *
+     * @return array
+     */
+    public function unifiedToElasticSearch($unified);
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/AccountManagerService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/AccountManagerService.php
@@ -26,25 +26,25 @@ namespace Shopware\Bundle\PluginInstallerBundle\Service;
 
 use GuzzleHttp\ClientInterface;
 use Shopware\Bundle\PluginInstallerBundle\Exception\StoreException;
-use Shopware\Bundle\PluginInstallerBundle\StoreClient;
+use Shopware\Bundle\PluginInstallerBundle\StoreClientInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\LocaleStruct;
-use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydrator;
+use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydratorInterface;
 use Shopware\Components\HttpClient\GuzzleFactory;
 use Shopware\Components\Model\ModelManager;
 
 /**
  * @package Shopware\Bundle\PluginInstallerBundle\Service
  */
-class AccountManagerService
+class AccountManagerService implements AccountManagerServiceInterface
 {
     /**
-     * @var StoreClient
+     * @var StoreClientInterface
      */
     private $storeClient;
 
     /**
-     * @var StructHydrator
+     * @var StructHydratorInterface
      */
     private $hydrator;
 
@@ -69,17 +69,18 @@ class AccountManagerService
     private $apiEndPoint;
 
     /**
-     * @param StoreClient $storeClient
-     * @param StructHydrator $structHydrator
+     * @param StoreClientInterface                 $storeClient
+     * @param StructHydratorInterface              $structHydrator
      * @param \Shopware_Components_Snippet_Manager $snippetManager
-     * @param ModelManager $entityManager
-     * @param GuzzleFactory $guzzleFactory
-     * @param String $apiEndPoint
+     * @param ModelManager                         $entityManager
+     * @param GuzzleFactory                        $guzzleFactory
+     * @param String                               $apiEndPoint
+     *
      * @internal param ClientInterface $guzzleHttpClient
      */
     public function __construct(
-        StoreClient $storeClient,
-        StructHydrator $structHydrator,
+        StoreClientInterface $storeClient,
+        StructHydratorInterface $structHydrator,
         \Shopware_Components_Snippet_Manager $snippetManager,
         ModelManager $entityManager,
         GuzzleFactory $guzzleFactory,

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/AccountManagerServiceInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/AccountManagerServiceInterface.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
+use Shopware\Bundle\PluginInstallerBundle\Struct\LocaleStruct;
+
+/**
+ * @package Shopware\Bundle\PluginInstallerBundle\Service
+ */
+interface AccountManagerServiceInterface
+{
+    /**
+     * @return string
+     */
+    public function getDomain();
+
+    /**
+     * Pings SBP to see if a connection is available and the service is up
+     *
+     * @throws \Exception
+     * @return boolean
+     */
+    public function pingServer();
+
+    /**
+     * Requests the creation of a new Shopware ID anc account (registration action)
+     *
+     * @param string $shopwareId
+     * @param string $email
+     * @param string $password
+     * @param int    $localeId
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function registerAccount($shopwareId, $email, $password, $localeId);
+
+    /**
+     * Gets a list of locales supported by the SBP
+     *
+     * @return LocaleStruct[] array of locale details
+     * @throws \Exception
+     */
+    public function getLocales();
+
+    /**
+     * Get the list of shops (and details) associated to the given user
+     *
+     * @param AccessTokenStruct $token
+     *
+     * @return array Array of shop details
+     * @throws \Exception
+     */
+    public function getShops(AccessTokenStruct $token);
+
+    /**
+     * Requests the domain hash and filename needed to generate the
+     * validation key, so that the current domain can be validated
+     *
+     * @param string            $domain
+     * @param AccessTokenStruct $token
+     *
+     * @return array Filename and domain hash of the domain validation file
+     * @throws \Exception
+     */
+    public function getDomainHash($domain, AccessTokenStruct $token);
+
+    /**
+     * Requests the validation of the current installation's domain
+     *
+     * @param string            $domain
+     * @param string            $shopwareVersion Current Shopware version
+     * @param AccessTokenStruct $token
+     *
+     * @return array Result of the validation operation (empty if successful)
+     * @throws \Exception
+     */
+    public function verifyDomain($domain, $shopwareVersion, AccessTokenStruct $token);
+
+    /**
+     * Gets an access token from the server using the provided auth credentials
+     *
+     * @param string $shopwareId
+     * @param string $password
+     *
+     * @return AccessTokenStruct Token to access the API
+     * @throws \Exception
+     */
+    public function getToken($shopwareId = null, $password = null);
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/DownloadService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/DownloadService.php
@@ -28,7 +28,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Bundle\PluginInstallerBundle\Context\DownloadRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\RangeDownloadRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\MetaRequest;
-use Shopware\Bundle\PluginInstallerBundle\StoreClient;
+use Shopware\Bundle\PluginInstallerBundle\StoreClientInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\MetaStruct;
 use ShopwarePlugins\SwagUpdate\Components\Steps\DownloadStep;
 use ShopwarePlugins\SwagUpdate\Components\Steps\FinishResult;
@@ -39,10 +39,10 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @package Shopware\Bundle\PluginInstallerBundle\Service
  */
-class DownloadService
+class DownloadService implements DownloadServiceInterface
 {
     /**
-     * @var StoreClient
+     * @var StoreClientInterface
      */
     private $storeClient;
 
@@ -62,15 +62,15 @@ class DownloadService
     private $rootDir;
 
     /**
-     * @param string $rootDir
-     * @param array $pluginDirectories
-     * @param StoreClient $storeClient
-     * @param Connection $connection
+     * @param string               $rootDir
+     * @param array                $pluginDirectories
+     * @param StoreClientInterface $storeClient
+     * @param Connection           $connection
      */
     public function __construct(
         $rootDir,
         array $pluginDirectories,
-        StoreClient $storeClient,
+        StoreClientInterface $storeClient,
         Connection $connection
     ) {
         $this->pluginDirectories = $pluginDirectories;

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/DownloadServiceInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/DownloadServiceInterface.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Shopware\Bundle\PluginInstallerBundle\Context\DownloadRequest;
+use Shopware\Bundle\PluginInstallerBundle\Context\MetaRequest;
+use Shopware\Bundle\PluginInstallerBundle\Context\RangeDownloadRequest;
+use Shopware\Bundle\PluginInstallerBundle\Struct\MetaStruct;
+use ShopwarePlugins\SwagUpdate\Components\Steps\FinishResult;
+use ShopwarePlugins\SwagUpdate\Components\Steps\ValidResult;
+
+/**
+ * @package Shopware\Bundle\PluginInstallerBundle\Service
+ */
+interface DownloadServiceInterface
+{
+    /**
+     * @param RangeDownloadRequest $request
+     *
+     * @return FinishResult|ValidResult
+     */
+    public function downloadRange(RangeDownloadRequest $request);
+
+    /**
+     * @param string $file
+     * @param string $pluginName
+     *
+     * @throws \Exception
+     */
+    public function extractPluginZip($file, $pluginName);
+
+    /**
+     * @param MetaRequest $request
+     *
+     * @return MetaStruct
+     */
+    public function getMetaInformation(MetaRequest $request);
+
+    /**
+     * @param DownloadRequest $request
+     *
+     * @return bool
+     */
+    public function download(DownloadRequest $request);
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/FirstRunWizardPluginStoreService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/FirstRunWizardPluginStoreService.php
@@ -24,32 +24,32 @@
 namespace Shopware\Bundle\PluginInstallerBundle\Service;
 
 use Shopware\Bundle\PluginInstallerBundle\Context\PluginsByTechnicalNameRequest;
-use Shopware\Bundle\PluginInstallerBundle\StoreClient;
+use Shopware\Bundle\PluginInstallerBundle\StoreClientInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\LocaleStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\PluginStruct;
-use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydrator;
+use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydratorInterface;
 
 class FirstRunWizardPluginStoreService
 {
     /**
-     * @var StoreClient
+     * @var StoreClientInterface
      */
     private $storeClient;
 
     /**
-     * @var StructHydrator
+     * @var StructHydratorInterface
      */
     private $hydrator;
 
     /**
-     * @var PluginLocalService
+     * @var PluginLocalServiceInterface
      */
     private $localPluginService;
 
     public function __construct(
-        StructHydrator $hydrator,
-        PluginLocalService $localPluginService,
-        StoreClient $storeClient
+        StructHydratorInterface $hydrator,
+        PluginLocalServiceInterface $localPluginService,
+        StoreClientInterface $storeClient
     ) {
         $this->hydrator = $hydrator;
         $this->localPluginService = $localPluginService;

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/InstallerService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/InstallerService.php
@@ -35,7 +35,7 @@ use Shopware\Components\Plugin\Context\UpdateContext;
 use Shopware\Models\Plugin\Plugin;
 use Shopware\Models\Shop\Shop;
 
-class InstallerService
+class InstallerService implements InstallerServiceInterface
 {
     /**
      * @var ModelManager
@@ -63,26 +63,26 @@ class InstallerService
     private $configWriter;
 
     /**
-     * @var LegacyPluginInstaller
+     * @var LegacyPluginInstallerInterface
      */
     private $legacyPluginInstaller;
 
     /**
-     * @var PluginInstaller
+     * @var PluginInstallerInterface
      */
     private $pluginInstaller;
 
     /**
-     * @param ModelManager $em
-     * @param PluginInstaller $pluginInstaller
-     * @param LegacyPluginInstaller $legacyPluginInstaller
-     * @param ConfigWriter $configWriter
-     * @param ConfigReader $configReader
+     * @param ModelManager                   $em
+     * @param PluginInstallerInterface       $pluginInstaller
+     * @param LegacyPluginInstallerInterface $legacyPluginInstaller
+     * @param ConfigWriter                   $configWriter
+     * @param ConfigReader                   $configReader
      */
     public function __construct(
         ModelManager $em,
-        PluginInstaller $pluginInstaller,
-        LegacyPluginInstaller $legacyPluginInstaller,
+        PluginInstallerInterface $pluginInstaller,
+        LegacyPluginInstallerInterface $legacyPluginInstaller,
         ConfigWriter $configWriter,
         ConfigReader $configReader
     ) {

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/InstallerServiceInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/InstallerServiceInterface.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Shopware\Components\Plugin\Context\ActivateContext;
+use Shopware\Components\Plugin\Context\DeactivateContext;
+use Shopware\Components\Plugin\Context\InstallContext;
+use Shopware\Components\Plugin\Context\UninstallContext;
+use Shopware\Components\Plugin\Context\UpdateContext;
+use Shopware\Models\Plugin\Plugin;
+use Shopware\Models\Shop\Shop;
+
+interface InstallerServiceInterface
+{
+    /**
+     * @param string $pluginName
+     *
+     * @return string
+     * @throws \Exception
+     */
+    public function getPluginPath($pluginName);
+
+    /**
+     * @param string $pluginName
+     *
+     * @throws \Exception
+     * @return Plugin
+     */
+    public function getPluginByName($pluginName);
+
+    /**
+     * Returns a certain plugin by plugin id.
+     *
+     * @param Plugin $plugin
+     *
+     * @return \Shopware_Components_Plugin_Bootstrap|null
+     */
+    public function getPluginBootstrap(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return InstallContext
+     * @throws \Exception
+     */
+    public function installPlugin(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     * @param bool   $removeData
+     *
+     * @return UninstallContext
+     * @throws \Exception
+     */
+    public function uninstallPlugin(Plugin $plugin, $removeData = true);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return UpdateContext
+     * @throws \Exception
+     */
+    public function updatePlugin(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return ActivateContext
+     * @throws \Exception
+     */
+    public function activatePlugin(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return DeactivateContext
+     * @throws \Exception
+     */
+    public function deactivatePlugin(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     * @param Shop   $shop
+     *
+     * @return array
+     */
+    public function getPluginConfig(Plugin $plugin, Shop $shop = null);
+
+    /**
+     * @param Plugin $plugin
+     * @param array  $elements
+     * @param Shop   $shop
+     */
+    public function savePluginConfig(Plugin $plugin, $elements, Shop $shop = null);
+
+    /**
+     * @param Plugin $plugin
+     * @param string $name
+     * @param mixed  $value
+     * @param Shop   $shop
+     *
+     * @throws \Exception
+     */
+    public function saveConfigElement(Plugin $plugin, $name, $value, Shop $shop = null);
+
+    public function refreshPluginList();
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/LegacyPluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/LegacyPluginInstaller.php
@@ -27,7 +27,7 @@ namespace Shopware\Bundle\PluginInstallerBundle\Service;
 use Shopware\Models\Plugin\Plugin;
 use Shopware\Components\Model\ModelManager;
 
-class LegacyPluginInstaller
+class LegacyPluginInstaller implements LegacyPluginInstallerInterface
 {
     /**
      * @var ModelManager

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/LegacyPluginInstallerInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/LegacyPluginInstallerInterface.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Shopware\Models\Plugin\Plugin;
+
+interface LegacyPluginInstallerInterface
+{
+    /**
+     * Returns a certain plugin by plugin id.
+     *
+     * @param Plugin $plugin
+     *
+     * @return \Shopware_Components_Plugin_Bootstrap|null
+     */
+    public function getPluginBootstrap(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function installPlugin(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     * @param bool   $removeData
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function uninstallPlugin(Plugin $plugin, $removeData = true);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function updatePlugin(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function activatePlugin(Plugin $plugin);
+
+    /**
+     * @inheritdoc
+     */
+    public function deactivatePlugin(Plugin $plugin);
+
+    /**
+     * @inheritdoc
+     */
+    public function refreshPluginList(\DateTimeInterface $refreshDate);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return string
+     * @throws \Exception
+     */
+    public function getPluginPath(Plugin $plugin);
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
@@ -42,7 +42,7 @@ use Shopware\Components\Plugin\XmlMenuReader;
 use Shopware\Components\Plugin\XmlConfigDefinitionReader;
 use Shopware\Components\Plugin\XmlPluginInfoReader;
 
-class PluginInstaller
+class PluginInstaller implements PluginInstallerInterface
 {
     /**
      * @var ModelManager

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstallerInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstallerInterface.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Shopware\Components\Plugin\Context\ActivateContext;
+use Shopware\Components\Plugin\Context\DeactivateContext;
+use Shopware\Components\Plugin\Context\InstallContext;
+use Shopware\Components\Plugin\Context\UninstallContext;
+use Shopware\Components\Plugin\Context\UpdateContext;
+use Shopware\Models\Plugin\Plugin;
+
+interface PluginInstallerInterface
+{
+    /**
+     * @param Plugin $plugin
+     *
+     * @return InstallContext
+     * @throws \Exception
+     */
+    public function installPlugin(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     * @param bool   $removeData
+     *
+     * @return UninstallContext
+     */
+    public function uninstallPlugin(Plugin $plugin, $removeData = true);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return UpdateContext
+     * @throws \Exception
+     */
+    public function updatePlugin(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return ActivateContext
+     */
+    public function activatePlugin(Plugin $plugin);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return DeactivateContext
+     */
+    public function deactivatePlugin(Plugin $plugin);
+
+    /**
+     * @param \DateTimeInterface $refreshDate
+     */
+    public function refreshPluginList(\DateTimeInterface $refreshDate);
+
+    /**
+     * @param Plugin $plugin
+     *
+     * @return string
+     */
+    public function getPluginPath(Plugin $plugin);
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLicenceService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLicenceService.php
@@ -26,11 +26,11 @@ namespace Shopware\Bundle\PluginInstallerBundle\Service;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Bundle\PluginInstallerBundle\Context\UpdateLicencesRequest;
-use Shopware\Bundle\PluginInstallerBundle\StoreClient;
+use Shopware\Bundle\PluginInstallerBundle\StoreClientInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\PluginInformationStruct;
 use Shopware\Components\License\Service\LocalLicenseUnpackService;
 
-class PluginLicenceService
+class PluginLicenceService implements PluginLicenceServiceInterface
 {
     const TYPE_UNLICENSED = 99;
 
@@ -40,12 +40,12 @@ class PluginLicenceService
     private $connection;
 
     /**
-     * @var InstallerService
+     * @var InstallerServiceInterface
      */
     private $installer;
 
     /**
-     * @var StoreClient
+     * @var StoreClientInterface
      */
     private $storeClient;
 
@@ -55,15 +55,15 @@ class PluginLicenceService
     private $unpackService;
 
     /**
-     * @param Connection $connection
-     * @param InstallerService $installer
-     * @param StoreClient $storeClient
+     * @param Connection                $connection
+     * @param InstallerServiceInterface $installer
+     * @param StoreClientInterface      $storeClient
      * @param LocalLicenseUnpackService $unpackService
      */
     public function __construct(
         Connection $connection,
-        InstallerService $installer,
-        StoreClient $storeClient,
+        InstallerServiceInterface $installer,
+        StoreClientInterface $storeClient,
         LocalLicenseUnpackService $unpackService
     ) {
         $this->connection = $connection;

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLicenceServiceInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLicenceServiceInterface.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Shopware\Bundle\PluginInstallerBundle\Context\UpdateLicencesRequest;
+use Shopware\Bundle\PluginInstallerBundle\Struct\PluginInformationStruct;
+
+interface PluginLicenceServiceInterface
+{
+    /**
+     * @param string $licenceKey
+     *
+     * @return int
+     */
+    public function importLicence($licenceKey);
+
+    /**
+     * @param UpdateLicencesRequest $request
+     *
+     * @return array
+     */
+    public function updateLicences(UpdateLicencesRequest $request);
+
+    /**
+     * function to get expired and soon expiring plugins
+     *
+     * @return PluginInformationStruct[]
+     */
+    public function getExpiringLicenses();
+
+    /**
+     * function to get only expired plugins
+     *
+     * @return PluginInformationStruct[]
+     */
+    public function getExpiredLicenses();
+
+    /**
+     * @param PluginInformationStruct[] $pluginInformation
+     * @param string                    $domain
+     */
+    public function updateLocalLicenseInformation(array $pluginInformation, $domain);
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLocalService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLocalService.php
@@ -30,13 +30,13 @@ use Shopware\Bundle\PluginInstallerBundle\Context\ListingRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\PluginsByTechnicalNameRequest;
 use Shopware\Bundle\PluginInstallerBundle\Struct\ListingResultStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\PluginStruct;
-use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydrator;
+use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydratorInterface;
 
 /**
  * Class PluginLocalService
  * @package Shopware\Bundle\PluginInstallerBundle\Service
  */
-class PluginLocalService
+class PluginLocalService implements PluginLocalServiceInterface
 {
     /**
      * @var Connection
@@ -44,15 +44,15 @@ class PluginLocalService
     private $connection;
 
     /**
-     * @var StructHydrator
+     * @var StructHydratorInterface
      */
     private $hydrator;
 
     /**
-     * @param Connection $connection
-     * @param StructHydrator $hydrator
+     * @param Connection              $connection
+     * @param StructHydratorInterface $hydrator
      */
-    public function __construct(Connection $connection, StructHydrator $hydrator)
+    public function __construct(Connection $connection, StructHydratorInterface $hydrator)
     {
         $this->connection = $connection;
         $this->hydrator = $hydrator;

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLocalServiceInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLocalServiceInterface.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Shopware\Bundle\PluginInstallerBundle\Context\ListingRequest;
+use Shopware\Bundle\PluginInstallerBundle\Context\PluginsByTechnicalNameRequest;
+use Shopware\Bundle\PluginInstallerBundle\Struct\ListingResultStruct;
+use Shopware\Bundle\PluginInstallerBundle\Struct\PluginStruct;
+
+/**
+ * Class PluginLocalService
+ *
+ * @package Shopware\Bundle\PluginInstallerBundle\Service
+ */
+interface PluginLocalServiceInterface
+{
+    /**
+     * @param ListingRequest $context
+     *
+     * @return ListingResultStruct
+     */
+    public function getListing(ListingRequest $context);
+
+    /**
+     * @param PluginsByTechnicalNameRequest $context
+     *
+     * @return PluginStruct
+     */
+    public function getPlugin(PluginsByTechnicalNameRequest $context);
+
+    /**
+     * @param PluginsByTechnicalNameRequest $context
+     *
+     * @return PluginStruct[]
+     */
+    public function getPlugins(PluginsByTechnicalNameRequest $context);
+
+    /**
+     * @return array indexed by technical name, value contains the version
+     */
+    public function getPluginsForUpdateCheck();
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginStoreService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginStoreService.php
@@ -29,37 +29,37 @@ use Shopware\Bundle\PluginInstallerBundle\Context\ListingRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\PluginLicenceRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\PluginsByTechnicalNameRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\UpdateListingRequest;
-use Shopware\Bundle\PluginInstallerBundle\StoreClient;
+use Shopware\Bundle\PluginInstallerBundle\StoreClientInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\CategoryStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\LicenceStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\ListingResultStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\PluginStruct;
-use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydrator;
+use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydratorInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\UpdateResultStruct;
 
 /**
  * Class PluginStoreService
  * @package Shopware\Bundle\PluginInstallerBundle\Service
  */
-class PluginStoreService
+class PluginStoreService implements PluginStoreServiceInterface
 {
     /**
-     * @var StoreClient
+     * @var StoreClientInterface
      */
     private $storeClient;
 
     /**
-     * @var StructHydrator
+     * @var StructHydratorInterface
      */
     private $hydrator;
 
     /**
-     * @param StoreClient $storeClient
-     * @param StructHydrator $hydrator
+     * @param StoreClientInterface    $storeClient
+     * @param StructHydratorInterface $hydrator
      */
     public function __construct(
-        StoreClient $storeClient,
-        StructHydrator $hydrator
+        StoreClientInterface $storeClient,
+        StructHydratorInterface $hydrator
     ) {
         $this->storeClient = $storeClient;
         $this->hydrator = $hydrator;
@@ -142,7 +142,7 @@ class PluginStoreService
                 'plugins' => $context->getPlugins()
             ]
         );
-        
+
         $plugins = $this->hydrator->hydrateStorePlugins($result['data']);
         $gtcAcceptanceRequired = isset($result['gtcAcceptanceRequired']) ? $result['gtcAcceptanceRequired'] : false;
         $result = new UpdateResultStruct($plugins, $gtcAcceptanceRequired);

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginStoreServiceInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginStoreServiceInterface.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Shopware\Bundle\PluginInstallerBundle\Context\LicenceRequest;
+use Shopware\Bundle\PluginInstallerBundle\Context\ListingRequest;
+use Shopware\Bundle\PluginInstallerBundle\Context\PluginLicenceRequest;
+use Shopware\Bundle\PluginInstallerBundle\Context\PluginsByTechnicalNameRequest;
+use Shopware\Bundle\PluginInstallerBundle\Context\UpdateListingRequest;
+use Shopware\Bundle\PluginInstallerBundle\Struct\CategoryStruct;
+use Shopware\Bundle\PluginInstallerBundle\Struct\LicenceStruct;
+use Shopware\Bundle\PluginInstallerBundle\Struct\ListingResultStruct;
+use Shopware\Bundle\PluginInstallerBundle\Struct\PluginStruct;
+use Shopware\Bundle\PluginInstallerBundle\Struct\UpdateResultStruct;
+
+/**
+ * Class PluginStoreService
+ *
+ * @package Shopware\Bundle\PluginInstallerBundle\Service
+ */
+interface PluginStoreServiceInterface
+{
+    /**
+     * @param ListingRequest $context
+     *
+     * @return ListingResultStruct
+     * @throws \Exception
+     */
+    public function getListing(ListingRequest $context);
+
+    /**
+     * @param PluginsByTechnicalNameRequest $context
+     *
+     * @return PluginStruct
+     */
+    public function getPlugin(PluginsByTechnicalNameRequest $context);
+
+    /**
+     * @param PluginsByTechnicalNameRequest $context
+     *
+     * @return PluginStruct[]
+     */
+    public function getPlugins(PluginsByTechnicalNameRequest $context);
+
+    /**
+     * @param UpdateListingRequest $context
+     *
+     * @return UpdateResultStruct
+     * @throws \Exception
+     */
+    public function getUpdates(UpdateListingRequest $context);
+
+    /**
+     * @param PluginLicenceRequest $context
+     *
+     * @return LicenceStruct
+     */
+    public function getPluginLicence(PluginLicenceRequest $context);
+
+    /**
+     * @param LicenceRequest $context
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function getLicences(LicenceRequest $context);
+
+    /**
+     * @return CategoryStruct[]
+     * @throws \Exception
+     */
+    public function getCategories();
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginViewService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginViewService.php
@@ -30,39 +30,39 @@ use Shopware\Bundle\PluginInstallerBundle\Context\PluginsByTechnicalNameRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\UpdateListingRequest;
 use Shopware\Bundle\PluginInstallerBundle\Struct\ListingResultStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\PluginStruct;
-use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydrator;
+use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydratorInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\UpdateResultStruct;
 
 /**
  * Class PluginViewService
  * @package Shopware\Bundle\PluginInstallerBundle\Service
  */
-class PluginViewService
+class PluginViewService implements PluginViewServiceInterface
 {
     /**
-     * @var PluginLocalService
+     * @var PluginLocalServiceInterface
      */
     private $localPluginService;
 
     /**
-     * @var PluginStoreService
+     * @var PluginStoreServiceInterface
      */
     private $storePluginService;
 
     /**
-     * @var StructHydrator
+     * @var StructHydratorInterface
      */
     private $hydrator;
 
     /**
-     * @param PluginLocalService $localPluginService
-     * @param PluginStoreService $storePluginService
-     * @param StructHydrator $hydrator
+     * @param PluginLocalServiceInterface $localPluginService
+     * @param PluginStoreServiceInterface $storePluginService
+     * @param StructHydratorInterface     $hydrator
      */
     public function __construct(
-        PluginLocalService $localPluginService,
-        PluginStoreService $storePluginService,
-        StructHydrator $hydrator
+        PluginLocalServiceInterface $localPluginService,
+        PluginStoreServiceInterface $storePluginService,
+        StructHydratorInterface $hydrator
     ) {
         $this->localPluginService = $localPluginService;
         $this->storePluginService = $storePluginService;

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginViewServiceInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginViewServiceInterface.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Shopware\Bundle\PluginInstallerBundle\Context\ListingRequest;
+use Shopware\Bundle\PluginInstallerBundle\Context\PluginsByTechnicalNameRequest;
+use Shopware\Bundle\PluginInstallerBundle\Context\UpdateListingRequest;
+use Shopware\Bundle\PluginInstallerBundle\Struct\ListingResultStruct;
+use Shopware\Bundle\PluginInstallerBundle\Struct\PluginStruct;
+use Shopware\Bundle\PluginInstallerBundle\Struct\UpdateResultStruct;
+
+/**
+ * Class PluginViewService
+ *
+ * @package Shopware\Bundle\PluginInstallerBundle\Service
+ */
+interface PluginViewServiceInterface
+{
+    /**
+     * @param PluginsByTechnicalNameRequest $context
+     *
+     * @return PluginStruct
+     */
+    public function getPlugin(PluginsByTechnicalNameRequest $context);
+
+    /**
+     * @param PluginsByTechnicalNameRequest $context
+     *
+     * @return array
+     */
+    public function getPlugins(PluginsByTechnicalNameRequest $context);
+
+    /**
+     * @param ListingRequest $context
+     *
+     * @return ListingResultStruct
+     */
+    public function getStoreListing(ListingRequest $context);
+
+    /**
+     * @param ListingRequest $context
+     *
+     * @return PluginStruct[]
+     */
+    public function getLocalListing(ListingRequest $context);
+
+    /**
+     * @param UpdateListingRequest $context
+     *
+     * @return UpdateResultStruct
+     */
+    public function getUpdates(UpdateListingRequest $context);
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/StoreOrderService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/StoreOrderService.php
@@ -25,34 +25,35 @@
 namespace Shopware\Bundle\PluginInstallerBundle\Service;
 
 use Shopware\Bundle\PluginInstallerBundle\Context\OrderRequest;
-use Shopware\Bundle\PluginInstallerBundle\StoreClient;
+use Shopware\Bundle\PluginInstallerBundle\StoreClientInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\BasketStruct;
-use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydrator;
+use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydratorInterface;
 
 /**
  * Class StoreOrderService
+ *
  * @package Shopware\Bundle\PluginInstallerBundle\Service
  */
-class StoreOrderService
+class StoreOrderService implements StoreOrderServiceInterface
 {
     /**
-     * @var StoreClient
+     * @var StoreClientInterface
      */
     private $storeClient;
 
     /**
-     * @var StructHydrator
+     * @var StructHydratorInterface
      */
     private $hydrator;
 
     /**
-     * @param StoreClient $storeClient
-     * @param StructHydrator $hydrator
+     * @param StoreClientInterface    $storeClient
+     * @param StructHydratorInterface $hydrator
      */
     public function __construct(
-        StoreClient $storeClient,
-        StructHydrator $hydrator
+        StoreClientInterface $storeClient,
+        StructHydratorInterface $hydrator
     ) {
         $this->storeClient = $storeClient;
         $this->hydrator = $hydrator;

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/StoreOrderServiceInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/StoreOrderServiceInterface.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Shopware\Bundle\PluginInstallerBundle\Context\OrderRequest;
+use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
+use Shopware\Bundle\PluginInstallerBundle\Struct\BasketStruct;
+
+/**
+ * Class StoreOrderService
+ *
+ * @package Shopware\Bundle\PluginInstallerBundle\Service
+ */
+interface StoreOrderServiceInterface
+{
+    /**
+     * @param AccessTokenStruct $token
+     * @param OrderRequest      $context
+     *
+     * @return BasketStruct
+     */
+    public function getCheckout(AccessTokenStruct $token, OrderRequest $context);
+
+    /**
+     * @param AccessTokenStruct $accessToken
+     * @param OrderRequest      $context
+     *
+     * @throws \Exception
+     * @return bool
+     */
+    public function orderPlugin(AccessTokenStruct $accessToken, OrderRequest $context);
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/SubscriptionService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/SubscriptionService.php
@@ -28,7 +28,7 @@ use Doctrine\DBAL\Connection;
 use Enlight_Controller_Request_Request as Request;
 use Enlight_Controller_Response_ResponseHttp as Response;
 use Shopware\Bundle\PluginInstallerBundle\Exception\ShopSecretException;
-use Shopware\Bundle\PluginInstallerBundle\StoreClient;
+use Shopware\Bundle\PluginInstallerBundle\StoreClientInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\PluginInformationResultStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\PluginInformationStruct;
 use Shopware\Components\Model\ModelManager;
@@ -37,7 +37,7 @@ use Shopware\Components\Model\ModelManager;
  * Class SubscriptionService
  * @package Shopware\Bundle\PluginInstallerBundle\Service
  */
-class SubscriptionService
+class SubscriptionService implements SubscriptionServiceInterface
 {
     /**
      * @var Connection
@@ -45,7 +45,7 @@ class SubscriptionService
     private $connection;
 
     /**
-     * @var StoreClient
+     * @var StoreClientInterface
      */
     private $storeClient;
 
@@ -55,17 +55,17 @@ class SubscriptionService
     private $models;
 
     /**
-     * @var PluginLicenceService
+     * @var PluginLicenceServiceInterface
      */
     private $pluginLicenceService;
 
     /**
-     * @param Connection $connection
-     * @param StoreClient $storeClient
-     * @param ModelManager $models
-     * @param PluginLicenceService $pluginLicenceService
+     * @param Connection                    $connection
+     * @param StoreClientInterface          $storeClient
+     * @param ModelManager                  $models
+     * @param PluginLicenceServiceInterface $pluginLicenceService
      */
-    public function __construct(Connection $connection, StoreClient $storeClient, ModelManager $models, PluginLicenceService $pluginLicenceService)
+    public function __construct(Connection $connection, StoreClientInterface $storeClient, ModelManager $models, PluginLicenceServiceInterface $pluginLicenceService)
     {
         $this->connection = $connection;
         $this->storeClient = $storeClient;
@@ -181,9 +181,9 @@ class SubscriptionService
             },
             $data['plugins']
         );
-        
+
         $this->pluginLicenceService->updateLocalLicenseInformation($pluginInformationStructs, $domain);
-        
+
         $informationResult = new PluginInformationResultStruct($pluginInformationStructs, $isShopUpgraded);
 
         return $informationResult;

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/SubscriptionServiceInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/SubscriptionServiceInterface.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use Enlight_Controller_Request_Request as Request;
+use Enlight_Controller_Response_ResponseHttp as Response;
+use Shopware\Bundle\PluginInstallerBundle\Struct\PluginInformationResultStruct;
+
+/**
+ * Class SubscriptionService
+ *
+ * @package Shopware\Bundle\PluginInstallerBundle\Service
+ */
+interface SubscriptionServiceInterface
+{
+    /**
+     * reset the Secret in the database
+     */
+    public function resetShopSecret();
+
+    /**
+     * get current secret from the database
+     *
+     * @return string
+     */
+    public function getShopSecret();
+
+    /**
+     * set new secret to the database
+     */
+    public function setShopSecret();
+
+    /**
+     * Returns information about shop upgrade state and installed plugins.
+     *
+     * @param Response $response
+     * @param Request  $request
+     *
+     * @return PluginInformationResultStruct|bool
+     */
+    public function getPluginInformation(Response $response, Request $request);
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/StoreClient.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/StoreClient.php
@@ -33,6 +33,7 @@ use Shopware\Bundle\PluginInstallerBundle\Exception\SbpServerException;
 use Shopware\Bundle\PluginInstallerBundle\Exception\ShopSecretException;
 use Shopware\Bundle\PluginInstallerBundle\Exception\StoreException;
 use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
+use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydratorInterface;
 use Shopware\Components\HttpClient\HttpClientInterface;
 use Shopware\Components\HttpClient\RequestException;
 use Shopware\Components\HttpClient\Response;
@@ -41,7 +42,7 @@ use Shopware\Components\OpenSSLVerifier;
 /**
  * @package Shopware\Bundle\PluginInstallerBundle
  */
-class StoreClient
+class StoreClient implements StoreClientInterface
 {
     /**
      * @var HttpClientInterface
@@ -54,7 +55,7 @@ class StoreClient
     private $apiEndPoint;
 
     /**
-     * @var Struct\StructHydrator
+     * @var StructHydratorInterface
      */
     private $structHydrator;
 
@@ -64,26 +65,27 @@ class StoreClient
     private $openSSLVerifier;
 
     /**
-     * @param HttpClientInterface $httpClient
-     * @param string $apiEndPoint
-     * @param Struct\StructHydrator $structHydrator
-     * @param OpenSSLVerifier $openSSLVerifier
+     * @param HttpClientInterface     $httpClient
+     * @param string                  $apiEndPoint
+     * @param StructHydratorInterface $structHydrator
+     * @param OpenSSLVerifier         $openSSLVerifier
      */
     public function __construct(
         HttpClientInterface $httpClient,
         $apiEndPoint,
-        Struct\StructHydrator $structHydrator,
+        StructHydratorInterface $structHydrator,
         OpenSSLVerifier $openSSLVerifier
     ) {
-        $this->httpClient = $httpClient;
-        $this->apiEndPoint = $apiEndPoint;
-        $this->structHydrator = $structHydrator;
+        $this->httpClient      = $httpClient;
+        $this->apiEndPoint     = $apiEndPoint;
+        $this->structHydrator  = $structHydrator;
         $this->openSSLVerifier = $openSSLVerifier;
     }
 
     /**
      * @param string $shopwareId
      * @param string $password
+     *
      * @return AccessTokenStruct
      * @throws \Exception
      */
@@ -102,8 +104,9 @@ class StoreClient
 
     /**
      * @param string $resource
-     * @param array $params
-     * @param array $headers
+     * @param array  $params
+     * @param array  $headers
+     *
      * @return array
      * @throws \Exception
      */
@@ -120,9 +123,10 @@ class StoreClient
 
     /**
      * @param AccessTokenStruct $accessToken
-     * @param string $resource
-     * @param array $params
-     * @param array $headers
+     * @param string            $resource
+     * @param array             $params
+     * @param array             $headers
+     *
      * @return array
      * @throws \Exception
      */
@@ -143,9 +147,10 @@ class StoreClient
     }
 
     /**
-     * @param $resource
+     * @param       $resource
      * @param array $params
      * @param array $headers
+     *
      * @return mixed
      * @throws \Exception
      */
@@ -162,9 +167,10 @@ class StoreClient
 
     /**
      * @param AccessTokenStruct $accessToken
-     * @param string $resource
-     * @param array $params
-     * @param array $headers
+     * @param string            $resource
+     * @param array             $params
+     * @param array             $headers
+     *
      * @return array
      * @throws \Exception
      */
@@ -180,13 +186,15 @@ class StoreClient
             $headers,
             $accessToken
         );
+
         return $response->getBody();
     }
 
     /**
      * @param string $resource
-     * @param array $params
-     * @param array $headers
+     * @param array  $params
+     * @param array  $headers
+     *
      * @return array
      * @throws \Exception
      */
@@ -197,13 +205,15 @@ class StoreClient
             $params,
             $headers
         );
+
         return json_decode($response->getBody(), true);
     }
 
     /**
      * @param AccessTokenStruct $accessToken
-     * @param string $resource
-     * @param array $params
+     * @param string            $resource
+     * @param array             $params
+     *
      * @return array
      * @throws \Exception
      */
@@ -224,8 +234,9 @@ class StoreClient
 
     /**
      * @param AccessTokenStruct $accessToken
-     * @param $resource
-     * @param $params
+     * @param                   $resource
+     * @param                   $params
+     *
      * @return Response
      * @throws \Exception
      */
@@ -249,17 +260,18 @@ class StoreClient
      */
     public function doPing()
     {
-        $response = $this->httpClient->get($this->apiEndPoint.'/ping', ['timeout' => 7]);
+        $response = $this->httpClient->get($this->apiEndPoint . '/ping', ['timeout' => 7]);
         $this->verifyResponseSignature($response);
 
         return json_decode($response->getBody(), true) ?: false;
     }
 
     /**
-     * @param $resource
-     * @param array $params
-     * @param array $headers
+     * @param                        $resource
+     * @param array                  $params
+     * @param array                  $headers
      * @param accessTokenStruct|null $token
+     *
      * @return Response
      * @throws \Exception
      * @internal param null|string $secret
@@ -267,7 +279,7 @@ class StoreClient
     private function getRequest($resource, $params, $headers = [], AccessTokenStruct $token = null)
     {
         $url = $this->apiEndPoint . $resource;
-        if (!empty($params)) {
+        if (! empty($params)) {
             $url .= '?' . http_build_query($params, null, '&');
         }
 
@@ -291,10 +303,11 @@ class StoreClient
     }
 
     /**
-     * @param $resource
-     * @param array $params
-     * @param array $headers
+     * @param                   $resource
+     * @param array             $params
+     * @param array             $headers
      * @param AccessTokenStruct $token
+     *
      * @return Response
      * @throws StoreException
      * @throws \Exception
@@ -332,6 +345,7 @@ class StoreClient
      * by SBP about what happened
      *
      * @param RequestException $requestException
+     *
      * @throws \Exception
      * @throws SbpServerException
      * @throws AuthenticationException
@@ -343,13 +357,13 @@ class StoreClient
      */
     private function handleRequestException(RequestException $requestException)
     {
-        if (!$requestException->getBody()) {
+        if (! $requestException->getBody()) {
             throw $requestException;
         }
 
         $data = json_decode($requestException->getBody(), true);
 
-        if (!isset($data['code'])) {
+        if (! isset($data['code'])) {
             throw $requestException;
         }
 
@@ -395,9 +409,11 @@ class StoreClient
             case 'BinariesException-19':
                 throw new SbpServerException($sbpCode, 'no_version_for_subscription', $httpCode, $requestException);
             case 'BinariesException-20':
-                throw new SbpServerException($sbpCode, 'no_version_for_provided_shopware_version', $httpCode, $requestException);
+                throw new SbpServerException($sbpCode, 'no_version_for_provided_shopware_version', $httpCode,
+                    $requestException);
             case 'BinariesException-21':
-                throw new SbpServerException($sbpCode, 'no_version_for_provided_shopware_version', $httpCode, $requestException);
+                throw new SbpServerException($sbpCode, 'no_version_for_provided_shopware_version', $httpCode,
+                    $requestException);
 
             case 'UsersException-4':          //Unauthorized
             case 'OrdersException-0':         //Order authentication failed
@@ -486,7 +502,7 @@ class StoreClient
             throw new \RuntimeException('Signature not found in x-shopware-signature header');
         }
 
-        if (!$this->openSSLVerifier->isSystemSupported()) {
+        if (! $this->openSSLVerifier->isSystemSupported()) {
             return;
         }
 

--- a/engine/Shopware/Bundle/PluginInstallerBundle/StoreClientInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/StoreClientInterface.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle;
+
+use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
+use Shopware\Components\HttpClient\Response;
+
+/**
+ * @package Shopware\Bundle\PluginInstallerBundle
+ */
+interface StoreClientInterface
+{
+    /**
+     * @param string $shopwareId
+     * @param string $password
+     *
+     * @return AccessTokenStruct
+     * @throws \Exception
+     */
+    public function getAccessToken($shopwareId, $password);
+
+    /**
+     * @param string $resource
+     * @param array  $params
+     * @param array  $headers
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function doGetRequest($resource, $params = [], $headers = []);
+
+    /**
+     * @param AccessTokenStruct $accessToken
+     * @param string            $resource
+     * @param array             $params
+     * @param array             $headers
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function doAuthGetRequest(AccessTokenStruct $accessToken, $resource, $params, $headers = []);
+
+    /**
+     * @param       $resource
+     * @param array $params
+     * @param array $headers
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function doGetRequestRaw($resource, $params = [], $headers = []);
+
+    /**
+     * @param AccessTokenStruct $accessToken
+     * @param string            $resource
+     * @param array             $params
+     * @param array             $headers
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function doAuthGetRequestRaw(AccessTokenStruct $accessToken, $resource, $params, $headers = []);
+
+    /**
+     * @param string $resource
+     * @param array  $params
+     * @param array  $headers
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function doPostRequest($resource, $params, $headers = []);
+
+    /**
+     * @param AccessTokenStruct $accessToken
+     * @param string            $resource
+     * @param array             $params
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function doAuthPostRequest(AccessTokenStruct $accessToken, $resource, $params);
+
+    /**
+     * @param AccessTokenStruct $accessToken
+     * @param                   $resource
+     * @param                   $params
+     *
+     * @return Response
+     * @throws \Exception
+     */
+    public function doAuthPostRequestRaw(AccessTokenStruct $accessToken, $resource, $params);
+
+    /**
+     * @return bool
+     */
+    public function doPing();
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Struct/StructHydrator.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Struct/StructHydrator.php
@@ -28,7 +28,7 @@ namespace Shopware\Bundle\PluginInstallerBundle\Struct;
  * Class StructHydrator
  * @package Shopware\Bundle\PluginInstallerBundle\Struct
  */
-class StructHydrator
+class StructHydrator implements StructHydratorInterface
 {
     /**
      * @param $data

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Struct/StructHydratorInterface.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Struct/StructHydratorInterface.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Bundle\PluginInstallerBundle\Struct;
+
+/**
+ * Class StructHydrator
+ *
+ * @package Shopware\Bundle\PluginInstallerBundle\Struct
+ */
+interface StructHydratorInterface
+{
+    /**
+     * @param $data
+     *
+     * @return BasketStruct
+     */
+    public function hydrateBasket($data);
+
+    /**
+     * @param array  $data
+     * @param string $shopwareId
+     *
+     * @return AccessTokenStruct
+     */
+    public function hydrateAccessToken($data, $shopwareId);
+
+    /**
+     * @param $data
+     *
+     * @return PluginStruct
+     */
+    public function hydrateStorePlugin($data);
+
+    /**
+     * @param $data
+     *
+     * @return PluginStruct
+     */
+    public function hydrateLocalPlugin($data);
+
+    /**
+     * @param $data
+     *
+     * @return PluginStruct[] Indexed by plugin code
+     */
+    public function hydrateStorePlugins($data);
+
+    /**
+     * @param $data
+     *
+     * @return PluginStruct[] Indexed by plugin code
+     */
+    public function hydrateLocalPlugins($data);
+
+    public function assignStorePluginStruct(PluginStruct $localPlugin, PluginStruct $storePlugin);
+
+    /**
+     * @param PluginStruct $storePlugin
+     * @param PluginStruct $localPlugin
+     */
+    public function assignLocalPluginStruct(PluginStruct $storePlugin, PluginStruct $localPlugin);
+
+    /**
+     * @param $data
+     *
+     * @return CategoryStruct[]
+     */
+    public function hydrateCategories($data);
+
+    public function hydrateLicences($data);
+
+    /**
+     * @param $data
+     *
+     * @return CategoryStruct
+     */
+    public function hydrateCategory($data);
+
+    /**
+     * @param PluginStruct $plugin
+     * @param              $data
+     */
+    public function assignLocalData(PluginStruct $plugin, $data);
+
+    /**
+     * @param $data
+     *
+     * @return LocaleStruct[]
+     */
+    public function hydrateLocales($data);
+}

--- a/engine/Shopware/Commands/PluginActivateCommand.php
+++ b/engine/Shopware/Commands/PluginActivateCommand.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Commands;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -63,7 +63,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var InstallerService $pluginManager */
+        /** @var InstallerServiceInterface $pluginManager */
         $pluginManager  = $this->container->get('shopware_plugininstaller.plugin_manager');
         $pluginName = $input->getArgument('plugin');
 

--- a/engine/Shopware/Commands/PluginConfigListCommand.php
+++ b/engine/Shopware/Commands/PluginConfigListCommand.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Commands;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Shopware\Components\Model\ModelManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -70,7 +70,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var InstallerService $pluginManager */
+        /** @var InstallerServiceInterface $pluginManager */
         $pluginManager  = $this->container->get('shopware_plugininstaller.plugin_manager');
         $pluginName = $input->getArgument('plugin');
 

--- a/engine/Shopware/Commands/PluginConfigSetCommand.php
+++ b/engine/Shopware/Commands/PluginConfigSetCommand.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Commands;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Shopware\Components\Model\ModelManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -76,7 +76,7 @@ class PluginConfigSetCommand extends ShopwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var InstallerService $pluginManager */
+        /** @var InstallerServiceInterface $pluginManager */
         $pluginManager  = $this->container->get('shopware_plugininstaller.plugin_manager');
         $pluginName = $input->getArgument('plugin');
 

--- a/engine/Shopware/Commands/PluginDeactivateCommand.php
+++ b/engine/Shopware/Commands/PluginDeactivateCommand.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Commands;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -63,7 +63,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var InstallerService $pluginManager */
+        /** @var InstallerServiceInterface $pluginManager */
         $pluginManager  = $this->container->get('shopware_plugininstaller.plugin_manager');
         $pluginName = $input->getArgument('plugin');
 

--- a/engine/Shopware/Commands/PluginDeleteCommand.php
+++ b/engine/Shopware/Commands/PluginDeleteCommand.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Commands;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -65,7 +65,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var InstallerService $pluginManager */
+        /** @var InstallerServiceInterface $pluginManager */
         $pluginManager  = $this->container->get('shopware_plugininstaller.plugin_manager');
         $pluginName = $input->getArgument('plugin');
 

--- a/engine/Shopware/Commands/PluginInstallCommand.php
+++ b/engine/Shopware/Commands/PluginInstallCommand.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Commands;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -69,7 +69,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var InstallerService $pluginManager */
+        /** @var InstallerServiceInterface $pluginManager */
         $pluginManager  = $this->container->get('shopware_plugininstaller.plugin_manager');
         $pluginName = $input->getArgument('plugin');
 

--- a/engine/Shopware/Commands/PluginRefreshCommand.php
+++ b/engine/Shopware/Commands/PluginRefreshCommand.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Commands;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -54,7 +54,7 @@ class PluginRefreshCommand extends ShopwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var  InstallerService $pluginManager */
+        /** @var  InstallerServiceInterface $pluginManager */
         $pluginManager  = $this->container->get('shopware_plugininstaller.plugin_manager');
         $pluginManager->refreshPluginList();
 

--- a/engine/Shopware/Commands/PluginReinstallCommand.php
+++ b/engine/Shopware/Commands/PluginReinstallCommand.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Commands;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -57,7 +57,7 @@ class PluginReinstallCommand extends ShopwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var InstallerService $pluginManager */
+        /** @var InstallerServiceInterface $pluginManager */
         $pluginManager  = $this->container->get('shopware_plugininstaller.plugin_manager');
         $pluginName = $input->getArgument('plugin');
 

--- a/engine/Shopware/Commands/PluginUninstallCommand.php
+++ b/engine/Shopware/Commands/PluginUninstallCommand.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Commands;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -69,7 +69,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var InstallerService $pluginManager */
+        /** @var InstallerServiceInterface $pluginManager */
         $pluginManager  = $this->container->get('shopware_plugininstaller.plugin_manager');
         $pluginName = $input->getArgument('plugin');
 

--- a/engine/Shopware/Commands/PluginUpdateCommand.php
+++ b/engine/Shopware/Commands/PluginUpdateCommand.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Commands;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -63,7 +63,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var InstallerService $pluginManager */
+        /** @var InstallerServiceInterface $pluginManager */
         $pluginManager  = $this->container->get('shopware_plugininstaller.plugin_manager');
         $pluginName = $input->getArgument('plugin');
 

--- a/engine/Shopware/Commands/StoreDownloadCommand.php
+++ b/engine/Shopware/Commands/StoreDownloadCommand.php
@@ -27,7 +27,7 @@ namespace Shopware\Commands;
 use Shopware\Bundle\PluginInstallerBundle\Context\DownloadRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\PluginLicenceRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\PluginsByTechnicalNameRequest;
-use Shopware\Bundle\PluginInstallerBundle\Service\PluginLicenceService;
+use Shopware\Bundle\PluginInstallerBundle\Service\PluginLicenceServiceInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\PluginStruct;
 use Shopware\Models\Plugin\Plugin;
@@ -218,7 +218,7 @@ class StoreDownloadCommand extends StoreCommand
 
         $request = new DownloadRequest($plugin->getTechnicalName(), $version, $domain, $token);
 
-        /**@var $service PluginLicenceService */
+        /**@var $service PluginLicenceServiceInterface */
         $this->container->get('shopware_plugininstaller.plugin_download_service')->download($request);
     }
 

--- a/engine/Shopware/Components/CategoryHandling/CategoryDuplicator.php
+++ b/engine/Shopware/Components/CategoryHandling/CategoryDuplicator.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Components\CategoryHandling;
 
-use Shopware\Bundle\AttributeBundle\Service\DataPersister;
+use Shopware\Bundle\AttributeBundle\Service\DataPersisterInterface;
 use Shopware\Components\Model\CategoryDenormalization;
 
 class CategoryDuplicator
@@ -40,19 +40,19 @@ class CategoryDuplicator
     protected $categoryDenormalization;
 
     /**
-     * @var DataPersister
+     * @var DataPersisterInterface
      */
     private $attributePersister;
 
     /**
-     * @param \PDO $connection
+     * @param \PDO                    $connection
      * @param CategoryDenormalization $categoryDenormalization
-     * @param DataPersister $attributePersister
+     * @param DataPersisterInterface  $attributePersister
      */
     public function __construct(
         \PDO $connection,
         CategoryDenormalization $categoryDenormalization,
-        DataPersister $attributePersister
+        DataPersisterInterface $attributePersister
     ) {
         $this->connection = $connection;
         $this->categoryDenormalization = $categoryDenormalization;

--- a/engine/Shopware/Components/Test/Plugin/TestCase.php
+++ b/engine/Shopware/Components/Test/Plugin/TestCase.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Components\Test\Plugin;
 
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 
 /**
  * Ensures a given plugin is installed and sets configuration.
@@ -46,7 +46,7 @@ use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
 abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var InstallerService
+     * @var InstallerServiceInterface
      */
     private static $pluginManager;
 

--- a/engine/Shopware/Controllers/Backend/FirstRunWizard.php
+++ b/engine/Shopware/Controllers/Backend/FirstRunWizard.php
@@ -1,7 +1,7 @@
 <?php
 
+use Shopware\Bundle\PluginInstallerBundle\Service\AccountManagerServiceInterface;
 use Shopware\Bundle\StoreFrontBundle;
-use Shopware\Bundle\PluginInstallerBundle\Service\AccountManagerService;
 use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\LocaleStruct;
 
@@ -197,7 +197,7 @@ class Shopware_Controllers_Backend_FirstRunWizard extends Shopware_Controllers_B
      */
     public function pingServerAction()
     {
-        /** @var AccountManagerService $accountManagerService */
+        /** @var AccountManagerServiceInterface $accountManagerService */
         $accountManagerService = $this->container->get('shopware_plugininstaller.account_manager_service');
 
         try {
@@ -271,7 +271,7 @@ class Shopware_Controllers_Backend_FirstRunWizard extends Shopware_Controllers_B
         $password = $this->Request()->getParam('password');
         $email = $this->Request()->getParam('email');
 
-        /** @var AccountManagerService $accountManagerService */
+        /** @var AccountManagerServiceInterface $accountManagerService */
         $accountManagerService = $this->container->get('shopware_plugininstaller.account_manager_service');
 
         try {
@@ -356,7 +356,7 @@ class Shopware_Controllers_Backend_FirstRunWizard extends Shopware_Controllers_B
             ));
         }
 
-        /** @var AccountManagerService $accountManagerService */
+        /** @var AccountManagerServiceInterface $accountManagerService */
         $accountManagerService = $this->container->get('shopware_plugininstaller.account_manager_service');
 
         try {
@@ -441,7 +441,7 @@ class Shopware_Controllers_Backend_FirstRunWizard extends Shopware_Controllers_B
         static $locales;
 
         if (empty($locales)) {
-            /** @var AccountManagerService $accountManagerService */
+            /** @var AccountManagerServiceInterface $accountManagerService */
             $accountManagerService = $this->container->get('shopware_plugininstaller.account_manager_service');
 
             try {
@@ -477,7 +477,7 @@ class Shopware_Controllers_Backend_FirstRunWizard extends Shopware_Controllers_B
      */
     private function getDomains(AccessTokenStruct $token)
     {
-        /** @var AccountManagerService $accountManagerService */
+        /** @var AccountManagerServiceInterface $accountManagerService */
         $accountManagerService = $this->container->get('shopware_plugininstaller.account_manager_service');
 
         try {
@@ -516,7 +516,7 @@ class Shopware_Controllers_Backend_FirstRunWizard extends Shopware_Controllers_B
                 throw new \RuntimeException('Could not login - missing login data');
             }
 
-            /** @var AccountManagerService $accountManagerService */
+            /** @var AccountManagerServiceInterface $accountManagerService */
             $accountManagerService = $this->container->get('shopware_plugininstaller.account_manager_service');
 
             $token = $accountManagerService->getToken($shopwareId, $password);

--- a/engine/Shopware/Controllers/Backend/Performance.php
+++ b/engine/Shopware/Controllers/Backend/Performance.php
@@ -23,7 +23,7 @@
  */
 
 use Doctrine\ORM\AbstractQuery;
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Shopware\Models\Config\Element;
 use Shopware\Models\Config\Form;
 use Shopware\Models\Plugin\Plugin;
@@ -98,7 +98,7 @@ class Shopware_Controllers_Backend_Performance extends Shopware_Controllers_Back
      */
     private function activeHttpCache($httpCache)
     {
-        /**@var $service InstallerService*/
+        /**@var $service InstallerServiceInterface */
         $service = Shopware()->Container()->get('shopware.plugin_manager');
 
         if (!$httpCache->getInstalled()) {
@@ -119,7 +119,7 @@ class Shopware_Controllers_Backend_Performance extends Shopware_Controllers_Back
             return;
         }
 
-        /**@var $service InstallerService*/
+        /**@var $service InstallerServiceInterface */
         $service = Shopware()->Container()->get('shopware.plugin_manager');
         $service->deactivatePlugin($httpCache);
     }

--- a/engine/Shopware/Controllers/Backend/UpdateWizard.php
+++ b/engine/Shopware/Controllers/Backend/UpdateWizard.php
@@ -26,8 +26,8 @@ use Doctrine\DBAL\Connection;
 use Shopware\Bundle\PluginInstallerBundle\Context\UpdateLicencesRequest;
 use Shopware\Bundle\PluginInstallerBundle\Exception\AuthenticationException;
 use Shopware\Bundle\PluginInstallerBundle\Exception\StoreException;
-use Shopware\Bundle\PluginInstallerBundle\Service\AccountManagerService;
-use Shopware\Bundle\PluginInstallerBundle\Service\PluginLicenceService;
+use Shopware\Bundle\PluginInstallerBundle\Service\AccountManagerServiceInterface;
+use Shopware\Bundle\PluginInstallerBundle\Service\PluginLicenceServiceInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
 
 class Shopware_Controllers_Backend_UpdateWizard extends Shopware_Controllers_Backend_ExtJs
@@ -47,10 +47,10 @@ class Shopware_Controllers_Backend_UpdateWizard extends Shopware_Controllers_Bac
     {
         $pluginCheck = new \ShopwarePlugins\SwagUpdate\Components\PluginCheck($this->container);
 
-        /** @var PluginLicenceService $service */
+        /** @var PluginLicenceServiceInterface $service */
         $licenceService = $this->get('shopware_plugininstaller.plugin_licence_service');
 
-        /** @var AccountManagerService $accountService */
+        /** @var AccountManagerServiceInterface $accountService */
         $accountService = $this->get('shopware_plugininstaller.account_manager_service');
 
         $request = new UpdateLicencesRequest(

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -23,6 +23,8 @@
  */
 
 use Shopware\Bundle\AccountBundle\Service\AddressServiceInterface;
+use Shopware\Bundle\AttributeBundle\Service\DataLoaderInterface;
+use Shopware\Bundle\AttributeBundle\Service\DataPersisterInterface;
 use Shopware\Bundle\StoreFrontBundle;
 use Shopware\Components\NumberRangeIncrementerInterface;
 use Shopware\Components\Validator\EmailValidatorInterface;
@@ -141,12 +143,12 @@ class sAdmin
     private $numberRangeIncrementer;
 
     /**
-     * @var Shopware\Bundle\AttributeBundle\Service\DataLoader
+     * @var DataLoaderInterface
      */
     private $attributeLoader;
 
     /**
-     * @var Shopware\Bundle\AttributeBundle\Service\DataPersister
+     * @var DataPersisterInterface
      */
     private $attributePersister;
 

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -22,6 +22,8 @@
  * our trademarks remain entirely with us.
  */
 
+use Shopware\Bundle\AttributeBundle\Service\DataLoaderInterface;
+use Shopware\Bundle\AttributeBundle\Service\DataPersisterInterface;
 use Shopware\Bundle\StoreFrontBundle;
 use Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface;
 use Shopware\Components\NumberRangeIncrementerInterface;
@@ -208,12 +210,12 @@ class sOrder
     private $numberRangeIncrementer;
 
     /**
-     * @var Shopware\Bundle\AttributeBundle\Service\DataLoader
+     * @var DataLoaderInterface
      */
     private $attributeLoader;
 
     /**
-     * @var Shopware\Bundle\AttributeBundle\Service\DataPersister
+     * @var DataPersisterInterface
      */
     private $attributePersister;
 

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Components/PluginCategoryService.php
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Components/PluginCategoryService.php
@@ -26,9 +26,9 @@ namespace ShopwarePlugins\PluginManager\Components;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\PDOStatement;
-use Shopware\Bundle\PluginInstallerBundle\Service\PluginStoreService;
+use Shopware\Bundle\PluginInstallerBundle\Service\PluginStoreServiceInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\CategoryStruct;
-use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydrator;
+use Shopware\Bundle\PluginInstallerBundle\Struct\StructHydratorInterface;
 
 /**
  * @package ShopwarePlugins\PluginManager\Components
@@ -40,7 +40,7 @@ class PluginCategoryService
     const CATEGORY_RECOMMENDATION = -3;
 
     /**
-     * @var PluginStoreService
+     * @var PluginStoreServiceInterface
      */
     private $pluginService;
 
@@ -50,19 +50,19 @@ class PluginCategoryService
     private $connection;
 
     /**
-     * @var StructHydrator
+     * @var StructHydratorInterface
      */
     private $hydrator;
 
     /**
-     * @param PluginStoreService $pluginService
-     * @param Connection $connection
-     * @param StructHydrator $hydrator
+     * @param PluginStoreServiceInterface $pluginService
+     * @param Connection                  $connection
+     * @param StructHydratorInterface     $hydrator
      */
     public function __construct(
-        PluginStoreService $pluginService,
+        PluginStoreServiceInterface $pluginService,
         Connection $connection,
-        StructHydrator $hydrator
+        StructHydratorInterface $hydrator
     ) {
         $this->pluginService = $pluginService;
         $this->connection = $connection;

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Controllers/Backend/PluginInstaller.php
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Controllers/Backend/PluginInstaller.php
@@ -22,8 +22,8 @@
  * our trademarks remain entirely with us.
  */
 
-use Shopware\Bundle\PluginInstallerBundle\Service\DownloadService;
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Bundle\PluginInstallerBundle\Service\DownloadServiceInterface;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 use Shopware\Components\Model\ModelRepository;
 use Shopware\Models\Plugin\Plugin;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -32,7 +32,7 @@ use Symfony\Component\HttpFoundation\FileBag;
 class Shopware_Controllers_Backend_PluginInstaller extends Shopware_Controllers_Backend_ExtJs
 {
     /**
-     * @var InstallerService
+     * @var InstallerServiceInterface
      */
     private $pluginManager;
 
@@ -193,7 +193,7 @@ class Shopware_Controllers_Backend_PluginInstaller extends Shopware_Controllers_
 
     public function uploadAction()
     {
-        /** @var DownloadService $service */
+        /** @var DownloadServiceInterface $service */
         $pluginDownloadService = Shopware()->Container()->get('shopware_plugininstaller.plugin_download_service');
 
         try {

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Controllers/Backend/PluginManager.php
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Controllers/Backend/PluginManager.php
@@ -32,13 +32,14 @@ use Shopware\Bundle\PluginInstallerBundle\Context\PluginsByTechnicalNameRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\UpdateListingRequest;
 use Shopware\Bundle\PluginInstallerBundle\Exception\AuthenticationException;
 use Shopware\Bundle\PluginInstallerBundle\Exception\StoreException;
-use Shopware\Bundle\PluginInstallerBundle\Service\DownloadService;
-use Shopware\Bundle\PluginInstallerBundle\Service\PluginLicenceService;
-use Shopware\Bundle\PluginInstallerBundle\Service\PluginLocalService;
-use Shopware\Bundle\PluginInstallerBundle\Service\PluginStoreService;
-use Shopware\Bundle\PluginInstallerBundle\Service\PluginViewService;
-use Shopware\Bundle\PluginInstallerBundle\Service\StoreOrderService;
-use Shopware\Bundle\PluginInstallerBundle\StoreClient;
+use Shopware\Bundle\PluginInstallerBundle\Service\DownloadServiceInterface;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
+use Shopware\Bundle\PluginInstallerBundle\Service\PluginLicenceServiceInterface;
+use Shopware\Bundle\PluginInstallerBundle\Service\PluginLocalServiceInterface;
+use Shopware\Bundle\PluginInstallerBundle\Service\PluginStoreServiceInterface;
+use Shopware\Bundle\PluginInstallerBundle\Service\PluginViewServiceInterface;
+use Shopware\Bundle\PluginInstallerBundle\Service\StoreOrderServiceInterface;
+use Shopware\Bundle\PluginInstallerBundle\StoreClientInterface;
 use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\BasketStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\PluginInformationResultStruct;
@@ -47,7 +48,6 @@ use Shopware\Models\Menu\Menu;
 use Shopware\Models\Plugin\Plugin;
 use ShopwarePlugins\PluginManager\Components\PluginCategoryService;
 use ShopwarePlugins\SwagUpdate\Components\Steps\FinishResult;
-use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
 
 class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Backend_ExtJs
 {
@@ -71,7 +71,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
                 $this->getAccessToken()
             );
 
-            /**@var $service DownloadService */
+            /**@var $service DownloadServiceInterface */
             $service = $this->get('shopware_plugininstaller.plugin_download_service');
             $result = $service->getMetaInformation($request);
         } catch (Exception $e) {
@@ -98,7 +98,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         $request = new RangeDownloadRequest($url, $offset, $size, $sha1, $destination);
 
         try {
-            /**@var $service DownloadService */
+            /**@var $service DownloadServiceInterface */
             $service = $this->get('shopware_plugininstaller.plugin_download_service');
             $result = $service->downloadRange($request);
         } catch (Exception $e) {
@@ -123,7 +123,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         try {
             $service->extractPluginZip($fileName, $technicalName);
 
-            /** @var InstallerService $pluginManager */
+            /** @var InstallerServiceInterface $pluginManager */
             $pluginManager  = $this->get('shopware_plugininstaller.plugin_manager');
             $pluginManager->refreshPluginList();
         } catch (Exception $e) {
@@ -240,7 +240,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         );
 
         try {
-            /** @var PluginViewService $pluginViewService */
+            /** @var PluginViewServiceInterface $pluginViewService */
             $pluginViewService = $this->get('shopware_plugininstaller.plugin_service_view');
             $listingResult = $pluginViewService->getStoreListing($context);
         } catch (Exception $e) {
@@ -261,7 +261,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
 
         $error = null;
         try {
-            /** @var InstallerService $pluginManager */
+            /** @var InstallerServiceInterface $pluginManager */
             $pluginManager = $this->get('shopware_plugininstaller.plugin_manager');
             $pluginManager->refreshPluginList();
         } catch (Exception $e) {
@@ -278,11 +278,11 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         );
 
         if ($this->isApiAvailable()) {
-            /** @var PluginViewService $pluginViewService */
+            /** @var PluginViewServiceInterface $pluginViewService */
             $pluginViewService = $this->get('shopware_plugininstaller.plugin_service_view');
             $plugins = $pluginViewService->getLocalListing($context);
         } else {
-            /** @var PluginLocalService $localService */
+            /** @var PluginLocalServiceInterface $localService */
             $localService = $this->get('shopware_plugininstaller.plugin_service_local');
             $plugins = $localService->getListing($context)->getPlugins();
         }
@@ -335,7 +335,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
             [$technicalName]
         );
 
-        /** @var PluginLocalService $localService */
+        /** @var PluginLocalServiceInterface $localService */
         $localService = $this->get('shopware_plugininstaller.plugin_service_local');
         $plugin = $localService->getPlugin($context);
 
@@ -352,7 +352,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         );
 
         try {
-            /** @var PluginStoreService $pluginStoreService */
+            /** @var PluginStoreServiceInterface $pluginStoreService */
             $pluginStoreService = $this->get('shopware_plugininstaller.plugin_service_store_production');
             $licences = $pluginStoreService->getLicences($context);
         } catch (Exception $e) {
@@ -376,7 +376,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         $secret = $subscriptionService->getShopSecret();
         $domain = empty($secret) ? null : $this->getDomain();
 
-        /** @var PluginLocalService $localService */
+        /** @var PluginLocalServiceInterface $localService */
         $localService = $this->get('shopware_plugininstaller.plugin_service_local');
         $plugins = $localService->getPluginsForUpdateCheck();
 
@@ -388,7 +388,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         );
 
         try {
-            /** @var PluginViewService $pluginViewService */
+            /** @var PluginViewServiceInterface $pluginViewService */
             $pluginViewService = $this->get('shopware_plugininstaller.plugin_service_view');
             $updates = $pluginViewService->getUpdates($context);
         } catch (Exception $e) {
@@ -419,7 +419,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
             $expiredPlugins
         );
 
-        /** @var PluginStoreService $pluginStoreService */
+        /** @var PluginStoreServiceInterface $pluginStoreService */
         $pluginStoreService = $this->get('shopware_plugininstaller.plugin_service_store_production');
         $plugins = $pluginStoreService->getPlugins($context);
 
@@ -455,7 +455,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         );
 
         try {
-            /** @var PluginViewService $pluginViewService */
+            /** @var PluginViewServiceInterface $pluginViewService */
             $pluginViewService = $this->get('shopware_plugininstaller.plugin_service_view');
             $data = $pluginViewService->getPlugin($context);
         } catch (Exception $e) {
@@ -491,7 +491,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         );
 
         try {
-            /** @var StoreOrderService $storeOrderService */
+            /** @var StoreOrderServiceInterface $storeOrderService */
             $storeOrderService = $this->get('shopware_plugininstaller.store_order_service');
             $storeOrderService->orderPlugin($token, $context);
         } catch (StoreException $e) {
@@ -521,7 +521,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         );
 
         try {
-            /** @var StoreOrderService $storeOrderService */
+            /** @var StoreOrderServiceInterface $storeOrderService */
             $storeOrderService = $this->get('shopware_plugininstaller.store_order_service');
             $basket = $storeOrderService->getCheckout($token, $context);
 
@@ -545,7 +545,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         $key = $this->Request()->getParam('licenceKey');
 
         try {
-            /**@var $service PluginLicenceService*/
+            /**@var $service PluginLicenceServiceInterface */
             $service = $this->get('shopware_plugininstaller.plugin_licence_service');
             $service->importLicence($key);
         } catch (Exception $e) {
@@ -570,7 +570,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
             $technicalName
         );
 
-        /** @var PluginStoreService $pluginStoreService */
+        /** @var PluginStoreServiceInterface $pluginStoreService */
         $pluginStoreService = $this->get('shopware_plugininstaller.plugin_service_store_production');
         $licence = $pluginStoreService->getPluginLicence($context);
 
@@ -586,7 +586,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         }
 
         try {
-            /**@var $service PluginLicenceService*/
+            /**@var $service PluginLicenceServiceInterface */
             $service = $this->get('shopware_plugininstaller.plugin_licence_service');
             $service->importLicence($licence->getLicenseKey());
         } catch (Exception $e) {
@@ -619,7 +619,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
         $password = $this->Request()->getParam('password');
 
         try {
-            /** @var StoreClient $storeClient */
+            /** @var StoreClientInterface $storeClient */
             $storeClient = $this->get('shopware_plugininstaller.store_client');
             $token = $storeClient->getAccessToken($shopwareId, $password);
         } catch (StoreException $e) {
@@ -780,7 +780,7 @@ class Shopware_Controllers_Backend_PluginManager extends Shopware_Controllers_Ba
             array_column($positions, 'technicalName')
         );
 
-        /** @var PluginStoreService $pluginStoreService */
+        /** @var PluginStoreServiceInterface $pluginStoreService */
         $pluginStoreService = $this->get('shopware_plugininstaller.plugin_service_store_production');
         $plugins = $pluginStoreService->getPlugins($context);
 

--- a/tests/Mink/features/bootstrap/FeatureContext.php
+++ b/tests/Mink/features/bootstrap/FeatureContext.php
@@ -14,6 +14,7 @@ use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use Behat\Testwork\Suite\Suite;
 use Behat\Testwork\Tester\Result\TestResult;
 use Doctrine\DBAL\Connection;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerServiceInterface;
 
 class FeatureContext extends SubContext implements SnippetAcceptingContext
 {
@@ -104,7 +105,7 @@ EOD;
 
         Helper::setCurrentLanguage('de');
 
-        /** @var \Shopware\Bundle\PluginInstallerBundle\Service\InstallerService $pluginManager */
+        /** @var InstallerServiceInterface $pluginManager */
         $pluginManager = $this->getService('shopware_plugininstaller.plugin_manager');
 
         // hack to prevent behat error handler kicking in.


### PR DESCRIPTION
Our plugins use a base plugin to do certain things that many of our plugins have to do to try and reduce redundant code in our plugins. Now we are refactoring our plugins to fit the new 5.2 plugin structure and tried to decorate certain core services like the plugin installer to do these things more easily. We discovered that when using PHP 7 this causes issues as any service that depends on these decorated services would TypeHint the default service. 

We approached developer support about this and were advised to open a pull request to introduce interfaces for these core services. 

The only significant side effect is that plugins that depend on these core services should TypeHint the interface instead of the service class.

| Questions | Answers |
| --- | --- |
| BC breaks? | yes - sort of |
| Tests pass? | yes |
| Related tickets? | n/a |
| How to test? | try to decorate one of the core services, implement the interface |
