### PR TITLE
Realpath abstraction / Plugin symlinks

### DIFF
--- a/engine/Library/Enlight/Components/Snippet/Resource.php
+++ b/engine/Library/Enlight/Components/Snippet/Resource.php
@@ -274,9 +274,9 @@ class Enlight_Components_Snippet_Resource extends Smarty_Internal_Resource_Exten
                 throw new Enlight_Exception("Missing name attribute in namespace block");
             }
         } else {
-            $path = realpath($source->filepath);
+            $path = Enlight_Loader::realpath($source->filepath);
             foreach ($source->smarty->getTemplateDir() as $template_dir) {
-                $template_dir = realpath($template_dir);
+                $template_dir = Enlight_Loader::realpath($template_dir);
                 if (strpos($path, $template_dir) === 0) {
                     $namespace = substr($path, strlen($template_dir));
                     $namespace = strtr($namespace, DIRECTORY_SEPARATOR, '/');

--- a/engine/Library/Enlight/Controller/Dispatcher/Default.php
+++ b/engine/Library/Enlight/Controller/Dispatcher/Default.php
@@ -112,7 +112,7 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
         }
 
         $module = $this->formatModuleName($module);
-        $path = realpath($path) . '/';
+        $path = Enlight_Loader::realpath($path) . '/';
 
         $this->controllerDirectory[$module] = $path;
 

--- a/engine/Library/Enlight/Controller/Dispatcher/Default.php
+++ b/engine/Library/Enlight/Controller/Dispatcher/Default.php
@@ -112,7 +112,7 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
         }
 
         $module = $this->formatModuleName($module);
-        $path = Enlight_Loader::realpath($path) . '/';
+        $path = realpath($path) . '/';
 
         $this->controllerDirectory[$module] = $path;
 

--- a/engine/Library/Enlight/Hook/ProxyFactory.php
+++ b/engine/Library/Enlight/Hook/ProxyFactory.php
@@ -110,7 +110,7 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
             throw new \RuntimeException(sprintf("Unable to write in the %s directory (%s)\n", "Proxy", $proxyDir));
         }
 
-        $proxyDir = rtrim(realpath($proxyDir), '\\/') . DIRECTORY_SEPARATOR;
+        $proxyDir = rtrim(Enlight_Loader::realpath($proxyDir), '\\/') . DIRECTORY_SEPARATOR;
 
         $this->proxyDir = $proxyDir;
     }

