### PR TITLE
Added check if the delete-icon should appear.

### DIFF
--- a/themes/Backend/ExtJs/backend/article/controller/detail.js
+++ b/themes/Backend/ExtJs/backend/article/controller/detail.js
@@ -804,8 +804,10 @@ Ext.define('Shopware.apps.Article.controller.Detail', {
                     nextRecord.set('from', event.value + 1);
                 }
             } else {
-                icon.removeCls('x-hidden');
-                icon.addCls('sprite-minus-circle-frame');
+                if (event.rowIdx != 0 || event.value != null) {
+                    icon.removeCls('x-hidden');
+                    icon.addCls('sprite-minus-circle-frame');
+                }
             }
         } else if ( event.field === 'price') {
             if (price && firstPrice > price) {


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
  * Without this it would be possible to delete the last price-entry of an article.
* What does it improve?
  * Adds a check if the delete-icon should appear.
* Does it have side effects?
  * No.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | pending
| Related tickets? | No
| How to test?     | Open article in backend. Click into the "to"-field in the price-table. Click away. Without this fix, there should now be a delete-icon next to the only price-entry. If that does not appear, this works.


In the prices-table you could delete the last remaining price if you clicked on the "to"-field and then clicked away without entering anything. This commit fixes that.