### PR TITLE
Added sAmountNumeric and sAmountNetNumeric to sOrder Mail

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -7,6 +7,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 * Added new rule for `/widgets/emotion` to robots.txt in `frontend/robots_txt/index.tpl`
 * Added new blocks in `themes/Frontend/Bare/frontend/account/index.tpl`
 * If shipping address equals billing address show notice instead of same address twice in account index
+* Added `$sAmountNumeric` and `$sAmountNetNumeric` to sOrder mail
 
 ## 5.2.10
 

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -789,22 +789,24 @@ class sOrder
             $this->sBasketData["content"]
         );
 
-        $variables = array(
-            "sOrderDetails"=>$details,
-            "billingaddress"=>$this->sUserData["billingaddress"],
-            "shippingaddress"=>$this->sUserData["shippingaddress"],
-            "additional"=>$this->sUserData["additional"],
-            "sShippingCosts"=>$this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($this->sShippingcosts)." ".$this->sSYSTEM->sCurrency["currency"],
-            "sAmount"=>$this->sAmountWithTax ? $this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($this->sAmountWithTax)." ".$this->sSYSTEM->sCurrency["currency"] : $this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($this->sAmount)." ".$this->sSYSTEM->sCurrency["currency"],
-            "sAmountNet"=>$this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($this->sBasketData["AmountNetNumeric"])." ".$this->sSYSTEM->sCurrency["currency"],
-            "sTaxRates"   => $this->sBasketData["sTaxRates"],
-            "ordernumber"=>$orderNumber,
-            "sOrderDay" => date("d.m.Y"),
-            "sOrderTime" => date("H:i"),
-            "sComment"=>$this->sComment,
-            'attributes' => $attributes,
-            "sEsd"=>$esdOrder
-        );
+        $variables = [
+            "sOrderDetails"     => $details,
+            "billingaddress"    => $this->sUserData["billingaddress"],
+            "shippingaddress"   => $this->sUserData["shippingaddress"],
+            "additional"        => $this->sUserData["additional"],
+            "sShippingCosts"    => $this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($this->sShippingcosts)." ".$this->sSYSTEM->sCurrency["currency"],
+            "sAmount"           => $this->sAmountWithTax ? $this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($this->sAmountWithTax)." ".$this->sSYSTEM->sCurrency["currency"] : $this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($this->sAmount)." ".$this->sSYSTEM->sCurrency["currency"],
+            "sAmountNumeric"    => $this->sAmountWithTax ? $this->sAmountWithTax : $this->sAmount,
+            "sAmountNet"        => $this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($this->sBasketData["AmountNetNumeric"])." ".$this->sSYSTEM->sCurrency["currency"],
+            "sAmountNetNumeric" => $this->sBasketData["AmountNetNumeric"],
+            "sTaxRates"         => $this->sBasketData["sTaxRates"],
+            "ordernumber"       => $orderNumber,
+            "sOrderDay"         => date("d.m.Y"),
+            "sOrderTime"        => date("H:i"),
+            "sComment"          => $this->sComment,
+            'attributes'        => $attributes,
+            "sEsd"              => $esdOrder
+        ];
 
         if ($dispatchId) {
             $variables["sDispatch"] = $this->sSYSTEM->sMODULES['sAdmin']->sGetPremiumDispatch($dispatchId);
@@ -1135,33 +1137,35 @@ class sOrder
 
         $shopContext = $this->contextService->getShopContext();
 
-        $context = array(
-            'sOrderDetails' => $variables["sOrderDetails"],
+        $context = [
+            'sOrderDetails'     => $variables["sOrderDetails"],
 
-            'billingaddress'  => $variables["billingaddress"],
-            'shippingaddress' => $variables["shippingaddress"],
-            'additional'      => $variables["additional"],
+            'billingaddress'    => $variables["billingaddress"],
+            'shippingaddress'   => $variables["shippingaddress"],
+            'additional'        => $variables["additional"],
 
-            'sTaxRates'      => $variables["sTaxRates"],
-            'sShippingCosts' => $variables["sShippingCosts"],
-            'sAmount'        => $variables["sAmount"],
-            'sAmountNet'     => $variables["sAmountNet"],
+            'sTaxRates'         => $variables["sTaxRates"],
+            'sShippingCosts'    => $variables["sShippingCosts"],
+            'sAmount'           => $variables["sAmount"],
+            'sAmountNumeric'    => $variables["sAmountNumeric"],
+            'sAmountNet'        => $variables["sAmountNet"],
+            'sAmountNetNumeric' => $variables["sAmountNetNumeric"],
 
-            'sOrderNumber' => $variables["ordernumber"],
-            'sOrderDay'    => $variables["sOrderDay"],
-            'sOrderTime'   => $variables["sOrderTime"],
-            'sComment'     => $variables["sComment"],
+            'sOrderNumber'      => $variables["ordernumber"],
+            'sOrderDay'         => $variables["sOrderDay"],
+            'sOrderTime'        => $variables["sOrderTime"],
+            'sComment'          => $variables["sComment"],
 
-            'attributes'     => $variables["attributes"],
-            'sCurrency'    => $this->sSYSTEM->sCurrency["currency"],
+            'attributes'        => $variables["attributes"],
+            'sCurrency'         => $this->sSYSTEM->sCurrency["currency"],
 
-            'sLanguage'    => $shopContext->getShop()->getId(),
+            'sLanguage'         => $shopContext->getShop()->getId(),
 
-            'sSubShop'     => $shopContext->getShop()->getId(),
+            'sSubShop'          => $shopContext->getShop()->getId(),
 
-            'sEsd'    => $variables["sEsd"],
-            'sNet'    => $this->sNet,
-        );
+            'sEsd'              => $variables["sEsd"],
+            'sNet'              => $this->sNet,
+        ];
 
         // Support for individual payment means with custom-tables
         if ($variables["additional"]["payment"]["table"]) {


### PR DESCRIPTION
## Description
Please describe your pull request:
* What does it improve?
Makes easier to calculate with $sAmount or $sAmountNet in sOrder
* Does it have side effects?
Nope




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Make a order and show variables


