### PR TITLE
When clearing proxy cache, clear APCu cache too

### DIFF
--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -211,6 +211,11 @@ class CacheManager
             $metaDataCache->deleteAll();
         }
 
+        // Clear the APCu cache because this may cause problems when attributes are removed
+        if (function_exists('apcu_clear_cache')) {
+            apcu_clear_cache();
+        }
+
         // Clear Shopware Proxies / Classmaps / Container
         $this->clearDirectory($this->container->getParameter('shopware.hook.proxyDir'));
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary? Hard-to-debug Doctrine errors may occur for users of plugins that change attribute configuration when APCu is enabled and used by Doctrine (see below for a detailed example).
* What does it improve? Clears the APCu cache when clearing the proxy cache, which should prevent instances of the issue described above.
* Does it have side effects? Clears the APCu cache, so may cause some additional cache misses after updating plugins, but this should not be a relevant drawback.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | since this is a once-in-a-blue-moon bug, it's not really testable

The log below shows an instance of the bug. This was observed on a customer's shop installation after the customer updated one of our plugins. During the upgrade, the `s_order_details_attributes` entry `viison_coupon_code_ids` was removed by the plugin. As the log output shows, Doctrine was still trying to access the attribute in question, although it was already removed from the model and from the database. Attributes were re-generated and the proxy cache was manually cleared several times, but the problem persisted. Calling `apcu_clear_cache()` once resolved the problem permanently.

