### PR TITLE
ArrayCollection Problem setOneToMany Function

### DIFF
--- a/engine/Shopware/Components/Model/ModelEntity.php
+++ b/engine/Shopware/Components/Model/ModelEntity.php
@@ -166,7 +166,7 @@ abstract class ModelEntity
      * <li>So the parameter expect <b>"customer"</b></li>
      * </ul>
      *
-     * @param array|null $data Model data, example: an array of \Shopware\Models\Order\Order
+     * @param \Doctrine\Common\Collections\ArrayCollection|array|null $data Model data, example: an array of \Shopware\Models\Order\Order
      * @param string $model Full namespace of the association model, example: '\Shopware\Models\Order\Order'
      * @param string $property Name of the association property, example: 'orders'
      * @param string $reference Name of the reference property, example: 'customer'
@@ -185,6 +185,10 @@ abstract class ModelEntity
             $this->$getterFunction()->clear();
             return $this;
         }
+        // if \Doctrine\Common\Collections\ArrayCollection
+		if($data instanceof \Doctrine\Common\Collections\ArrayCollection){
+			$data = $data.toArray();
+		}
         //if no array passed or if false passed, return
         if (!is_array($data)) {
             return $this;

--- a/engine/Shopware/Components/Model/ModelEntity.php
+++ b/engine/Shopware/Components/Model/ModelEntity.php
@@ -185,10 +185,10 @@ abstract class ModelEntity
             $this->$getterFunction()->clear();
             return $this;
         }
-        // if \Doctrine\Common\Collections\ArrayCollection
-		if($data instanceof \Doctrine\Common\Collections\ArrayCollection){
-			$data = $data.toArray();
-		}
+        //if \Doctrine\Common\Collections\ArrayCollection
+        if($data instanceof \Doctrine\Common\Collections\ArrayCollection){
+            $data = $data->toArray();
+        }
         //if no array passed or if false passed, return
         if (!is_array($data)) {
             return $this;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary? In Models when we have ManyToMany RelationShip variables declared as ArrayCollection but Set function use setOneToMany function to set the values which expected Array not ArrayCollection.
* What does it improve? We have the appilty now to add the variables as Array like in the shopware core or as ArrayCollection as in the declaration 
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes/no
| Tests pass?      | yes
| Related tickets? | http://issues.shopware.com/issues/SW-16893
| How to test?     | https://forum.shopware.com/discussion/41791/anlegen-eines-configuratorsets-via-models#Comment_177874

**more details hier:**
https://forum.shopware.com/discussion/41791/anlegen-eines-configuratorsets-via-models#Comment_177874