### PR TITLE
Fix for not creating attributes in depending tables

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
@@ -140,7 +140,6 @@ class CrudService
 
         if (!$config) {
             $this->createAttribute($table, $columnName, $unifiedType, $data, $defaultValue);
-            return;
         }
 
         $newColumnName = $newColumnName?: $columnName;


### PR DESCRIPTION
## Description

Please describe your pull request:
- Why is it necessary? attributes in depending tables are not created
- What does it improve? creates attributes in depending tables
- Does it have side effects? no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? |  |
| How to test? | see below |

```
$this->get('shopware_attribute.crud_service')->update(
                's_user_addresses_attributes',
                'abc_test',
                'boolean',
                array(),
                null,
                true
            );
```

this will create an attribute `abc_test` in `s_user_addresses_attributes` but not in `s_user_shippingaddress_attributes`,
`s_user_billingaddress_attributes`,
`s_order_shippingaddress_attributes`,
`s_order_billingaddress_attributes`

This pull request will fix this, so the attributes are created as expected