--- a/engine/Library/Enlight/Loader.php
+++ b/engine/Library/Enlight/Loader.php
@@ -152,32 +152,34 @@ class Enlight_Loader
     /**
      * Realpath implementation that is 100% compatible but symlink aware
      *
-     * @param $path
-     *
+     * @param string $path
      * @return string
      */
     public static function realpath($path)
     {
         // No symlink
-        if (realpath($path) == $path) {
+        if (realpath($path) === $path) {
             return $path;
         }
 
+        if (!isset($path['0'])) {
+            return getcwd();
+        }
         // Make path absolute
-        if ($path[0] != DIRECTORY_SEPARATOR) {
+        if ($path[0] !== DIRECTORY_SEPARATOR) {
             $path = getcwd().DIRECTORY_SEPARATOR.$path;
         }
 
         // Remove . and ..
         // See http://php.net/manual/en/function.realpath.php#84012
-        $path = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $path);
+        $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
         $parts = array_filter(explode(DIRECTORY_SEPARATOR, $path), 'strlen');
-        $absolutes = array();
+        $absolutes = [];
         foreach ($parts as $part) {
-            if ('.' == $part) {
+            if ('.' === $part) {
                 continue;
             }
-            if ('..' == $part) {
+            if ('..' === $part) {
                 array_pop($absolutes);
             } else {
                 $absolutes[] = $part;

--- a/engine/Library/Enlight/Loader.php
+++ b/engine/Library/Enlight/Loader.php
@@ -150,6 +150,50 @@ class Enlight_Loader
     }
 
     /**
+     * Realpath implementation that is 100% compatible but symlink aware
+     *
+     * @param $path
+     *
+     * @return string
+     */
+    public static function realpath($path)
+    {
+        // No symlink
+        if (realpath($path) == $path) {
+            return $path;
+        }
+
+        // Make path absolute
+        if ($path[0] != DIRECTORY_SEPARATOR) {
+            $path = getcwd().DIRECTORY_SEPARATOR.$path;
+        }
+
+        // Remove . and ..
+        // See http://php.net/manual/en/function.realpath.php#84012
+        $path = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $path);
+        $parts = array_filter(explode(DIRECTORY_SEPARATOR, $path), 'strlen');
+        $absolutes = array();
+        foreach ($parts as $part) {
+            if ('.' == $part) {
+                continue;
+            }
+            if ('..' == $part) {
+                array_pop($absolutes);
+            } else {
+                $absolutes[] = $part;
+            }
+        }
+        $newPath = DIRECTORY_SEPARATOR.implode(DIRECTORY_SEPARATOR, $absolutes);
+
+        // Check if path/file exists
+        if (!file_exists($newPath)) {
+            return false;
+        }
+
+        return $newPath;
+    }
+
+    /**
      * Explodes the given path by the PATH_SEPARATOR constant
      *
      * @param   string $path

--- a/engine/Library/Enlight/Plugin/Namespace/Loader.php
+++ b/engine/Library/Enlight/Plugin/Namespace/Loader.php
@@ -68,7 +68,7 @@ class Enlight_Plugin_Namespace_Loader extends Enlight_Plugin_Namespace
     public function addPrefixPath($prefix, $path)
     {
         $prefix = trim($prefix, '_');
-        $path = realpath($path) . DIRECTORY_SEPARATOR;
+        $path = Enlight_Loader::realpath($path) . DIRECTORY_SEPARATOR;
         $this->prefixPaths[$path] = $prefix;
         return $this;
     }

--- a/engine/Library/Enlight/Template/Manager.php
+++ b/engine/Library/Enlight/Template/Manager.php
@@ -247,7 +247,7 @@ class Enlight_Template_Manager extends Smarty
     public function unifyDirectories($inheritance)
     {
         $inheritance = $this->enforceEndingSlash($inheritance);
-        $inheritance = array_map('realpath', $inheritance);
+        $inheritance = array_map('Enlight_Loader::realpath', $inheritance);
         $inheritance = array_filter($inheritance);
         $inheritance = array_unique($inheritance);
         return $inheritance;

--- a/engine/Library/Enlight/Template/Plugins/function.flink.php
+++ b/engine/Library/Enlight/Template/Plugins/function.flink.php
@@ -42,7 +42,7 @@ function smarty_function_flink($params, $template)
         // try to find the file on the filesystem
         foreach ($template->smarty->getTemplateDir() as $dir) {
             if (file_exists($dir . $file)) {
-                $file = realpath($dir) . DS . str_replace('/', DS, $file);
+                $file = Enlight_Loader::realpath($dir) . DS . str_replace('/', DS, $file);
                 break;
             }
             if ($useIncludePath) {

--- a/engine/Library/Enlight/Template/Plugins/resource.parent.php
+++ b/engine/Library/Enlight/Template/Plugins/resource.parent.php
@@ -41,7 +41,7 @@ class Smarty_Resource_Parent extends Smarty_Internal_Resource_File
         $hit = false;
 
         foreach ($source->smarty->getTemplateDir() as $_directory) {
-            $_filePath = realpath($_directory . $file);
+            $_filePath = Enlight_Loader::realpath($_directory . $file);
             if ($this->fileExists($source, $_filePath)) {
                 if ($hit) {
                     return $_filePath;

--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -217,14 +217,8 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
     final public function getPath()
     {
         if (null === $this->path) {
-            // Resolve path where the plugin is expected to be installed
-            $this->path = \Enlight_Loader::realpath(__DIR__.'/../../../custom/plugins/'.$this->getName());
-
-            // Path not found -> previous behaviour
-            if (false === $this->path) {
-                $reflected = new \ReflectionObject($this);
-                $this->path = dirname($reflected->getFileName());
-            }
+            $reflected = new \ReflectionObject($this);
+            $this->path = dirname($reflected->getFileName());
         }
 
         return $this->path;

--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -72,7 +72,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
      */
     final public function __construct($isActive)
     {
-        $this->isActive = (bool)$isActive;
+        $this->isActive = (bool) $isActive;
     }
 
     /**
@@ -94,6 +94,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
 
     /**
      * This method can be overridden
+     *
      * @param InstallContext $context
      */
     public function install(InstallContext $context)
@@ -102,6 +103,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
 
     /**
      * This method can be overridden
+     *
      * @param UpdateContext $context
      */
     public function update(UpdateContext $context)
@@ -111,6 +113,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
 
     /**
      * This method can be overridden
+     *
      * @param ActivateContext $context
      */
     public function activate(ActivateContext $context)
@@ -120,6 +123,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
 
     /**
      * This method can be overridden
+     *
      * @param DeactivateContext $context
      */
     public function deactivate(DeactivateContext $context)
@@ -129,6 +133,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
 
     /**
      * This method can be overridden
+     *
      * @param UninstallContext $context
      */
     public function uninstall(UninstallContext $context)
@@ -148,8 +153,8 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
      */
     public function build(ContainerBuilder $container)
     {
-        $container->setParameter($this->getContainerPrefix() . '.plugin_dir', $this->getPath());
-        $container->setParameter($this->getContainerPrefix() . '.plugin_name', $this->getName());
+        $container->setParameter($this->getContainerPrefix().'.plugin_dir', $this->getPath());
+        $container->setParameter($this->getContainerPrefix().'.plugin_name', $this->getName());
         $this->loadFiles($container);
     }
 
@@ -163,8 +168,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
         }
 
         $loader = new XmlFileLoader(
-            $container,
-            new FileLocator()
+            $container, new FileLocator()
         );
 
         $loader->load($this->getPath().'/Resources/services.xml');
@@ -205,7 +209,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
         return $this->camelCaseToUnderscore($this->getName());
     }
 
-     /**
+    /**
      * Gets the Plugin directory path.
      *
      * @return string The Plugin absolute path
@@ -213,8 +217,14 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
     final public function getPath()
     {
         if (null === $this->path) {
-            $reflected = new \ReflectionObject($this);
-            $this->path = dirname($reflected->getFileName());
+            // Resolve path where the plugin is expected to be installed
+            $this->path = \Enlight_Loader::realpath(__DIR__.'/../../../custom/plugins/'.$this->getName());
+
+            // Path not found -> previous behaviour
+            if (false === $this->path) {
+                $reflected = new \ReflectionObject($this);
+                $this->path = dirname($reflected->getFileName());
+            }
         }
 
         return $this->path;
@@ -222,6 +232,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
 
     /**
      * @param string $string
+     *
      * @return string
      */
     private function camelCaseToUnderscore($string)

--- a/tests/Unit/EnlightLoaderTest.php
+++ b/tests/Unit/EnlightLoaderTest.php
@@ -83,4 +83,40 @@ class EnlightLoaderTest extends TestCase
 
         $this->assertFalse($found);
     }
+
+    /**
+     * Test realpath abstraction
+     *
+     * @dataProvider dataProviderRealpath
+     */
+    public function testRealpath($path, $expected)
+    {
+        $result = \Enlight_Loader::realpath($path);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Provide test cases
+     *
+     * @return array
+     */
+    public function dataProviderRealpath()
+    {
+        return array(
+            // Absolute paths
+            array('/', '/'),
+            array(getcwd().'/', getcwd()),
+            array(getcwd().'/test/..', getcwd()),
+
+            // Relative paths
+            array('', getcwd()),
+            array('./', getcwd()),
+            array('../', realpath(getcwd().'/../')),
+
+            // Nonexisting paths
+            array('/nonexisting', false),
+            array('../nonexisting', false),
+            array('nonexisting', false),
+        );
+    }
 }

--- a/tests/Unit/EnlightLoaderTest.php
+++ b/tests/Unit/EnlightLoaderTest.php
@@ -102,21 +102,23 @@ class EnlightLoaderTest extends TestCase
      */
     public function dataProviderRealpath()
     {
-        return array(
-            // Absolute paths
-            array('/', '/'),
-            array(getcwd().'/', getcwd()),
-            array(getcwd().'/test/..', getcwd()),
+        return [
+            // Nonexisting paths
+            ['/nonexisting', false],
+            ['../nonexisting', false],
+            ['nonexisting', false],
+            [' ', false],
 
             // Relative paths
-            array('', getcwd()),
-            array('./', getcwd()),
-            array('../', realpath(getcwd().'/../')),
+            ['', getcwd()],
+            ['./', getcwd()],
+            ['../', realpath(getcwd().'/../')],
+            ['tests/Unit/Plugin/../../', getcwd().'/tests'],
 
-            // Nonexisting paths
-            array('/nonexisting', false),
-            array('../nonexisting', false),
-            array('nonexisting', false),
-        );
+            // Absolute paths
+            ['/', '/'],
+            [getcwd().'/', getcwd()],
+            [getcwd().'/test/..', getcwd()],
+        ];
     }
 }


### PR DESCRIPTION
## Description
With this patch it is possible to access files in symlinked themes or plugins. 
It adds an abstraction layer for the php builtin realpath() function. It is in most parts compatible but does not resolve symlinks. Also there are some tests added for the new realpath abstraction. Another benefit is,  that with the abstraction it would be possible to fully unittest the calling methods by mocking the abstraction.


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://github.com/shopware/shopware/pull/349 and https://issues.shopware.com/issues/SW-14241
| How to test?     | Create a symlink to a theme inheriting from responsive. See that images are not broken.


This allow symlinks to work