### PR TITLE
Fix error when manufacturer is null

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -545,12 +545,25 @@ class LegacyStructConverter
             $data["sLinks"][] = $temp;
         }
 
-        $data["sLinks"][] = array(
+        /*$data["sLinks"][] = array(
             'supplierSearch' => true,
             'description' => $product->getManufacturer()->getName(),
             'target' => '_parent',
             'link' => $this->getSupplierListingLink($product->getManufacturer())
-        );
+        );*/
+        // load manufacturer
+        $manufacturer = $product->getManufacturer();
+
+        // check if manufacturer is not null
+        // prevent Call to am member function getName() on null if manufactuer was not set via API
+        if($manufacturer != null) {
+            $data["sLinks"][] = array(
+                'supplierSearch' => true,
+                'description' => $manufacturer->getName(),
+                'target' => '_parent',
+                'link' => $this->getSupplierListingLink($manufacturer)
+            );
+        }
 
         $data['sRelatedArticles'] = array();
         foreach ($product->getRelatedProducts() as $relatedProduct) {

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -556,7 +556,7 @@ class LegacyStructConverter
 
         // check if manufacturer is not null
         // prevent Call to am member function getName() on null if manufactuer was not set via API
-        if($manufacturer != null) {
+        if ($manufacturer != null) {
             $data["sLinks"][] = array(
                 'supplierSearch' => true,
                 'description' => $manufacturer->getName(),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary?
  At the moment it is possible to add articles without manufacturers with the REST API. Articles without manufacturers cannot be displayed on the "details page" because there is a call to a function of an object which is null.
- What does it improve?
  The function manufacturer object is only called when the object is not null.
- Does it have side effects?
  No known side effects.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | manually tested. |
| Related tickets? | none |
| How to test? | add an article (via REST) and view the article details page in shopware. |
