### PR TITLE
[TASK] Added console command sw:rebuild:seo:index

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -17,6 +17,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
     * The session handler can be overwritten by replacing the `session.save_handler`-Service. A instance of `\SessionHandlerInterface` has to be returned.
 * Changed return value of `sArticles::sGetArticleById()` to provide an additional text if none is given and display the cover image by default when using the selection configurator
 * Changed url parameter in last seen articles to deeplink to an article variant instead of the article
+* Added console command `sw:rebuild:seo:index` to rebuild the SEO index on demand
 
 ### Autoloading of plugin resources
 

--- a/engine/Shopware/Commands/RebuildSeoIndexCommand.php
+++ b/engine/Shopware/Commands/RebuildSeoIndexCommand.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RebuildSeoIndexCommand extends ShopwareCommand
+{
+    /** @var \Shopware_Components_SeoIndex */
+    protected $seoIndex;
+
+    /** @var \sRewriteTable */
+    protected $rewriteTable;
+
+    /** @var \sCategories */
+    protected $categories;
+
+    /** @var \Doctrine\DBAL\Connection */
+    protected $database;
+
+    /** @var \Shopware_Components_Modules */
+    protected $modules;
+
+    /** @var \Shopware\Components\Model\ModelManager */
+    protected $modelManager;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sw:rebuild:seo:index')
+            ->setDescription('Rebuild the SEO index')
+            ->addArgument('shopId', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The Id of the shop')
+            ->setHelp('The <info>%command.name%</info> rebuilds the SEO index')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->database = $this->container->get('dbal_connection');
+        $this->modules = $this->container->get('modules');
+        $this->modelManager = $this->container->get('models');
+        $this->seoIndex = $this->container->get('SeoIndex');
+        $this->rewriteTable = $this->modules->RewriteTable();
+
+        $shops = $input->getArgument('shopId');
+
+        if (empty($shops)) {
+            /** @var \Doctrine\DBAL\Query\QueryBuilder $query */
+            $query = $this->database->createQueryBuilder();
+            $shops = $query->select('id')
+                ->from('s_core_shops', 'shops')
+                ->where('active', 1)
+                ->execute()
+                ->fetchAll(\PDO::FETCH_COLUMN);
+        }
+
+        $currentTime = new \DateTime();
+
+        $this->seoIndex->registerShop($shops[0]);
+        $this->rewriteTable->sCreateRewriteTableCleanup();
+
+        foreach ($shops as $shopId) {
+            $output->writeln("Rebuilding SEO index for shop " . $shopId);
+            /** @var $repository \Shopware\Models\Shop\Repository */
+            $repository = $this->modelManager->getRepository('Shopware\Models\Shop\Shop');
+            $shop = $repository->getActiveById($shopId);
+
+            if ($shop === null) {
+                throw new \Exception('No valid shop id passed');
+            }
+
+            $shop->registerResources();
+            $this->modules->Categories()->baseId = $shop->getCategory()->getId();
+
+            list($cachedTime, $elementId, $shopId) = $this->seoIndex->getCachedTime();
+
+            $this->seoIndex->setCachedTime($currentTime->format('Y-m-d h:m:i'), $elementId, $shopId);
+            $this->rewriteTable->baseSetup();
+
+            $offset = 0;
+            $limit = 10000;
+            $lastId = null;
+            $lastUpdateVal = '0000-00-00 00:00:00';
+
+            do {
+                $lastUpdateVal = $this->rewriteTable->sCreateRewriteTableArticles($lastUpdateVal, $limit, $offset);
+                $lastId = $this->rewriteTable->getRewriteArticleslastId();
+                $offset = $offset + $limit;
+            } while ($lastId !== null);
+
+            $this->seoIndex->setCachedTime($currentTime->format('Y-m-d h:m:i'), $elementId, $shopId);
+
+            $context = $this->container->get('shopware_storefront.context_service')->createShopContext($shopId);
+
+            $this->rewriteTable->sCreateRewriteTableCategories();
+            $this->rewriteTable->sCreateRewriteTableCampaigns();
+            $this->rewriteTable->sCreateRewriteTableContent();
+            $this->rewriteTable->sCreateRewriteTableBlog();
+            $this->rewriteTable->sCreateRewriteTableSuppliers(null, null, $context);
+            $this->rewriteTable->sCreateRewriteTableStatic();
+        }
+
+        $output->writeln("The SEO index was rebuild successfully.");
+    }
+}

--- a/engine/Shopware/Core/sRewriteTable.php
+++ b/engine/Shopware/Core/sRewriteTable.php
@@ -224,7 +224,7 @@ class sRewriteTable
         MemoryLimit::setMinimumMemoryLimit(1024*1024*512);
         @set_time_limit(0);
 
-        $keys = array_keys($this->template->registered_plugins['function']);
+        $keys = isset($this->template->registered_plugins['function']) ? array_keys($this->template->registered_plugins['function']) : [];
         if (!(in_array('sCategoryPath', $keys))) {
             $this->template->registerPlugin(
                 Smarty::PLUGIN_FUNCTION, 'sCategoryPath',
@@ -750,6 +750,7 @@ class sRewriteTable
      */
     public function sSmartyCategoryPath($params)
     {
+        $parts = null;
         if (!empty($params['articleID'])) {
             $parts = $this->sCategoryPathByArticleId(
                 $params['articleID'],
@@ -761,10 +762,12 @@ class sRewriteTable
         if (empty($params['separator'])) {
             $params['separator'] = '/';
         }
-        foreach ($parts as &$part) {
-            $part = str_replace($params['separator'], '', $part);
+        if (!empty($parts)) {
+            foreach ($parts as &$part) {
+                $part = str_replace($params['separator'], '', $part);
+            }
+            $parts = implode($params['separator'], $parts);
         }
-        $parts = implode($params['separator'], $parts);
         return $parts;
     }
 


### PR DESCRIPTION
Please describe your pull request:
* Why is it necessary? Because you cannot rebuild the SEO index on CLI.
* What does it improve? Enables you to rebuild the SEO index on CLI on demand.
* Does it have side effects? No

Inspired by `Shopware_Plugins_Core_RebuildIndex_Bootstrap::onRefreshSeoIndex()`. I have also added the possibility to add a `shopId` argument to rebuild URLs for this shop only.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | Truncate table `s_core_rewrite_urls` and run the new command `bin/console sw:rebuild:seo:index`. After the command is finished the generated SEO urls should be present in the database.

