### PR TITLE
Do not show inactive product variants in bonus products

### DIFF
--- a/engine/Shopware/Core/sMarketing.php
+++ b/engine/Shopware/Core/sMarketing.php
@@ -462,7 +462,7 @@ class sMarketing
                 return array(
                     'ordernumber' => $elem->getNumber(),
                     'additionaltext' => $elem->getAdditional(),
-                    'stock' => $elem->getStock()
+                    'instock' => $elem->getStock()
                 );
             },
             $products

--- a/engine/Shopware/Core/sMarketing.php
+++ b/engine/Shopware/Core/sMarketing.php
@@ -420,9 +420,9 @@ class sMarketing
     {
         $context = $this->contextService->getShopContext();
 
-        $sql = "SELECT id, ordernumber, additionaltext
+        $sql = "SELECT id, ordernumber, additionaltext, instock
             FROM s_articles_details
-            WHERE articleID = :articleId AND kind != 3";
+            WHERE articleID = :articleId AND kind != 3 AND active > 0 ";
 
         $variantsData = Shopware()->Db()->fetchAll(
             $sql,
@@ -451,6 +451,7 @@ class sMarketing
             }
 
             $product->setAdditional($variantData['additionaltext']);
+            $product->setStock($variantData['instock']);
             $products[$variantData['ordernumber']] = $product;
         }
 
@@ -460,7 +461,8 @@ class sMarketing
             function (StoreFrontBundle\Struct\ListProduct $elem) {
                 return array(
                     'ordernumber' => $elem->getNumber(),
-                    'additionaltext' => $elem->getAdditional()
+                    'additionaltext' => $elem->getAdditional(),
+                    'stock' => $elem->getStock()
                 );
             },
             $products


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary?

Inactive product variants can be selected and added to the cart in the bonus product section of the cart.
I think this should not be the case. If you show the customer a bonus product and allow to add it to cart the product has to be available.
- What does it improve?

To achieve this I removed inactive variants from the selection and additionally added a template variable of the stock value to make it possible to hide variants that have no stock.
 Given the fact that not every store will manage stock levels, I did not add the stock check to the database query, but added the template variable. This way we can hide variants without stock with a template overwrite if desired.
- Does it have side effects?

I do not know any.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | none found |
| How to test? | setup demo store. Configure a bonus product with variants like the T-SHIRT LOGO TEE CHARCOAL. Set one variant to inactive. Fill your cart to match the bonus product criteria. validate that the inactive variant is not listed in the options. To check the template variable you need the shopware-profiler plugin. I will not go into details here. |
