### PR TITLE
Fix url-parsing in jquery.ajax-variants

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -236,15 +236,15 @@
          * @private
          */
         _getUrlParams: function() {
-            var url = window.decodeURIComponent(window.location.search.substring(1)),
-                urlParams = url.split('&'),
+            var search = window.location.search.substring(1),
+                urlParams = search.split('&'),
                 params = {};
 
             $.each(urlParams, function(i, param) {
                 param = param.split('=');
 
                 if(param[0].length && param[1].length && !params.hasOwnProperty(param[0])) {
-                    params[param[0]] = param[1];
+                    params[decodeURIComponent(param[0])] = decodeURIComponent(param[1]);
                 }
             });
 


### PR DESCRIPTION
This PR fixes the url-parameter parsing method of the jquery.ajax-variants plugin:

`PluginsCollection.swAjaxVariant._getUrlParams`

The problem of the original is that it first decodes the location.search and then splits the parameters.

That leads to problems when a parameter contains an encoded `&` or `=`. The plugin won't be able to correctly parse urls like this:
* http://www.shopwaredemo.de/pocketknife-39?number=SW10039.1&foo%26=bar
* http://www.shopwaredemo.de/pocketknife-39?number=SW10039.1&foo=bar%26

Note that the ajax-variant feature is broken with this links.

This is a problem, when developers need to append their own parameters containing `&` or `=`.

## Description
Please describe your pull request:
* Why is it necessary? Fixes ajax-variants when url has a parameter containing `&` or `=`
* What does it improve? Bugfix
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | Open one of the provided links


