### PR TITLE
Add article number to customer questions form

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Forms.php
+++ b/engine/Shopware/Controllers/Frontend/Forms.php
@@ -171,7 +171,9 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
                             if ($this->Request()->getParam('sOrdernumber', null) !== null) {
                                 $getName = Shopware()->Modules()->Articles()->sGetArticleNameByOrderNumber($this->Request()->getParam('sOrdernumber'));
                                 $text = Shopware()->Snippets()->getNamespace('frontend/detail/comment')->get('InquiryTextArticle');
-                                $text .= ' ' . $getName;
+                                // Add name and number of article
+                                $escapedArticleNumber = $this->get('shopware.escaper')->escapeHtml($this->Request()->getParam('sOrdernumber'));
+                                $text .= ' ' . $getName . ' (' . $escapedArticleNumber . '): ';
                                 $this->_elements[$id]['value'] = $text;
                                 $element['value'] = $text;
                             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request: Adds the article number to the customer questions form for an article.
* Why is it necessary? Makes answering the question easier, since the article number provides an exact reference to the article.
* What does it improve? Searching for the article the question is about in the shop is easer.
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://issues.shopware.com/issues/SW-15693
| How to test?     | Use the customer article question form in the frontend

<img width="917" alt="screenshot 2016-11-14 18 51 59" src="https://cloud.githubusercontent.com/assets/710188/20276288/e7dcfef4-aa9b-11e6-8219-31a6d97af087.png">