### PR TITLE
jquery-plugins - use exposed pluginbase

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
@@ -373,10 +373,10 @@
                             pluginData = new plugin();
                         } else {
                             var Plugin = function () {
-                                PluginBase.call(this, name, element, options);
+                                $.PluginBase.call(this, name, element, options);
                             };
 
-                            Plugin.prototype = $.extend(Object.create(PluginBase.prototype), { constructor: Plugin }, plugin);
+                            Plugin.prototype = $.extend(Object.create($.PluginBase.prototype), { constructor: Plugin }, plugin);
                             pluginData = new Plugin();
                         }
 
@@ -427,10 +427,10 @@
 
                 if (!pluginData) {
                     var Plugin = function () {
-                        PluginBase.call(this, pluginName, element, options);
+                        $.PluginBase.call(this, pluginName, element, options);
                     };
 
-                    Plugin.prototype = $.extend(Object.create(PluginBase.prototype), { constructor: Plugin, superclass: overridePlugin }, overridePlugin, override);
+                    Plugin.prototype = $.extend(Object.create($.PluginBase.prototype), { constructor: Plugin, superclass: overridePlugin }, overridePlugin, override);
                     pluginData = new Plugin();
 
                     $.data(element, 'plugin_' + pluginName, pluginData);


### PR DESCRIPTION
This change is necessary in order to be able to replace the global `$.PluginBase`.

This enables developers to use their own implementation of the PluginBase.



## Description
Please describe your pull request:
* Why is it necessary? Developer friendliness
* What does it improve? jQuery-Plugin creation by allowing custom plugin-bases
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | replace `$.PluginBase` with your own function


