### PR TITLE
fix common attribute translation migration helper

### DIFF
--- a/_sql/migrations/common/AttributeTranslationMigrationHelper.php
+++ b/_sql/migrations/common/AttributeTranslationMigrationHelper.php
@@ -81,9 +81,12 @@ EOL
             $ids = array_keys($values);
 
             $this->connection->exec('DELETE FROM s_core_translations WHERE id IN (' . implode(',', $ids) . ')');
-            $this->connection->exec(
-                'INSERT INTO s_core_translations (objecttype, objectdata, objectkey, objectlanguage) VALUES ' . implode(',', $values)
-            );
+			
+			foreach($values as $id => $value)
+			{
+				$query = $this->connection->prepare('INSERT INTO s_core_translations (objecttype, objectdata, objectkey, objectlanguage) VALUES(:objecttype, :objectdata, :objectkey, :objectlanguage)');
+				$query->execute([':objecttype' => $value['objecttype'], ':objectdata' => $value['objectdata'], ':objectkey' => $value['objectkey'], ':objectlanguage' => $value['objectlanguage']]);
+			}
 
             $lastId = array_pop($rows)['id'];
             $statement->execute([':lastId' => $lastId, ':maxId' => $maxId]);
@@ -180,7 +183,12 @@ EOL
 
             $updated = serialize($updated);
 
-            $values[$row['id']] = "('{$row['objecttype']}', '{$updated}', {$row['objectkey']}, {$row['objectlanguage']})";
+            $values[$row['id']] = [
+									'objecttype' => $row['objecttype'], 
+									'objectdata' => $updated, 
+									'objectkey' => $row['objectkey'],
+									'objectlanguage' => $row['objectlanguage']
+			];
         }
 
         return $values;


### PR DESCRIPTION
escape the sql insert statements

<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary? On the Showpare update, it caused an mysql error, because the sql query is not escaped.
* What does it improve? The migriation prozess.
* Does it have side effects? No.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | http://issues.shopware.com/issues/SW-17440.
| How to test?     | Migrate translations with ' in column objectdata.

