### PR TITLE
[FIX] Possibility to set a non ssl/tls mailer for the newsletter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,17 +18,18 @@ Thumbs.db
 /vendor/*
 !/vendor/.htaccess
 
-# Internal Repositories
-/internal
-/engine/Shopware/Plugins/Commercial/
-
 # User installed plugins
-/engine/Shopware/Plugins/Community/
-/engine/Shopware/Plugins/Local/
-/custom/plugins/
+/engine/Shopware/Plugins/Community/Backend/*
+/engine/Shopware/Plugins/Community/Core/*
+/engine/Shopware/Plugins/Community/Frontend/*
+/engine/Shopware/Plugins/Local/Backend/*
+/engine/Shopware/Plugins/Local/Core/*
+/engine/Shopware/Plugins/Local/Frontend/*
+
+/custom/plugins/*
 
 # User installed themes
-/themes/Frontend
+/themes/Frontend/*
 !/themes/Frontend/Bare
 !/themes/Frontend/Responsive
 
@@ -40,12 +41,10 @@ Thumbs.db
 .php_cs
 .php_cs.cache
 /tests/Shopware/TempFiles/*
-!/tests/Shopware/TempFiles/.gitkeep
 /var/cache/*
 !/var/cache/.htaccess
 !/var/cache/clear_cache.sh
 /web/cache/*
-!/web/cache/.gitkeep
 
 # Log files
 /var/log/*
@@ -53,18 +52,20 @@ Thumbs.db
 
 
 # User provided content
-/media/archive/
-/media/image/
-/media/music/
-/media/pdf/
-/media/temp/
-/media/unknown/
-/media/video/
+/media/archive/*
+/media/image/*
+!/media/image/thumbnail
+/media/image/thumbnail/*
+/media/music/*
+/media/pdf/*
+/media/temp/*
+!/media/temp/.htaccess
+/media/unknown/*
+/media/video/*
 
 /files/documents/*
 !/files/documents/.htaccess
 /files/downloads/*
-!/files/downloads/.gitkeep
 
 # Snippet exports
 /snippetsExport/

--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -15,6 +15,8 @@ This changelog references changes done in Shopware 5.2 patch versions.
 * Changed frontendsession to a locking session handler
     * Added new configuration parameter `session.locking` which is `true` by default
     * The session handler can be overwritten by replacing the `session.save_handler`-Service. A instance of `\SessionHandlerInterface` has to be returned.
+* Changed return value of `sArticles::sGetArticleById()` to provide an additional text if none is given and display the cover image by default when using the selection configurator
+* Changed url parameter in last seen articles to deeplink to an article variant instead of the article
 
 ### Autoloading of plugin resources
 

--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -12,6 +12,9 @@ This changelog references changes done in Shopware 5.2 patch versions.
 * Added `Shopware\Components\Plugin\PaymentInstaller` class to install payment methods in plugins
 * Changed theme path for plugins of new plugin system from `/resources` to `/Resources`
 * Changed parsing of JSON `POST`ed to the REST API to not remove top-level `NULL` values
+* Changed frontendsession to a locking session handler
+    * Added new configuration parameter `session.locking` which is `true` by default
+    * The session handler can be overwritten by replacing the `session.save_handler`-Service. A instance of `\SessionHandlerInterface` has to be returned.
 
 ### Autoloading of plugin resources
 

--- a/_sql/migrations/799-attribute-translation-fix-1-of-10.php
+++ b/_sql/migrations/799-attribute-translation-fix-1-of-10.php
@@ -1,0 +1,27 @@
+<?php
+
+class Migrations_Migration799 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->prepare();
+
+        require_once __DIR__ . '/common/AttributeTranslationMigrationHelper.php';
+        $helper = new AttributeTranslationMigrationHelper($this->connection);
+        $helper->migrate(200000);
+    }
+
+    private function prepare()
+    {
+        $this->connection->exec(<<<EOL
+DROP TABLE IF EXISTS translation_migration_id;
+
+CREATE TABLE `translation_migration_id` (
+  `max_id` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+EOL
+        );
+
+        $this->connection->exec('INSERT INTO translation_migration_id (max_id) SELECT MAX(id) as id FROM s_core_translations;');
+    }
+}

--- a/_sql/migrations/800-attribute-translation-fix-2-of-10.php
+++ b/_sql/migrations/800-attribute-translation-fix-2-of-10.php
@@ -1,0 +1,11 @@
+<?php
+
+class Migrations_Migration800 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        require_once __DIR__ . '/common/AttributeTranslationMigrationHelper.php';
+        $helper = new AttributeTranslationMigrationHelper($this->connection);
+        $helper->migrate(200000);
+    }
+}

--- a/_sql/migrations/801-attribute-translation-fix-3-of-10.php
+++ b/_sql/migrations/801-attribute-translation-fix-3-of-10.php
@@ -1,0 +1,11 @@
+<?php
+
+class Migrations_Migration801 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        require_once __DIR__ . '/common/AttributeTranslationMigrationHelper.php';
+        $helper = new AttributeTranslationMigrationHelper($this->connection);
+        $helper->migrate(200000);
+    }
+}

--- a/_sql/migrations/802-attribute-translation-fix-4-of-10.php
+++ b/_sql/migrations/802-attribute-translation-fix-4-of-10.php
@@ -1,0 +1,11 @@
+<?php
+
+class Migrations_Migration802 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        require_once __DIR__ . '/common/AttributeTranslationMigrationHelper.php';
+        $helper = new AttributeTranslationMigrationHelper($this->connection);
+        $helper->migrate(200000);
+    }
+}

--- a/_sql/migrations/803-attribute-translation-fix-5-of-10.php
+++ b/_sql/migrations/803-attribute-translation-fix-5-of-10.php
@@ -1,0 +1,11 @@
+<?php
+
+class Migrations_Migration803 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        require_once __DIR__ . '/common/AttributeTranslationMigrationHelper.php';
+        $helper = new AttributeTranslationMigrationHelper($this->connection);
+        $helper->migrate(200000);
+    }
+}

--- a/_sql/migrations/804-attribute-translation-fix-6-of-10.php
+++ b/_sql/migrations/804-attribute-translation-fix-6-of-10.php
@@ -1,0 +1,11 @@
+<?php
+
+class Migrations_Migration804 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        require_once __DIR__ . '/common/AttributeTranslationMigrationHelper.php';
+        $helper = new AttributeTranslationMigrationHelper($this->connection);
+        $helper->migrate(200000);
+    }
+}

--- a/_sql/migrations/805-attribute-translation-fix-7-of-10.php
+++ b/_sql/migrations/805-attribute-translation-fix-7-of-10.php
@@ -1,0 +1,11 @@
+<?php
+
+class Migrations_Migration805 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        require_once __DIR__ . '/common/AttributeTranslationMigrationHelper.php';
+        $helper = new AttributeTranslationMigrationHelper($this->connection);
+        $helper->migrate(200000);
+    }
+}

--- a/_sql/migrations/806-attribute-translation-fix-8-of-10.php
+++ b/_sql/migrations/806-attribute-translation-fix-8-of-10.php
@@ -1,0 +1,11 @@
+<?php
+
+class Migrations_Migration806 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        require_once __DIR__ . '/common/AttributeTranslationMigrationHelper.php';
+        $helper = new AttributeTranslationMigrationHelper($this->connection);
+        $helper->migrate(200000);
+    }
+}

--- a/_sql/migrations/807-attribute-translation-fix-9-of-10.php
+++ b/_sql/migrations/807-attribute-translation-fix-9-of-10.php
@@ -1,0 +1,11 @@
+<?php
+
+class Migrations_Migration807 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        require_once __DIR__ . '/common/AttributeTranslationMigrationHelper.php';
+        $helper = new AttributeTranslationMigrationHelper($this->connection);
+        $helper->migrate(200000);
+    }
+}

--- a/_sql/migrations/808-attribute-translation-fix-10-of-10.php
+++ b/_sql/migrations/808-attribute-translation-fix-10-of-10.php
@@ -1,0 +1,13 @@
+<?php
+
+class Migrations_Migration808 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        require_once __DIR__ . '/common/AttributeTranslationMigrationHelper.php';
+        $helper = new AttributeTranslationMigrationHelper($this->connection);
+        $helper->migrate(200000);
+
+        $this->connection->exec('DROP TABLE IF EXISTS translation_migration_id;');
+    }
+}

--- a/_sql/migrations/809-change-session-tables.php
+++ b/_sql/migrations/809-change-session-tables.php
@@ -1,0 +1,37 @@
+<?php
+
+class Migrations_Migration809 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql(<<<SQL
+DROP TABLE `s_core_sessions`;
+SQL
+        );
+
+        $this->addSql(<<<SQL
+CREATE TABLE `s_core_sessions` (
+    `id` VARCHAR(128) NOT NULL PRIMARY KEY,
+    `data` MEDIUMBLOB NOT NULL,
+    `modified` INTEGER UNSIGNED NOT NULL,
+    `expiry` MEDIUMINT NOT NULL
+) COLLATE utf8_bin, ENGINE = InnoDB;
+SQL
+        );
+
+        $this->addSql(<<<SQL
+DROP TABLE `s_core_sessions_backend`;
+SQL
+        );
+
+        $this->addSql(<<<SQL
+CREATE TABLE `s_core_sessions_backend` (
+    `id` VARCHAR(128) NOT NULL PRIMARY KEY,
+    `data` MEDIUMBLOB NOT NULL,
+    `modified` INTEGER UNSIGNED NOT NULL,
+    `expiry` MEDIUMINT NOT NULL
+) COLLATE utf8_bin, ENGINE = InnoDB;
+SQL
+        );
+    }
+}

--- a/_sql/migrations/810-change-description-of-article-cover-setting.php
+++ b/_sql/migrations/810-change-description-of-article-cover-setting.php
@@ -1,0 +1,20 @@
+<?php
+
+class Migrations_Migration810 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql(<<<SQL
+SET @elementId = (SELECT id FROM `s_core_config_elements` WHERE `name` = 'forceArticleMainImageInListing');
+
+UPDATE `s_core_config_elements`
+  SET `label` = 'Immer das Artikel-Vorschaubild anzeigen', `description` = 'z.B. im Listing oder beim Auswahl- und Bildkonfigurator ohne ausgewählte Variante'
+  WHERE `id` = @elementId;
+
+UPDATE `s_core_config_element_translations`
+  SET `label` = 'Always display the article preview image', `description` = 'e.g. in listings or when using selection or picture configurator with no selected variant'
+  WHERE `element_id` = @elementId;
+SQL
+        );
+    }
+}

--- a/_sql/migrations/common/AttributeTranslationMigrationHelper.php
+++ b/_sql/migrations/common/AttributeTranslationMigrationHelper.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * This helper class extracts the logic for the migration of translated article attributes from Shopware 5.1 to 5.2.
+ * This allows to split this migration into multiple (ten in this case) steps and therefor makes it possible to migrate
+ * a greater amount of translatable article attributes on low performance hosting solutions.
+ */
+class AttributeTranslationMigrationHelper
+{
+    /**
+     * @var PDO
+     */
+    private $connection;
+
+    /**
+     * @param PDO $connection
+     */
+    public function __construct(PDO $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @param int $maxCount
+     * @return int
+     */
+    public function migrate($maxCount)
+    {
+        $maxId = $this->connection->query('SELECT max_id FROM translation_migration_id')->fetch(PDO::FETCH_COLUMN);
+
+        $columns = $this->getColumns();
+
+        $statement = $this->connection->prepare(
+<<<EOL
+          SELECT * 
+          FROM s_core_translations
+          WHERE objecttype IN ("article", "variantMain", "variant")
+          AND id > :lastId
+          AND id <= :maxId
+          ORDER BY id ASC
+          LIMIT 250
+EOL
+        );
+
+        $lastId = 0;
+        $statement->execute([':lastId' => $lastId, ':maxId' => $maxId]);
+        $count = 0;
+
+        while ($rows = $statement->fetchAll(PDO::FETCH_ASSOC)) {
+            if (empty($rows)) {
+                break;
+            }
+
+            $values = $this->getUpdatedTranslations($rows, $columns);
+            if (empty($values)) {
+                continue;
+            }
+
+            $ids = array_keys($values);
+
+            $this->connection->exec('DELETE FROM s_core_translations WHERE id IN (' . implode(',', $ids) . ')');
+            $this->connection->exec(
+                'INSERT INTO s_core_translations (objecttype, objectdata, objectkey, objectlanguage) VALUES ' . implode(',', $values)
+            );
+
+            $lastId = array_pop($rows)['id'];
+            $statement->execute([':lastId' => $lastId, ':maxId' => $maxId]);
+
+            $count += count($rows);
+            if ($count > $maxCount) {
+                break;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getColumns()
+    {
+        $columns = $this->connection->query('SHOW COLUMNS FROM s_articles_attributes')->fetchAll(PDO::FETCH_ASSOC);
+
+        $columns = array_column($columns, 'Field');
+
+        $mapping = [];
+        foreach ($columns as $column) {
+            $mapping[$column] = $column;
+            $camelCase = $this->underscoreToCamelCase($column);
+            $mapping[$camelCase] = $column;
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * @param string $str
+     * @return string
+     */
+    private function underscoreToCamelCase($str)
+    {
+        return preg_replace_callback('/_([a-zA-Z])/', function ($c) {
+            return strtoupper($c[1]);
+        }, $str);
+    }
+
+    /**
+     * @param array $data
+     * @param array $columns
+     * @return null|array
+     */
+    private function filter($data, array $columns)
+    {
+        if (!is_array($data)) {
+            return null;
+        }
+
+        $updated = false;
+        foreach ($columns as $key => $column) {
+            if (array_key_exists($key, $data)) {
+                $newKey = '__attribute_' . $column;
+
+                if (!array_key_exists($newKey, $data)) {
+                    $data[$newKey] = $data[$key];
+                    $updated = true;
+                }
+            }
+        }
+
+        if (!$updated) {
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array[] $rows
+     * @param string[] $columns
+     * @return string[] indexed by translation id
+     */
+    private function getUpdatedTranslations($rows, $columns)
+    {
+        $values = [];
+
+        foreach ($rows as $row) {
+            try {
+                $updated = $this->filter(unserialize($row['objectdata']), $columns);
+            } catch (Exception $e) {
+                //serialize error - continue with next translation
+                continue;
+            }
+
+            if ($updated === null) {
+                continue;
+            }
+
+            $updated = serialize($updated);
+
+            $values[$row['id']] = "('{$row['objecttype']}', '{$updated}', {$row['objectkey']}, {$row['objectlanguage']})";
+        }
+
+        return $values;
+    }
+}

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,2 +1,3 @@
-logs/
+logs/*
+!logs/.gitkeep
 build.properties

--- a/build/gitHooks/pre-commit
+++ b/build/gitHooks/pre-commit
@@ -190,7 +190,7 @@ class PreCommitChecks
      */
     private function hasDuplicateMigrations()
     {
-        exec('find ./_sql/migrations -type f | cut -d\/ -f4 | cut -d\- -f1 | sort | uniq -d', $output);
+        exec('find ./_sql/migrations -maxdepth 1 -type f | cut -d\/ -f4 | cut -d\- -f1 | sort | uniq -d', $output);
         if (count($output)) {
             return current($output);
         }

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "league/flysystem": "1.0.22",
         "paragonie/random_compat": "1.4.1",
         "cocur/slugify": "2.2",
-        "bcremer/line-reader": "^0.1.0"
+        "bcremer/line-reader": "^0.2.0"
     },
     "suggest": {
         "ext-apcu": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7331fe51e3da94f73a48d9c6be6de4dc",
+    "content-hash": "e77b2f4d9be74c6a60a6eed0a4087a41",
     "packages": [
         {
             "name": "bcremer/line-reader",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bcremer/LineReader.git",
-                "reference": "2fd53b5821891e136414e782893b204faea6a7f5"
+                "reference": "b2bdbcf97df9a05b8ce317c3a5382610cd832419"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bcremer/LineReader/zipball/2fd53b5821891e136414e782893b204faea6a7f5",
-                "reference": "2fd53b5821891e136414e782893b204faea6a7f5",
+                "url": "https://api.github.com/repos/bcremer/LineReader/zipball/b2bdbcf97df9a05b8ce317c3a5382610cd832419",
+                "reference": "b2bdbcf97df9a05b8ce317c3a5382610cd832419",
                 "shasum": ""
             },
             "require": {
-                "php": "~5.6|~7.0"
+                "php": "~5.6|~7.0|~7.1"
             },
             "require-dev": {
+                "humbug/humbug": "dev-master@DEV",
                 "phpunit/phpunit": "^5.4"
             },
             "type": "library",
@@ -42,7 +43,8 @@
                     "email": "b.cremer@shopware.com"
                 }
             ],
-            "time": "2016-08-05T08:43:01+00:00"
+            "description": "Read large files line by line in a memory efficient (constant) way.",
+            "time": "2016-12-12T09:04:04+00:00"
         },
         {
             "name": "beberlei/assert",

--- a/config.php.dist
+++ b/config.php.dist
@@ -1,10 +1,10 @@
 <?php
-return array(
-    'db' => array(
+return [
+    'db' => [
         'username' => '%db.user%',
         'password' => '%db.password%',
         'dbname' => '%db.database%',
         'host' => '%db.host%',
         'port' => '%db.port%'
-    )
-);
+    ]
+];

--- a/engine/Library/Enlight/Hook/ProxyFactory.php
+++ b/engine/Library/Enlight/Hook/ProxyFactory.php
@@ -275,12 +275,17 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
                     $proxy_params .= ', ';
                     $array_params .= ', ';
                 }
+
+                $array_param = '';
                 if ($rp->isPassedByReference()) {
                     $params .= '&';
+                    $proxy_params .= '$';
+                    $array_param .= '&';
                 }
                 $params .= '$' . $rp->getName();
                 $proxy_params .= '$' . $rp->getName();
-                $array_params .= '\'' . $rp->getName() . '\'=>$' . $rp->getName();
+                $array_param .= '$' . $rp->getName();
+                $array_params .= '\'' . $rp->getName() . '\'=>' . $array_param;
                 if ($rp->isOptional()) {
                     $params .= ' = ' . str_replace("\n", '', var_export($rp->getDefaultValue(), true));
                 }

--- a/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
@@ -140,7 +140,6 @@ class CrudService
 
         if (!$config) {
             $this->createAttribute($table, $columnName, $unifiedType, $data, $defaultValue);
-            return;
         }
 
         $newColumnName = $newColumnName?: $columnName;

--- a/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
@@ -87,7 +87,7 @@ class CrudService
         $column = $this->formatColumnName($column);
 
         if (!$this->tableMapping->isTableColumn($table, $column)) {
-            throw new \Exception(sprintf('Table %s has no column with name %s', $table, $column));
+            throw new \RuntimeException(sprintf('Table %s has no column with name %s', $table, $column));
         }
 
         $this->schemaOperator->dropColumn($table, $column);
@@ -108,9 +108,9 @@ class CrudService
             return;
         }
 
-        $tables = $this->tableMapping->getDependingTables($table);
-        foreach ($tables as $table) {
-            $this->delete($table, $column);
+        $dependingTables = $this->tableMapping->getDependingTables($table);
+        foreach ($dependingTables as $dependingTable) {
+            $this->delete($dependingTable, $column);
         }
     }
 
@@ -119,7 +119,7 @@ class CrudService
      * @param string $columnName
      * @param string $unifiedType
      * @param array $data
-     * @param null $newColumnName
+     * @param null|string $newColumnName
      * @param bool $updateDependingTables
      * @param null|string|int|float $defaultValue
      * @throws \Exception
@@ -134,25 +134,23 @@ class CrudService
         $defaultValue = null
     ) {
         $columnName = $this->formatColumnName($columnName);
-        $newColumnName = $this->formatColumnName($newColumnName);
+        $newColumnName = $newColumnName ? $this->formatColumnName($newColumnName) : $columnName;
 
         $config = $this->get($table, $columnName);
 
         if (!$config) {
             $this->createAttribute($table, $columnName, $unifiedType, $data, $defaultValue);
+        } else {
+            $this->changeAttribute($table, $columnName, $newColumnName, $unifiedType, $data, $defaultValue);
         }
-
-        $newColumnName = $newColumnName?: $columnName;
-
-        $this->changeAttribute($table, $columnName, $newColumnName, $unifiedType, $data, $defaultValue);
 
         if (!$updateDependingTables) {
             return;
         }
 
-        $tables = $this->tableMapping->getDependingTables($table);
-        foreach ($tables as $table) {
-            $this->update($table, $columnName, $unifiedType, $data, $newColumnName, false, $defaultValue);
+        $dependingTables = $this->tableMapping->getDependingTables($table);
+        foreach ($dependingTables as $dependingTable) {
+            $this->update($dependingTable, $columnName, $unifiedType, $data, $newColumnName, false, $defaultValue);
         }
     }
 
@@ -331,8 +329,14 @@ class CrudService
      * @param array $data
      * @throws \Exception
      */
-    private function changeAttribute($table, $originalColumnName, $newColumnName, $unifiedType, array $data = [], $defaultValue = null)
-    {
+    private function changeAttribute(
+        $table,
+        $originalColumnName,
+        $newColumnName,
+        $unifiedType,
+        array $data = [],
+        $defaultValue = null
+    ) {
         $config = $this->get($table, $originalColumnName);
 
         $data = array_merge($data, [

--- a/engine/Shopware/Bundle/ESIndexingBundle/ShopIndexer.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/ShopIndexer.php
@@ -80,6 +80,7 @@ class ShopIndexer implements ShopIndexerInterface
      * @param DataIndexerInterface[] $indexer
      * @param MappingInterface[] $mappings
      * @param SettingsInterface[] $settings
+     * @param array $configuration
      */
     public function __construct(
         Client $client,

--- a/engine/Shopware/Bundle/MediaBundle/Commands/MediaCleanupCommand.php
+++ b/engine/Shopware/Bundle/MediaBundle/Commands/MediaCleanupCommand.php
@@ -48,7 +48,7 @@ class MediaCleanupCommand extends ShopwareCommand
         $this
             ->setName('sw:media:cleanup')
             ->setHelp("The <info>%command.name%</info> collects unused media and deletes them.")
-            ->setDescription("Collect unused media move them to trash.")
+            ->setDescription("Collect unused media and move them to trash.")
             ->addOption('delete', false, InputOption::VALUE_NONE, "Delete unused media.");
     }
 

--- a/engine/Shopware/Bundle/MediaBundle/MediaService.php
+++ b/engine/Shopware/Bundle/MediaBundle/MediaService.php
@@ -78,7 +78,8 @@ class MediaService implements MediaServiceInterface
             throw new \Exception(sprintf("Please provide a 'mediaUrl' in your %s adapter.", $config['type']));
         }
 
-        $this->mediaUrl = $config['mediaUrl'] ?: $this->createFallbackMediaUrl();
+        $mediaUrl = $config['mediaUrl'] ?: $this->createFallbackMediaUrl();
+        $this->mediaUrl = rtrim($mediaUrl, '/');
     }
 
     /**
@@ -113,13 +114,13 @@ class MediaService implements MediaServiceInterface
         }
 
         if ($this->strategy->isEncoded($path)) {
-            return $this->mediaUrl . $path;
+            return $this->mediaUrl . '/' . ltrim($path, '/');
         }
 
         $this->migrateFile($path);
         $path = $this->strategy->encode($path);
 
-        return $this->mediaUrl . $path;
+        return $this->mediaUrl . '/' . ltrim($path, '/');
     }
 
     /**

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use PDO;
+use Shopware\Components\Plugin;
+use Symfony\Component\ClassLoader\Psr4ClassLoader;
+
+class PluginInitializer
+{
+    /**
+     * @var PDO
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $pluginDirectory;
+
+    /**
+     * @param PDO $connection
+     * @param $pluginDirectory
+     */
+    public function __construct(PDO $connection, $pluginDirectory)
+    {
+        $this->connection = $connection;
+        $this->pluginDirectory = $pluginDirectory;
+    }
+
+    /**
+     * @return Plugin[]
+     * @throws \RuntimeException
+     */
+    public function initializePlugins()
+    {
+        $plugins = [];
+
+        $classLoader = new Psr4ClassLoader();
+        $classLoader->register(true);
+
+        $stmt = $this->connection->query('SELECT name FROM s_core_plugins WHERE namespace LIKE "ShopwarePlugins" AND active = 1 AND installation_date IS NOT NULL;');
+        $activePlugins = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        foreach (new \DirectoryIterator($this->pluginDirectory) as $pluginDir) {
+            if ($pluginDir->isFile() || $pluginDir->getBasename()[0] === '.') {
+                continue;
+            }
+
+            $pluginName = $pluginDir->getBasename();
+            $pluginFile = $pluginDir->getPathname() . '/'. $pluginName . '.php';
+            if (!is_file($pluginFile)) {
+                continue;
+            }
+
+            $namespace = $pluginName;
+            $className = '\\' . $namespace . '\\' .  $pluginName;
+            $classLoader->addPrefix($namespace, $pluginDir->getPathname());
+
+            if (!class_exists($className)) {
+                throw new \RuntimeException(sprintf('Unable to load class %s for plugin %s in file %s', $className, $pluginName, $pluginFile));
+            }
+
+            $isActive = in_array($pluginName, $activePlugins, true);
+
+            /** @var Plugin $plugin */
+            $plugin = new $className($isActive);
+
+            if (!$plugin instanceof Plugin) {
+                throw new \RuntimeException(sprintf('Class %s must extend %s in file %s', get_class($plugin), Plugin::class, $pluginFile));
+            }
+            $plugins[$plugin->getName()] = $plugin;
+        }
+
+        return $plugins;
+    }
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
@@ -65,19 +65,35 @@ class PluginInstaller
     private $requirementValidator;
 
     /**
+     * @var \PDO
+     */
+    private $pdo;
+
+    /**
+     * @var string
+     */
+    private $rootDirectory;
+
+    /**
      * @param ModelManager $em
      * @param DatabaseHandler $snippetHandler
      * @param RequirementValidator $requirementValidator
+     * @param \PDO $pdo
+     * @param $rootDirectory
      */
     public function __construct(
         ModelManager $em,
         DatabaseHandler $snippetHandler,
-        RequirementValidator $requirementValidator
+        RequirementValidator $requirementValidator,
+        \PDO $pdo,
+        $rootDirectory
     ) {
         $this->em = $em;
         $this->connection = $this->em->getConnection();
         $this->snippetHandler = $snippetHandler;
         $this->requirementValidator = $requirementValidator;
+        $this->pdo = $pdo;
+        $this->rootDirectory = $rootDirectory;
     }
 
     /**
@@ -250,9 +266,11 @@ class PluginInstaller
      */
     public function refreshPluginList(\DateTimeInterface $refreshDate)
     {
-        /** @var Kernel $kernel */
-        $kernel = Shopware()->Container()->get('kernel');
-        $plugins = $kernel->getPlugins();
+        $initializer = new PluginInitializer(
+            $this->pdo,
+            $this->rootDirectory . '/custom/plugins'
+        );
+        $plugins = $initializer->initializePlugins();
 
         foreach ($plugins as $plugin) {
             $pluginInfoPath = $plugin->getPath().'/plugin.xml';

--- a/engine/Shopware/Bundle/PluginInstallerBundle/services.xml
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/services.xml
@@ -21,6 +21,8 @@
             <argument type="service" id="models"/>
             <argument type="service" id="shopware.snippet_database_handler" />
             <argument type="service" id="shopware.plugin_requirement_validator" />
+            <argument type="service" id="db_connection" />
+            <argument>%kernel.root_dir%</argument>
         </service>
 
         <service id="shopware_plugininstaller.legacy_plugin_installer" class="Shopware\Bundle\PluginInstallerBundle\Service\LegacyPluginInstaller">

--- a/engine/Shopware/Commands/MigrateArticleAttributeTranslationsCommand.php
+++ b/engine/Shopware/Commands/MigrateArticleAttributeTranslationsCommand.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Shopware\Bundle\AttributeBundle\Service\CrudService;
+use Shopware\Models\Attribute\Article as ArticleAttribute;
+
+/**
+ * Migrates article attribute translations from Shopware 5.1 to Shopware 5.2.
+ *
+ * @package Shopware\Commands
+ */
+class MigrateArticleAttributeTranslationsCommand extends ShopwareCommand
+{
+    /**
+     * @var \PDO
+     */
+    private $connection;
+
+    /**
+     * @var array
+     */
+    private $columns;
+
+    /**
+     * @var \Doctrine\DBAL\Driver\Statement
+     */
+    private $updateStatement;
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this->setName('sw:migrate:article:attribute:translations');
+        $this->setDescription('Migrates article attribute translations from Shopware 5.1 to Shopware 5.2');
+        $this->setHelp('The <info>%command.name%</info> migrates article attribute translations from Shopware 5.1 to Shopware 5.2.');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $this->connection = $this->container->get('dbal_connection');
+        $this->updateStatement = $this->connection->prepare('UPDATE s_core_translations SET objectdata=:data WHERE id=:id');
+        $this->columns = $this->getColumns();
+
+        $result = $this->connection
+            ->query('SELECT MAX(id) AS maxId, count(1) AS count FROM s_core_translations;')
+            ->fetch(\PDO::FETCH_ASSOC);
+
+        $this->migrate($io->createProgressBar($result['count']), $result['maxId']);
+    }
+
+    /**
+     * @param ProgressBar $progressBar
+     * @param int $maxId
+     */
+    private function migrate(ProgressBar $progressBar, $maxId)
+    {
+        $selectStatement = $this->connection->prepare(
+<<<EOL
+SELECT id, objectdata
+FROM s_core_translations
+WHERE objecttype IN ("article", "variantMain", "variant")
+AND id > :lastId
+AND id <= :maxId
+ORDER BY id ASC
+LIMIT 250
+EOL
+        );
+
+        $lastId = 0;
+        $progressBar->start();
+
+        do {
+            $selectStatement->execute([':lastId' => $lastId, ':maxId' => $maxId]);
+            $rows = $selectStatement->fetchAll(\PDO::FETCH_ASSOC);
+
+            if (empty($rows)) {
+                continue;
+            }
+
+            $this->migrateTranslations($rows);
+            $progressBar->advance(count($rows));
+
+            $lastId = array_pop($rows)['id'];
+        } while (!empty($rows));
+
+        $progressBar->finish();
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getColumns()
+    {
+        $columns = $this->connection->query('SHOW COLUMNS FROM s_articles_attributes')->fetchAll(\PDO::FETCH_ASSOC);
+
+        $columns = array_column($columns, 'Field');
+
+        $mapping = [];
+        foreach ($columns as $column) {
+            $mapping[$column] = $column;
+            $camelCase = $this->underscoreToCamelCase($column);
+            $mapping[$camelCase] = $column;
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * @param string $underscored
+     * @return string
+     */
+    private function underscoreToCamelCase($underscored)
+    {
+        return preg_replace_callback('/_([a-zA-Z])/', function ($c) {
+            return strtoupper($c[1]);
+        }, $underscored);
+    }
+
+    /**
+     * @param array $data
+     * @param array $columns
+     * @return null|array
+     */
+    private function filter($data, array $columns)
+    {
+        if (!is_array($data)) {
+            return null;
+        }
+
+        $updated = false;
+        foreach ($columns as $key => $column) {
+            if (array_key_exists($key, $data)) {
+                $newKey = CrudService::EXT_JS_PREFIX . $column;
+
+                if (!array_key_exists($newKey, $data)) {
+                    $data[$newKey] = $data[$key];
+                    $updated = true;
+                }
+            }
+        }
+
+        if (!$updated) {
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array[] $rows
+     * @param string[] $columns
+     * @return string[] indexed by translation id
+     */
+    private function getUpdatedTranslations($rows, $columns)
+    {
+        $values = [];
+
+        foreach ($rows as $row) {
+            try {
+                $updated = $this->filter(unserialize($row['objectdata']), $columns);
+            } catch (\Exception $e) {
+                //serialize error - continue with next translation
+                continue;
+            }
+
+            if ($updated === null) {
+                continue;
+            }
+
+            $values[$row['id']] = serialize($updated);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array $rows
+     */
+    private function migrateTranslations($rows)
+    {
+        $values = $this->getUpdatedTranslations($rows, $this->columns);
+        foreach ($values as $id => $objectData) {
+            $this->updateStatement->execute([':id' => $id, ':data' => $objectData]);
+        }
+    }
+}

--- a/engine/Shopware/Commands/RefreshSearchIndexCommand.php
+++ b/engine/Shopware/Commands/RefreshSearchIndexCommand.php
@@ -39,7 +39,7 @@ class RefreshSearchIndexCommand extends ShopwareCommand
     {
         $this
             ->setName('sw:refresh:search:index')
-            ->setDescription('refreshes and regenerates the search index')
+            ->setDescription('Refreshes and regenerates the search index')
             ->setHelp('The <info>%command.name%</info> regenerates the search index')
             ->addOption(
                 'clear-table',

--- a/engine/Shopware/Commands/SnippetsToDbCommand.php
+++ b/engine/Shopware/Commands/SnippetsToDbCommand.php
@@ -77,12 +77,12 @@ class SnippetsToDbCommand extends ShopwareCommand
         $databaseLoader = $this->container->get('shopware.snippet_database_handler');
         $force = $input->getOption('force');
 
-        $sourceDir = $this->container->getParameter('kernel.root_dir') . DIRECTORY_SEPARATOR . $input->getOption('source') . DIRECTORY_SEPARATOR;
+        $sourceDir = $this->container->getParameter('kernel.root_dir') . '/' . $input->getOption('source') . '/';
 
         $databaseLoader->setOutput($output);
         $databaseLoader->loadToDatabase($sourceDir, $force);
 
-        //Import plugin snippets
+        // Import plugin snippets
         if ($input->getOption('include-plugins')) {
             $pluginRepository = $this->container->get('shopware.model_manager')->getRepository('Shopware\Models\Plugin\Plugin');
 
@@ -92,12 +92,14 @@ class SnippetsToDbCommand extends ShopwareCommand
             $pluginDirectories = $this->container->getParameter('shopware.plugin_directories');
 
             foreach ($plugins as $plugin) {
-                $pluginPath = $pluginDirectories[$plugin->getSource()] . $plugin->getNamespace() . DIRECTORY_SEPARATOR . $plugin->getName();
+                if (array_key_exists($plugin->getSource(), $pluginDirectories)) {
+                    $pluginPath = $pluginDirectories[$plugin->getSource()] . $plugin->getNamespace() . '/' . $plugin->getName();
 
-                $output->writeln('<info>Importing snippets for '.$plugin->getName().' plugin</info>');
-                $databaseLoader->loadToDatabase($pluginPath.'/Snippets/', $force);
-                $databaseLoader->loadToDatabase($pluginPath.'/snippets/', $force);
-                $databaseLoader->loadToDatabase($pluginPath.'/Resources/snippet/', $force);
+                    $output->writeln('<info>Importing snippets for ' . $plugin->getName() . ' plugin</info>');
+                    $databaseLoader->loadToDatabase($pluginPath . '/Snippets/', $force);
+                    $databaseLoader->loadToDatabase($pluginPath . '/snippets/', $force);
+                    $databaseLoader->loadToDatabase($pluginPath . '/Resources/snippet/', $force);
+                }
 
                 if ($plugin = $this->getPlugin($plugin->getName())) {
                     $databaseLoader->loadToDatabase($plugin->getPath() . '/Resources/snippets/', $force);

--- a/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
+++ b/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
@@ -39,7 +39,7 @@ class WarmUpHttpCacheCommand extends ShopwareCommand
     {
         $this
             ->setName('sw:warm:http:cache')
-            ->setDescription('warm up http cache')
+            ->setDescription('Warm up http cache')
             ->addArgument('shopId', InputArgument::OPTIONAL, 'The Id of the shop')
             ->setHelp('The <info>%command.name%</info> warms up the http cache')
         ;

--- a/engine/Shopware/Components/CSRFTokenValidator.php
+++ b/engine/Shopware/Components/CSRFTokenValidator.php
@@ -115,7 +115,7 @@ class CSRFTokenValidator implements SubscriberInterface
         }
 
         if (!hash_equals($expected, $token)) {
-            throw new CSRFTokenValidationException("The provided CSRF-Token is invalid. If you're sure that the request should be valid, the called controller action needs to be whitelisted using the CSRFWhitelistAware interface.");
+            throw new CSRFTokenValidationException(sprintf('The provided CSRF-Token is invalid. If you\'re sure that the request to path "%s" should be valid, the called controller action needs to be whitelisted using the CSRFWhitelistAware interface.', $controller->Request()->getRequestUri()));
         }
     }
 
@@ -158,7 +158,7 @@ class CSRFTokenValidator implements SubscriberInterface
             $requestToken = $request->getParam('__csrf_token') ? : $request->getHeader('X-CSRF-Token');
             if (!hash_equals($token, $requestToken)) {
                 $this->generateToken($controller->Response());
-                throw new CSRFTokenValidationException("The provided X-CSRF-Token is invalid. Please go back, reload the page and try again.");
+                throw new CSRFTokenValidationException(sprintf('The provided X-CSRF-Token for path "%s" is invalid. Please go back, reload the page and try again.', $request->getRequestUri()));
             }
         }
     }

--- a/engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
@@ -56,9 +56,6 @@ class MailTransport
                 $options['username'] = $config->MailerUsername;
                 $options['password'] = $config->MailerPassword;
             }
-            if (!isset($options['ssl']) && !empty($config->MailerSMTPSecure)) {
-                $options['ssl'] = $config->MailerSMTPSecure;
-            }
             if (!isset($options['port']) && !empty($config->MailerPort)) {
                 $options['port'] = $config->MailerPort;
             }

--- a/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
@@ -25,6 +25,7 @@
 namespace Shopware\Components\DependencyInjection\Bridge;
 
 use Shopware\Components\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
 /**
  * Session Dependency Injection Bridge
@@ -38,9 +39,37 @@ class Session
 {
     /**
      * @param Container $container
+     * @return \SessionHandlerInterface|null
+     */
+    public function createSaveHandler(Container $container)
+    {
+        $sessionOptions = $container->getParameter('shopware.session');
+        if (isset($sessionOptions['save_handler']) && $sessionOptions['save_handler'] !== 'db') {
+            return null;
+        }
+
+        $dbOptions = $container->getParameter('shopware.db');
+        $conn = Db::createPDO($dbOptions);
+
+        return new PdoSessionHandler(
+            $conn,
+            [
+                'db_table'        => 's_core_sessions',
+                'db_id_col'       => 'id',
+                'db_data_col'     => 'data',
+                'db_lifetime_col' => 'expiry',
+                'db_time_col'     => 'modified',
+                'lock_mode'       => $sessionOptions['locking'] ? PdoSessionHandler::LOCK_TRANSACTIONAL : PdoSessionHandler::LOCK_NONE,
+            ]
+        );
+    }
+
+    /**
+     * @param Container $container
+     * @param \SessionHandlerInterface $saveHandler
      * @return \Enlight_Components_Session_Namespace
      */
-    public function factory(Container $container)
+    public function createSession(Container $container, \SessionHandlerInterface $saveHandler = null)
     {
         $sessionOptions = $container->getParameter('shopware.session');
 
@@ -64,20 +93,12 @@ class Session
             $sessionOptions['cookie_secure'] = true;
         }
 
-        if (!isset($sessionOptions['save_handler']) || $sessionOptions['save_handler'] == 'db') {
-            $config_save_handler = array(
-                'db'             => $container->get('Db'),
-                'name'           => 's_core_sessions',
-                'primary'        => 'id',
-                'modifiedColumn' => 'modified',
-                'dataColumn'     => 'data',
-                'lifetimeColumn' => 'expiry'
-            );
-            \Enlight_Components_Session::setSaveHandler(
-                new \Enlight_Components_Session_SaveHandler_DbTable($config_save_handler)
-            );
+        if ($saveHandler) {
+            session_set_save_handler($saveHandler);
             unset($sessionOptions['save_handler']);
         }
+
+        unset($sessionOptions['locking']);
 
         \Enlight_Components_Session::start($sessionOptions);
 

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -50,9 +50,14 @@
         </service>
 
         <service id="session_factory" class="Shopware\Components\DependencyInjection\Bridge\Session" />
-        <service id="session" class="Enlight_Components_Session_Namespace">
-            <factory service="session_factory" method="factory" />
+        <service id="session.save_handler" class="SessionHandlerInterface" public="false">
+            <factory service="session_factory" method="createSaveHandler" />
             <argument type="service" id="service_container"/>
+        </service>
+        <service id="session" class="Enlight_Components_Session_Namespace">
+            <factory service="session_factory" method="createSession" />
+            <argument type="service" id="service_container"/>
+            <argument type="service" id="session.save_handler"/>
         </service>
 
         <service id="mailtransport_factory" class="Shopware\Components\DependencyInjection\Bridge\MailTransport" />

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -133,6 +133,7 @@ return array_replace_recursive([
         'gc_divisor' => 100,
         'save_handler' => 'db',
         'use_trans_sid' => 0,
+        'locking' => true,
     ],
     'phpsettings' => [
         'error_reporting' => E_ALL & ~E_USER_DEPRECATED,
@@ -172,5 +173,6 @@ return array_replace_recursive([
         'cookie_lifetime' => 0,
         'cookie_httponly' => 1,
         'use_trans_sid' => 0,
+        'locking' => false,
     ],
 ], $customConfig);

--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -350,8 +350,8 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
         $repository = Shopware()->Models()->getRepository('Shopware\Models\Order\Order');
 
         $query = $repository->getPaymentStatusQuery(
-            $filter = $this->Request()->getParam('filter', array()),
-            $order = $this->Request()->getParam('sort', array()),
+            $filter = $this->Request()->getParam('filter'),
+            $order = $this->Request()->getParam('sort'),
             $offset = $this->Request()->getParam('start'),
             $limit = $this->Request()->getParam('limit')
         );

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -263,21 +263,27 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
     }
 
     /**
-     * This class has its own OrderStatusQuery as we need to get rid of states with satus.id = -1
+     * This class has its own OrderStatusQuery as we need to get rid of states with status.id = -1
+     * @param array|null $filter
+     * @param array|null $order
+     * @param int|null $offset
+     * @param int|null $limit
+     * @return \Doctrine\ORM\Query
      */
     public function getOrderStatusQuery($filter = null, $order = null, $offset = null, $limit = null)
     {
         $builder = Shopware()->Models()->createQueryBuilder();
         $builder->select(array('status'))
             ->from('Shopware\Models\Order\Status', 'status')
-            ->andWhere("status.group = 'state'")
-            ->orderBy( "status.position", "ASC" );
+            ->andWhere("status.group = 'state'");
 
         if ($filter !== null) {
             $builder->addFilter($filter);
         }
         if ($order !== null) {
             $builder->addOrderBy($order);
+        } else {
+            $builder->orderBy('status.position', 'ASC');
         }
 
         if ($offset !== null) {

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -270,7 +270,8 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
         $builder = Shopware()->Models()->createQueryBuilder();
         $builder->select(array('status'))
             ->from('Shopware\Models\Order\Status', 'status')
-            ->andWhere("status.group = 'state'");
+            ->andWhere("status.group = 'state'")
+            ->orderBy( "status.position", "ASC" );
 
         if ($filter !== null) {
             $builder->addFilter($filter);

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -27,6 +27,7 @@ use Shopware\Bundle\SearchBundle\Sorting\PopularitySorting;
 use Shopware\Bundle\SearchBundle\Sorting\ReleaseDateSorting;
 use Shopware\Bundle\SearchBundle\SortingInterface;
 use Shopware\Bundle\StoreFrontBundle;
+use Shopware\Bundle\StoreFrontBundle\Service\Core\ConfiguratorService;
 use Shopware\Bundle\StoreFrontBundle\Struct\BaseProduct;
 use Shopware\Bundle\StoreFrontBundle\Struct\Product;
 use Shopware\Components\QueryAliasMapper;
@@ -2324,9 +2325,25 @@ class sArticles
 
             $convertedConfiguratorPrice = $this->legacyStructConverter->convertConfiguratorPrice($product, $configurator);
             $data = array_merge($data, $convertedConfiguratorPrice);
+
+            // generate additional text
+            if (!empty($selection)) {
+                $this->additionalTextService->buildAdditionalText($product, $this->contextService->getShopContext());
+                $data['additionaltext'] = $product->getAdditional();
+            }
+
+            if ($this->config->get('forceArticleMainImageInListing') && $configurator->getType() !== ConfiguratorService::CONFIGURATOR_TYPE_STANDARD && empty($selection)) {
+                $data['image'] = $this->legacyStructConverter->convertMediaStruct($product->getCover());
+                $data['images'] = [];
+                foreach ($product->getMedia() as $image) {
+                    if ($image->getId() !== $product->getCover()->getId()) {
+                        $data['images'][] = $this->legacyStructConverter->convertMediaStruct($image);
+                    }
+                }
+            }
         }
 
-        $data = array_merge($data, $this->getLinksOfProduct($product, $categoryId));
+        $data = array_merge($data, $this->getLinksOfProduct($product, $categoryId, $selection));
 
         $data["articleName"] = $this->sOptimizeText($data["articleName"]);
         $data["description_long"] = htmlspecialchars_decode($data["description_long"]);
@@ -2354,14 +2371,18 @@ class sArticles
      *
      * @param StoreFrontBundle\Struct\ListProduct $product
      * @param null $categoryId
+     * @param array $selection
      * @return array
      */
-    private function getLinksOfProduct(StoreFrontBundle\Struct\ListProduct $product, $categoryId = null)
+    private function getLinksOfProduct(StoreFrontBundle\Struct\ListProduct $product, $categoryId = null, array $selection)
     {
         $baseFile = $this->config->get('baseFile');
         $context = $this->contextService->getShopContext();
 
         $detail = $baseFile . "?sViewport=detail&sArticle=" . $product->getId();
+        if (!empty($selection)) {
+            $detail .= '&number=' . $product->getNumber();
+        }
         if ($categoryId) {
             $detail .= '&sCategory=' . $categoryId;
         }

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -2343,7 +2343,7 @@ class sArticles
             }
         }
 
-        $data = array_merge($data, $this->getLinksOfProduct($product, $categoryId, $selection));
+        $data = array_merge($data, $this->getLinksOfProduct($product, $categoryId, !empty($selection)));
 
         $data["articleName"] = $this->sOptimizeText($data["articleName"]);
         $data["description_long"] = htmlspecialchars_decode($data["description_long"]);
@@ -2371,20 +2371,20 @@ class sArticles
      *
      * @param StoreFrontBundle\Struct\ListProduct $product
      * @param null $categoryId
-     * @param array $selection
+     * @param bool $addNumber
      * @return array
      */
-    private function getLinksOfProduct(StoreFrontBundle\Struct\ListProduct $product, $categoryId = null, array $selection)
+    private function getLinksOfProduct(StoreFrontBundle\Struct\ListProduct $product, $categoryId = null, $addNumber = false)
     {
         $baseFile = $this->config->get('baseFile');
         $context = $this->contextService->getShopContext();
 
         $detail = $baseFile . "?sViewport=detail&sArticle=" . $product->getId();
-        if (!empty($selection)) {
-            $detail .= '&number=' . $product->getNumber();
-        }
         if ($categoryId) {
             $detail .= '&sCategory=' . $categoryId;
+        }
+        if ($addNumber) {
+            $detail .= '&number=' . $product->getNumber();
         }
         $rewrite = Shopware()->Modules()->Core()->sRewriteLink($detail, $product->getName());
 

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1017,7 +1017,7 @@ class sBasket
         }
 
         if (!$tax) {
-            $tax = 119;
+            $tax = 19;
         }
 
         if ((!$this->sSYSTEM->sUSERGROUPDATA["tax"] && $this->sSYSTEM->sUSERGROUPDATA["id"])) {

--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -79,6 +79,8 @@ class Repository extends ModelRepository
         }
         if ($order !== null) {
             $builder->addOrderBy($order);
+        } else {
+            $builder->orderBy('status.position', 'ASC');
         }
 
         return $builder;
@@ -129,6 +131,8 @@ class Repository extends ModelRepository
         }
         if ($order !== null) {
             $builder->addOrderBy($order);
+        } else {
+            $builder->orderBy('status.position', 'ASC');
         }
 
         return $builder;

--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -415,7 +415,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
 
         if ($shop && $request->getCookie('shop') !== null && $request->getPost('__shop') == null) {
             $requestShop = $repository->getActiveByRequest($request);
-            if ($shop->getId() !== $requestShop->getId() && $shop->getBaseUrl() !== $requestShop->getBaseUrl()) {
+            if ($requestShop !== null && $shop->getId() !== $requestShop->getId() && $shop->getBaseUrl() !== $requestShop->getBaseUrl()) {
                 $shop = $requestShop;
             }
         }

--- a/eula.txt
+++ b/eula.txt
@@ -61,7 +61,7 @@ Die shopware AG räumt dem Kunden das Recht ein, das Basis-Produkt und Shopware 
 
 7.1.	Das Basis-Produkt und – soweit vom Vertrag erfasst – die Shopware Premium-Plugins sowie die nach den Ziffern 4 und 5 eingeräumten Rechte dürfen dauerhaft auf Dritte übertragen werden, wenn der Dritte diesen Nutzungsbedingungen zustimmt. Der Dritte ist zur Nutzung in demselben Umfang berechtigt, wie der Kunde es aufgrund des mit der shopware AG geschlossenen Professional-, Enterprise Business- oder Enterprise Cluster-Vertrags war.
 7.2.	Im Fall der Übertragung ist der Kunde verpflichtet, sämtliche auf den Web- oder Datenbank-Servern vorhandenen Kopien der Produkte zu löschen und diese Löschung gegenüber der shopware AG beispielsweise durch Abgabe einer Vernichtungserklärung nachzuweisen.
-7.3.	Die showare AG erstellt für den Dritten auf Anfrage und ohne zusätzliche Kosten einen neuen Lizenzschlüssel, mit dem der Dritte die Produkte auf dem neuen Web- oder Datenbank-Server freischalten kann.
+7.3.	Die shopware AG erstellt für den Dritten auf Anfrage und ohne zusätzliche Kosten einen neuen Lizenzschlüssel, mit dem der Dritte die Produkte auf dem neuen Web- oder Datenbank-Server freischalten kann.
 
 8.	GEWÄHRLEISTUNG
 

--- a/recovery/update/src/Controller/CleanupController.php
+++ b/recovery/update/src/Controller/CleanupController.php
@@ -274,7 +274,7 @@ SQL;
             }
 
             $iterator = new RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($directory->getPath(), FilesystemIterator::SKIP_DOTS),
+                new \RecursiveDirectoryIterator($directory->getRealPath(), FilesystemIterator::SKIP_DOTS),
                 RecursiveIteratorIterator::CHILD_FIRST
             );
 

--- a/shopware.php
+++ b/shopware.php
@@ -40,7 +40,11 @@ if (is_file('files/update/update.json') || is_dir('update-assets')) {
     header('Content-type: text/html; charset=utf-8', true, 503);
     header('Status: 503 Service Temporarily Unavailable');
     header('Retry-After: 1200');
-    echo file_get_contents(__DIR__ . '/recovery/update/maintenance.html');
+    if (file_exists(__DIR__ . '/maintenance.html')) {
+        echo file_get_contents(__DIR__ . '/maintenance.html');
+    } else {
+        echo file_get_contents(__DIR__ . '/recovery/update/maintenance.html');
+    }
     return;
 }
 

--- a/tests/Unit/Components/Hook/EnlightHookProxyFactoryTest.php
+++ b/tests/Unit/Components/Hook/EnlightHookProxyFactoryTest.php
@@ -1,0 +1,134 @@
+<?php
+namespace Shopware\Tests\Unit\Components;
+
+use PHPUnit\Framework\TestCase;
+
+interface MyInterface
+{
+    public function myPublic($bar, $foo = 'bar');
+}
+
+interface MyReferenceInterface
+{
+    public function myPublic(&$bar, $foo);
+}
+
+class MyBasicTestClass implements MyInterface
+{
+    public function myPublic($bar, $foo = 'bar')
+    {
+        return $bar.$foo;
+    }
+
+    protected function myProtected($bar)
+    {
+    }
+}
+
+class MyReferenceTestClass implements MyReferenceInterface
+{
+    public function myPublic(&$bar, $foo)
+    {
+        return $bar.$foo;
+    }
+}
+
+class TestProxyFactory extends \Enlight_Hook_ProxyFactory
+{
+    public function __construct(\Enlight_Hook_HookManager $hookManager, $proxyNamespace)
+    {
+        $this->hookManager = $hookManager;
+        $this->proxyNamespace = $proxyNamespace;
+    }
+}
+
+class EnlightHookProxyFactoryTest extends TestCase
+{
+    private $proxyFactory;
+
+    public function setUp()
+    {
+        /** @var \Enlight_Hook_HookManager $SUT */
+        $hookManager = $this->createConfiguredMock(\Enlight_Hook_HookManager::class, [
+            'hasHooks' => true,
+        ]);
+
+        $this->proxyFactory = new TestProxyFactory($hookManager, 'ShopwareTests');
+    }
+
+    private function invokeMethod($object, $methodName, array $parameters = array())
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+
+    public function testGenerateBasicProxyClass()
+    {
+        $generatedClass  = $this->invokeMethod($this->proxyFactory, 'generateProxyClass', [MyBasicTestClass::class]);
+        $expectedClass = <<<'EOT'
+<?php
+class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends Shopware\Tests\Unit\Components\MyBasicTestClass implements Enlight_Hook_Proxy
+{
+    public function executeParent($method, $args = array())
+    {
+        return call_user_func_array(array($this, 'parent::' . $method), $args);
+    }
+
+    public static function getHookMethods()
+    {
+        return array (  0 => 'myPublic',  1 => 'myProtected',);
+    }
+    
+    public function myPublic($bar, $foo = 'bar')
+    {
+        return Shopware()->Hooks()->executeHooks(
+            $this, 'myPublic', array('bar'=>$bar, 'foo'=>$foo)
+        );
+    }
+
+    protected function myProtected($bar)
+    {
+        return Shopware()->Hooks()->executeHooks(
+            $this, 'myProtected', array('bar'=>$bar)
+        );
+    }
+
+}
+
+EOT;
+        $this->assertSame($expectedClass, $generatedClass);
+    }
+
+    public function testGenerateProxyClassWithReferenceParameter()
+    {
+        $generatedClass  = $this->invokeMethod($this->proxyFactory, 'generateProxyClass', [MyReferenceTestClass::class]);
+        $expectedClass = <<<'EOT'
+<?php
+class ShopwareTests_ShopwareTestsUnitComponentsMyReferenceTestClassProxy extends Shopware\Tests\Unit\Components\MyReferenceTestClass implements Enlight_Hook_Proxy
+{
+    public function executeParent($method, $args = array())
+    {
+        return call_user_func_array(array($this, 'parent::' . $method), $args);
+    }
+
+    public static function getHookMethods()
+    {
+        return array (  0 => 'myPublic',);
+    }
+    
+    public function myPublic(&$bar, $foo)
+    {
+        return Shopware()->Hooks()->executeHooks(
+            $this, 'myPublic', array('bar'=>&$bar, 'foo'=>$foo)
+        );
+    }
+
+}
+
+EOT;
+        $this->assertSame($expectedClass, $generatedClass);
+    }
+}

--- a/themes/Frontend/Bare/documents/index.tpl
+++ b/themes/Frontend/Bare/documents/index.tpl
@@ -71,6 +71,7 @@ td.head  {
 	{$Containers.Content_Info.style}
 }
 </style>
+</head>
 
 <body>
 {foreach from=$Pages item=postions name="pagingLoop" key=page}

--- a/themes/Frontend/Bare/frontend/index/index.tpl
+++ b/themes/Frontend/Bare/frontend/index/index.tpl
@@ -148,7 +148,7 @@
     {/block}
 
 {block name="frontend_index_header_javascript"}
-    <script type="text/javascript">
+    <script type="text/javascript" id="footer--js-inline">
         //<![CDATA[
         {block name="frontend_index_header_javascript_inline"}
             var timeNow = {time() nocache};
@@ -187,7 +187,7 @@
                     {/foreach}
                     'articleId': ~~('{$sArticle.articleID}'),
                     'linkDetailsRewritten': '{$sArticle.linkDetailsRewrited}',
-                    'articleName': '{$sArticle.articleName|escape:"javascript"}',
+                    'articleName': '{$sArticle.articleName|escape:"javascript"}{if $sArticle.additionaltext} {$sArticle.additionaltext|escape:"javascript"}{/if}',
                     'imageTitle': '{$sArticle.image.description|escape:"javascript"}',
                     'images': {ldelim}
 						{foreach $sArticle.image.thumbnails as $key => $image}

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -34,7 +34,8 @@
             configuratorFormSelector: '.configurator--form',
             orderNumberSelector: '.entry--sku .entry--content',
             historyIdentifier: 'sw-ajax-variants',
-            productDetailsDescriptionSelector: '.content--description'
+            productDetailsDescriptionSelector: '.content--description',
+            footerJavascriptInlineSelector: '#footer--js-inline'
         },
 
         /**
@@ -118,7 +119,7 @@
                 data: values,
                 method: 'GET',
                 success: function(response) {
-                    var $response = $($.parseHTML(response)),
+                    var $response = $($.parseHTML(response, document, true)),
                         $productDetails,
                         $productDescription,
                         ordernumber;
@@ -133,6 +134,10 @@
 
                     // Get the ordernumber for the url
                     ordernumber = $.trim(me.$el.find(me.opts.orderNumberSelector).text());
+
+                    // Update global variables
+                    window.controller = window.snippets = window.themeConfig = window.lastSeenProductsConfig = window.csrfConfig = null;
+                    $(me.opts.footerJavascriptInlineSelector).replaceWith($response.filter(me.opts.footerJavascriptInlineSelector));
 
                     StateManager.addPlugin('select:not([data-no-fancy-select="true"])', 'swSelectboxReplacement')
                         .addPlugin('*[data-image-slider="true"]', 'swImageSlider', { touchControls: true })

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.last-seen-products.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.last-seen-products.js
@@ -120,9 +120,36 @@
 
             if ($('body').hasClass('is--ctl-detail')) {
                 me.collectProduct(me.opts.currentArticle);
+                $.subscribe(me.getEventName('plugin/swAjaxVariant/onRequestData'), $.proxy(me.onAjaxVariantChange, me));
             }
 
             me.createProductList();
+        },
+
+        /**
+         * Refresh the last seen article if the customer switches between variants
+         *
+         * @private
+         * @method onAjaxVariantChange
+         */
+        onAjaxVariantChange: function() {
+            var me = this;
+
+            me.collectProduct(window.lastSeenProductsConfig.currentArticle);
+            me.clearProductList();
+            me.createProductList();
+        },
+
+        /**
+         * Removes all products from the displayed slider
+         *
+         * @public
+         * @method clearProductList
+         */
+        clearProductList: function () {
+            var me = this;
+
+            me.$container.children().remove();
         },
 
         /**
@@ -255,26 +282,34 @@
                 products = productsJson ? $.parseJSON(productsJson) : [],
                 len = products.length,
                 i = 0,
-                url;
+                url,
+                urlQuery,
+                linkDetailsQuery;
 
             if (!newProduct || $.isEmptyObject(newProduct)) {
                 return;
             }
 
             for (; i < len; i++) {
-                if (products[i].articleId === newProduct.articleId) {
-                    newProduct = products.splice(i, 1)[0];
-                    break;
+                if (products[i] && products[i].articleId === newProduct.articleId) {
+                    products.splice(i, 1);
                 }
             }
 
             url = newProduct.linkDetailsRewritten;
+            urlQuery = me.extractQueryParameters(url);
+
+            // Remove category from query string
+            delete urlQuery.c;
+            if (linkDetailsQuery = $.param(urlQuery)) {
+                linkDetailsQuery = '?' + linkDetailsQuery;
+            }
 
             // Remove query string from article url
             if (url.indexOf('/sCategory') !== -1) {
                 newProduct.linkDetailsRewritten = url.substring(0, url.indexOf('/sCategory'));
             } else if (url.indexOf('?') !== -1) {
-                newProduct.linkDetailsRewritten = url.substring(0, url.indexOf('?'));
+                newProduct.linkDetailsRewritten = url.substring(0, url.indexOf('?')) + linkDetailsQuery;
             }
 
             products.splice(0, 0, newProduct);
@@ -286,6 +321,30 @@
             me.storage.setItem(itemKey, JSON.stringify(products));
 
             $.publish('plugin/swLastSeenProducts/onCollectProduct', [ me, newProduct ]);
+        },
+
+        /**
+         * Extracts the query string as object from a given url
+         *
+         * @private
+         * @method extractQueryParameters
+         * @param {string} url
+         * @return {Object}
+         */
+        extractQueryParameters: function (url) {
+            var queryParams = {};
+
+            if (url.indexOf('?') === -1) {
+                return {};
+            }
+
+            url = url.substring(url.indexOf('?'));
+            $.each(url.split('&'), function (key, param) {
+                param = param.split('=');
+                queryParams[param[0]] = param[1];
+            });
+
+            return queryParams;
         }
     });
 }(jQuery));

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-manager.js
@@ -243,8 +243,16 @@
          * @returns {boolean}
          */
         function hasCookiesSupport() {
-            return ('cookie' in document && (document.cookie.length > 0 ||
-            (document.cookie = 'test').indexOf.call(document.cookie, 'test') > -1));
+            // if cookies are already present assume cookie support
+            if ('cookie' in document && (document.cookie.length > 0)) {
+                return true;
+            }
+
+            document.cookie = "testcookie=1;";
+            var writeTest = (document.cookie.indexOf("testcookie") !== -1);
+            document.cookie = "testcookie=1"+';expires=Sat, 01-Jan-2000 00:00:00 GMT';
+
+            return writeTest;
         }
 
         /**

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/checkbox.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/checkbox.less
@@ -81,7 +81,7 @@ The checkboxes can be used in a `span` element containing an `input` tag or insi
 				.unitize(line-height, 12);
 				.unitize(font-size, 7);
 				display: inline-block;
-				font-family: 'shopware';
+				font-family: @sw-icon-fontname;
 				font-weight: normal;
 				text-align: center;
 				vertical-align: top;
@@ -106,7 +106,7 @@ The checkboxes can be used in a `span` element containing an `input` tag or insi
 				.unitize(line-height, 12);
 				.unitize(font-size, 7);
 				display: inline-block;
-				font-family: 'shopware';
+				font-family: @sw-icon-fontname;
 				font-weight: normal;
 				text-align: center;
 				vertical-align: top;

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/collapse.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/collapse.less
@@ -59,7 +59,7 @@ Displays a folding box that responds if the content does not fit the element.
         .unitize(line-height, 16);
         position: absolute;
         font-weight: normal;
-        font-family: 'shopware';
+        font-family: @sw-icon-fontname;
 
         &:before {
             content: @sw-icon-arrow-down;

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/filter-panel.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/filter-panel.less
@@ -103,7 +103,7 @@ The styling includes the collapsed and expanded styling and the panel component 
     .tap-highlight-color(rgba(0, 0, 0, 0));
     display: inline-block;
     position: absolute;
-    font-family: "shopware";
+    font-family: @sw-icon-fontname;
     text-align: center;
     cursor: pointer;
     pointer-events: none;
@@ -199,7 +199,7 @@ The styling includes the collapsed and expanded styling and the panel component 
                 .unitize(line-height, 12);
                 .unitize(font-size, 7);
                 display: block;
-                font-family: 'shopware';
+                font-family: @sw-icon-fontname;
                 font-weight: normal;
                 text-align: center;
                 color: #fff;
@@ -330,7 +330,7 @@ The styling includes the collapsed and expanded styling and the panel component 
                 .border-radius(8px);
                 display: block;
                 position: absolute;
-                font-family: 'shopware';
+                font-family: @sw-icon-fontname;
                 font-weight: normal;
                 text-align: center;
                 color: #fff;
@@ -415,7 +415,7 @@ The styling includes the collapsed and expanded styling and the panel component 
         .unitize(font-size, 30);
         position: absolute;
         top: 0; left: 0;
-        font-family: 'shopware';
+        font-family: @sw-icon-fontname;
         font-weight: normal;
         color: @rating-star-color;
 
@@ -505,7 +505,7 @@ The styling includes the collapsed and expanded styling and the panel component 
         .unitize(font-size, 8);
         .unitize(-1, 16, top);
         position: relative;
-        font-family: 'shopware';
+        font-family: @sw-icon-fontname;
         color: @text-color;
 
         &:before {

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/icon-set.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/icon-set.less
@@ -1264,7 +1264,7 @@ Example: `<i class="icon--cart"></i>`
 */
 
 @font-face {
-	font-family: 'shopware';
+	font-family: @sw-icon-fontname;
 	src:url('@{font-directory}/shopware.eot?@{shopware-revision}');
 	src:url('@{font-directory}/shopware.eot?#@{shopware-revision}') format('embedded-opentype'),
 		url('@{font-directory}/shopware.woff?@{shopware-revision}') format('woff'),
@@ -1275,7 +1275,7 @@ Example: `<i class="icon--cart"></i>`
 }
 
 [class^="icon--"], [class*=" icon--"] {
-	font-family: 'shopware';
+	font-family: @sw-icon-fontname;
 	speak: none;
 	font-style: normal;
 	font-weight: normal;

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/image-slider.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/image-slider.less
@@ -42,7 +42,7 @@ It contains the viewport specific styles inside media queries.
         position: absolute;
         top: 50%;
         z-index: @zindex-image-slider-arrow;
-        font-family: 'shopware';
+        font-family: @sw-icon-fontname;
         text-align: center;
         color: @text-color;
         cursor: pointer;
@@ -168,7 +168,7 @@ It contains the viewport specific styles inside media queries.
         display: none;
         position: absolute;
         z-index: @zindex-image-slider-arrow;
-        font-family: 'shopware';
+        font-family: @sw-icon-fontname;
         text-align: center;
         color: @text-color;
         border: 1px solid rgba(255, 255, 255, 0.85);

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/menu-scroller.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/menu-scroller.less
@@ -34,7 +34,7 @@ Some styling rules can also be found in the hacks.less!
     .unitize(top, 1);
     border: 1px solid @btn-default-border-color;
     position: absolute;
-    font-family: "shopware";
+    font-family: @sw-icon-fontname;
     text-align: center;
     color: @btn-default-text-color;
     cursor: pointer;

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/panel.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/panel.less
@@ -312,7 +312,7 @@ Displays an arrow button that is used to navigate through the slider pages.
     position: absolute;
     top: 50%;
     z-index: @zindex-panel-arrow;
-    font-family: 'shopware';
+    font-family: @sw-icon-fontname;
     text-align: center;
     color: @text-color;
 
@@ -551,7 +551,7 @@ Displays an arrow button that is used to navigate through the slider pages.
         top: 0;
         right: 0;
         border-left: 1px solid @border-color;
-        font-family: 'shopware';
+        font-family: @sw-icon-fontname;
         text-align: center;
 
         &:before,

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/product-slider.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/product-slider.less
@@ -112,7 +112,7 @@ For initializing a product slider the outer `product-slider` wrapper has to have
     position: absolute;
     top: 50%;
     z-index: @zindex-product-slider;
-    font-family: 'shopware';
+    font-family: @sw-icon-fontname;
     text-align: center;
     color: @btn-default-text-color;
     border: 1px solid @btn-default-border-color;

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_mixins/icon-element.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_mixins/icon-element.less
@@ -14,7 +14,7 @@ This mixin provides you a method to set any webfont icon from the Shopware icon-
         .unitize-width(20, 16);
         .unitize(@listIconSize, 16, font-size);
         .unitize(-20, 16, left);
-        font-family: shopware;
+        font-family: @sw-icon-fontname;
         content: "@{listIcon}";
         position: absolute;
         top: 0;

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/detail.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/detail.less
@@ -541,7 +541,7 @@ It contains the product actions, the product information such as pictures and de
         top: 50%;
         margin-top: -9px;
         content: "";
-        font-family: shopware;
+        font-family: @sw-icon-fontname;
     }
 }
 
@@ -844,7 +844,7 @@ It contains the product actions, the product information such as pictures and de
             float: left;
 
             &:before {
-                font-family: 'shopware';
+                font-family: @sw-icon-fontname;
                 content: @sw-icon-arrow-left;
             }
         }
@@ -854,7 +854,7 @@ It contains the product actions, the product information such as pictures and de
             float: right;
 
             &:before {
-                font-family: 'shopware';
+                font-family: @sw-icon-fontname;
                 content: @sw-icon-arrow-right;
             }
         }

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/footer.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/footer.less
@@ -44,7 +44,7 @@ The footer element sizes are defined with the unitize mixin.
 
         &::after {
             .unitize(font-size, 18);
-            font-family: 'shopware';
+            font-family: @sw-icon-fontname;
             color: @text-color;
             font-weight: 700;
             content: @sw-icon-plus3;

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/header.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/header.less
@@ -612,7 +612,7 @@ More precise designations are commented inside the document.
                     .unitize(-3, 16, top);
                     .unitize(margin-left, 5);
                     content: @sw-icon-arrow-down;
-                    font-family: 'shopware';
+                    font-family: @sw-icon-fontname;
                     position: relative;
                 }
 

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/listing.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/listing.less
@@ -303,7 +303,7 @@ It contains the viewport specific styles inside media queries.
                 .unitize(margin-top, -8);
                 .unitize(font-size, 6);
                 .unitize(line-height, 16);
-                font-family: "shopware";
+                font-family: @sw-icon-fontname;
                 content: @sw-icon-arrow-down;
                 position: absolute;
                 text-align: center;

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/register.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/register.less
@@ -135,7 +135,7 @@ The user can see the registration steps, advantages and required information.
                 .unitize(font-size, 6);
                 .unitize(right, 10);
                 position: absolute;
-                font-family: "shopware";
+                font-family: @sw-icon-fontname;
                 font-weight: normal;
                 content: @sw-icon-arrow-down;
                 color: inherit;

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_variables/icons.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_variables/icons.less
@@ -13,9 +13,14 @@ content: @sw-icon-grid;
 content: @sw-icon-facebook;
 ```
 
+The variable `@sw-icon-fontname` contains the name of the font which will be
+used for all icons.
+
 For an overview of available variables, visit the
 <a href="https://developers.shopware.com/styletile/_components-icon-set.html">docs on available icons</a>.
 */
+
+@sw-icon-fontname: 'shopware';
 
 @sw-icon-percent2: "\e723";
 @sw-icon-percent: "\e722";


### PR DESCRIPTION
## Description
Please describe your pull request:
* When the default mailer in shopware is ssl/tls, then it is not possible to set an non ssl/tls mailer for the newsletter, because the setting ssl => null is getting always overwritten. 0 or an emtpy string is also not possible because of the Zend_Mail_Protocol_Smtp
* You can set a non ssl/tls newsletter mailer, even the default mailer is ssl/tls?
* No?




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes
| Tests pass?      | yes
| Related tickets? | No
| How to test?     | Try to setup a non ssl/tls newsletter mailer when the default mailer is ssl/tls

