### PR TITLE
Add hideTop check in Category Side Menue

### DIFF
--- a/themes/Frontend/Bare/frontend/index/sidebar-categories.tpl
+++ b/themes/Frontend/Bare/frontend/index/sidebar-categories.tpl
@@ -7,26 +7,28 @@
         {block name="frontend_index_categories_left_before"}{/block}
         {foreach $categories as $category}
             {block name="frontend_index_categories_left_entry"}
-                <li class="navigation--entry{if $category.flag} is--active{/if}{if $category.subcategories} has--sub-categories{/if}{if $category.childrenCount} has--sub-children{/if}" role="menuitem">
-                    <a class="navigation--link{if $category.flag} is--active{/if}{if $category.subcategories} has--sub-categories{/if}{if $category.childrenCount} link--go-forward{/if}"
-                       href="{$category.link}"
-                       data-categoryId="{$category.id}"
-                       data-fetchUrl="{url module=widgets controller=listing action=getCategory categoryId={$category.id}}"
-                       title="{$category.description|escape}">
-                        {$category.description}
+                {if !$category.hideTop}
+                    <li class="navigation--entry{if $category.flag} is--active{/if}{if $category.subcategories} has--sub-categories{/if}{if $category.childrenCount} has--sub-children{/if}" role="menuitem">
+                        <a class="navigation--link{if $category.flag} is--active{/if}{if $category.subcategories} has--sub-categories{/if}{if $category.childrenCount} link--go-forward{/if}"
+                           href="{$category.link}"
+                           data-categoryId="{$category.id}"
+                           data-fetchUrl="{url module=widgets controller=listing action=getCategory categoryId={$category.id}}"
+                           title="{$category.description|escape}">
+                            {$category.description}
 
-                        {if $category.childrenCount}
-                            <span class="is--icon-right">
-                                <i class="icon--arrow-right"></i>
-                            </span>
-                        {/if}
-                    </a>
-                    {block name="frontend_index_categories_left_entry_subcategories"}
-                        {if $category.subcategories}
-                            {call name=categories categories=$category.subcategories level=$level+1}
-                        {/if}
-                    {/block}
-                </li>
+                            {if $category.childrenCount}
+                                <span class="is--icon-right">
+                                    <i class="icon--arrow-right"></i>
+                                </span>
+                            {/if}
+                        </a>
+                        {block name="frontend_index_categories_left_entry_subcategories"}
+                            {if $category.subcategories}
+                                {call name=categories categories=$category.subcategories level=$level+1}
+                            {/if}
+                        {/block}
+                    </li>
+                {/if}
             {/block}
         {/foreach}
         {block name="frontend_index_categories_left_after"}{/block}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Categories which are marked as "Hide in Top Navigation" are still appearing in the catagory side Menu on mobile view. 

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | no |
| How to test? | Set the "Hide in Top Navigation" mark on a category and reload. It disappears in the Desktop Menue but is still visible on mobile. |
