### PR TITLE
[Papercut][SW-12743] Fix image title attributes

### DIFF
--- a/themes/Frontend/Bare/frontend/blog/box.tpl
+++ b/themes/Frontend/Bare/frontend/blog/box.tpl
@@ -81,11 +81,11 @@
 								{if isset($sArticle.media.thumbnails)}
 									<img srcset="{$sArticle.media.thumbnails[0].sourceSet}"
 										 alt="{$sArticle.title|escape}"
-										 title="{$sArticle.title|escape|truncate:25:""}" />
+										 title="{$sArticle.title|escape|truncate:160}" />
 								{else}
 									<img src="{link file='frontend/_public/src/img/no-picture.jpg'}"
 										 alt="{$sArticle.title|escape}"
-										 title="{$sArticle.title|escape|truncate:25:""}" />
+										 title="{$sArticle.title|escape|truncate:160}" />
 								{/if}
 							</a>
 						</div>

--- a/themes/Frontend/Bare/frontend/blog/images.tpl
+++ b/themes/Frontend/Bare/frontend/blog/images.tpl
@@ -20,7 +20,7 @@
                     <img srcset="{$sArticle.preview.thumbnails[1].sourceSet}"
                          class="blog--image panel has--border is--rounded"
                          alt="{$alt}"
-						 title="{$alt|truncate:25:""}" />
+						 title="{$alt|truncate:160}" />
 				</a>
 			</div>
 		{/block}
@@ -46,7 +46,7 @@
                                <img srcset="{$sArticleMedia.thumbnails[0].sourceSet}"
                                     class="blog--thumbnail-image"
                                     alt="{s name="BlogThumbnailText" namespace="frontend/blog/detail"}{/s}: {$alt}"
-                                    title="{s name="BlogThumbnailText" namespace="frontend/blog/detail"}{/s}: {$alt|truncate:25:""}" />
+                                    title="{s name="BlogThumbnailText" namespace="frontend/blog/detail"}{/s}: {$alt|truncate:160}" />
 							</a>
 						{/if}
 					{/foreach}

--- a/themes/Frontend/Bare/frontend/checkout/ajax_add_article.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/ajax_add_article.tpl
@@ -36,10 +36,10 @@
 
                         <span class="image--media">
                             {if isset($image.thumbnails)}
-                                <img srcset="{$image.thumbnails[0].sourceSet}" alt="{$alt}" title="{$alt|truncate:25:""}" />
+                                <img srcset="{$image.thumbnails[0].sourceSet}" alt="{$alt}" title="{$alt|truncate:160}" />
                             {else}
                                 {block name='frontend_detail_image_fallback'}
-                                    <img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$alt}" title="{$alt|truncate:25:""}" />
+                                    <img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$alt}" title="{$alt|truncate:160}" />
                                 {/block}
                             {/if}
                         </span>

--- a/themes/Frontend/Bare/frontend/checkout/ajax_cart_item.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/ajax_cart_item.tpl
@@ -26,9 +26,10 @@
                         {if $basketItem.additional_details.image.description}
                             {$desc = $basketItem.additional_details.image.description|escape}
                         {/if}
-                        <img srcset="{$basketItem.additional_details.image.thumbnails[0].sourceSet}" alt="{$desc}" title="{$desc|truncate:25:""}" class="thumbnail--image"/>
+                        <img srcset="{$basketItem.additional_details.image.thumbnails[0].sourceSet}" alt="{$desc}" title="{$desc|truncate:160}" class="thumbnail--image" />
+
                     {elseif $basketItem.image.src.0}
-                        <img src="{$basketItem.image.src.0}" alt="{$desc}" title="{$desc|truncate:25:""}" class="thumbnail--image"/>
+                        <img src="{$basketItem.image.src.0}" alt="{$desc}" title="{$desc|truncate:160}" class="thumbnail--image" />
                     {/if}
                 {/if}
             {/block}

