### PR TITLE
Added ability to create cronjobs with cronjob.xml in Plugins

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
@@ -38,9 +38,11 @@ use Shopware\Kernel;
 use Shopware\Models\Plugin\Plugin;
 use Shopware\Components\Plugin\FormSynchronizer;
 use Shopware\Components\Plugin\MenuSynchronizer;
+use Shopware\Components\Plugin\CronjobSynchronizer;
 use Shopware\Components\Plugin\XmlMenuReader;
 use Shopware\Components\Plugin\XmlConfigDefinitionReader;
 use Shopware\Components\Plugin\XmlPluginInfoReader;
+use Shopware\Components\Plugin\XmlCronjobReader;
 
 class PluginInstaller
 {
@@ -215,6 +217,10 @@ class PluginInstaller
             $this->installMenu($plugin, $bootstrap->getPath().'/Resources/menu.xml');
         }
 
+        if (is_file($bootstrap->getPath().'/Resources/cronjob.xml')) {
+            $this->installCronjob($plugin, $bootstrap->getPath().'/Resources/cronjob.xml');
+        }
+
         if (file_exists($bootstrap->getPath() . '/Resources/snippets')) {
             $this->installSnippets($bootstrap);
         }
@@ -364,6 +370,19 @@ class PluginInstaller
 
         $menuSynchronizer = new MenuSynchronizer($this->em);
         $menuSynchronizer->synchronize($plugin, $menu);
+    }
+
+    /**
+     * @param Plugin $plugin
+     * @param string $file
+     */
+    private function installCronjob(Plugin $plugin, $file)
+    {
+        $cronjobReader = new XmlCronjobReader();
+        $cronjobs = $cronjobReader->read($file);
+
+        $cronjobSynchronizer = new CronjobSynchronizer($this->em->getConnection());
+        $cronjobSynchronizer->synchronize($plugin, $cronjobs);
     }
 
     /**

--- a/engine/Shopware/Components/Plugin/CronjobSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/CronjobSynchronizer.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin;
+
+use DateTime;
+use Doctrine\DBAL\Connection;
+use Shopware\Models\Plugin\Plugin;
+
+/**
+ * Class CronjobSynchronizer
+ * @package Shopware\Components\Plugin
+ */
+class CronjobSynchronizer
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * CronjobSyncronizer constructor.
+     * @param Connection $connection
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @param Plugin $plugin
+     * @param array $cronjobs
+     * @throws \InvalidArgumentException
+     */
+    public function synchronize(Plugin $plugin, array $cronjobs)
+    {
+        foreach ($cronjobs as $cronjob) {
+            $this->addCronjob($plugin, $cronjob);
+        }
+
+        $this->removeNotExistingEntries($plugin->getId(), array_column($cronjobs, 'action'));
+    }
+
+    /**
+     * @param Plugin $plugin
+     * @param $cronjob
+     */
+    private function addCronjob(Plugin $plugin, $cronjob)
+    {
+        $cronjob['pluginID'] = $plugin->getId();
+
+        // Prevent SQL Error when using reserved word
+        if (isset($cronjob['interval'])) {
+            $cronjob['`interval`'] = $cronjob['interval'];
+            unset($cronjob['interval']);
+        }
+
+        $id = $this->connection->fetchColumn('SELECT id FROM s_crontab WHERE `action` = ? AND pluginID = ?', [$cronjob['action'], $plugin->getId()]);
+
+        if ($id) {
+            // Don't overwrite user cronjob state
+            unset($cronjob['active']);
+
+            $this->connection->update('s_crontab', $cronjob, ['id' => $id]);
+        } else {
+            $cronjob['next'] = new DateTime();
+            $this->connection->insert('s_crontab', $cronjob, ['next' => 'datetime']);
+        }
+    }
+
+    /**
+     * @param int $pluginId
+     * @param array $cronjobActions
+     */
+    private function removeNotExistingEntries($pluginId, array $cronjobActions)
+    {
+        $builder = $this->connection->createQueryBuilder();
+        $builder->delete('s_crontab');
+        $builder->where('action NOT IN (:cronjobActions)');
+        $builder->andWhere('pluginID = :pluginId');
+        $builder->setParameter(':cronjobActions', $cronjobActions, Connection::PARAM_STR_ARRAY);
+        $builder->setParameter(':pluginId', $pluginId);
+        $builder->execute();
+    }
+}

