### PR TITLE
[FEATURE] Allow prices with amount 0 for free articles

### DIFF
--- a/_sql/migrations/796-add-free-articles-config-element.php
+++ b/_sql/migrations/796-add-free-articles-config-element.php
@@ -1,0 +1,13 @@
+<?php
+
+class Migrations_Migration796 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = <<<SQL
+INSERT INTO `s_core_config_elements` (`id`, `form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`)
+VALUES (NULL,259,'allowFreeArticles','b:1;','Allow free articles','Allows users to store prices with the amount "0"','boolean',0,0,0)
+SQL;
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2508,7 +2508,7 @@ class sBasket
         ) ? : array();
 
         // Load prices from default group if article prices are not defined
-        if (!$queryNewPrice["price"]) {
+        if ($queryNewPrice["price"] === null) {
             // In the case no price is available for this customer group, use price of default customer group
             $sql = 'SELECT s_articles_prices.price AS price, taxID, s_core_tax.tax AS tax,
               s_articles_details.id AS articleDetailsID, s_articles_details.articleID,

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1432,8 +1432,7 @@ class sBasket
         list($queryAdditionalInfo, $quantity) = $this->getAdditionalInfoForUpdateArticle($id, $quantity);
         $queryNewPrice = $this->getPriceForUpdateArticle($id, $quantity, $queryAdditionalInfo);
 
-
-        if (empty($queryNewPrice["price"]) && empty($queryNewPrice["config"])) {
+        if ($queryNewPrice["price"] === null && empty($queryNewPrice["config"])) {
             // If no price is set for default customer group, delete article from basket
             $this->sDeleteArticle($id);
             return false;
@@ -2657,10 +2656,6 @@ class sBasket
             ) ? : array();
         }
 
-        if (!$price["price"] && !$article["free"]) {
-            // No price could acquired
-            throw new Enlight_Exception("BASKET-INSERT #01 No price acquired");
-        }
 
         // If configuration article
         if (

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2746,7 +2746,7 @@ class sBasket
         if ($article['configurator_set_id'] > 0) {
             $context = $this->contextService->getShopContext();
             $product = Shopware()->Container()->get('shopware_storefront.list_product_service')->get($article['ordernumber'], $context);
-            if(null === $product) {
+            if (null === $product) {
                 return false;
             }
             $product = $this->additionalTextService->buildAdditionalText($product, $context);

--- a/themes/Backend/ExtJs/backend/article/controller/detail.js
+++ b/themes/Backend/ExtJs/backend/article/controller/detail.js
@@ -327,7 +327,7 @@ Ext.define('Shopware.apps.Article.controller.Detail', {
         var firstCustomerGroup = me.subApplication.firstCustomerGroup;
 
         priceStore.each(function(price) {
-            if (price.get('customerGroupKey') == firstCustomerGroup.get('key') && price.get('price') > 0) {
+            if (price.get('customerGroupKey') == firstCustomerGroup.get('key') && (price.get('price') > 0 || '{config name="allowFreeArticles"}')) {
                 priceExist = true;
                 return true;
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Although it is already possible to have free articles by adding articles with some price and create a price group with a 100% discount I see no reason why prices should not be 0 in the first place. There are just a few error checks that need to be removed/adjusted.
Just so we don't change the current behaviour I added a setting that disallows storing prices with 0. It can be changed in System>Backend




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | none
| How to test?     | Execute migration 796, set option in Settings > System > Backend, create Article with Price 0 (optionally with variants), buy article in FE


