### PR TITLE
[Papercut][SW-16407] collect meta data per variant order number

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -341,7 +341,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
 
         $articleModule = Shopware()->Modules()->Articles();
         foreach ($positions as &$position) {
-            $position['meta'] = $articleModule->sGetPromotionById('fix', 0, (int) $position['articleID']);
+            $position['meta'] = $articleModule->sGetPromotionById('fix', 0, $position['articleordernumber']);
         }
 
         if ($this->_config["_previewForcePagebreak"]) {


### PR DESCRIPTION
## Description
- Why is it necessary?
  - collecting of the meta data on creating a document is wrong
- What does it improve?
  - collects the data of a variant, not of the main variant
- Does it have side effects?
  - maybe templates which rely on this information could break

| Questions | Answers |
| --- | --- |
| BC breaks? | maybe, see above |
| Tests pass? | yes |
| Related tickets? | [Issue](https://issues.shopware.com/#/issues/SW-16407) |
| How to test? | extend the document template to show the whole data |
