### PR TITLE
SW-16815 - fix empty category in export feed

### DIFF
--- a/engine/Shopware/Core/sCategories.php
+++ b/engine/Shopware/Core/sCategories.php
@@ -435,7 +435,7 @@ class sCategories
             $articleId
         ));
 
-        return $id;
+        return ($id) ? $id : $parentId;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
* Why is it necessary?
  * Because it fixes a bug in the export module. That bug would output an empty string when trying to get a category while having a category without subcategories selected as the parent category.
* What does it improve?
  * It outputs the category name correctly.
* Does it have side effects?
  * None that I know of.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | Somehow not. I don't know why.
| Related tickets? | [SW-16815](http://issues.shopware.com/issues/SW-16815)
| How to test?     | Configure a Google XML export feed in the backend and set a category without subcategories as parent category. If there is a category path in <g:product_type>, it works.


The category field was empty if the selected parent category in the feed settings has no subcategories.