### PR TITLE
Update Shopware.form.field.ComboTree.js

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.ComboTree.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.ComboTree.js
@@ -162,6 +162,14 @@ Ext.define('Shopware.form.field.ComboTree', {
             inputEl.removeCls(me.emptyCls);
         }
         me.value = value;
+        
+        /** 
+        * Setzen von rawValue, sonst wird der Wert im Inputelement nicht angezeigt - SN - 22.11.2016
+        */
+        if (inputEl && !Ext.isEmpty(value)){
+            me.setRawValue(value); 
+        }  
+
         me.applyEmptyText();
     },
 

--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.ComboTree.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.ComboTree.js
@@ -164,7 +164,7 @@ Ext.define('Shopware.form.field.ComboTree', {
         me.value = value;
         
         /** 
-        * Setzen von rawValue, sonst wird der Wert im Inputelement nicht angezeigt - SN - 22.11.2016
+        * Setting rawValue, otherwise the value of the input element is not displayed - SN - 22/11/2016
         */
         if (inputEl && !Ext.isEmpty(value)){
             me.setRawValue(value); 

--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.ComboTree.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.ComboTree.js
@@ -163,9 +163,6 @@ Ext.define('Shopware.form.field.ComboTree', {
         }
         me.value = value;
         
-        /** 
-        * Setting rawValue, otherwise the value of the input element is not displayed - SN - 22/11/2016
-        */
         if (inputEl && !Ext.isEmpty(value)){
             me.setRawValue(value); 
         }  


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
* What does it improve?
* Does it have side effects?




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes/no
| Tests pass?      | yes/no
| Related tickets? | If this PR fixes an existing [Issue](https://issues.shopware.com) ticket, please add its complete issue URL.
| How to test?     | Please describe how to best verify that this PR is correct.


Beim Laden der Werte einer Form, werden diese über die setValue Methode an die Komponenten weitergegeben. Beim ComboTree wird der gesetzte Wert aber nicht an das Inputelement weitergegeben und deshalb dort nicht angezeigt. Dazu muß zusätzlich die setRawValue Methode aufgerufen werden.

VG
JM