### PR TITLE
Fixing emotion copy error

### DIFF
--- a/engine/Shopware/Controllers/Backend/Emotion.php
+++ b/engine/Shopware/Controllers/Backend/Emotion.php
@@ -1182,7 +1182,7 @@ SELECT `objecttype`,
 `objectlanguage`,
 `dirty`
 FROM `s_core_translations`
-WHERE objectkey = :oldObjectKey
+WHERE objectkey = :oldObjectKey AND `objecttype` = 'emotionElement'
 EOD;
 
         /** @var Element $el */


### PR DESCRIPTION
Not only copy all translation with the old objectkey but also use objecttype as well.

