### PR TITLE
jquery.selectbox-replacement - provide a better fallback

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.selectbox-replacement.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.selectbox-replacement.js
@@ -78,7 +78,14 @@
             me.$triggerEl =$('<div>', { 'class': me.opts.baseCls + '-trigger', 'html': me.opts.triggerText }).appendTo(wrapEl);
 
             me.selected = me.$el.find(':selected');
-            me.$textEl.html(me.selected.html());
+
+            // if no option is selected fall back to the first one
+            if(me.selected.length === 0){
+                me.selected = me.$el.find('option:first');
+            }
+
+            // prevent collapsing, when there are no options available
+            me.$textEl.html(me.selected.html() || '&nbsp;');
 
             $.publish('plugin/swSelectboxReplacement/onCreateTemplate', [ me, wrapEl ]);
 


### PR DESCRIPTION
This PR provides a graceful fallback for selectbox-content. The default for setting the text-content of selectboxes is to use the text from the `:selected` option. Problems arise if there is no `:selected` option. If the css doesn't account for `.js--fancy-select-text` having no content, the selectbox just collapses. Collapsed selectboxes are not clickable!

This is what happens in the default Responsive Theme:

![image](https://cloud.githubusercontent.com/assets/765896/20304915/04d691ea-ab33-11e6-98dc-9551ff325a4e.png)
`<div class="js--fancy-select-text"></div>`

This PR addresses that problem by falling back to the tex of the first option, if no option is `:selected`. If that doesn't work, too the plugin will use `&nbsp;` to prevent collapsing.

## Description
Please describe your pull request:
* Why is it necessary? To account for not-selected `select`s using the `swSelectboxReplacement`-plugin
* What does it improve? Prevents collapsing of select-boxes
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | If this PR fix

## How to test?

```html
<select id="fixture">
  <option>foo</option>
  <option>bar</option>
</select>
```

run this before the selectbox-replacement
```javascript
$('#fixture').val(null)
```

this produces a collapsed, unclickable selectbox which **has selectable options**.
