### PR TITLE
Fix jquery.plugin-base event listener removal

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
@@ -153,7 +153,9 @@
                 name = me.getName();
 
             $.each(me._events, function (i, obj) {
-                obj.el.off(obj.event);
+                if (typeof obj !== 'undefined') {
+                    obj.el.off(obj.event);
+                }
             });
 
             // remove all references of extern plugins
@@ -211,7 +213,7 @@
                     return typeof obj !== 'undefined' && pluginEvent === obj.event && $element[0] === obj.el[0];
                 });
 
-            $.each(filteredEvents, function (event) {
+            $.each(filteredEvents, function (index, event) {
                 $element.off.call($element, event.event);
             });
 

--- a/themes/Frontend/Responsive/tests/spec/jquery.plugin-base-spec.js
+++ b/themes/Frontend/Responsive/tests/spec/jquery.plugin-base-spec.js
@@ -237,4 +237,47 @@ describe('Plugin base class', function() {
 
         $testElement.remove();
     });
+
+    it('should add event listener to element', function() {
+        var $testElement, data, events;
+
+        $.plugin('yay', {
+            init: function() {}
+        });
+
+        $testElement = $('<div>', {
+            'class': 'test--element'
+        }).appendTo($('body')).yay();
+        data = $testElement.data('plugin_yay');
+        data._on($testElement, 'testEvent1', $.noop);
+        data._on($testElement, 'testEvent2', $.noop);
+
+        events = $._data($testElement[0]).events;
+        expect(Object.keys(events).length).toBe(2);
+
+        $testElement.remove();
+        data._destroy();
+    });
+
+    it('should remove event listener from element', function() {
+        var $testElement, data, events;
+
+        $.plugin('yay', {
+            init: function() {}
+        });
+
+        $testElement = $('<div>', {
+            'class': 'test--element'
+        }).appendTo($('body')).yay();
+        data = $testElement.data('plugin_yay');
+        data._on($testElement, 'testEvent1', $.noop);
+        data._on($testElement, 'testEvent2', $.noop);
+        data._off($testElement, 'testEvent1', $.noop);
+
+        events = $._data($testElement[0]).events;
+        expect(Object.keys(events).length).toBe(1);
+
+        $testElement.remove();
+        data._destroy();
+    });
 });


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
The jquery.plugin-base _off function used wrong parameters in one of the $.each function callbacks, resulting in wrong behaviour. Under certain cirumstances this even resulted in the loss of all event listeners attached to the specified element.
* What does it improve?
The PR fixes the parameters in the $.each function callback so that only the passed event is removed as a listener from the element.
* Does it have side effects?
No.



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | http://issues.shopware.com/issues/SW-17258
| How to test?     | Add some event listeners to an element using plugin._on and remove one using plugin._off. Check event listeners on the element using $._data(element)


