### PR TITLE
enable session usage in the backend / prevent fatal error

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
@@ -25,6 +25,7 @@
 namespace Shopware\Components\DependencyInjection\Bridge;
 
 use Shopware\Components\DependencyInjection\Container;
+use Shopware\Models\Shop\Shop;
 
 /**
  * Session Dependency Injection Bridge
@@ -56,14 +57,19 @@ class Session
         /** @var $shop \Shopware\Models\Shop\Shop */
         $shop = $container->get('Shop');
 
-        $name = 'session-' . $shop->getId();
-        $sessionOptions['name'] = $name;
+        if (! $shop instanceof Shop) {
+            $name = 'session-backend';
+        } else {
+            $name = 'session-' . $shop->getId();
 
-        $mainShop = $shop->getMain() ?: $shop;
-        if ($mainShop->getAlwaysSecure()) {
-            $sessionOptions['cookie_secure'] = true;
+            $mainShop = $shop->getMain() ?: $shop;
+            if ($mainShop->getAlwaysSecure()) {
+                $sessionOptions['cookie_secure'] = true;
+            }
         }
 
+        $sessionOptions['name'] = $name;
+        
         if (!isset($sessionOptions['save_handler']) || $sessionOptions['save_handler'] == 'db') {
             $config_save_handler = array(
                 'db'             => $container->get('Db'),


### PR DESCRIPTION
## Description

Please describe your pull request:
- Why is it necessary? When a symfony service/subscriber injects the session service, it will lead to a fatal error in the Backend. This pull request prevents this error.
- What does it improve? The session handling
- Does it have side effects? No

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | If this PR fixes an existing [Issue](https://issues.shopware.com) ticket, please add its complete issue URL. |
| How to test? | Inject the session service into a service or subscriber and load the Backend. |

this prevents a fatal error in the backend, when a symfony service/subscriber injects the session service
