### PR TITLE
[Papercut][SW-16376] remove unused image handling in last seen articl…

### DIFF
--- a/_sql/migrations/791-change-last-articles-plugin.php
+++ b/_sql/migrations/791-change-last-articles-plugin.php
@@ -1,0 +1,34 @@
+<?php
+
+use Shopware\Components\Migrations\AbstractMigration;
+
+class Migrations_Migration791 extends AbstractMigration
+{
+    /**
+     * @inheritdoc
+     */
+    public function up($modus)
+    {
+        $sql = <<<'SQL'
+            UPDATE `s_core_subscribes`
+            SET `subscribe` = 'Enlight_Controller_Action_PostDispatchSecure_Frontend'
+            WHERE `listener` = 'Shopware_Plugins_Frontend_LastArticles_Bootstrap::onPostDispatch';
+SQL;
+        $this->addSql($sql);
+
+        $sql = <<<'SQL'
+            ALTER TABLE `s_emarketing_lastarticles` DROP `img`;
+SQL;
+        $this->addSql($sql);
+
+        $sql = <<<'SQL'
+            SET @formId = (SELECT id FROM `s_core_config_forms` WHERE `name` = 'LastArticles');
+
+            UPDATE `s_core_config_elements`
+            SET `scope` = '1'
+            WHERE `form_id` = @formId
+              AND (`name` = 'lastarticlestoshow' OR `name` = 'time');
+SQL;
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Plugins/Default/Frontend/LastArticles/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/LastArticles/Bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -22,6 +23,8 @@
  * our trademarks remain entirely with us.
  */
 
+use Shopware\Models\Config\Element;
+
 /**
  * Shopware LastArticles Plugin
  */
@@ -35,62 +38,84 @@ class Shopware_Plugins_Frontend_LastArticles_Bootstrap extends Shopware_Componen
     public function install()
     {
         $this->subscribeEvent(
-            'Enlight_Controller_Action_PostDispatch',
+            'Enlight_Controller_Action_PostDispatchSecure_Frontend',
             'onPostDispatch'
         );
-        $form = $this->Form();
-        $parent = $this->Forms()->findOneBy(array('name' => 'Frontend'));
-        $form->setParent($parent);
-        $form->setElement('checkbox', 'show', array(
-            'label' => 'Artikelverlauf anzeigen',
-            'value' => true,
-            'scope' => Shopware\Models\Config\Element::SCOPE_SHOP
-        ));
-        $form->setElement('text', 'controller', array(
-            'label' => 'Controller-Auswahl',
-            'value' => 'index, listing, detail, custom, newsletter, sitemap, campaign',
-            'scope' => Shopware\Models\Config\Element::SCOPE_SHOP
-        ));
-        $form->setElement('number', 'thumb', array(
-            'label' => 'Vorschaubild-Größe',
-            'value' => 2,
-            'scope' => Shopware\Models\Config\Element::SCOPE_SHOP
-        ));
-        $form->setElement('number', 'lastarticlestoshow', array(
-            'label' => 'Anzahl Artikel in Verlauf (zuletzt angeschaut)',
-            'value' => 5
-        ));
-        $form->setElement('number', 'time', array(
-            'label' => 'Speicherfrist in Tagen',
-            'value' => 15
-        ));
 
-        $this->addFormTranslations(
-            array(
-                'en_GB' => array(
-                    'plugin_form' => array(
-                        'label' => 'Recently viewed items'
-                    ),
-                    'show' => array(
-                        'label' => 'Display recently viewed items'
-                    ),
-                    'controller' => array(
-                        'label' => 'Controller selection'
-                    ),
-                    'thumb' => array(
-                        'label' => 'Thumbnail size',
-                        'description' => 'Index of the thumbnail size of the associated album to use. Starts at 0'
-                    ),
-                    'lastarticlestoshow' => array(
-                        'label' => 'Maximum number of items to display'
-                    ),
-                    'time' => array(
-                        'label' => 'Storage period in days'
-                    )
-                )
-            )
-        );
+        $this->createConfigForm();
+
         return true;
+    }
+
+    /**
+     * create the configuration for the last viewed products
+     */
+    private function createConfigForm()
+    {
+        $form = $this->Form();
+        /** @var \Shopware\Models\Config\Form $parent */
+        $parent = $this->Forms()->findOneBy(['name' => 'Frontend']);
+        $form->setParent($parent);
+
+        $form->setElement(
+            'checkbox',
+            'show',
+            [
+                'label' => 'Artikelverlauf anzeigen',
+                'value' => true,
+                'scope' => Element::SCOPE_SHOP
+            ]
+        );
+
+        $form->setElement(
+            'text',
+            'controller',
+            [
+                'label' => 'Controller-Auswahl',
+                'value' => 'index, listing, detail, custom, newsletter, sitemap, campaign',
+                'scope' => Element::SCOPE_SHOP
+            ]
+        );
+
+        $form->setElement(
+            'number',
+            'lastarticlestoshow',
+            [
+                'label' => 'Anzahl Artikel in Verlauf (zuletzt angeschaut)',
+                'value' => 5,
+                'scope' => Element::SCOPE_SHOP
+            ]
+        );
+
+        $form->setElement(
+            'number',
+            'time',
+            [
+                'label' => 'Speicherfrist in Tagen',
+                'value' => 15,
+                'scope' => Element::SCOPE_SHOP
+            ]
+        );
+
+        $this->addFormTranslations([
+           'en_GB' => [
+               'plugin_form' => [
+                   'label' => 'Recently viewed items'
+               ],
+               'show' => [
+                   'label' => 'Display recently viewed items'
+               ],
+               'controller' => [
+                   'label' => 'Controller selection'
+               ],
+               'lastarticlestoshow' => [
+                   'label' => 'Maximum number of items to display'
+               ],
+               'time' => [
+                   'label' => 'Storage period in days'
+               ]
+           ]
+       ]);
     }
 
     /**
@@ -98,9 +123,9 @@ class Shopware_Plugins_Frontend_LastArticles_Bootstrap extends Shopware_Componen
      */
     public function getInfo()
     {
-        return array(
+        return [
             'label' => 'Artikelverlauf'
-        );
+        ];
     }
 
     /**
@@ -109,44 +134,30 @@ class Shopware_Plugins_Frontend_LastArticles_Bootstrap extends Shopware_Componen
      * Read the last article in defined controllers
      * Saves the last article in detail controller
      *
-     * @param Enlight_Event_EventArgs $args
+     * @param Enlight_Controller_ActionEventArgs $args
      */
-    public function onPostDispatch(Enlight_Event_EventArgs $args)
+    public function onPostDispatch(Enlight_Controller_ActionEventArgs $args)
     {
         $request = $args->getSubject()->Request();
-        $response = $args->getSubject()->Response();
         $view = $args->getSubject()->View();
-
-        if (!$request->isDispatched()
-            || $response->isException()
-            || $request->getModuleName() != 'frontend'
-            //|| !empty(Shopware()->Session()->Bot)
-            || !$view->hasTemplate()
-        ) {
-            return;
-        }
-
         $config = $this->Config();
 
         if (rand(0, 100) === 0) {
-            $time = $config->time > 0 ? (int) $config->time : 15;
-            $sql = '
-                DELETE FROM s_emarketing_lastarticles
-                WHERE time < DATE_SUB(CONCAT(CURDATE(), ?), INTERVAL ? DAY)
-            ';
-            Shopware()->Db()->query($sql, array(' 00:00:00', $time));
+            $time = $config->get('time') > 0 ? (int) $config->get('time') : 15;
+            $sql = 'DELETE FROM s_emarketing_lastarticles
+                    WHERE time < DATE_SUB(CONCAT(CURDATE(), ?), INTERVAL ? DAY);';
+            $this->get('db')->query($sql, [' 00:00:00', $time]);
 
-            Shopware()->Events()->notify('Shopware_Plugins_LastArticles_ResetLastArticles', array(
+            $this->get('events')->notify('Shopware_Plugins_LastArticles_ResetLastArticles', [
                 'subject' => $this
-            ));
+            ]);
         }
 
         if (empty($config->show)) {
             return;
         }
-        if (!empty($config->controller)
-            && strpos($config->controller, $request->getControllerName()) === false
-        ) {
+
+        if (!empty($config->controller) && strpos($config->controller, $request->getControllerName()) === false) {
             return;
         }
 
@@ -157,65 +168,38 @@ class Shopware_Plugins_Frontend_LastArticles_Bootstrap extends Shopware_Componen
      * Creates a new s_emarketing_lastarticles entry for the passed article id.
      *
      * @param int $articleId
-     * @return \Zend_Db_Statement_Pdo
      */
     public function setLastArticleById($articleId)
     {
-        $article = $this->getArticleData((int) $articleId);
+        /** @var \Enlight_Components_Session_Namespace $session */
+        $session = $this->get('session');
+        $session->offsetSet('sLastArticle', $articleId);
+        $sessionId = $session->get('sessionId');
+        $articleName = (string) Shopware()->Modules()->Articles()->sGetArticleNameByArticleId($articleId);
 
-        Shopware()->Session()->sLastArticle = $articleId;
-        $sessionId = Shopware()->Session()->get('sessionId');
-
-        if (empty($sessionId) || empty($article['articleName']) || empty($articleId)) {
+        if (!$sessionId || !$articleName || !$articleId) {
             return;
         }
 
-        Shopware()->Events()->notify('Shopware_Modules_Articles_Before_SetLastArticle', array(
-            'subject'   => Shopware()->Modules()->Articles(),
-            'article'   => $articleId
-        ));
+        $this->get('events')->notify('Shopware_Modules_Articles_Before_SetLastArticle', [
+            'subject' => Shopware()->Modules()->Articles(),
+            'article' => $articleId
+        ]);
 
-        return Shopware()->Db()->query('
-            INSERT INTO s_emarketing_lastarticles
-                (img, name, articleID, sessionID, time, userID, shopID)
-            VALUES
-                (?, ?, ?, ?, NOW(), ?, ?)
-            ON DUPLICATE KEY UPDATE time=NOW(), userID=VALUES(userID)
-        ', array(
-            (string) $article['image'],
-            (string) $article['articleName'],
-            $articleId,
-            $sessionId,
-            (int) Shopware()->Session()->sUserId,
-            (int) Shopware()->Shop()->getId()
-        ));
-    }
-
-    /**
-     * Helper function which returns a data array with the article id,
-     * name and preview image.
-     *
-     * @param $id
-     * @return array
-     */
-    protected function getArticleData($id)
-    {
-        $images = Shopware()->Modules()->Articles()->sGetArticlePictures($id, true);
-
-        $size = $this->Config()->thumb;
-        if (!$size) {
-            $size = Shopware()->Config()->lastArticlesThumb;
-        }
-        $image = null;
-
-        if (isset($images['src'][$size])) {
-            $image = $images['src'][$size];
-        }
-
-        return array(
-            'articleID' => $id,
-            'image' => $image,
-            'articleName' => Shopware()->Modules()->Articles()->sGetArticleNameByArticleId($id)
+        $sql = 'INSERT INTO s_emarketing_lastarticles
+                    (name, articleID, sessionID, time, userID, shopID)
+                VALUES
+                    (?, ?, ?, NOW(), ?, ?)
+                ON DUPLICATE KEY UPDATE time=NOW(), userID=VALUES(userID);';
+        $this->get('db')->query(
+            $sql,
+            [
+                $articleName,
+                $articleId,
+                $sessionId,
+                (int) $session->get('sUserId'),
+                (int) $this->get('shop')->getId()
+            ]
         );
     }
 }

--- a/tests/Functional/Plugins/Core/MarketingAggregate/Components/SimilarShownTest.php
+++ b/tests/Functional/Plugins/Core/MarketingAggregate/Components/SimilarShownTest.php
@@ -33,6 +33,9 @@ use Shopware\Tests\Functional\Plugins\Core\MarketingAggregate\AbstractMarketing;
  */
 class SimilarShownTest extends AbstractMarketing
 {
+    /**
+     * @return array
+     */
     protected function getDemoData()
     {
         return require __DIR__ . '/fixtures/similarShown.php';
@@ -44,32 +47,40 @@ class SimilarShownTest extends AbstractMarketing
     protected function insertDemoData()
     {
         $this->Db()->query("DELETE FROM s_emarketing_lastarticles");
-        $statement = $this->Db()->prepare("
-            INSERT INTO s_emarketing_lastarticles (img, name, articleID, sessionID, time, userID, shopID)
-            VALUES(:img, :name, :articleID, :sessionID, :time, :userID, :shopID)"
+        $statement = $this->Db()->prepare(
+            "INSERT INTO s_emarketing_lastarticles (name, articleID, sessionID, time, userID, shopID)
+             VALUES(:name, :articleID, :sessionID, :time, :userID, :shopID);"
         );
         foreach ($this->getDemoData() as $data) {
             $statement->execute($data);
         }
     }
 
+    /**
+     * @param string $condition
+     * @return array
+     */
     protected function getAllSimilarShown($condition = '')
     {
         return $this->Db()->fetchAll('SELECT * FROM s_articles_similar_shown_ro ' . $condition);
     }
 
+    /**
+     * @param string $condition
+     */
     protected function resetSimilarShown($condition = '')
     {
         $this->Db()->query("DELETE FROM s_articles_similar_shown_ro " . $condition);
     }
 
+    /**
+     * @param string $date
+     * @param string $condition
+     */
     protected function setSimilarShownInvalid($date = '2010-01-01', $condition = '')
     {
-        $this->Db()->query(" UPDATE s_articles_similar_shown_ro SET init_date = :date " . $condition, array(
-            'date' => $date
-        ));
+        $this->Db()->query(" UPDATE s_articles_similar_shown_ro SET init_date = :date " . $condition, ['date' => $date]);
     }
-
 
     public function testResetSimilarShown()
     {
@@ -142,7 +153,7 @@ class SimilarShownTest extends AbstractMarketing
 
         $this->setSimilarShownInvalid('2010-01-01', 'LIMIT 20');
 
-        Shopware()->Events()->notify('Shopware_Plugins_LastArticles_ResetLastArticles', array());
+        Shopware()->Events()->notify('Shopware_Plugins_LastArticles_ResetLastArticles', []);
 
         $articles = $this->getAllSimilarShown();
 
@@ -169,7 +180,7 @@ class SimilarShownTest extends AbstractMarketing
         $this->assertNotEmpty($cron);
 
         //the cron plugin isn't installed, so we can't use a dispatch on /backend/cron
-        $this->Plugin()->refreshSimilarShown(new \Enlight_Event_EventArgs(array('subject' => $this)));
+        $this->Plugin()->refreshSimilarShown(new \Enlight_Event_EventArgs(['subject' => $this]));
 
         $articles = $this->getAllSimilarShown(" WHERE init_date > '2010-01-01' ");
         $this->assertCount(

--- a/tests/Functional/Plugins/Core/MarketingAggregate/Components/fixtures/similarShown.php
+++ b/tests/Functional/Plugins/Core/MarketingAggregate/Components/fixtures/similarShown.php
@@ -1,25 +1,25 @@
 <?php
 
-return array(
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Sonnenbrille-rot_105x105.jpg','name'=>'Sonnenbrille "Red"','articleID'=>'170','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:11','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Sonnenbrille-Pilot-silber_105x105.jpg','name'=>'Pilotenbrille Silver Sky','articleID'=>'169','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:19','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Sonnenbrille-Pilot-rot_105x105.jpg','name'=>'Pilotenbrille Sunset Red','articleID'=>'168','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:20','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Sonnenbrille-gruen_105x105.jpg','name'=>'Sonnenbrille Speed Eyes','articleID'=>'167','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:22','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Sonnenbrille-Damen-rot_105x105.jpg','name'=>'Sonnenbrille Big Eyes','articleID'=>'166','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:23','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Schal-bunt-Blumen_105x105.jpg','name'=>'Sommerschal Flower Power','articleID'=>'163','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:26','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Hut-Strohhut-Women_105x105.jpg','name'=>'Strohhut Women mit UV Schutz','articleID'=>'159','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:27','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/VINTAGEDRIVER-Collection-Basecap-beige_720x600503f743e2f461_105x105.jpg','name'=>'Mütze Vintage Driver','articleID'=>'145','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:17:59','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Heiku-Kickerfigurenuebersicht_105x105.jpg','name'=>'Kicker Figuren Set, große Auswahl','articleID'=>'117','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:01','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Dart-Set_105x105.jpg','name'=>'Dart-Set','articleID'=>'246','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:01','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Bumerang_105x105.jpg','name'=>'Bumerang','articleID'=>'245','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:02','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Steel-Dartpfeil_105x105.jpg','name'=>'Dartpfeil Steel Smiley 745','articleID'=>'242','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:04','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Steel-Dartpfeil-Atomic_105x105.jpg','name'=>'Dartpfeil Steel Atomic','articleID'=>'241','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:05','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Dartscheibe-Dartona_105x105.jpg','name'=>'Dartscheibe Circle','articleID'=>'240','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:06','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Kicker-Service-Box5034905cc23c9_105x105.jpg','name'=>'Kicker Service Box','articleID'=>'195','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:08','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Reisetasche-Gladstone-Canvas_720x600503f778670dd3_105x105.jpg','name'=>'Reisetasche Gladstone Wildleder','articleID'=>'148','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:09','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Navigator-Lederhaube-schwarz_105x105.jpg','name'=>'Navigator Lederhaube schwarz','articleID'=>'144','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:10','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Lagerkorn_XO_105x105.jpg','name'=>'Special Finish Lagerkorn X.O. 32%','articleID'=>'9','sessionID'=>'c0f4a00b957676b84329e060616c0db25434a7d5','time'=>'2013-06-19 13:18:25','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Cigar_Special_105x105.jpg','name'=>'Cigar Special 40%','articleID'=>'6','sessionID'=>'c0f4a00b957676b84329e060616c0db25434a7d5','time'=>'2013-06-19 13:18:27','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Muensterlaender_Aperitif_Flasche_105x105.jpg','name'=>'Münsterländer Aperitif 16%','articleID'=>'3','sessionID'=>'c0f4a00b957676b84329e060616c0db25434a7d5','time'=>'2013-06-19 13:18:28','userID'=>'0','shopID'=>'1'),
-    array('img'=>'http://dr.test.shopware.in/next/media/image/thumbnail/Muensterlaender_Lagerkorn_105x105.jpg','name'=>'Münsterländer Lagerkorn 32%','articleID'=>'2','sessionID'=>'c0f4a00b957676b84329e060616c0db25434a7d5','time'=>'2013-06-19 13:18:29','userID'=>'0','shopID'=>'1')
-);
+return [
+    ['name'=>'Sonnenbrille "Red"','articleID'=>'170','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:11','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Pilotenbrille Silver Sky','articleID'=>'169','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:19','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Pilotenbrille Sunset Red','articleID'=>'168','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:20','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Sonnenbrille Speed Eyes','articleID'=>'167','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:22','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Sonnenbrille Big Eyes','articleID'=>'166','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:23','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Sommerschal Flower Power','articleID'=>'163','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:26','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Strohhut Women mit UV Schutz','articleID'=>'159','sessionID'=>'a0485a6170e87c0ef86e537c5f1bd91b57468327','time'=>'2013-06-19 13:16:27','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Mütze Vintage Driver','articleID'=>'145','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:17:59','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Kicker Figuren Set, große Auswahl','articleID'=>'117','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:01','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Dart-Set','articleID'=>'246','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:01','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Bumerang','articleID'=>'245','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:02','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Dartpfeil Steel Smiley 745','articleID'=>'242','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:04','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Dartpfeil Steel Atomic','articleID'=>'241','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:05','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Dartscheibe Circle','articleID'=>'240','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:06','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Kicker Service Box','articleID'=>'195','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:08','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Reisetasche Gladstone Wildleder','articleID'=>'148','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:09','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Navigator Lederhaube schwarz','articleID'=>'144','sessionID'=>'47648a89ea936eb2b2a44a3404958ed5ebfb2f70','time'=>'2013-06-19 13:18:10','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Special Finish Lagerkorn X.O. 32%','articleID'=>'9','sessionID'=>'c0f4a00b957676b84329e060616c0db25434a7d5','time'=>'2013-06-19 13:18:25','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Cigar Special 40%','articleID'=>'6','sessionID'=>'c0f4a00b957676b84329e060616c0db25434a7d5','time'=>'2013-06-19 13:18:27','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Münsterländer Aperitif 16%','articleID'=>'3','sessionID'=>'c0f4a00b957676b84329e060616c0db25434a7d5','time'=>'2013-06-19 13:18:28','userID'=>'0','shopID'=>'1'],
+    ['name'=>'Münsterländer Lagerkorn 32%','articleID'=>'2','sessionID'=>'c0f4a00b957676b84329e060616c0db25434a7d5','time'=>'2013-06-19 13:18:29','userID'=>'0','shopID'=>'1']
+];


### PR DESCRIPTION
## Description

Please describe your pull request:
- What does it improve?
  - the last seen products widgets shows now the correct preview image. the same as in the listing. also the plugin was cleaned up and unnecessary code was removed. the image info was not saved correctly, so I removed it. Also I changed the scope of two config options, so you can select different amounts for subshops
- Does it have side effects?
  - no

| Questions | Answers |
| --- | --- |
| BC breaks? | maybe if someone relies on the `img` column of `s_emarketing_lastarticles` but it was never filled in 5.2.6 |
| Related tickets? | [Issue](https://issues.shopware.com/#/issues/SW-16376) |
| How to test? | browse through the shop to different products and have a look if the image of the products is correct in the last seen widget |
