### PR TITLE
Prevent PHP notices in AttributeHydrator

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/AttributeHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/AttributeHydrator.php
@@ -88,8 +88,12 @@ class AttributeHydrator extends Hydrator
 
         if ($translationKey) {
             $translationKey = '__' . $translationKey . '_translation';
-            $attribute['translation'] = $data[$translationKey];
-            $attribute['translation_fallback'] = $data[$translationKey . '_fallback'];
+            if (isset($data[$translationKey])) {
+                $attribute['translation'] = $data[$translationKey];
+            }
+            if (isset($data[$translationKey . '_fallback'])) {
+                $attribute['translation_fallback'] = $data[$translationKey . '_fallback'];
+            }
         }
 
         $struct->addAttribute($attributeKey, $this->hydrate($attribute));


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary? Because the `sw:es:index:populate` console command throws many many PHP notices.
* What does it improve? This PR removes the PHP notices.
* Does it have side effects? No

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | Run the `sw:es:index:populate` command. You won't see this notices anymore:

`Notice: Undefined index: __manufacturer_translation in /www/htdocs/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/AttributeHydrator.php on line 91`
`PHP Notice:  Undefined index: __manufacturer_translation_fallback in /www/htdocs/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/AttributeHydrator.php on line 92`


