### PR TITLE
SW-16604 Widgets cannot be removed during uninstall if there's no corresponding widget_view

### DIFF
--- a/engine/Shopware/Components/Plugin/Namespace.php
+++ b/engine/Shopware/Components/Plugin/Namespace.php
@@ -550,7 +550,7 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
         $sql = "
             DELETE widgets, views, priv
             FROM s_core_widgets widgets
-                INNER JOIN s_core_widget_views views
+                LEFT JOIN s_core_widget_views views
                     ON views.widget_id = widgets.id
                 LEFT JOIN s_core_acl_privileges priv
                     ON priv.name = widgets.name


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? widgets without a view are not correctly uninstalled
- What does it improve? uninstall widgets correctly
- Does it have side effects? none

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | --- |
| Related tickets? | https://issues.shopware.com/issues/SW-16604 |
| How to test? | install a plugin with a widget than uninstall plugin - in s_core_widgets the row is persistent |
