### PR TITLE
fixing customernumber in billing address when restoring order from cancelled basket - Shopware 5.2.x

### DIFF
--- a/engine/Shopware/Controllers/Backend/CanceledOrder.php
+++ b/engine/Shopware/Controllers/Backend/CanceledOrder.php
@@ -127,9 +127,9 @@ class Shopware_Controllers_Backend_CanceledOrder extends Shopware_Controllers_Ba
         if ($result[0]['customer']['shipping'] === null) {
             $result[0]['customer']['shipping'] = $result[0]['customer']['billing'];
         }
-		
-		// copy customer number into billing address from customer
-		$result[0]['customer']['billing']['number'] = $result[0]['customer']['number'];
+
+        // copy customer number into billing address from customer
+        $result[0]['customer']['billing']['number'] = $result[0]['customer']['number'];
 
         // Create new entry in s_order_billingaddress
         $billingModel = new Shopware\Models\Order\Billing();

--- a/engine/Shopware/Controllers/Backend/CanceledOrder.php
+++ b/engine/Shopware/Controllers/Backend/CanceledOrder.php
@@ -127,6 +127,9 @@ class Shopware_Controllers_Backend_CanceledOrder extends Shopware_Controllers_Ba
         if ($result[0]['customer']['shipping'] === null) {
             $result[0]['customer']['shipping'] = $result[0]['customer']['billing'];
         }
+		
+		// copy customer number into billing address from customer
+		$result[0]['customer']['billing']['number'] = $result[0]['customer']['number'];
 
         // Create new entry in s_order_billingaddress
         $billingModel = new Shopware\Models\Order\Billing();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary? Orders restored from cancelled baskets are missing the customers number in the billing address due to refacturing of the address model
* What does it improve? Adds the customer number to the billing address, if orders are restored from cancelled baskets
* Does it have side effects? none visible.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | -
| Tests pass?      | -
| Related tickets? | -
| How to test?     | 1. Fill a basket 2. log in in frontend 3. Don't finish order 4. Restore basket in backend 5. customernumber missing in s_order_billing_address. 6. Install patch 7. repeat above steps 8. customernumber will be filled in s_order_billing_address 9. ??? 10. PROFIT!


Bei Wiederherstellung abgebrochener Warenkörbe wird die Kundennummer in die Rechnungsadresse kopiert.