### PR TITLE
Fixed table name case in addtribute administration migration

### DIFF
--- a/_sql/migrations/793-fix-attribute-administration.php
+++ b/_sql/migrations/793-fix-attribute-administration.php
@@ -1,0 +1,31 @@
+<?php
+
+use Shopware\Components\Migrations\AbstractMigration;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+class Migrations_Migration793 extends AbstractMigration
+{
+    /** @var CamelCaseToSnakeCaseNameConverter */
+    protected $converter;
+
+    /**
+     * @param \PDO $connection
+     */
+    public function __construct(\PDO $connection)
+    {
+        parent::__construct($connection);
+        $this->converter = new CamelCaseToSnakeCaseNameConverter();
+    }
+
+    public function up($modus)
+    {
+        $statement = $this->connection->query("SELECT * FROM `s_core_engine_elements`");
+        $attributes = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        foreach ($attributes as $attribute) {
+            $nameConverted = $this->converter->normalize($attribute['name']);
+            $statement = $this->connection->prepare("UPDATE `s_attribute_configuration` SET `column_name` = ? WHERE `column_name` = ?");
+            $statement->execute([$nameConverted, $attribute['name']]);
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary?
- What does it improve?
- Does it have side effects?

| Questions | Answers |
| --- | --- |
| BC breaks? | yes/no |
| Tests pass? | yes/no |
| Related tickets? | If this PR fixes an existing [Issue](https://issues.shopware.com) ticket, please add its complete issue URL. |
| How to test? | Please describe how to best verify that this PR is correct. |
## Description

When upgrading a 5.1 shop to 5.2 this migration creates entries in `s_attribute_configuration` based on the entries in the `s_core_engine_elements` table. The `name` column in `s_core_engine_elements` has a lowerCamelCase value but the `column_name` column in the `s_attributes_configuration` table needs a snake_case value. This PR fixes the attribute migration. 

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | No |
| How to test? | Upgrade a 5.1 shop to 5.2 and have a look into the `s_attribute_configuration` table where the values in the column `column_name` for existing attributes should be in snake_case. |