--- a/themes/Frontend/Bare/frontend/checkout/items/premium-product.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/items/premium-product.tpl
@@ -28,7 +28,7 @@
                                             {if $sBasketItem.image.description}
                                                 {$desc = $sBasketItem.image.description|escape}
                                             {/if}
-                                            <img src="{$sBasketItem.image.src.2}" alt="{$desc}" title="{$desc|truncate:25:""}" />
+                                            <img src="{$sBasketItem.image.src.2}" alt="{$desc}" title="{$desc|truncate:160}" />
                                             <span class="cart--badge">
                                                 <span>{s name="CartItemInfoFree"}{/s}</span>
                                             </span>

--- a/themes/Frontend/Bare/frontend/checkout/items/product.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/items/product.tpl
@@ -41,10 +41,10 @@
                                                         {$desc = $image.description|escape}
                                                     {/if}
 
-                                                    <img srcset="{$image.thumbnails[0].sourceSet}" alt="{$desc}" title="{$desc|truncate:25:""}" />
+                                                    <img srcset="{$image.thumbnails[0].sourceSet}" alt="{$desc}" title="{$desc|truncate:160}" />
                                                 </a>
                                             {else}
-                                                <img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$desc}" title="{$desc|truncate:25:""}" />
+                                                <img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$desc}" title="{$desc|truncate:160}" />
                                             {/if}
                                         {/block}
                                     </div>

--- a/themes/Frontend/Bare/frontend/compare/col.tpl
+++ b/themes/Frontend/Bare/frontend/compare/col.tpl
@@ -22,11 +22,11 @@
 
                                         <img srcset="{$sArticle.image.thumbnails[0].sourceSet}"
                                              alt="{$desc}"
-                                             title="{$desc|truncate:25:""}" />
+                                             title="{$desc|truncate:160}" />
                                     {else}
                                         <img src="{link file='frontend/_public/src/img/no-picture.jpg'}"
                                              alt="{$desc}"
-                                             title="{$desc|truncate:25:""}" />
+                                             title="{$desc|truncate:160}" />
                                     {/if}
                                 </span>
                             </span>

--- a/themes/Frontend/Bare/frontend/detail/images.tpl
+++ b/themes/Frontend/Bare/frontend/detail/images.tpl
@@ -23,7 +23,7 @@
                         {block name='frontend_detail_image_thumbs_main_img'}
                             <img srcset="{$sArticle.image.thumbnails[0].sourceSet}"
                                  alt="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt}"
-                                 title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt|truncate:25:""}"
+                                 title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt|truncate:160}"
                                  class="thumbnail--image" />
                         {/block}
                     </a>
@@ -46,7 +46,7 @@
                                 {block name='frontend_detail_image_thumbs_images_img'}
                                     <img srcset="{$image.thumbnails[0].sourceSet}"
                                          alt="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt}"
-                                         title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt|truncate:25:""}"
+                                         title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt|truncate:160}"
                                          class="thumbnail--image" />
                                 {/block}
                             </a>

--- a/themes/Frontend/Bare/frontend/listing/product-box/box-big-image.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/box-big-image.tpl
@@ -24,12 +24,12 @@
                         {block name='frontend_listing_box_article_image_picture_element'}
                             <img srcset="{$sArticle.image.thumbnails[1].sourceSet}"
                                  alt="{$desc}"
-                                 title="{$desc|truncate:25:""}" />
+                                 title="{$desc|truncate:160}" />
                         {/block}
                     {else}
                         <img src="{link file='frontend/_public/src/img/no-picture.jpg'}"
                              alt="{$desc}"
-                             title="{$desc|truncate:25:""}" />
+                             title="{$desc|truncate:160}" />
                     {/if}
                 </span>
             {/block}

