### PR TITLE
Fix PHP warnings in CRUD service

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Service/TableMapping.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/TableMapping.php
@@ -66,7 +66,8 @@ class TableMapping
             throw new \Exception(sprintf("Table %s is no attribute table", $table));
         }
         $config = $this->tables[$table];
-        $columns = array_map('strtolower', $config['identifiers']);
+        $identifiers = isset($config['identifiers']) ? $config['identifiers'] : [];
+        $columns = array_map('strtolower', $identifiers);
         return in_array(strtolower($name), $columns);
     }
 
@@ -82,7 +83,8 @@ class TableMapping
             throw new \Exception(sprintf("Table %s is no attribute table", $table));
         }
         $config = $this->tables[$table];
-        $columns = array_map('strtolower', $config['coreAttributes']);
+        $coreAttributes = isset($config['coreAttributes']) ? $config['coreAttributes'] : [];
+        $columns = array_map('strtolower', $coreAttributes);
         return in_array(strtolower($name), $columns);
     }
 


### PR DESCRIPTION
## Description

I'm getting PHP warnings when the crud service accesses undefined array keys from
`shopware/engine/Shopware/Bundle/AttributeBundle/DependencyInjection/Resources/table_entity_mapping.php`

namely

`PHP Warning:  in_array() expects parameter 2 to be array, null given in /var/www/localdev_swtest/engine/Shopware/Bundle/AttributeBundle/Service/TableMapping.php on line 89`

and

`PHP Warning:  array_map(): Argument #2 should be an array in /var/www/localdev_swtest/engine/Shopware/Bundle/AttributeBundle/Service/TableMapping.php on line 88`

The warnings occured on simple `$crudService->update(...)` calls.

This doesn't break anything, just adds an `isset` to make sure the corresponding array keys exist, otherwise return empty arrays.