### PR TITLE
Fixed some problems with the Cron manager and DBAL

### DIFF
--- a/engine/Library/Enlight/Components/Cron/Adapter/DBAL.php
+++ b/engine/Library/Enlight/Components/Cron/Adapter/DBAL.php
@@ -67,6 +67,7 @@ class Enlight_Components_Cron_Adapter_DBAL implements Enlight_Components_Cron_Ad
         $data['start']            = ($job->getStart()) ? $job->getStart()->toString('YYYY-MM-dd HH:mm:ss') : null;
         $data['end']              = ($job->getEnd()) ? $job->getEnd()->toString('YYYY-MM-dd HH:mm:ss') : null;
         $data['disable_on_error'] = ($job->getDisableOnError()) ? '1' : '0';
+        $data["name"]             = $job->getName();
 
         if (is_null($job->getId())) {
             $this->connection->insert($this->tableName, $data);

--- a/engine/Library/Enlight/Components/Cron/Manager.php
+++ b/engine/Library/Enlight/Components/Cron/Manager.php
@@ -213,7 +213,7 @@ class Enlight_Components_Cron_Manager
      */
     public function addJob(Enlight_Components_Cron_Job $job)
     {
-        $this->adapter->addJob($job);
+        $this->adapter->updateJob($job);
         return $this;
     }
 


### PR DESCRIPTION
## Description

Please describe your pull request:
- Why is it necessary?
  - Changes to Enlight_Components_Cron_Manager::addJob were made because it used a non-existing addJob method in its adapter property (not part of the Enlight_Components_Cron_Adapter interface). Now uses the updateJob method, which has facilities for creating new jobs.
  - Changes to Enlight_Components_Cron_Adapter_DBAL::updateJob were made because the method had no facilities to actually update a jobs name and since it appears to be the only facility to create a new job, name changes are necessary.
- What does it improve?
  - Makes Enlight_Components_Cron_Manager::addJob not cause an error and actually function
  - Makes Enlight_Components_Cron_Adapter_DBAL::updateJob cleanly create new jobs with a name
- Does it have side effects?
  - Enlight_Components_Cron_Adapter_DBAL::updateJob actually changing names could interfere with use cases that relied on the old implementation

Sorry, tests were srcapped as no isse existed before and these classes were apparently not covered by tests.
## Original Commit Message
- Changed addJob method in the manager class to utilize adapters existing updateJob method instead of non-existing addJob method.
- Changed adapters updateJob method to actually update the name as well. (necessary for clean new job creation and definitely sensible for updates as well)
