### PR TITLE
Add State Info to order billing and shipping address information

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -178,6 +178,8 @@ class Repository extends ModelRepository
             'billing',
             'billingCountry',
             'shippingCountry',
+            'billingState',
+            'shippingState',
             'shop',
             'dispatch',
             'paymentStatus',
@@ -205,6 +207,7 @@ class Repository extends ModelRepository
                 ->leftJoin('orders.paymentInstances', 'paymentInstances')
                 ->leftJoin('orders.billing', 'billing')
                 ->leftJoin('billing.country', 'billingCountry')
+                ->leftJoin('billing.state', 'billingState')
                 ->leftJoin('orders.shipping', 'shipping')
                 ->leftJoin('orders.shop', 'shop')
                 ->leftJoin('orders.dispatch', 'dispatch')
@@ -217,7 +220,8 @@ class Repository extends ModelRepository
                 ->leftJoin('orders.attribute', 'attribute')
                 ->leftJoin('orders.languageSubShop', 'subShop')
                 ->leftJoin('subShop.locale', 'locale')
-                ->leftJoin('shipping.country', 'shippingCountry');
+                ->leftJoin('shipping.country', 'shippingCountry')
+                ->leftJoin('shipping.state', 'shippingState');
 
         if (!empty($filters)) {
             $builder = $this->filterListQuery($builder, $filters);


### PR DESCRIPTION
## Description
### **Why is it necessary?**
in Reset Api document man can see that by the [address ](https://developers.shopware.com/developers-guide/rest-api/models/#address) there is Country and State info.
but when you check the return data you find just the country info there is no State info.
### **What does it improve?**
This change will add the State info to the return data.
### **Does it have side effects?**
no



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | just try to call an order by id by Reset Api.

