### PR TITLE
Ignore empty elements from (broken) manufacturer filter URLs

### DIFF
--- a/engine/Shopware/Bundle/SearchBundle/CriteriaRequestHandler/CoreCriteriaRequestHandler.php
+++ b/engine/Shopware/Bundle/SearchBundle/CriteriaRequestHandler/CoreCriteriaRequestHandler.php
@@ -176,9 +176,12 @@ class CoreCriteriaRequestHandler implements CriteriaRequestHandlerInterface
             return;
         }
 
-        $manufacturers = explode(
-            '|',
-            $request->getParam('sSupplier')
+        /* Split filter parameter. Do not return empty elements from broken urls */
+        preg_split(
+            '/|/',
+            $request->getParam('sSupplier'),
+            -1,
+            PREG_SPLIT_NO_EMPTY
         );
 
         if (!empty($manufacturers)) {


### PR DESCRIPTION
Broken filter URLs for manufacturer filter that look like this

/?s=|1234

lead to an Exception not displaying the listing page. (Oops an error occured)

When using explode on this parameter, an array with two elements is created,
one of which empty. This leads to the following Exception, when Shopware
processes the Criteria:

core.ERROR: exception 'Assert\InvalidArgumentException' with message 'Value "" is not an integer or a number castable to integer.' in vendor/beberlei/assert/lib/Assert/Assertion.php:212

Using preg_split with PREG_SPLIT_NO_EMPTY prevents the creation of empty
array elements and fixes this problem.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | n/a |
| How to test? | Test filter parameter in listing with valid manufacturer id. ?s=|123. With PR no Exception is thrown |