--- a/themes/Frontend/Bare/frontend/listing/product-box/box-emotion.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/box-emotion.tpl
@@ -64,7 +64,7 @@
                                                     <picture>
                                                         {if $srcSetRetina}<source sizes="(min-width: 48em) {$itemSize}, 100vw" srcset="{$srcSetRetina}" media="(min-resolution: 192dpi)" />{/if}
                                                         {if $srcSet}<source sizes="(min-width: 48em) {$itemSize}, 100vw" srcset="{$srcSet}" />{/if}
-                                                        <img src="{$baseSource}" alt="{$desc}" title="{$desc|truncate:25:""}" />
+                                                        <img src="{$baseSource}" alt="{$desc}" title="{$desc|truncate:160}" />
                                                     </picture>
                                                 {/block}
                                             </span>

--- a/themes/Frontend/Bare/frontend/listing/product-box/product-image.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/product-image.tpl
@@ -18,12 +18,12 @@
                         {block name='frontend_listing_box_article_image_picture_element'}
                             <img srcset="{$sArticle.image.thumbnails[0].sourceSet}"
                                  alt="{$desc}"
-                                 title="{$desc|truncate:25:""}" />
+                                 title="{$desc|truncate:160}" />
                         {/block}
                     {else}
                         <img src="{link file='frontend/_public/src/img/no-picture.jpg'}"
                              alt="{$desc}"
-                             title="{$desc|truncate:25:""}" />
+                             title="{$desc|truncate:160}" />
                     {/if}
                 </span>
             {/block}

--- a/themes/Frontend/Bare/frontend/note/item.tpl
+++ b/themes/Frontend/Bare/frontend/note/item.tpl
@@ -20,14 +20,14 @@
 								{$desc = $sBasketItem.image.description|escape}
 							{/if}
 							<a href="{$detailLink}" title="{$sBasketItem.articlename|escape}" class="note--image-link">
-                                <img srcset="{$sBasketItem.image.thumbnails[0].sourceSet}" alt="{$desc}" title="{$desc|truncate:25:""}" class="note--image" />
+                                <img srcset="{$sBasketItem.image.thumbnails[0].sourceSet}" alt="{$desc}" title="{$desc|truncate:160}" class="note--image" />
 							</a>
 
 							{* Zoom picture *}
 							{block name="frontend_note_item_image_zoom"}{/block}
 						{else}
 							<a href="{$detailLink}" title="{$sBasketItem.articlename|escape}" class="note--image-link">
-								<img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$desc}" title="{$desc|truncate:25:""}" class="note--image" />
+								<img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$desc}" title="{$desc|truncate:160}" class="note--image" />
 							</a>
 						{/if}
 					</div>

--- a/themes/Frontend/Bare/newsletter/container/article.tpl
+++ b/themes/Frontend/Bare/newsletter/container/article.tpl
@@ -27,7 +27,7 @@
                                     <div align="center" style="overflow:hidden;">
                                         <a target="_blank" href="{url controller=detail sArticle=$sArticle.articleID}" title="{$sArticle.articleName|escape}">
                                             {if $sArticle.image.source}
-                                                <img style="max-height: 160px; max-width: 160px;" src="{$sArticle.image.thumbnails[0].source}" border="0" alt="{$sArticle.articleName|escape|truncate:155}">
+                                                <img style="max-height: 160px; max-width: 160px;" src="{$sArticle.image.thumbnails[0].source}" border="0" alt="{$sArticle.articleName|escape|truncate:160}">
                                             {else}
                                                 <img style="max-height: 160px; max-width: 160px;" src="{link file='frontend/_public/src/img/no-picture.jpg' fullPath}" alt="{s name="ListingBoxNoPicture" namespace="frontend/listing/box_article"}{/s}" border="0"/>
                                             {/if}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? Fixes title tag for article images with length > 25
- What does it improve? Look & feel
- Does it have side effects? No.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-12743 |
| How to test? | Articles with image title set to something with " " will not be cutted. Cutting was not because of " " but of short truncate length of 25. After talking to STP there is no reason to limit this to 25. |