```
[2016-11-18 16:57:27] plugin.ERROR: ViisonPickwarePOS: Failed to create order via REST API {"exception":"[object] (ReflectionException(code: 0): Property Shopware\\Models\\Attribute\\OrderDetail::$viisonCouponCodeIds does not exist at /var/www/web1/htdocs/shopware4/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php:80)"} {"uid":"11cc323"}
[2016-11-18 16:57:27] plugin.ERROR: Stack trace:
 #0 /var/www/web1/htdocs/shopware4/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php(80): ReflectionProperty->__construct('Shopware\\Models...', 'viisonCouponCod...')
 #1 /var/www/web1/htdocs/shopware4/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php(959): Doctrine\Common\Persistence\Mapping\RuntimeReflectionService->getAccessibleProperty('Shopware\\Models...', 'viisonCouponCod...')
 #2 /var/www/web1/htdocs/shopware4/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php(721): Doctrine\ORM\Mapping\ClassMetadataInfo->wakeupReflection(Object(Doctrine\Common\Persistence\Mapping\RuntimeReflectionService))
 #3 /var/www/web1/htdocs/shopware4/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php(214): Doctrine\ORM\Mapping\ClassMetadataFactory->wakeupReflection(Object(Doctrine\ORM\Mapping\ClassMetadata), Object(Doctrine\Common\Persistence\Mapping\RuntimeReflectionService))
 #4 /var/www/web1/htdocs/shopware4/vendor/doctrine/orm/lib/Doctrine/ORM/EntityManager.php(281): Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory->getMetadataFor('Shopware\\Models...')
 #5 /var/www/web1/htdocs/shopware4/engine/Library/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php(1255): Doctrine\ORM\EntityManager->getClassMetadata('Shopware\\Models...')
 #6 /var/www/web1/htdocs/shopware4/engine/Library/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php(1100): Doctrine\ORM\Persisters\Entity\BasicEntityPersister->getSelectColumnsSQL()
 #7 /var/www/web1/htdocs/shopware4/engine/Library/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php(1835): Doctrine\ORM\Persisters\Entity\BasicEntityPersister->getSelectSQL(Array, Array, NULL, NULL, NULL)
 #8 /var/www/web1/htdocs/shopware4/engine/Library/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php(1777): Doctrine\ORM\Persisters\Entity\BasicEntityPersister->getOneToManyStatement(Array, Object(Shopware\Models\Order\Order))
 #9 /var/www/web1/htdocs/shopware4/vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php(2835): Doctrine\ORM\Persisters\Entity\BasicEntityPersister->loadOneToManyCollection(Array, Object(Shopware\Models\Order\Order), Object(Doctrine\ORM\PersistentCollection))
 #10 /var/www/web1/htdocs/shopware4/vendor/doctrine/orm/lib/Doctrine/ORM/PersistentCollection.php(697): Doctrine\ORM\UnitOfWork->loadCollection(Object(Doctrine\ORM\PersistentCollection))
 #11 /var/www/web1/htdocs/shopware4/vendor/doctrine/orm/lib/Doctrine/ORM/PersistentCollection.php(214): Doctrine\ORM\PersistentCollection->doInitialize()
 #12 /var/www/web1/htdocs/shopware4/vendor/doctrine/collections/lib/Doctrine/Common/Collections/AbstractLazyCollection.php(76): Doctrine\ORM\PersistentCollection->initialize()
 #13 /var/www/web1/htdocs/shopware4/vendor/doctrine/orm/lib/Doctrine/ORM/PersistentCollection.php(429): Doctrine\Common\Collections\AbstractLazyCollection->contains(Object(Shopware\Models\Order\Detail))
 #14 /var/www/web1/htdocs/shopware4/engine/Shopware/Components/Model/ModelEntity.php(227): Doctrine\ORM\PersistentCollection->contains(Object(Shopware\Models\Order\Detail))
 #15 /var/www/web1/htdocs/shopware4/engine/Shopware/Models/Order/Order.php(1011): Shopware\Components\Model\ModelEntity->setOneToMany(Array, '\\Shopware\\Model...', 'details', 'order')
 #16 /var/www/web1/htdocs/shopware4/engine/Shopware/Components/Model/ModelEntity.php(55): Shopware\Models\Order\Order->setDetails(Array)
 #17 /var/www/web1/htdocs/shopware4/engine/Shopware/Plugins/Community/Core/ViisonPickwarePOS/Components/Resources/Order.php(329): Shopware\Components\Model\ModelEntity->fromArray()
 #18 /var/www/web1/htdocs/shopware4/engine/Shopware/Plugins/Community/Core/ViisonPickwarePOS/Components/Resources/Order.php(77): Shopware\Plugins\ViisonPickwarePOS\Components\Resources\Order->createOrder()
 #19 /var/www/web1/htdocs/shopware4/engine/Shopware/Plugins/Community/Core/ViisonPickwarePOS/Controllers/Api/ViisonPickwarePOSOrders.php(98): Shopware\Plugins\ViisonPickwarePOS\Components\Resources\Order->create(Array)
 #20 /var/www/web1/htdocs/shopware4/engine/Library/Enlight/Controller/Action.php(159): Shopware_Controllers_Api_ViisonPickwarePOSOrders->postAction()
 #21 /var/www/web1/htdocs/shopware4/engine/Library/Enlight/Controller/Dispatcher/Default.php(523): Enlight_Controller_Action->dispatch('postAction')
 #22 /var/www/web1/htdocs/shopware4/engine/Library/Enlight/Controller/Front.php(223): Enlight_Controller_Dispatcher_Default->dispatch(Object(Enlight_Controller_Request_RequestHttp), Object(Enlight_Controller_Response_ResponseHttp))
 #23 /var/www/web1/htdocs/shopware4/engine/Shopware/Kernel.php(177): Enlight_Controller_Front->dispatch()
 #24 /var/www/web1/htdocs/shopware4/vendor/symfony/http-kernel/HttpCache/HttpCache.php(487): Shopware\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
 #25 /var/www/web1/htdocs/shopware4/engine/Shopware/Components/HttpCache/AppCache.php(255): Symfony\Component\HttpKernel\HttpCache\HttpCache->forward(Object(Symfony\Component\HttpFoundation\Request), true, NULL)
 #26 /var/www/web1/htdocs/shopware4/vendor/symfony/http-kernel/HttpCache/HttpCache.php(258): Shopware\Components\HttpCache\AppCache->forward(Object(Symfony\Component\HttpFoundation\Request), true)
 #27 /var/www/web1/htdocs/shopware4/vendor/symfony/http-kernel/HttpCache/HttpCache.php(275): Symfony\Component\HttpKernel\HttpCache\HttpCache->pass(Object(Symfony\Component\HttpFoundation\Request), true)
 #28 /var/www/web1/htdocs/shopware4/engine/Shopware/Components/HttpCache/AppCache.php(133): Symfony\Component\HttpKernel\HttpCache\HttpCache->invalidate(Object(Symfony\Component\HttpFoundation\Request), true)
 #29 /var/www/web1/htdocs/shopware4/vendor/symfony/http-kernel/HttpCache/HttpCache.php(206): Shopware\Components\HttpCache\AppCache->invalidate(Object(Symfony\Component\HttpFoundation\Request), true)
 #30 /var/www/web1/htdocs/shopware4/engine/Shopware/Components/HttpCache/AppCache.php(114): Symfony\Component\HttpKernel\HttpCache\HttpCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
 #31 /var/www/web1/htdocs/shopware4/shopware.php(113): Shopware\Components\HttpCache\AppCache->handle(Object(Symfony\Component\HttpFoundation\Request))
 #32 {main} [] {"uid":"11cc323"}
```

By the way, I'm a new VIISON employee working on Pickware.