### PR TITLE
Pass pass-by-reference parameters as references in hook proxy classes.

### DIFF
--- a/engine/Library/Enlight/Hook/ProxyFactory.php
+++ b/engine/Library/Enlight/Hook/ProxyFactory.php
@@ -275,12 +275,17 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
                     $proxy_params .= ', ';
                     $array_params .= ', ';
                 }
+
+                $array_param = '';
                 if ($rp->isPassedByReference()) {
                     $params .= '&';
+                    $proxy_params .= '$';
+                    $array_param .= '&';
                 }
                 $params .= '$' . $rp->getName();
                 $proxy_params .= '$' . $rp->getName();
-                $array_params .= '\'' . $rp->getName() . '\'=>$' . $rp->getName();
+                $array_param .= '$' . $rp->getName();
+                $array_params .= '\'' . $rp->getName() . '\'=>' . $array_param;
                 if ($rp->isOptional()) {
                     $params .= ' = ' . str_replace("\n", '', var_export($rp->getDefaultValue(), true));
                 }

--- a/tests/Unit/Components/Hook/EnlightHookProxyFactoryTest.php
+++ b/tests/Unit/Components/Hook/EnlightHookProxyFactoryTest.php
@@ -1,0 +1,134 @@
+<?php
+namespace Shopware\Tests\Unit\Components;
+
+use PHPUnit\Framework\TestCase;
+
+interface MyInterface
+{
+    public function myPublic($bar, $foo = 'bar');
+}
+
+interface MyReferenceInterface
+{
+    public function myPublic(&$bar, $foo);
+}
+
+class MyBasicTestClass implements MyInterface
+{
+    public function myPublic($bar, $foo = 'bar')
+    {
+        return $bar.$foo;
+    }
+
+    protected function myProtected($bar)
+    {
+    }
+}
+
+class MyReferenceTestClass implements MyReferenceInterface
+{
+    public function myPublic(&$bar, $foo)
+    {
+        return $bar.$foo;
+    }
+}
+
+class TestProxyFactory extends \Enlight_Hook_ProxyFactory
+{
+    public function __construct(\Enlight_Hook_HookManager $hookManager, $proxyNamespace)
+    {
+        $this->hookManager = $hookManager;
+        $this->proxyNamespace = $proxyNamespace;
+    }
+}
+
+class EnlightHookProxyFactoryTest extends TestCase
+{
+    private $proxyFactory;
+
+    public function setUp()
+    {
+        /** @var \Enlight_Hook_HookManager $SUT */
+        $hookManager = $this->createConfiguredMock(\Enlight_Hook_HookManager::class, [
+            'hasHooks' => true,
+        ]);
+
+        $this->proxyFactory = new TestProxyFactory($hookManager, 'ShopwareTests');
+    }
+
+    private function invokeMethod($object, $methodName, array $parameters = array())
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+
+    public function testGenerateBasicProxyClass()
+    {
+        $generatedClass  = $this->invokeMethod($this->proxyFactory, 'generateProxyClass', [MyBasicTestClass::class]);
+        $expectedClass = <<<'EOT'
+<?php
+class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends Shopware\Tests\Unit\Components\MyBasicTestClass implements Enlight_Hook_Proxy
+{
+    public function executeParent($method, $args = array())
+    {
+        return call_user_func_array(array($this, 'parent::' . $method), $args);
+    }
+
+    public static function getHookMethods()
+    {
+        return array (  0 => 'myPublic',  1 => 'myProtected',);
+    }
+    
+    public function myPublic($bar, $foo = 'bar')
+    {
+        return Shopware()->Hooks()->executeHooks(
+            $this, 'myPublic', array('bar'=>$bar, 'foo'=>$foo)
+        );
+    }
+
+    protected function myProtected($bar)
+    {
+        return Shopware()->Hooks()->executeHooks(
+            $this, 'myProtected', array('bar'=>$bar)
+        );
+    }
+
+}
+
+EOT;
+        $this->assertSame($expectedClass, $generatedClass);
+    }
+
+    public function testGenerateProxyClassWithReferenceParameter()
+    {
+        $generatedClass  = $this->invokeMethod($this->proxyFactory, 'generateProxyClass', [MyReferenceTestClass::class]);
+        $expectedClass = <<<'EOT'
+<?php
+class ShopwareTests_ShopwareTestsUnitComponentsMyReferenceTestClassProxy extends Shopware\Tests\Unit\Components\MyReferenceTestClass implements Enlight_Hook_Proxy
+{
+    public function executeParent($method, $args = array())
+    {
+        return call_user_func_array(array($this, 'parent::' . $method), $args);
+    }
+
+    public static function getHookMethods()
+    {
+        return array (  0 => 'myPublic',);
+    }
+    
+    public function myPublic(&$bar, $foo)
+    {
+        return Shopware()->Hooks()->executeHooks(
+            $this, 'myPublic', array('bar'=>&$bar, 'foo'=>$foo)
+        );
+    }
+
+}
+
+EOT;
+        $this->assertSame($expectedClass, $generatedClass);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?

A hook on a method with pass-by-reference parameters currently breaks the hooked method. This is due to an incorrect parameter array being created in `\Enlight_Hook_ProxyFactory:: generateMethods($class)`.

As stated in http://php.net/manual/en/function.call-user-func-array.php#example-5925, the parameter array for `call_user_func_array` has to pass in the values as references, if the called method expects pass-by-reference arguments.
This is currently not the case. The reference sign `&` is only used in the signature of the hooked method in the proxy class, not in the parameter array for the actual method call.

* What does it improve?

This PR adds a reference sign for both `$proxy_params` and `$array_params`. The `$params` are being prefixed correctly already. This allows for hooks on methods that expect a parameter passed as a reference.

* Does it have side effects?

The test suite passes and it fixes the error case for a plugin of ours. There are currently no explicit test cases for hook methods, but I'm assuming this does not affect any use cases, as it merely fixes a broken implementation for a specific use case.

The placeholder `<proxyMethodParameters>` is not used in the class template, but I included the `$proxy_params` in my change. This may or may not be correct, depending on how (if?) these are used. I could not find any actual usage of `<proxyMethodParameters>`in any case.


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | Install [SwagImportExport](https://github.com/shopwareLabs/SwagImportExport) in a shopware installation. Create, install and enable a new plugin with a hook for `Shopware\Components\SwagImportExport\DbAdapters\CustomerDbAdapter::prepareCustomer::before`. The hook method doesn't need to do anything. A customer import through Import/Export Advanced will then fail. Apply the PR, try again, the customer import will work correctly.