### PR TITLE
Changed description of image integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ You can also start testing with lower permissions due to security reasons (644 f
 
 4.) Download the test images and extract them:
 
-Go to the checkout directory and download the test images:
+Go to the root directory of your shopware system and download the test images:
 
 	wget -O test_images.zip http://releases.s3.shopware.com/test_images.zip
 
-Unzip the files to the checkout directory:
+Unzip the files inside the root directory:
 
 	unzip test_images.zip
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description
- Confusing description of image integration process
- Makes it easier to understand where to put the images
- No side effect

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | - |
| How to test? | Compare suggested description with old description |
## Detail

Suggestion to change the description for the image integration cause "go to the checkout" directory is not necessary understood as the GIT checkout target - it sounds more like you have to look for a directory which is called "checkout" in the shopware system.
