### PR TITLE
Set partner id to optional in order entity

### DIFF
--- a/engine/Shopware/Models/Order/Order.php
+++ b/engine/Shopware/Models/Order/Order.php
@@ -124,7 +124,7 @@ class Order extends ModelEntity
     /**
      * @var string $partnerId
      *
-     * @ORM\Column(name="partnerID", type="string", length=255, nullable=false)
+     * @ORM\Column(name="partnerID", type="string", length=255, nullable=true)
      */
     private $partnerId;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->
## Description

Please describe your pull request:
- Why is it necessary? The order entity requires adding a marketing partner when creating an order which is not correct IMO cause an order isn´t related to a partner in the most cases.
- What does it improve? Sets the partnerId to be nullable.
- Does it have side effects? None known

| Questions | Answers |
| --- | --- |
| BC breaks? | yes/no |
| Tests pass? | yes/no |
| Related tickets? | no |
| How to test? | Create a new order via the entity and don´t specify a partner. |
