### PR TITLE
[papercut] SW-15574 throw exception if manufacturer doesn't exist

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -139,6 +139,13 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
                 $manufacturerId,
                 $this->get('shopware_storefront.context_service')->getShopContext()
             );
+            
+            if ($manufacturer === null) {
+                throw new Enlight_Controller_Exception(
+                    'Manufacturer missing, non-existent or invalid',
+                    404
+                );
+            }
 
             $manufacturerContent = $this->getSeoDataOfManufacturer($manufacturer);
 


### PR DESCRIPTION
Please describe your pull request:

> Why is it necessary?

Shopware will throw an avoidable runtime exception if an invalid manufacturer id is provided in the listing controller index action ( e.g. /supplier/index/sSupplier/12345 )

> What does it improve?

Handle an invalid id properly by throwing a not found exception

> Does it have side effects?

no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-15574 |
| How to test? | Enter an invalid supplier id: /supplier/index/sSupplier/12345  you should be redirected to the set 404 page now |
