### PR TITLE
[Papercut][SW-16211] resolve double negatives by offering config type boolean-reverse

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/element/boolean_select.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/boolean_select.js
@@ -39,11 +39,23 @@ Ext.define('Shopware.apps.Base.view.element.BooleanSelect', {
     queryMode: 'local',
     forceSelection: true,
     editable: false,
+    reverse: false,
 
     store: [
         ["", 'Inherited'],
         [true, 'Yes'],
         [false, 'No']
-    ]
+    ],
+    initComponent: function(){
+        var me = this;
+        if(me.reverse) {
+            me.store[1][0] = false;
+            me.store[2][0] = true;
+        } else {
+            me.store[1][0] = true;
+            me.store[2][0] = false;
+        }
+        me.callParent(arguments);
+    }
 });
 //{/block}

--- a/themes/Backend/ExtJs/backend/config/view/main/form.js
+++ b/themes/Backend/ExtJs/backend/config/view/main/form.js
@@ -139,7 +139,7 @@ Ext.define('Shopware.apps.Config.view.main.Form', {
                     allowBlank: !element.get('required') || !shop.get('default')
                 }, options);
 
-                if (field.xtype == "config-element-boolean" || field.xtype == "config-element-checkbox") {
+                if (field.xtype === "config-element-boolean" || field.xtype === "config-element-boolean-reverse" || field.xtype === "config-element-checkbox") {
                     field = me.convertCheckBoxToComboBox(field, shop, initialValue);
                 }
 
@@ -205,6 +205,7 @@ Ext.define('Shopware.apps.Config.view.main.Form', {
         Ext.apply(field, {
             xtype: "base-element-boolean-select",
             value: booleanSelectValue,
+            reverse: field.xtype === "config-element-boolean-reverse",
             emptyText: ""
         });
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? Labels of config fields use double negatives to describe the effect. This is confusing. The consequence of changing the wording without negatives would be the necessity to  refactor every condition where the boolean value is queried.
- What does it improve? By using the config element typ boolean-reverse the wording can be changed so no negatives are used without the need to refactor every condition elsewhere. It just changes the label for false values to "Yes" and respectively the value of true values to "No".
- Does it have side effects? None so far.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/issues/SW-16211#/issues/SW-16211 |
| How to test? | Set Config Form Element  with type boolean-reverse "Yes" should be false "No" should be true |
