### PR TITLE
Support lazy services

### DIFF
--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -526,6 +526,10 @@ class Kernel implements HttpKernelInterface
     {
         // cache the container
         $dumper = new PhpDumper($container);
+        
+        if (class_exists('ProxyManager\Configuration') && class_exists('Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper')) {
+            $dumper->setProxyDumper(new \Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper(md5($cache->getPath())));
+        }
 
         $content = $dumper->dump(array('class' => $class, 'base_class' => $baseClass));
 


### PR DESCRIPTION
## Description
This change allows the use of lazy services. The Symfony Kernel does this by default (\Symfony\Component\HttpKernel\Kernel::dumpContainer).
When you install the composer requirement symfony/proxy-manager-bridge, the class is injected and lazy services are generated.

See
https://symfony.com/doc/current/service_container/lazy_services.html

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | -
| How to test?     | Use lazy="true" in your service definition, install symfony/proxy-manager-bridge, rebuild the container. Inject the lazy service somewhere. You should see, instead of the real service, a proxy class should be injected.

