### PR TITLE
Prevent Javascript-Error if single quote is used

### DIFF
--- a/themes/Frontend/Bare/frontend/index/index.tpl
+++ b/themes/Frontend/Bare/frontend/index/index.tpl
@@ -169,7 +169,7 @@
             {rdelim};
 
             var snippets = snippets || {ldelim}
-                'noCookiesNotice': '{s name="IndexNoCookiesNotice"}{/s}'
+                'noCookiesNotice': '{"{s name='IndexNoCookiesNotice'}{/s}"|escape:"javascript"}'
             {rdelim};
 
             var themeConfig = themeConfig || {ldelim}


### PR DESCRIPTION
Actually the JS crashes, if a single quote is used for "IndexNoCookiesNotice". It needs to be escaped.

## Description
Please describe your pull request:
* Why is it necessary?
Solves bug in shop-frontend

* What does it improve?
Allows single quote for IndexNoCookiesNotice snippet

* Does it have side effects?
No



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | Use a single quote in text (e.g. "nous vous conseillons d'activer les cookies dans votre navigateur.") for snippet IndexNoCookiesNotice, clear cache and reload frontend.

