### PR TITLE
[Papercut][SW-16380] Added Purchaseprice to Productexport

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -904,6 +904,7 @@ class sExport
                 a.filtergroupID,
                 a.supplierID,
                 d.unitID,
+                d.purchaseprice,
                 IF(a.changetime!='0000-00-00 00:00:00',a.changetime,'') as `changed`,
                 IF(a.datum!='0000-00-00',a.datum,'') as `added`,
                 IF(d.releasedate!='0000-00-00',d.releasedate,'') as `releasedate`,


### PR DESCRIPTION
## Description

It makes to available to use purchaseprice in productexports

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-16380 |
| How to test? | Use {$sArticle.purchaseprice} in productexport |
