### PR TITLE
SW-16364: Fix PHP Notice: Undefined index: key

### DIFF
--- a/engine/Library/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/engine/Library/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -667,12 +667,13 @@ class BasicEntityPersister implements EntityPersister
 
                 $this->quotedColumns[$sourceColumn]  = $quotedColumn;
                 $this->columnTypes[$sourceColumn]    = PersisterHelper::getTypeOfColumn($targetColumn, $targetClass, $this->em);
-                $result[$owningTable][$sourceColumn] = $newValId
-                    ? $newValId[$targetClass->getFieldForColumn($targetColumn)]
-                    : null;
 
                 // @shopware-hack: allow non primary keys as foreign-key target
                 $isDefault = (isset($newValId[$targetClass->fieldNames[$targetColumn]]));
+                // Fix SW-16364 PHP Notice: Undefined index: key
+                $result[$owningTable][$sourceColumn] = ($isDefault)
+                    ? $newValId[$targetClass->getFieldForColumn($targetColumn)]
+                    : null;
 
                 // Set data to result set, only if no exits.
                 $skipValue = false;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
Shopware had added a hook to Doctrine\ORM\Persisters\Entity\BasicEntityPersister to allow non primary keys as foreign-key target but this return a php notice with teh non primary keys (Undefined index).
* What does it improve?
this change imporve the Shopware hook and solve the php notice message.
* Does it have side effects?
no



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | [SW-16364](http://issues.shopware.com/issues/SW-16364?_ga=1.228537437.1118238299.1444314914) , [SW-16685](http://issues.shopware.com/issues/SW-16685?_ga=1.228537437.1118238299.1444314914)
| How to test?     | you can find hier a plugin to test this issuse [TestKeyIssue](https://github.com/synonymous1984/TestKeyIssue)


