### PR TITLE
Fixed wrong '38 rating mails was sent.' message

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/CronRating/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/CronRating/Bootstrap.php
@@ -62,6 +62,7 @@ class Shopware_Plugins_Core_CronRating_Bootstrap extends Shopware_Components_Plu
         $customers = $this->getCustomers($orderIds);
         $positions = $this->getPositions($orderIds);
 
+        $message = [];
         foreach ($orders as $orderId => $order) {
             if (empty($customers[$orderId]['email']) || count($positions[$orderId]) === 0) {
                 continue;
@@ -94,9 +95,12 @@ class Shopware_Plugins_Core_CronRating_Bootstrap extends Shopware_Components_Plu
             $mail = Shopware()->TemplateMail()->createMail('sARTICLECOMMENT', $context);
             $mail->addTo($customers[$orderId]['email']);
             $mail->send();
+            $message[] = "Mail sent to '{$customers[$orderId]['email']}'.";
         }
 
-        return count($order) . ' rating mails was sent.';
+        if( count($message)<=20 )
+            return date("Y-m-d H:i:s").": ".implode(" \n",$message);
+        return date("Y-m-d H:i:s").": ".count($message) . ' rating mails have been sent.';
     }
 
     /**

--- a/engine/Shopware/Plugins/Default/Core/CronRating/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/CronRating/Bootstrap.php
@@ -98,8 +98,9 @@ class Shopware_Plugins_Core_CronRating_Bootstrap extends Shopware_Components_Plu
             $message[] = "Mail sent to '{$customers[$orderId]['email']}'.";
         }
 
-        if( count($message)<=20 )
+        if( count($message)>0 && count($message)<=20 ) {
             return date("Y-m-d H:i:s").": ".implode(" \n",$message);
+        }
         return date("Y-m-d H:i:s").": ".count($message) . ' rating mails have been sent.';
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
Because it's a bugfix
* What does it improve?
It fixes a bug and improves feedback to the admin
* Does it have side effects?
no



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | no
| Related tickets? | no
| How to test?     | Have a CronRating running


RatingCron did always report it's result as '38 rating mails was sent.' because there was a bug in the code.
Fixed that plus added some more info to the output.