### PR TITLE
Join s_order_basket_attributes in sGetDispatchBasket

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -23,6 +23,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 * Replaced the default filter on `dispatches.active` added in `Shopware_Controllers_Backend_Base::getDispatchesAction()` by a default filter on `active` added in `Shopware.apps.Base.store.Dispatch`
 * Refactored jQuery product slider plugin for sliding infinitely
 * Added `initOnEvent` option to cross selling tabs on detail page for the combination of tabs with product sliders
+* Left join s_order_basket_attributes to use fields in own dispatch calculation
 
 ## 5.2.9
 

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2577,6 +2577,9 @@ SQL;
                 $sql_select
             FROM s_order_basket b
 
+            LEFT JOIN s_order_basket_attributes ba
+            ON b.id = ba.basketID
+
             LEFT JOIN s_articles a
             ON b.articleID = a.id
             AND b.modus = 0

--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -1377,6 +1377,9 @@ class sExport
                     '' as ob_attr6
             ) as b
 
+            LEFT JOIN s_order_basket_attributes ba
+            ON b.id = ba.basketID
+
             LEFT JOIN s_articles a
             ON b.articleID=a.id
             AND b.modus=0


### PR DESCRIPTION
## Description

Please describe your pull request:
- Why is it necessary? If you want to calculate shipping costs based on bundle informations you need the s_order_basket_attributes table joined.
- What does it improve? More fields for the Field "Calculation" in the dispatch modul. (e.g For Bundle or AboCommerce)
- Does it have side effects?
  no

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | yes |
| Related tickets? | none |
| How to test? | Use fields in your own calculation. For example count bundles with "COUNT(DISTINCT  ba.bundle_id)" |
