### PR TITLE
[Papercut][SW-16367] Ensure array key exists in changeset

### DIFF
--- a/engine/Shopware/Models/Media/Media.php
+++ b/engine/Shopware/Models/Media/Media.php
@@ -1587,8 +1587,8 @@ class Media extends ModelEntity
         //returns a change set for the model, which contains all changed properties with the old and new value.
         $changeSet = Shopware()->Models()->getUnitOfWork()->getEntityChangeSet($this);
 
-        $isNameChanged  = $changeSet['name'][0] !== $changeSet['name'][1];
-        $isAlbumChanged = $changeSet['albumId'][0] !== $changeSet['albumId'][1];
+        $isNameChanged  = isset($changeSet['name']) && $changeSet['name'][0] !== $changeSet['name'][1];
+        $isAlbumChanged = isset($changeSet['albumId']) && $changeSet['albumId'][0] !== $changeSet['albumId'][1];
 
         //name changed || album changed?
         if ($isNameChanged || $isAlbumChanged) {


### PR DESCRIPTION
## Description

Ensure array key exists in changeset to avoid notices

new one instead of https://github.com/shopware/shopware/pull/760

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-16367 |
