### PR TITLE
improved check before cutting baseUrl  from url in router

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -452,7 +452,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
         }
 
         $baseUrl = $request->getBaseUrl();
-        if (strpos($url, $baseUrl) === 0) {
+        if (strpos($url, $baseUrl.'/') === 0) {
             $url = substr($url, strlen($baseUrl));
         }
 


### PR DESCRIPTION
## Description

This PR fixes a bug in the router for a special case. 

Assuming the shop is configured with two languages and a landingpage in the following way:

| Shop ID | Language | Virtual URL |
| --- | --- | --- |
| 1 | English |  |
| 2 | German | /de |

Landing Page:

| Language | Name | Resulting URL |
| --- | --- | --- |
| English | Demonstration | /demonstration |
| German | Dehnbund Hosen | /de/dehnbund-hosen |

_Note: Both names starting with 'de' - the choosen virtual url for the german shop._

If you want to switch the language from english to german on this landingpage, you get an 404 because the router rewrites the url in a wrong way: `/demonstration` -> `/de/hnbund-hosen`.

The router code checks a given url for removing the virtual url part only on the virtual url itself. But it should check on the virtual url followed by an slash (`/`). This PR improves this check.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | ? |
| Related tickets? | not yet |
| How to test? | see above |

Edit: 
- added shop ids, to make clear that I changed the locale of the default shop (but I think it doesn't matter)
