### PR TITLE
[BUGFIX] Prevent shop from crashing when requestShop is null in router

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -415,7 +415,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
 
         if ($shop && $request->getCookie('shop') !== null && $request->getPost('__shop') == null) {
             $requestShop = $repository->getActiveByRequest($request);
-            if ($shop->getId() !== $requestShop->getId() && $shop->getBaseUrl() !== $requestShop->getBaseUrl()) {
+            if ($requestShop !== null && $shop->getId() !== $requestShop->getId() && $shop->getBaseUrl() !== $requestShop->getBaseUrl()) {
                 $shop = $requestShop;
             }
         }


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
PHP Fatal error when object is null. $repository->getActiveByRequest($request); Can return null.
* What does it improve?
Handle possibility of $requestShop being null.
* Does it have side effects?
No



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://forum.shopware.com/discussion/40749/vereinzelter-fehler-bei-einigen-nutzern-fatal-error-call-to-a-member-function-getid-on-null
| How to test?     | Sometimes is $requestShop is null. No persistent behavior. Grep error.log for 'Bootstrap.php on line 418' |

Issue started with:
git bisect bad
70c5e64c82c6f007ef4ded4dca56f3bd029e0d87 is the first bad commit
commit 70c5e64c82c6f007ef4ded4dca56f3bd029e0d87
Author: Oliver Skroblin <dr@shopware.com>
Date:   Thu Nov 26 09:06:59 2015 +0100

    SW-13269 - Fix router shop selection for cookies and virtuel urls

:040000 040000 92be515ba9a89dcf75d7f9b902925ff3e535e65f 4c45db0cdf7fbc913a7a44d1ba8d9042c9f30a4c M      engine |

