### PR TITLE
Alter order repository to include order attributes for the backend too

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -287,7 +287,8 @@ class Repository extends ModelRepository
                 ->leftJoin('billing.country', 'billingCountry')
                 ->leftJoin('billing.state', 'billingState')
                 ->leftJoin('orders.shop', 'shop')
-                ->leftJoin('orders.dispatch', 'dispatch');
+                ->leftJoin('orders.dispatch', 'dispatch')
+                ->leftJoin('orders.attribute', 'attribute');
 
         if (!empty($filters)) {
             $builder = $this->filterListQuery($builder, $filters);


### PR DESCRIPTION

<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
This pull request is necessary so that backend order queries can use the attributes as well. This is needed e.g. to provide sorting and filtering in the backend order overview based on custom attributes. This **does not** add this functionality, but merely provides the needed core changes for plugins to be able to use such functionality.


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       |no
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | see below


You can easily see that this behaviour is broken by using the Backend "Order" controller's _getList_ endpoint. Take for example:

    /backend/Order/getList?_dc=1484413981137&page=1&start=0&limit=60&filter=[{%22property%22:%22attribute.type%22,%22value%22:8,%22operator%22:null,%22expression%22:null}]

this URL (assuming disabled CSRF protection for debugging) will throw an Exception in an unaltered Shopware 5 installation, since the query builder which the controller uses internally (see changed files) does not care about the "attribute" relationship.

Adding the changes proposed in this PR makes filtering by attributes work.

This PR does not include tests, since I could not find a relevant test in the current test suite either.