--- a/engine/Shopware/Components/Plugin/XmlCronjobReader.php
+++ b/engine/Shopware/Components/Plugin/XmlCronjobReader.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin;
+
+use Symfony\Component\Config\Util\XmlUtils;
+
+/**
+ * Class XmlCronjobReader
+ * @package Shopware\Components\Plugin
+ */
+class XmlCronjobReader
+{
+    public function read($file)
+    {
+        try {
+            $dom = XmlUtils::loadFile($file, __DIR__.'/schema/cronjob.xsd');
+        } catch (\Exception $e) {
+            throw new \InvalidArgumentException(sprintf('Unable to parse file "%s".', $file), $e->getCode(), $e);
+        }
+
+        return $this->parseInfo($dom);
+    }
+
+    /**
+     * @param \DOMDocument $xml
+     * @return array
+     */
+    private function parseInfo(\DOMDocument $xml)
+    {
+        $xpath = new \DOMXPath($xml);
+
+        if (false === $entries = $xpath->query('//cronjobs/cronjob')) {
+            return;
+        }
+
+        $cronjobs = [];
+        foreach ($entries as $entry) {
+            $cronjobs[] = $this->parseEntry($entry);
+        }
+
+        return $cronjobs;
+    }
+
+    /**
+     * @param \DOMElement $entry
+     * @return array
+     */
+    private function parseEntry(\DOMElement $entry)
+    {
+        $cronjobEntry = [];
+
+        $cronjobEntry['name'] = $this->getFirstChild($entry, 'name');
+        $cronjobEntry['action'] = $this->getFirstChild($entry, 'action');
+        $cronjobEntry['active'] = $this->toBool($this->getFirstChild($entry, 'active'));
+        $cronjobEntry['interval'] = $this->getFirstChild($entry, 'interval');
+        $cronjobEntry['disable_on_error'] = $this->toBool($this->getFirstChild($entry, 'disableOnError'));
+
+        return $cronjobEntry;
+    }
+
+    /**
+     * @param \DOMNode $node
+     * @param $name
+     * @return null|string
+     */
+    private function getFirstChild(\DOMNode $node, $name)
+    {
+        if ($children = $this->getChildren($node, $name)) {
+            return $children[0]->nodeValue;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get child elements by name.
+     *
+     * @param \DOMNode $node
+     * @param mixed    $name
+     *
+     * @return \DOMElement[]
+     */
+    private function getChildren(\DOMNode $node, $name)
+    {
+        $children = array();
+        foreach ($node->childNodes as $child) {
+            if ($child instanceof \DOMElement && $child->localName === $name) {
+                $children[] = $child;
+            }
+        }
+
+        return $children;
+    }
+
+    /**
+     * @param string $string
+     * @return bool
+     */
+    private function toBool($string)
+    {
+        return $string == 'true' ? true : false;
+    }
+}

--- a/engine/Shopware/Components/Plugin/schema/cronjob.xsd
+++ b/engine/Shopware/Components/Plugin/schema/cronjob.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+    <xsd:element name="cronjobs" type="cronjobsType"/>
+
+    <xsd:complexType name="cronjobsType">
+        <xsd:sequence>
+            <xsd:element name="cronjob" type="cronjobType" minOccurs="1" maxOccurs="unbounded" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="cronjobType">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="action" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="active" type="xsd:boolean" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="interval" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="disableOnError" type="xsd:boolean" minOccurs="1" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+</xsd:schema>

--- a/tests/Unit/Components/Plugin/XmlCronjobReaderReaderTest.php
+++ b/tests/Unit/Components/Plugin/XmlCronjobReaderReaderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Shopware\Tests\Unit\Components\Plugin;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Components\Plugin\XmlCronjobReader;
+
+class XmlCronjobReaderReaderTest extends TestCase
+{
+    /**
+     * @var XmlCronjobReader
+     */
+    private $SUT;
+
+    private $result = [
+        'name' => 'Article Importer',
+        'action' => 'ImportArticle',
+        'active' => true,
+        'interval' => 3600,
+        'disable_on_error' => false
+    ];
+
+    protected function setUp()
+    {
+        $this->SUT = new XmlCronjobReader();
+    }
+
+    public function testCanReadAndVerify()
+    {
+        $result = $this->SUT->read(__DIR__.'/examples/cronjob.xml');
+        $this->assertInternalType('array', $result);
+    }
+
+    public function testReadCronjob()
+    {
+        $result = $this->SUT->read(__DIR__.'/examples/cronjob.xml');
+
+        $this->assertArraySubset(current($result), $this->result);
+    }
+}

--- a/tests/Unit/Components/Plugin/examples/cronjob.xml
+++ b/tests/Unit/Components/Plugin/examples/cronjob.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cronjobs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../engine/Shopware/Components/Plugin/schema/cronjob.xsd">
+    <cronjob>
+        <name>Article Importer</name>
+        <action>ImportArticle</action>
+        <active>true</active>
+        <interval>3600</interval>
+        <disableOnError>false</disableOnError>
+    </cronjob>
+</cronjobs>


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Makes easier to install cronjobs like menu/plugin config :)
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Create a cronjob.xml in your Plugin Resources folder

Example:

```xml
<?xml version="1.0" encoding="utf-8"?>
<cronjobs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="../../../../../engine/Shopware/Components/Plugin/schema/cronjob.xsd">
    <cronjob>
        <name>Article Importer</name>
        <action>ImportArticle</action>
        <active>true</active>
        <interval>3600</interval>
        <disableOnError>false</disableOnError>
    </cronjob>
</cronjobs>

