### PR TITLE
Fix Api to create image mappings

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -1877,7 +1877,6 @@ class Article extends Resource implements BatchInterface
             $options = new ArrayCollection();
 
             foreach ($mappingData as $option) {
-
                 $conditions = [];
 
                 if ($option['id']) {

--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -1880,7 +1880,7 @@ class Article extends Resource implements BatchInterface
 
                 $conditions = [];
 
-                if($option['id']) {
+                if ($option['id']) {
                     $conditions['id'] = $option['id'];
                 }
 

--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -1881,10 +1881,10 @@ class Article extends Resource implements BatchInterface
                 $conditions = [];
 
                 if($option['id']) {
-                    $conditions[] = $option['id'];
+                    $conditions['id'] = $option['id'];
                 }
 
-                $conditions[] = $option['name'];
+                $conditions['name'] = $option['name'];
 
                 $available = $this->getCollectionElementByProperties($configuratorOptions, $conditions);
 

--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -1877,10 +1877,16 @@ class Article extends Resource implements BatchInterface
             $options = new ArrayCollection();
 
             foreach ($mappingData as $option) {
-                $available = $this->getCollectionElementByProperties($configuratorOptions, [
-                    'id' => $option['id'],
-                    'name' => $option['name'],
-                ]);
+
+                $conditions = [];
+
+                if($option['id']) {
+                    $conditions[] = $option['id'];
+                }
+
+                $conditions[] = $option['name'];
+
+                $available = $this->getCollectionElementByProperties($configuratorOptions, $conditions);
 
                 if (!$available) {
                     $property = $option['id'] ? $option['id'] : $option['name'];


### PR DESCRIPTION
## Description

* Why is it necessary?
The Problem is, when you do a Post Request to insert a new Product, with complete new Variant Options and Images, that are not known in Shopware. These Options, don't have got an ID when the Image Mapping is done. The Method "getCollectionElementByProperty" in Resource/Resource.php compares null == null (ID) and returns true, even the found option is not the searched one.  

* What does it improve?
It only adds the Parameter ID when the Parameter is not null, so that there is no Comparison of null==null. 

* How To Reproduce?
1. Upload two Images with the Media Manager and notice the IDs of the Media. For Example: 1 & 2.
2. Do following API Post Request: 
`{
    "descriptionLong": "test1",
    "name": "test1",
    "configuratorSet": {
        "type": 2,
        "groups": [{
            "name": "Neu1",
            "options": [{
                "name": "NeuVal1"
            }, {
                "name": "Neuval2"
            }]
        }]
    },
    "taxId": 1,
    "mainDetail": {
        "number": "PR0017840-02",
        "active": true,
        "prices": [{
            "price": 0.0,
            "pseudoPrice": 0.0,
            "customerGroupKey": "EK"
        }],
        "configuratorOptions": [{
            "group": "Neu1",
            "option": "NeuVal1"
        }],
        "shippingTime": 7.0,
        "width": 0,
        "inStock": 2
    },
    "filterGroupId": null,
    "images": [{
        "position": 0,
        "main": 1,
        "mediaId": "1",
        "description": "147quad1809 603994396334907 1063748094 n",
        "options": [
            [{
                "name": "NeuVal1"
            }]
        ]
    }, {
        "position": 0,
        "main": 2,
        "mediaId": "2",
        "description": "IMG 7228",
        "options": [
            [{
                "name": "Neuval2"
            }]
        ]
    }],
    "lastStock": true,
    "variants": [{
        "number": "PR0017840-03",
        "active": true,
        "prices": [{
            "price": 0.0,
            "pseudoPrice": 0.0,
            "customerGroupKey": "EK"
        }],
        "configuratorOptions": [{
            "group": "Neu1",
            "option": "Neuval2"
        }],
        "shippingTime": 7.0,
        "width": 0,
        "isMain": 0,
        "inStock": 2
    }],
    "active": true
}`
3. Compare the Image Configuration in the Backen, and see that it is not correct. Both Images are Bound to "Neuval1", but the second should be bound to "Neuval2".

4. You can now do the same Request again, but now as a PUT-Call. The same Pictures now will be added again to the Product, but now with the correct image Configuration, because the given options are already known in Shopware.

With the changes in the Pull request, the Image Configuration is correct at the first time.

* Does it have side effects?
Not that I know of



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | -
| Tests pass?      | -
| Related tickets? | No
| How to test?     | Reproduce like duescripted
