### PR TITLE
Render no-cookie-message on bottom of page for SEO-Reasons

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.shopware-responsive.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.shopware-responsive.js
@@ -126,7 +126,7 @@
 
         // Create the no cookies notification message
         function createNoCookiesNoticeBox(message) {
-            $('<div/>', { 'class': 'alert is--warning' }).append(
+            $('<div/>', { 'class': 'alert is--warning no--cookies' }).append(
                 $('<div/>', {'class': 'alert--icon'}).append(
                     $('<i/>', {'class': 'icon--element icon--warning'})
                 )
@@ -134,8 +134,15 @@
                 $('<div/>', {
                     'class': 'alert--content',
                     'html': message
+                }).append(
+                    $('<a/>', {
+                        'class': 'close--alert',
+                        'html': '✕'
+                    })
+                ).on('click', function () {
+                    $(this).parent().hide();
                 })
-            ).prependTo('.page-wrap');
+            ).appendTo('.page-wrap');
         }
 
         // Lightbox auto trigger

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/alert.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/alert.less
@@ -56,6 +56,23 @@ Options: `is--success`, `is--info`, `is--warning`, `is--error`.
             background: @highlight-error;
         }
     }
+
+    &.no--cookies {
+        position: fixed;
+        z-index: 99999;
+        top: 0;
+        left: 0;
+        right: 0;
+        &:hover {
+            a.close--alert {
+                text-decoration: underline;
+            }
+        }
+        .close--alert {
+            float: right;
+        }
+    }
+
 /*
 ######With an Icon inside of the box.</h6>
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description
- Why is it necessary?
  https://forum.shopware.com/discussion/31675/cookietext-erscheint-in-den-google-serps
  (cookie text appears in google serps)

Since the google crawler has cookies disabled by default, the first thing it crawls on each page is the disabled cookie warning:

> We have detected that cookies are disabled in your browser. To be able to use %shopname% in full range, we recommend activating Cookies in your browser.

On pages that usually have no meta description (e.g blog listing/legal notice/privacy policy etc) this text gets shown in Google SERPs. Many shops are affected. 

Proof, text rendered by javascript will be indexed in this case
https://www.google.de/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=%22We+have+detected+that+cookies+are+disabled+in+your+browser.%22
- What does it improve?
  This will render the notice above the closing ".page-wrap"-tag so it isn't the first string google recieves, thus not displaying is on the search results. Also adds a close button to the alert
- Does it have side effects?
  since it's fixed, it might conflict with some custom themes with sticky navigations, but most of them conflict with the absolutely positioned alert anyways. So this will probably do more good than evil.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | -- |
| Related tickets? | -- |
| How to test? | Test in browser with disabled cookies. |
