### PR TITLE
[SW-15993] Adding namecheck for freetextfield

### DIFF
--- a/snippets/backend/attributes/main.ini
+++ b/snippets/backend/attributes/main.ini
@@ -117,6 +117,8 @@ Shopware\Models\Shop\Shop = "Shop"
 array_store_field_label = "Selection"
 define_value = "define value"
 define_key = "define key"
+error_namecheck_title = "The name already exists"
+error_namecheck_message = The Name already exists. Please use an other name.
 
 [de_DE]
 table/s_articles_attributes = "Artikel"
@@ -237,3 +239,5 @@ Shopware\Models\Shop\Shop = "Shop"
 array_store_field_label = "Auswahl"
 define_value = "Wert definieren"
 define_key = "Key definieren"
+error_namecheck_title = "Dieser Name existiert bereits."
+error_namecheck_message = "Dieser Name existiert bereits. Bitte verwenden Sie einen anderen."

--- a/themes/Backend/ExtJs/backend/attributes/controller/main.js
+++ b/themes/Backend/ExtJs/backend/attributes/controller/main.js
@@ -132,7 +132,7 @@ Ext.define('Shopware.apps.Attributes.controller.Main', {
         var me = this;
         var window = me.getWindow();
 
-        window.setLoading('Überprüft ob Freitextfeldname schon vorhanden');
+        window.setLoading(true);
 
         newColumnName = record.get('columnName');
         me.getListing().getStore().remove(record);
@@ -142,6 +142,8 @@ Ext.define('Shopware.apps.Attributes.controller.Main', {
             return true;
         }
 
+        Shopware.Notification.createGrowlMessage('{s name="error_namecheck_title"}The name already exists{/s}',
+            '{s name="error_namecheck_message"}The Name already exists. Use an other name.{/s}');
         me.getListing().getStore().reload();
         window.setLoading(false);
         return false;


### PR DESCRIPTION
This PR add a namespace check for the free text fields. the check first filters the entry that we want to save or update out. Then it searches after the name we want to save our record to. If it already exists we dont save our record.  The PR make it impossible to save a textfield on a name that already exists.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/issues/SW-15993 |
| How to test? | Reload snippets. Try to create a new Free text field or update one with the name of an other entry. |
