### PR TITLE
Disabled strip_tags on password parameters.

### DIFF
--- a/_sql/migrations/795-prepare-password-types-for-reencoding.php
+++ b/_sql/migrations/795-prepare-password-types-for-reencoding.php
@@ -1,0 +1,9 @@
+<?php
+
+class Migrations_Migration795 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql("UPDATE s_user SET encoder = 'StripTags';");
+    }
+}

--- a/_sql/migrations/795-prepare-password-types-for-reencoding.php
+++ b/_sql/migrations/795-prepare-password-types-for-reencoding.php
@@ -4,6 +4,6 @@ class Migrations_Migration795 extends Shopware\Components\Migrations\AbstractMig
 {
     public function up($modus)
     {
-        $this->addSql("UPDATE s_user SET encoder = 'StripTags';");
+        $this->addSql("UPDATE s_user SET encoder = 'StripTags' WHERE encoder IN ('bcrypt', 'sha256', 'md5');");
     }
 }

--- a/engine/Shopware/Components/Password/Encoder/StripTags.php
+++ b/engine/Shopware/Components/Password/Encoder/StripTags.php
@@ -25,7 +25,15 @@ class StripTags implements PasswordEncoderInterface
      */
     public function isPasswordValid($password, $hash)
     {
-        return password_verify(strip_tags($password), $hash);
+        $passwordManager = new \Shopware\Components\Password\Manager(
+            Shopware()->Config()
+        );
+
+        $password = strip_tags($password);
+
+        return $passwordManager->isPasswordValid($password, $hash, 'bcrypt') ||
+            $passwordManager->isPasswordValid($password, $hash, 'sha256') ||
+            $passwordManager->isPasswordValid($password, $hash, 'md5');
     }
 
     /**

--- a/engine/Shopware/Components/Password/Encoder/StripTags.php
+++ b/engine/Shopware/Components/Password/Encoder/StripTags.php
@@ -2,47 +2,47 @@
 
 class StripTags implements PasswordEncoderInterface
 {
-	/**
-	 * @return string
-	 */
-	public function getName()
-	{
-		return 'StripTags';
-	}
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'StripTags';
+    }
 
-	/**
-	 * @return boolean
-	 */
-	public function isCompatible()
-	{
-		return version_compare(PHP_VERSION, '5.3.7', '>=');
-	}
+    /**
+     * @return boolean
+     */
+    public function isCompatible()
+    {
+        return version_compare(PHP_VERSION, '5.3.7', '>=');
+    }
 
-	/**
-	 * @param  string $password
-	 * @param  string $hash
-	 * @return bool
-	 */
-	public function isPasswordValid($password, $hash)
-	{
-		return password_verify(strip_tags($password), $hash);
-	}
+    /**
+     * @param  string $password
+     * @param  string $hash
+     * @return bool
+     */
+    public function isPasswordValid($password, $hash)
+    {
+        return password_verify(strip_tags($password), $hash);
+    }
 
-	/**
-	 * @param  string $password
-	 * @return string
-	 */
-	public function encodePassword($password)
-	{
-		throw new Exception('Shoud never be called.');
-	}
+    /**
+     * @param  string $password
+     * @return string
+     */
+    public function encodePassword($password)
+    {
+        throw new Exception('Shoud never be called.');
+    }
 
-	/**
-	 * @param  string $hash
-	 * @return bool
-	 */
-	public function isReencodeNeeded($hash)
-	{
-		return true;
-	}
+    /**
+     * @param  string $hash
+     * @return bool
+     */
+    public function isReencodeNeeded($hash)
+    {
+        return true;
+    }
 }

--- a/engine/Shopware/Components/Password/Encoder/StripTags.php
+++ b/engine/Shopware/Components/Password/Encoder/StripTags.php
@@ -1,0 +1,48 @@
+<?php
+
+class StripTags implements PasswordEncoderInterface
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'StripTags';
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isCompatible()
+    {
+        return version_compare(PHP_VERSION, '5.3.7', '>=');
+    }
+
+    /**
+     * @param  string $password
+     * @param  string $hash
+     * @return bool
+     */
+    public function isPasswordValid($password, $hash)
+    {
+        return password_verify(strip_tags($password), $hash);
+    }
+
+    /**
+     * @param  string $password
+     * @return string
+     */
+    public function encodePassword($password)
+    {
+	    throw new Exception('Shoud never be called.');
+    }
+
+    /**
+     * @param  string $hash
+     * @return bool
+     */
+    public function isReencodeNeeded($hash)
+    {
+        return true;
+    }
+}

