### PR TITLE
[Papercut][SW-15915] Disable shop selection when start compiling

### DIFF
--- a/themes/Backend/ExtJs/backend/index/view/theme_cache/theme_cache_warm_up.js
+++ b/themes/Backend/ExtJs/backend/index/view/theme_cache/theme_cache_warm_up.js
@@ -271,6 +271,7 @@ Ext.define('Shopware.apps.Index.view.themeCache.ThemeCacheWarmUp', {
                 }
                 me.closeButton.disable();
                 me.filterThemes();
+                me.shopSelector.disable();
                 me.fireEvent('themeCacheWarmUpStartProcess');
             }
         });
@@ -307,6 +308,7 @@ Ext.define('Shopware.apps.Index.view.themeCache.ThemeCacheWarmUp', {
             hidden: true,
             handler: function() {
                 this.disable();
+                me.shopSelector.enable();
                 me.fireEvent('themeCacheWarmUpCancelProcess');
             }
         });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? Fixes small issue when starting theme compiling
- What does it improve? Disables shop selection when compiling starts
- Does it have side effects? no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://jira.shopware.com/browse/SW-15915 |
| How to test? | Start theme compiling - Shop selection will be disabled, on cancel enabled |
