### PR TITLE
Force getClientIp() to work with HTTP_X_FORWARDED_FOR

### DIFF
--- a/engine/Library/Zend/Controller/Request/Http.php
+++ b/engine/Library/Zend/Controller/Request/Http.php
@@ -1060,7 +1060,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
         if ($checkProxy && $this->getServer('HTTP_CLIENT_IP') != null) {
             $ip = $this->getServer('HTTP_CLIENT_IP');
         } else if ($checkProxy && $this->getServer('HTTP_X_FORWARDED_FOR') != null) {
-            $ip = array_shift(explode(',', $this->getServer('HTTP_X_FORWARDED_FOR'));
+            $ip = array_shift(explode(',', $this->getServer('HTTP_X_FORWARDED_FOR')));
         } else {
             $ip = $this->getServer('REMOTE_ADDR');
         }

--- a/engine/Library/Zend/Controller/Request/Http.php
+++ b/engine/Library/Zend/Controller/Request/Http.php
@@ -1060,7 +1060,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
         if ($checkProxy && $this->getServer('HTTP_CLIENT_IP') != null) {
             $ip = $this->getServer('HTTP_CLIENT_IP');
         } else if ($checkProxy && $this->getServer('HTTP_X_FORWARDED_FOR') != null) {
-            $ip = $this->getServer('HTTP_X_FORWARDED_FOR');
+            $ip = array_shift(explode(',', $this->getServer('HTTP_X_FORWARDED_FOR'));
         } else {
             $ip = $this->getServer('REMOTE_ADDR');
         }


### PR DESCRIPTION
## Description
Please describe your pull request:

This fix forces the method getClientIp() to return the client IP-Address. Actually it just returns the defined Server-Value (which may contain a set of IP's in HTTP_X_FORWARDED_FOR). As definded, the first IP in this Server-Value is the "true" Client-IP. See also https://tools.ietf.org/html/rfc7239 and http://stackoverflow.com/a/24606761 .

The Enlight_Controller_Front does still use this old, insecure Zend Framework 1 class (This should change in 5.3, please).

* Why is it necessary?
Because the method getClientIp() does promise to return a single IP-Address (of the client).

* What does it improve?
Fixes the usage of HTTP_X_FORWARDED_FOR

* Does it have side effects?
This method does not longer return all IP's defined in HTTP_X_FORWARDED_FOR. For this case there are other (clean) methods to access the server-variables.


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | Use the $front->Request()->getClientIp() where $front is a Enlight_Controller_Front.




Cheers,
Rafael Kutscha