--- a/engine/Shopware/Components/Password/Encoder/StripTags.php
+++ b/engine/Shopware/Components/Password/Encoder/StripTags.php
@@ -34,7 +34,7 @@ class StripTags implements PasswordEncoderInterface
      */
     public function encodePassword($password)
     {
-        throw new Exception('Shoud never be called.');
+        throw new RuntimeException('Should never be called.');
     }
 
     /**

--- a/engine/Shopware/Components/Password/Encoder/StripTags.php
+++ b/engine/Shopware/Components/Password/Encoder/StripTags.php
@@ -2,47 +2,47 @@
 
 class StripTags implements PasswordEncoderInterface
 {
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'StripTags';
-    }
+	/**
+	 * @return string
+	 */
+	public function getName()
+	{
+		return 'StripTags';
+	}
 
-    /**
-     * @return boolean
-     */
-    public function isCompatible()
-    {
-        return version_compare(PHP_VERSION, '5.3.7', '>=');
-    }
+	/**
+	 * @return boolean
+	 */
+	public function isCompatible()
+	{
+		return version_compare(PHP_VERSION, '5.3.7', '>=');
+	}
 
-    /**
-     * @param  string $password
-     * @param  string $hash
-     * @return bool
-     */
-    public function isPasswordValid($password, $hash)
-    {
-        return password_verify(strip_tags($password), $hash);
-    }
+	/**
+	 * @param  string $password
+	 * @param  string $hash
+	 * @return bool
+	 */
+	public function isPasswordValid($password, $hash)
+	{
+		return password_verify(strip_tags($password), $hash);
+	}
 
-    /**
-     * @param  string $password
-     * @return string
-     */
-    public function encodePassword($password)
-    {
-	    throw new Exception('Shoud never be called.');
-    }
+	/**
+	 * @param  string $password
+	 * @return string
+	 */
+	public function encodePassword($password)
+	{
+		throw new Exception('Shoud never be called.');
+	}
 
-    /**
-     * @param  string $hash
-     * @return bool
-     */
-    public function isReencodeNeeded($hash)
-    {
-        return true;
-    }
+	/**
+	 * @param  string $hash
+	 * @return bool
+	 */
+	public function isReencodeNeeded($hash)
+	{
+		return true;
+	}
 }

--- a/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
@@ -115,7 +115,8 @@ class Shopware_Plugins_Frontend_InputFilter_Bootstrap extends Shopware_Component
                     $process[$key][self::filterValue($k, $regex)] = $v;
                     $process[] = &$process[$key][self::filterValue($k, $regex)];
                 } else {
-                    $process[$key][self::filterValue($k, $regex)] = self::filterValue($v, $regex);
+                    $stripTags = !in_array($k, ['password', 'passwordConfirmation', 'currentPassword']);
+                    $process[$key][self::filterValue($k, $regex)] = self::filterValue($v, $regex, $stripTags);
                 }
             }
         }
@@ -131,10 +132,10 @@ class Shopware_Plugins_Frontend_InputFilter_Bootstrap extends Shopware_Component
      * @param string $regex
      * @return string
      */
-    public static function filterValue($value, $regex)
+    public static function filterValue($value, $regex, $stripTags = true)
     {
         if (!empty($value)) {
-            $value = strip_tags($value);
+            if ($stripTags) $value = strip_tags($value);
             if (preg_match($regex, $value)) {
                 $value = null;
             }

--- a/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
@@ -135,7 +135,9 @@ class Shopware_Plugins_Frontend_InputFilter_Bootstrap extends Shopware_Component
     public static function filterValue($value, $regex, $stripTags = true)
     {
         if (!empty($value)) {
-            if ($stripTags) $value = strip_tags($value);
+            if ($stripTags) {
+                $value = strip_tags($value);
+            }
             if (preg_match($regex, $value)) {
                 $value = null;
             }


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
  * It allows more secure passwords.
* What does it improve?
  * It allows "<" and ">" in customer passwords.
* Does it have side effects?
  * No.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass? | yes
| Related tickets? | [#SW-16954](http://issues.shopware.com/issues/SW-16954)
| How to test?     | Make a frontend user with password "abcd<3defg"


These changes allow "<" and ">" in passwords of customers.