### PR TITLE
remove scrollbar styling on filter-panels

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/hacks.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/hacks.less
@@ -54,32 +54,6 @@ More precise designations are commented inside the document.
     }
 }
 
-    // Changing the appearance of the scrollbar in filter panels.
-.filter-panel--content {
-
-    // IE styles
-    scrollbar-arrow-color: @text-color;
-    scrollbar-base-color: @body-bg;
-    scrollbar-track-color: @body-bg;
-    scrollbar-face-color: @border-color;
-    scrollbar-highlight-color: @body-bg;
-    scrollbar-3dlight-color: @body-bg;
-    scrollbar-darkshadow-color: @body-bg;
-    scrollbar-shadow-color: @body-bg;
-
-    // WebKit styles
-    &::-webkit-scrollbar {
-        width: 14px;
-        background: @body-bg;
-    }
-    &::-webkit-scrollbar-track {
-        background: @body-bg;
-    }
-    &::-webkit-scrollbar-thumb {
-        background: @border-color;
-    }
-}
-
     // inactive class for disabling scrolling on different parts of Shopware
 .is--inactive {
     overflow: hidden !important;


### PR DESCRIPTION
## Description

This PR removes the hacked-together styling of Scrollbars in the filter Panel.
### Why is this necessary?
- Scrollbar stylings for IE are almost impossible to reset
- They only look "kinda" nice in the default theme
- It's in the _hacks.less because, yes, it is a hack

If you insist on doing this, please consider using a flag for this and spare us developers from working around this.

We want default scrollbars.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| How to test? | Test filter panels |
