### PR TITLE
[FEATURE] Autoload resource files

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/theme.xml
+++ b/engine/Shopware/Components/DependencyInjection/theme.xml
@@ -81,6 +81,7 @@
             <argument type="service" id="js_compressor" />
             <argument type="service" id="events" />
             <argument type="service" id="theme_timestamp_persistor" />
+            <argument type="service" id="service_container" />
 
         </service>
 

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -41,6 +41,7 @@ use Shopware\Components\DependencyInjection\Compiler\EventSubscriberCompilerPass
 use Shopware\Components\ConfigLoader;
 use Shopware\Components\DependencyInjection\Container;
 use Shopware\Components\Plugin;
+use Shopware\Components\Theme\Compiler;
 use Symfony\Component\ClassLoader\Psr4ClassLoader;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\FileLocator;


### PR DESCRIPTION
With this change, CSS, JS and LESS files of a plugin are automatically loaded if they are stored in one of the resource directories (Resources/css, Resources/js or Resources/less) in plugin directory.

Example:
- custom/plugins/ReplyTest/Resources/css/test.css
- custom/plugins/ReplyTest/Resources/js/test.js
- custom/plugins/ReplyTest/Resources/less/test.less

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | no |
| How to test? | Create a plugin in custom/plugins and add some resources |
