### PR TITLE
Add articleId check to Variant Api Resource

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -467,7 +467,7 @@ class Variant extends Resource implements BatchInterface
             $connection = Shopware()->Container()->get('dbal_connection');
 
             // Number changed, hence make sure it does not already exist in another variant
-            $exists = $connection->fetchColumn('SELECT id FROM s_articles_details WHERE ordernumber = ? AND articleID != ?', [$data['number'],$article->getId()]);
+            $exists = $connection->fetchColumn('SELECT id FROM s_articles_details WHERE ordernumber = ? AND articleID != ?', [$data['number'], $article->getId()]);
             if ($exists) {
                 throw new ApiException\CustomValidationException(sprintf('A variant with the given order number "%s" already exists.', $data['number']));
             }

--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -467,7 +467,7 @@ class Variant extends Resource implements BatchInterface
             $connection = Shopware()->Container()->get('dbal_connection');
 
             // Number changed, hence make sure it does not already exist in another variant
-            $exists = $connection->fetchColumn('SELECT id FROM s_articles_details WHERE ordernumber = ?', [$data['number']]);
+            $exists = $connection->fetchColumn('SELECT id FROM s_articles_details WHERE ordernumber = ? AND articleID != ?', [$data['number'],$article->getId()]);
             if ($exists) {
                 throw new ApiException\CustomValidationException(sprintf('A variant with the given order number "%s" already exists.', $data['number']));
             }


### PR DESCRIPTION
## Description
Allow the mainDetail->number to be changed within the pool of variant ordernumbers of that specific article that already exists over the API



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | none
| How to test?     | Change mainDetail->number to another ordernumber of a variant already exists within this article over API.

