### PR TITLE
[Papercut][SW-15491] count orders for CronRating return value

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/CronRating/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/CronRating/Bootstrap.php
@@ -86,7 +86,7 @@ class Shopware_Plugins_Core_CronRating_Bootstrap extends Shopware_Components_Plu
             }
         }
 
-        return count($orders) . ' rating mails was sent.';
+        return count($orders) . ' rating mails were sent.';
     }
 
     public function getOrders($sendTime)

--- a/engine/Shopware/Plugins/Default/Core/CronRating/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/CronRating/Bootstrap.php
@@ -86,7 +86,7 @@ class Shopware_Plugins_Core_CronRating_Bootstrap extends Shopware_Components_Plu
             }
         }
 
-        return count($order) . ' rating mails was sent.';
+        return count($orders) . ' rating mails was sent.';
     }
 
     public function getOrders($sendTime)


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? Return value of CronRating would constantly stay the same
- What does it improve? The iteration of orders array was counted instead of the the array itself. Also fixed a grammar mistake in the return message.
- Does it have side effects? no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-15491 |
| How to test? | run cron job of action Shopware_CronJob_ArticleComment |
