### PR TITLE
Added onInit event to the StateManager.

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
@@ -400,6 +400,8 @@
             me._setDeviceCookie();
 
             $($.proxy(me.initQueuedPlugins, me, true));
+            
+            $.publish('StateManager/onInit', [ me ]);
 
             return me;
         },


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
** It created a standard way to register custom jQuery plugins.
* What does it improve?
** You don't have to use $(document).ready() anymore.
* Does it have side effects?
** No.



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | None
| How to test?     | Register a jQuery plugin by using `$.subscribe('StateManager/onInit', addMyPlugin);`


This event could be useful to register custom jQuery plugins to the StateManager. Instead of using $(document).ready() a plugin could then be registered by $.subscribe('StateManager', addMyPlugin);