### PR TITLE
Prevent php notice, if translations missing

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/AttributeHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/AttributeHydrator.php
@@ -88,8 +88,8 @@ class AttributeHydrator extends Hydrator
 
         if ($translationKey) {
             $translationKey = '__' . $translationKey . '_translation';
-            $attribute['translation'] = $data[$translationKey];
-            $attribute['translation_fallback'] = $data[$translationKey . '_fallback'];
+            $attribute['translation'] = !empty($data[$translationKey]) ? $data[$translationKey] : null;
+            $attribute['translation_fallback'] = !empty($data[$translationKey . '_fallback']) ? $data[$translationKey . '_fallback'] : null;
         }
 
         $struct->addAttribute($attributeKey, $this->hydrate($attribute));


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
I have today imported 20k products to elasticsearch and i got for every product the php notice that he can't find the translation for that product..
* What does it improve?
Prevents a php notice :)
* Does it have side effects?
Nope


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | Nope
| How to test?     | Please describe how to best verify that this PR is correct.


