### PR TITLE
Fix shop and locale id for missing snippets

### DIFF
--- a/engine/Library/Enlight/Config.php
+++ b/engine/Library/Enlight/Config.php
@@ -107,7 +107,7 @@ class Enlight_Config extends Enlight_Config_BaseConfig implements ArrayAccess
             $this->_adapter = self::$_defaultAdapter;
         }
         if (isset($options['section'])) {
-            $this->_section = $options['section'];
+            $this->setSection($options['section']);
         }
         if (isset($options['extends'])) {
             $this->setExtends($options['extends']);

--- a/engine/Library/Enlight/Config/Adapter/DbTable.php
+++ b/engine/Library/Enlight/Config/Adapter/DbTable.php
@@ -245,10 +245,7 @@ class Enlight_Config_Adapter_DbTable extends Enlight_Config_Adapter
         }
 
         $name = $this->_namePrefix . $config->getName() . $this->_nameSuffix;
-        $section = $config->getSection();
-        if (is_string($section)) {
-            $section = explode($config->getSectionSeparator(), $config->getSection());
-        }
+        $section = explode($config->getSectionSeparator(), $config->getSection());
 
         $dbTable = $this->getTable($this->_namespaceColumn === null ? $name : null);
         $db = $dbTable->getAdapter();

--- a/engine/Shopware/Components/Snippet/DbAdapter.php
+++ b/engine/Shopware/Components/Snippet/DbAdapter.php
@@ -43,7 +43,7 @@ class DbAdapter extends \Enlight_Config_Adapter_DbTable
      */
     private function overwriteWithDefaultShopValues(\Enlight_Config $config)
     {
-        $section = $config->getSection();
+        $section = explode($config->getSectionSeparator(), $config->getSection());
         foreach ($this->_sectionColumn as $key => $columnName) {
             switch ($columnName) {
                 case 'shopID':

--- a/tests/Unit/Components/Config/ConfigTest.php
+++ b/tests/Unit/Components/Config/ConfigTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Tests
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+class ConfigTest extends Enlight_Components_Test_TestCase
+{
+    /**
+     * Test case
+     */
+    public function testMissingSnippetsConfigSection()
+    {
+        // Configure snippet database adapter
+        $adapter = new Shopware\Components\Snippet\DbAdapter([
+            'sectionColumn' => ['shopID', 'localeID']
+        ]);
+
+        // Simple default config object with section
+        $config = new \Enlight_Config([], [
+            'section' => '1:1'
+        ]);
+
+        // Write multiple times
+        $adapter->write($config);
+        $adapter->write($config);
+        $adapter->write($config);
+
+        // Section should not be modified
+        $this->assertEquals('1:1', $config->getSection());
+    }
+}


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary? Otherwise snippets referenced in the code but missing form the `.ini` files are imported into the database with `shopID` `111` and `localeID` `0`
* What does it improve? Import such snippets with the correct default `shopID` `1` and `localeID` `1`
* Does it have side effects? Nope




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | Execute the test case while reverting the other commits (or copy the test case to a clean shopware `5.2.9`), the test will fail


The following unwanted mutations of `section` will happen with each subsequent run because from 2. onwards array access on a string is performed:
1. `[1,1]` (array)
2. `'1:1'` (string)
3. `'111'` (string)
...

This then ends up in the database as `shopID` `111` and `localeID` `0`.