### PR TITLE
[Papercut][SW-14728] Follow link show listing

### DIFF
--- a/themes/Frontend/Bare/frontend/listing/listing.tpl
+++ b/themes/Frontend/Bare/frontend/listing/listing.tpl
@@ -43,7 +43,7 @@
                 {if !$showListing}
                     {block name="frontend_listing_list_promotion_link_show_listing"}
                         <div class="emotion--show-listing{if $fullscreen} is--align-center{/if}">
-                            <a href="{url controller='cat' sPage=1 sCategory=$sCategoryContent.id}" title="{$sCategoryContent.name|escape}" class="link--show-listing{if $fullscreen} btn is--primary{/if}" rel="nofollow">
+                            <a href="{url controller='cat' sPage=1 sCategory=$sCategoryContent.id}" title="{$sCategoryContent.name|escape}" class="link--show-listing{if $fullscreen} btn is--primary{/if}">
                                 {s name="ListingActionsOffersLink"}Weitere Artikel in dieser Kategorie &raquo;{/s}
                             </a>
                         </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? Google recommends to follow all internal links
- What does it improve? google page indexing
- Does it have side effects? no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-14728 |
| How to test? | navigate to a category with associated emotion. removed rel attribute for link to listing below the emotion. |
