### PR TITLE
[SW-15644] Adding Productnavigation for Productstream

### DIFF
--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -765,7 +765,7 @@ class sArticles
         
         $streamId = $this->checkProductStream($categoryId);
         if ($streamId !== null) {
-
+            
             /** @var \Shopware\Components\ProductStream\CriteriaFactoryInterface $factory */
             $factory = Shopware()->Container()->get('shopware_product_stream.criteria_factory');
             $criteriaProductStream = $factory->createCriteria($request, $context);

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -762,16 +762,10 @@ class sArticles
             $context,
             $categoryId
         );
-
-        $searchResult = $this->productNumberSearch->search(
-            $criteria,
-            $context
-        );
-
+        
         $streamId = $this->checkProductStream($categoryId);
         if ($streamId !== null) {
 
-            //searchResult erweitern fehlt
             /** @var \Shopware\Components\ProductStream\CriteriaFactoryInterface $factory */
             $factory = Shopware()->Container()->get('shopware_product_stream.criteria_factory');
             $criteriaProductStream = $factory->createCriteria($request, $context);
@@ -783,6 +777,11 @@ class sArticles
 
             $searchResult = $this->productNumberSearch->search(
                 $criteriaProductStream,
+                $context
+            );
+        } else {
+            $searchResult = $this->productNumberSearch->search(
+                $criteria,
                 $context
             );
         }

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -768,6 +768,25 @@ class sArticles
             $context
         );
 
+        $streamId = $this->checkProductStream($categoryId);
+        if ($streamId !== null) {
+
+            //searchResult erweitern fehlt
+            /** @var \Shopware\Components\ProductStream\CriteriaFactoryInterface $factory */
+            $factory = Shopware()->Container()->get('shopware_product_stream.criteria_factory');
+            $criteriaProductStream = $factory->createCriteria($request, $context);
+            $criteriaProductStream->limit(null);
+
+            /** @var \Shopware\Components\ProductStream\RepositoryInterface $streamRepository */
+            $streamRepository = Shopware()->Container()->get('shopware_product_stream.repository');
+            $streamRepository->prepareCriteria($criteriaProductStream, $streamId);
+
+            $searchResult = $this->productNumberSearch->search(
+                $criteriaProductStream,
+                $context
+            );
+        }
+
         $navigation = $this->buildNavigation(
             $searchResult,
             $orderNumber,
@@ -778,6 +797,18 @@ class sArticles
         $navigation["currentListing"]["link"] = $this->buildCategoryLink($categoryId, $request);
 
         return $navigation;
+    }
+
+    /**
+     * @param int $categoryId
+     * @return boolean
+     */
+    private function checkProductStream($categoryId)
+    {
+        $streamId = $this->db->fetchRow("
+          SELECT stream_id FROM s_categories WHERE id=?
+        ", array($categoryId));
+        return $streamId['stream_id'];
     }
 
     /**


### PR DESCRIPTION
This PR checks, when the Productnavigation is created, if a the category is a productstream. If it is, the criteria for his Productstream will be selected. And then the Programm seraches with the new criteria for the items.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | https://issues.shopware.com/issues/SW-15644 |
| How to test? | Create a Productstream and a category with that Productstream. Go to that category and click on an article. Then check if you can go to the next or/and privious items on the Product detail page. |
