### PR TITLE
fixed the entity creation inside the acl component

### DIFF
--- a/engine/Shopware/Components/Acl.php
+++ b/engine/Shopware/Components/Acl.php
@@ -164,6 +164,8 @@ class Shopware_Components_Acl extends Zend_Acl
         $resource->setPluginId($pluginID);
 
         if (!empty($privileges)) {
+            $privilegeObjects = [];
+
             foreach ($privileges as $name) {
                 $privilege = new \Shopware\Models\User\Privilege();
                 $privilege->setName($name);
@@ -173,9 +175,9 @@ class Shopware_Components_Acl extends Zend_Acl
 
                 $privilegeObjects[] = $privilege;
             }
-        }
 
-        $resource->setPrivileges($privilegeObjects);
+            $resource->setPrivileges($privilegeObjects);
+        }
 
         $this->em->persist($resource);
         $this->em->flush();

--- a/engine/Shopware/Components/Acl.php
+++ b/engine/Shopware/Components/Acl.php
@@ -49,8 +49,8 @@ class Shopware_Components_Acl extends Zend_Acl
     private function initShopwareAclTree()
     {
         $this->initAclResources()
-             ->initAclRoles()
-             ->initAclRoleConditions();
+            ->initAclRoles()
+            ->initAclRoleConditions();
     }
 
     /**
@@ -163,14 +163,22 @@ class Shopware_Components_Acl extends Zend_Acl
         $resource->setName($resourceName);
         $resource->setPluginId($pluginID);
 
-        $this->em->persist($resource);
-        $this->em->flush();
-
         if (!empty($privileges)) {
-            foreach ($privileges as $privilege) {
-                $this->createPrivilege($resource->getId(), $privilege);
+            foreach ($privileges as $name) {
+                $privilege = new \Shopware\Models\User\Privilege();
+                $privilege->setName($name);
+                $privilege->setResource($resource);
+
+                $this->em->persist($privilege);
+
+                $privilegeObjects[] = $privilege;
             }
         }
+
+        $resource->setPrivileges($privilegeObjects);
+
+        $this->em->persist($resource);
+        $this->em->flush();
     }
 
     /**
@@ -207,6 +215,10 @@ class Shopware_Components_Acl extends Zend_Acl
             "DELETE FROM s_core_acl_roles WHERE resourceID = ?",
             [$resource->getId()]
         );
+
+        foreach ($resource->getPrivileges()->toArray() as $privilege) {
+            $this->em->remove($privilege);
+        }
 
         //The privileges will be removed automatically
         $this->em->remove($resource);

--- a/tests/Functional/Modules/Acl/RemoveAndCreateResourceTest.php
+++ b/tests/Functional/Modules/Acl/RemoveAndCreateResourceTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Class RemoveAndCreateResourceTest
+ */
+class RemoveAndCreateResourceTest extends Enlight_Components_Test_TestCase
+{
+    public function test_remove_and_create_a_resource()
+    {
+        $em = Shopware()->Container()->get('models');
+
+        $acl = new Shopware_Components_Acl($em);
+
+        $name = 'test' . mt_rand(0,5000000);
+
+        $this->assertNull($acl->createResource($name, ['read', 'write']));
+        $this->assertTrue($acl->deleteResource($name));
+        $this->assertNull($acl->createResource($name, ['read', 'write']));
+        $this->assertTrue($acl->deleteResource($name));
+    }
+}


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
I recently tried to remove and add resources. Unfortunatly after the second createResource call the whole thing fired an exception:

  [Doctrine\ORM\ORMInvalidArgumentException]
  A new entity was found through the relationship 'Shopware\Models\User\Privilege#resource' that was not configured to cascade persist operations for entity: Shopware\Models\User\Resource@00000000366
  c554a000000006ab7bc45. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOn
  e(..,cascade={"persist"}). If you cannot find out which entity causes the problem implement 'Shopware\Models\User\Resource#__toString()' to get a clue.

* What does it improve?
reworked the resource creation and deletion to create proper relationships between the two models. 
* Does it have side effects?
ACL Resource functions as it is. 

TBD: The createPrivilege function can be removed and the PR needs review if thats the best way to solve the issue




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | none
| How to test?     | remove my changes to the acl component and rerun attached test, it should break without

