### PR TITLE
fix modal-sizing on ios safari

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.modal.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.modal.js
@@ -150,7 +150,7 @@
 
             /**
              * The max height if sizing is set to `content`
-             * 
+             *
              * @type {Number}
              */
             maxHeight: 0,
@@ -621,9 +621,13 @@
          */
         center: function () {
             var me = this,
-                $modalBox = me._$modalBox;
+                $modalBox = me._$modalBox,
+                windowHeight = window.innerHeight ? window.innerHeight : $(window).height();
 
-            $modalBox.css('top', ($(window).height() - $modalBox.height()) / 2);
+            // use window.innerHeight when available for correct results.
+            // @link https://bugs.jquery.com/ticket/6724
+
+            $modalBox.css('top', (windowHeight - $modalBox.height()) / 2);
 
             $.publish('plugin/swModal/onCenter', [ me ]);
         },
@@ -798,4 +802,3 @@
         }
     });
 })(jQuery, window);
-


### PR DESCRIPTION
This PR fixes works around a [jquery-bug](https://bugs.jquery.com/ticket/6724), returning an incorrect window-height on safari@ios. This bug results in modals not being correctly displayed when the address-bar is visible and a modal is being opened.

See this screenshot:
![iphone-ios-safari-modal-bug](https://cloud.githubusercontent.com/assets/765896/19762155/1698d4aa-9c39-11e6-9eb2-59314c0f970b.jpg)
_This shows the modal scrolled all the way up._

This is due to the fact, that jquery's `$(window).height()` is more of a guesswork than a precise method to get the window-height.

The modal-plugin uses this wrong size excluding the areas covered by the top-bar to center the modal, resulting in a negative top-value.

This pr fixes this by using the built-in `window.innerHeight` when available. That fixes the issue, because safari then correctly returns the height including the area covered by the topbar.

For a more in-depth look into the issue, see this [jquery.documentsize](https://github.com/hashchange/jquery.documentsize#what-does-it-do-that-jquery-doesnt).
## Description

Please describe your pull request:
- Why is it necessary? To improve the usability of the modal in iphone safari
- Does it have side effects? No

This is the only occurence of `$(window).height()` in all scripts.

| Questions | Answers |
| --- | --- |
| BC breaks? | no |
| Tests pass? | no |
| How to test? | Open a modal on safari ios. I reproduced this with a content-sized modal with overflowing content. Then compare patched and non-patched versions. |
