### PR TITLE
[SW-16191] Fix Productstream Price Filter when maxvalue is null

### DIFF
--- a/engine/Shopware/Components/ProductStream/FacetFilter.php
+++ b/engine/Shopware/Components/ProductStream/FacetFilter.php
@@ -179,7 +179,9 @@ class FacetFilter implements FacetFilterInterface
             $condition = $criteria->getBaseCondition('price');
 
             $facet->setMin($condition->getMinPrice());
-            $facet->setMax($condition->getMaxPrice());
+            if ($condition->getMaxPrice() != 0) {
+                $facet->setMax($condition->getMaxPrice());
+            }
         }
     }
 


### PR DESCRIPTION
The PR don't switch the critera for the Product stream if the maxvalue is 0 (null in the database), so the maxvalue from all articles in the Productstream is taken for the Pricefilter.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/issues/SW-16191 |
| How to test? | Create a product Stream for a category and then check if the maxvalue for the Price filter in the Frontend is not null. |
