### PR TITLE
[SW-16059] Adding Voucher variables to the email templates 

### DIFF
--- a/engine/Shopware/Controllers/Backend/CanceledOrder.php
+++ b/engine/Shopware/Controllers/Backend/CanceledOrder.php
@@ -281,7 +281,14 @@ class Shopware_Controllers_Backend_CanceledOrder extends Shopware_Controllers_Ba
     private function getFreeVoucherCode($voucherId)
     {
         $builder = Shopware()->Models()->createQueryBuilder();
-        $builder->select(array('voucherCodes.id', 'voucherCodes.code'))
+        $builder->select(array(
+            'voucherCodes.id',
+            'voucherCodes.code',
+            'voucher.validTo',
+            'voucher.value',
+            'voucher.percental',
+            'voucher.validFrom'
+        ))
                 ->from('Shopware\Models\Voucher\Voucher', 'voucher')
                 ->leftJoin('voucher.codes', 'voucherCodes')
                 ->where('voucher.modus = ?1')
@@ -359,8 +366,18 @@ class Shopware_Controllers_Backend_CanceledOrder extends Shopware_Controllers_Ba
                 ]);
                 return;
             }
+            if ($code[0]['validTo'] !== null) {
+                $code[0]['validTo'] = $code[0]['validTo']->format('Y-m-d');
+            }
+            if ($code[0]['validFrom'] !== null) {
+                $code[0]['validFrom'] = $code[0]['validFrom']->format('Y-m-d');
+            }
             $context = array(
-                'sVouchercode' => $code[0]['code']
+                'sVouchercode' => $code[0]['code'],
+                'sVouchervalue' => $code[0]['value'],
+                'sVouchervalidto' => $code[0]['validTo'],
+                'sVouchervalidfrom' => $code[0]['validFrom'],
+                'sVoucherpercental' => $code[0]['percental']
             );
         }
 

--- a/engine/Shopware/Plugins/Default/Core/CronBirthday/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/CronBirthday/Bootstrap.php
@@ -99,9 +99,10 @@ class Shopware_Plugins_Core_CronBirthday_Bootstrap extends Shopware_Components_P
 
         foreach ($users as $user) {
             $sql = '
-                SELECT evc.id as vouchercodeID, evc.code
-                FROM s_emarketing_voucher_codes evc
+                SELECT evc.id as vouchercodeID, evc.code, ev.value, ev.percental, ev.valid_to, ev.valid_from
+                FROM s_emarketing_voucher_codes evc, s_emarketing_vouchers ev
                 WHERE evc.voucherID = ?
+                AND ev.id = evc.voucherID
                 AND evc.userID IS NULL
                 AND evc.cashed = 0
             ';


### PR DESCRIPTION
This PR adds the voucher variables value, validTo, validFrom and percental to the email templates sCanceledVoucher and sBirthday so that you can use them there to create these Emails with the voucher variables.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/#/issues/SW-16059 |
| How to test? | Create sCanceledVoucher and sBirthday templates in the backend with the new variables sVouchervalue sVouchervalidto sVouchervalidfrom sVoucherpercental. And send them to see if the variables are correct. |
