### PR TITLE
Console commands: unified command descriptions and fixed typo

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/Commands/MediaCleanupCommand.php
+++ b/engine/Shopware/Bundle/MediaBundle/Commands/MediaCleanupCommand.php
@@ -48,7 +48,7 @@ class MediaCleanupCommand extends ShopwareCommand
         $this
             ->setName('sw:media:cleanup')
             ->setHelp("The <info>%command.name%</info> collects unused media and deletes them.")
-            ->setDescription("Collect unused media move them to trash.")
+            ->setDescription("Collect unused media and move them to trash.")
             ->addOption('delete', false, InputOption::VALUE_NONE, "Delete unused media.");
     }
 

--- a/engine/Shopware/Commands/RefreshSearchIndexCommand.php
+++ b/engine/Shopware/Commands/RefreshSearchIndexCommand.php
@@ -39,7 +39,7 @@ class RefreshSearchIndexCommand extends ShopwareCommand
     {
         $this
             ->setName('sw:refresh:search:index')
-            ->setDescription('refreshes and regenerates the search index')
+            ->setDescription('Refreshes and regenerates the search index')
             ->setHelp('The <info>%command.name%</info> regenerates the search index')
             ->addOption(
                 'clear-table',

--- a/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
+++ b/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
@@ -39,7 +39,7 @@ class WarmUpHttpCacheCommand extends ShopwareCommand
     {
         $this
             ->setName('sw:warm:http:cache')
-            ->setDescription('warm up http cache')
+            ->setDescription('Warm up http cache')
             ->addArgument('shopId', InputArgument::OPTIONAL, 'The Id of the shop')
             ->setHelp('The <info>%command.name%</info> warms up the http cache')
         ;


### PR DESCRIPTION
## Description
Very small PR that unifies command descriptions and fixes a typo to make reading the descriptions of the console commands easier. 

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes [assumption]
| Related tickets? | no [assumption]
| How to test?     | - [This PR does add or change behaviour, only output strings]

