### PR TITLE
Fix overwriting ssl for newsletter mailer 53/5.3

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
@@ -56,9 +56,6 @@ class MailTransport
                 $options['username'] = $config->MailerUsername;
                 $options['password'] = $config->MailerPassword;
             }
-            if (!isset($options['ssl']) && !empty($config->MailerSMTPSecure)) {
-                $options['ssl'] = $config->MailerSMTPSecure;
-            }
             if (!isset($options['port']) && !empty($config->MailerPort)) {
                 $options['port'] = $config->MailerPort;
             }


### PR DESCRIPTION
## Description

* Why is it necessary?
When the default mailer in shopware is ssl/tls, then it is not possible to set an non ssl/tls mailer for the newsletter, because the setting ssl => null is getting always overwritten. 0 or an emtpy string is also not possible because of the Zend_Mail_Protocol_Smtp

* What does it improve?
You can set a non ssl/tls newsletter mailer, even the default mailer is ssl/tls

* Does it have side effects?
No


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes
| Tests pass?      | yes
| Related tickets? | None
| How to test?     | Try to setup a non ssl/tls newsletter mailer when the default mailer is ssl/tls

