### PR TITLE
Fixes undefined index error in sw:snippets:to:db --include-plugins

### DIFF
--- a/engine/Shopware/Commands/SnippetsToDbCommand.php
+++ b/engine/Shopware/Commands/SnippetsToDbCommand.php
@@ -92,12 +92,14 @@ class SnippetsToDbCommand extends ShopwareCommand
             $pluginDirectories = $this->container->getParameter('shopware.plugin_directories');
 
             foreach ($plugins as $plugin) {
-                $pluginPath = $pluginDirectories[$plugin->getSource()] . $plugin->getNamespace() . DIRECTORY_SEPARATOR . $plugin->getName();
+                if (array_key_exists($plugin->getSource(), $pluginDirectories)) {
+                    $pluginPath = $pluginDirectories[$plugin->getSource()] . $plugin->getNamespace() . DIRECTORY_SEPARATOR . $plugin->getName();
 
-                $output->writeln('<info>Importing snippets for '.$plugin->getName().' plugin</info>');
-                $databaseLoader->loadToDatabase($pluginPath.'/Snippets/', $force);
-                $databaseLoader->loadToDatabase($pluginPath.'/snippets/', $force);
-                $databaseLoader->loadToDatabase($pluginPath.'/Resources/snippet/', $force);
+                    $output->writeln('<info>Importing snippets for ' . $plugin->getName() . ' plugin</info>');
+                    $databaseLoader->loadToDatabase($pluginPath . '/Snippets/', $force);
+                    $databaseLoader->loadToDatabase($pluginPath . '/snippets/', $force);
+                    $databaseLoader->loadToDatabase($pluginPath . '/Resources/snippet/', $force);
+                }
 
                 if ($plugin = $this->getPlugin($plugin->getName())) {
                     $databaseLoader->loadToDatabase($plugin->getPath() . '/Resources/snippets/', $force);


### PR DESCRIPTION
## Description
This fixes some `PHP Notice` errors that will be raised because of an unchecked array access when working with plugins in new structure. This pull request adds a check before accessing the array.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | Create a plugin with new plugin structure. Add snippets. Run import command