### PR TITLE
Allow the serialization of Enlight exceptions

### DIFF
--- a/engine/Library/Enlight/Exception.php
+++ b/engine/Library/Enlight/Exception.php
@@ -32,7 +32,7 @@
  * @copyright  Copyright (c) 2011, shopware AG (http://www.shopware.de)
  * @license    http://enlight.de/license     New BSD License
  */
-class Enlight_Exception extends Exception
+class Enlight_Exception extends Exception implements Serializable
 {
     /**
      * Constant that a class could not be found
@@ -97,5 +97,33 @@ class Enlight_Exception extends Exception
             }
         }
         return parent::__toString();
+    }
+
+    /**
+     * Custom serialization to ommit the backtrace
+     * That way the exception can be serialized although a class in the trace
+     * required for example a PDO object
+     *
+     * @see Serializable::serialize
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        return serialize(array($this->validator, $this->arguments, $this->code, $this->message));
+    }
+
+    /**
+     * Custom unserialization to match the serialization without backtrace
+     *
+     * @see Serializable::unserialize
+     *
+     * @param string $serialized
+     *
+     * @return void
+     */
+    public function unserialize($serialized)
+    {
+        list($this->validator, $this->arguments, $this->code, $this->message) = unserialize($serialized);
     }
 }


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
  If for example the advertised ShyimProfiler plugin is used everytime an exception is thrown there will be an error, that a PDO object can not be serialized
* What does it improve?
  It improves compatability with plugins that try to serialize exeptions
* Does it have side effects?
  The backtrace of unserialized exceptions will be missing.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | none
| How to test?     | Example: Install Shyim Profiler plugin and provoke a CSRF token exception


The backtrace often contains objects that required PDO objects as
arguments.
To allow the serialization of exceptions the backtrace is simply
omitted.