### PR TITLE
Fix PHP 7 fatal error in mPDF SVG rendering

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -2,6 +2,12 @@
 
 This changelog references changes done in Shopware 5.2 patch versions.
 
+## 5.2.8
+
+[View all changes from v5.2.7...v5.2.8](https://github.com/shopware/shopware/compare/v5.2.7...v5.2.8)
+
+* Fixed a PHP 7 fatal error in the SVG rendering of mPDF
+
 ## 5.2.7
 
 [View all changes from v5.2.6...v5.2.7](https://github.com/shopware/shopware/compare/v5.2.6...v5.2.7)

--- a/engine/Library/Mpdf/classes/svg.php
+++ b/engine/Library/Mpdf/classes/svg.php
@@ -2707,7 +2707,7 @@ function svgDefineTxtStyle($critere_style)
 					return;
 				}
 				else if (strtolower($name) == 'stop'){
-						if (!$last_gradid) break;
+						if (!$last_gradid) return;
 						$color = '#000000';
 						if (isset($attribs['style']) AND preg_match('/stop-color:\s*([^;]*)/i',$attribs['style'],$m)) {
 							$color = trim($m[1]);


### PR DESCRIPTION
### Why is it necessary?

When rendering HTML to a PDF using mPDF, it is generally possible that the HTML contains an `img` tag, whose `src` is a base64 encoded SVG. However, when running PHP 7, a fatal error can be raised while rendering the SVG:

```
Fatal error: 'break' not in the 'loop' or 'switch' context
```

As a result, it is currently impossible to use mPDF for rendering any HTML containing encoded SVG images in PHP 7.
### What does it improve?

This PR fixes the fatal error by replacing the wrong `break` with a `return` statement. This is the same fix that was done in the main mPDF repository (mpdf/mpdf@002bb8ae97f81299ac79e472a86c051993e43444).
### Does it have side effects?

No.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | n/a |
| How to test? | Add the HTML of **[1]** to an order document template (e.g. [`index.tpl`](https://github.com/shopware/shopware/blob/f98211cc7201f4988e8fc37db69f54cce40a96f5/themes/Frontend/Bare/documents/index.tpl)) and try to create/preview such a document via the backend. |

**[1]**:

``` html
<img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgd2lkdGg9IjExOC41IiBoZWlnaHQ9IjMwIj4KICA8dGl0bGU+QmFyY29kZSBDT0RFMTI4IF4yODc8L3RpdGxlPgogIDxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMTcuNSIgaGVpZ2h0PSIyOSIgZmlsbD0icmdiKDI1NSwgMjU1LCAyNTUpIi8+CiAgPHBvbHlnb24gcG9pbnRzPSIwIDAgMCAyOSAxMTggMjkgMTE4IDAiIGZpbGw9InJnYigyNTUsIDI1NSwgMjU1KSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMCAwIDAgMzAgMSAzMCAxIDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMSAwIDEgMzAgMyAzMCAzIDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iNCAwIDQgMzAgNiAzMCA2IDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iOSAwIDkgMzAgMTAgMzAgMTAgMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSIxNiAwIDE2IDMwIDE4IDMwIDE4IDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMTggMCAxOCAzMCAxOSAzMCAxOSAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjE5IDAgMTkgMzAgMjEgMzAgMjEgMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSIyMSAwIDIxIDMwIDIyIDMwIDIyIDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMjcgMCAyNyAzMCAyOCAzMCAyOCAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjMwIDAgMzAgMzAgMzEgMzAgMzEgMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSIzMyAwIDMzIDMwIDM0IDMwIDM0IDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMzQgMCAzNCAzMCAzNiAzMCAzNiAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjM5IDAgMzkgMzAgNDAgMzAgNDAgMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSI0MCAwIDQwIDMwIDQyIDMwIDQyIDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iNDIgMCA0MiAzMCA0MyAzMCA0MyAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjQ2IDAgNDYgMzAgNDggMzAgNDggMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSI0OSAwIDQ5IDMwIDUxIDMwIDUxIDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iNTEgMCA1MSAzMCA1MiAzMCA1MiAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjUyIDAgNTIgMzAgNTQgMzAgNTQgMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSI1NSAwIDU1IDMwIDU3IDMwIDU3IDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iNjAgMCA2MCAzMCA2MSAzMCA2MSAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjYxIDAgNjEgMzAgNjMgMzAgNjMgMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSI2NiAwIDY2IDMwIDY3IDMwIDY3IDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iNjcgMCA2NyAzMCA2OSAzMCA2OSAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjY5IDAgNjkgMzAgNzAgMzAgNzAgMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSI3MiAwIDcyIDMwIDczIDMwIDczIDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iNzMgMCA3MyAzMCA3NSAzMCA3NSAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9Ijc2IDAgNzYgMzAgNzggMzAgNzggMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSI3OCAwIDc4IDMwIDc5IDMwIDc5IDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iNzkgMCA3OSAzMCA4MSAzMCA4MSAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjgyIDAgODIgMzAgODQgMzAgODQgMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSI4NCAwIDg0IDMwIDg1IDMwIDg1IDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iODUgMCA4NSAzMCA4NyAzMCA4NyAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9Ijg4IDAgODggMzAgOTAgMzAgOTAgMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSI5MCAwIDkwIDMwIDkxIDMwIDkxIDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iOTMgMCA5MyAzMCA5NCAzMCA5NCAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9Ijk5IDAgOTkgMzAgMTAwIDMwIDEwMCAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjEwMCAwIDEwMCAzMCAxMDIgMzAgMTAyIDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMTA2IDAgMTA2IDMwIDEwOCAzMCAxMDggMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSIxMDggMCAxMDggMzAgMTA5IDMwIDEwOSAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjEwOSAwIDEwOSAzMCAxMTEgMzAgMTExIDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMTEyIDAgMTEyIDMwIDExNCAzMCAxMTQgMCIgZmlsbD0icmdiKDAsIDAsIDApIi8+CiAgPHBvbHlnb24gcG9pbnRzPSIxMTUgMCAxMTUgMzAgMTE3IDMwIDExNyAwIiBmaWxsPSJyZ2IoMCwgMCwgMCkiLz4KICA8cG9seWdvbiBwb2ludHM9IjExNyAwIDExNyAzMCAxMTggMzAgMTE4IDAiIGZpbGw9InJnYigwLCAwLCAwKSIvPgo8L3N2Zz4K">
```
