### PR TITLE
define plugin permissions via xml

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/services.xml
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/services.xml
@@ -22,6 +22,7 @@
             <argument type="service" id="shopware.snippet_database_handler" />
             <argument type="service" id="shopware.plugin_requirement_validator" />
             <argument type="service" id="db_connection" />
+            <argument type="service" id="acl" />
             <argument>%kernel.root_dir%</argument>
         </service>
 

--- a/engine/Shopware/Components/Plugin/PermissionsSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/PermissionsSynchronizer.php
@@ -92,17 +92,17 @@ class PermissionsSynchronizer
      */
     private function synchronizePrivileges(\Shopware\Models\User\Resource $resource, array $permissions)
     {
-        $existingPrivileges = array_filter($resource->getPrivileges()->toArray(), function(Privilege $privilege) use ($permissions) {
+        $existingPrivileges = array_filter($resource->getPrivileges()->toArray(), function (Privilege $privilege) use ($permissions) {
             return in_array($privilege->getName(), $permissions, true);
         });
 
-        $existingPrivileges = array_map(function(Privilege $privilege) {
+        $existingPrivileges = array_map(function (Privilege $privilege) {
             return $privilege->getName();
         }, $existingPrivileges);
 
         $newPrivileges = array_diff($permissions, $existingPrivileges);
 
-        array_walk($newPrivileges, function($name) use ($resource) {
+        array_walk($newPrivileges, function ($name) use ($resource) {
             $this->acl->createPrivilege($resource->getId(), $name);
         });
     }
@@ -115,7 +115,7 @@ class PermissionsSynchronizer
     {
         $existingPrivileges = $resource->getPrivileges()->toArray();
 
-        $orphanedPrivileges = array_filter($existingPrivileges, function(Privilege $privilege) use ($permissions) {
+        $orphanedPrivileges = array_filter($existingPrivileges, function (Privilege $privilege) use ($permissions) {
             return !in_array($privilege->getName(), $permissions, true);
         });
 
@@ -123,7 +123,7 @@ class PermissionsSynchronizer
             return;
         }
 
-        array_walk($orphanedPrivileges, function(Privilege $privilege) {
+        array_walk($orphanedPrivileges, function (Privilege $privilege) {
             $this->em->remove($privilege);
         });
 

--- a/engine/Shopware/Components/Plugin/PermissionsSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/PermissionsSynchronizer.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Shopware\Components\Plugin;
+
+use Enlight_Exception;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Components\Model\ModelRepository;
+use Shopware\Models\Plugin\Plugin;
+use Shopware\Models\User\Privilege;
+use Shopware_Components_Acl;
+
+/**
+ * Class PermissionsSynchronizer
+ */
+class PermissionsSynchronizer
+{
+    /**
+     * @var ModelManager
+     */
+    private $em;
+
+    /**
+     * @var ModelRepository
+     */
+    private $repository;
+
+    /**
+     * @var Shopware_Components_Acl
+     */
+    private $acl;
+
+    /**
+     * CronjobSyncronizer constructor.
+     *
+     * @param ModelManager $em
+     * @param Shopware_Components_Acl $acl
+     */
+    public function __construct(ModelManager $em, Shopware_Components_Acl $acl)
+    {
+        $this->em = $em;
+        $this->repository = $this->em->getRepository(\Shopware\Models\User\Resource::class);
+        $this->acl = $acl;
+    }
+
+    /**
+     * @param Plugin $plugin
+     * @param array $permissions
+     */
+    public function synchronize(Plugin $plugin, array $permissions)
+    {
+        $resource = $this->getResource($plugin->getName());
+
+        if (null === $resource) {
+            $this->createResource($plugin, $permissions);
+
+            return;
+        }
+
+        $this->synchronizePrivileges($resource, $permissions);
+        $this->removeNotExistingPrivileges($resource, $permissions);
+    }
+
+    /**
+     * @param $resourceName
+     *
+     * @return \Shopware\Models\User\Resource
+     */
+    private function getResource($resourceName)
+    {
+        return $this->repository->findOneBy(['name' => $resourceName]);
+    }
+
+    /**
+     * @param Plugin $plugin
+     * @param array $permissions
+     *
+     * @throws Enlight_Exception
+     */
+    private function createResource(Plugin $plugin, array $permissions)
+    {
+        $this->acl->createResource(
+            $plugin->getName(),
+            $permissions,
+            $plugin->getLabel(),
+            $plugin->getId()
+        );
+    }
+
+    /**
+     * @param \Shopware\Models\User\Resource $resource
+     * @param array $permissions
+     */
+    private function synchronizePrivileges(\Shopware\Models\User\Resource $resource, array $permissions)
+    {
+        $existingPrivileges = array_filter($resource->getPrivileges()->toArray(), function(Privilege $privilege) use ($permissions) {
+            return in_array($privilege->getName(), $permissions, true);
+        });
+
+        $existingPrivileges = array_map(function(Privilege $privilege) {
+            return $privilege->getName();
+        }, $existingPrivileges);
+
+        $newPrivileges = array_diff($permissions, $existingPrivileges);
+
+        array_walk($newPrivileges, function($name) use ($resource) {
+            $this->acl->createPrivilege($resource->getId(), $name);
+        });
+    }
+
+    /**
+     * @param \Shopware\Models\User\Resource $resource
+     * @param array $permissions
+     */
+    protected function removeNotExistingPrivileges(\Shopware\Models\User\Resource $resource, array $permissions)
+    {
+        $existingPrivileges = $resource->getPrivileges()->toArray();
+
+        $orphanedPrivileges = array_filter($existingPrivileges, function(Privilege $privilege) use ($permissions) {
+            return !in_array($privilege->getName(), $permissions, true);
+        });
+
+        if (empty($orphanedPrivileges)) {
+            return;
+        }
+
+        array_walk($orphanedPrivileges, function(Privilege $privilege) {
+            $this->em->remove($privilege);
+        });
+
+        $this->em->flush();
+    }
+}

--- a/engine/Shopware/Components/Plugin/XmlPermissionsReader.php
+++ b/engine/Shopware/Components/Plugin/XmlPermissionsReader.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use Exception;
+use InvalidArgumentException;
+use Symfony\Component\Config\Util\XmlUtils;
+
+/**
+ * Class XmlPermissionsReader
+ */
+class XmlPermissionsReader
+{
+    /**
+     * @param $file
+     *
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    public function read($file)
+    {
+        try {
+            $dom = XmlUtils::loadFile($file, __DIR__ . '/schema/permission.xsd');
+        } catch (Exception $e) {
+            throw new InvalidArgumentException(sprintf('Unable to parse file "%s".', $file), $e->getCode(), $e);
+        }
+
+        $permissions = $this->parsePermissions($dom);
+
+        return array_column($permissions, 'name');
+    }
+
+    /**
+     * @param DOMDocument $xml
+     *
+     * @return array
+     */
+    private function parsePermissions(DOMDocument $xml)
+    {
+        $xpath = new DOMXPath($xml);
+
+        $entries = $xpath->query('//permissions/permission');
+
+        if (false === $entries) {
+            return [];
+        }
+
+        $permissions = [];
+        foreach ($entries as $entry) {
+            $permissions[] = $this->parseEntry($entry);
+        }
+
+        return $permissions;
+    }
+
+    /**
+     * @param DOMElement $entry
+     *
+     * @return array
+     */
+    private function parseEntry(DOMElement $entry)
+    {
+        $cronjobEntry = [];
+
+        $cronjobEntry['name'] = $this->getFirstChild($entry, 'name');
+
+        return $cronjobEntry;
+    }
+
+    /**
+     * @param DOMNode $node
+     * @param $name
+     *
+     * @return null|string
+     */
+    private function getFirstChild(DOMNode $node, $name)
+    {
+        if ($children = $this->getChildren($node, $name)) {
+            return $children[0]->nodeValue;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get child elements by name.
+     *
+     * @param DOMNode $node
+     * @param mixed $name
+     *
+     * @return DOMElement[]
+     */
+    private function getChildren(DOMNode $node, $name)
+    {
+        $children = array();
+
+        foreach ($node->childNodes as $child) {
+            if ($child instanceof DOMElement && $child->localName === $name) {
+                $children[] = $child;
+            }
+        }
+
+        return $children;
+    }
+}

--- a/engine/Shopware/Components/Plugin/schema/permission.xsd
+++ b/engine/Shopware/Components/Plugin/schema/permission.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xsd:element name="permissions" type="permissionsType"/>
+
+    <xsd:complexType name="permissionsType">
+        <xsd:sequence>
+            <xsd:element name="permission" type="permissionType" minOccurs="1" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="permissionType">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:schema>

--- a/tests/Unit/Components/Plugin/XmlPermissionsReaderTest.php
+++ b/tests/Unit/Components/Plugin/XmlPermissionsReaderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Shopware\Tests\Unit\Components\Plugin;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Components\Plugin\XmlPermissionsReader;
+
+/**
+ * Class XmlPermissionsReaderTest
+ */
+class XmlPermissionsReaderTest extends TestCase
+{
+    /**
+     * @var XmlPermissionsReader
+     */
+    private $reader;
+
+    /**
+     * @var array
+     */
+    private $result = [
+        'read',
+        'write',
+        'blog'
+    ];
+
+    protected function setUp()
+    {
+        $this->reader = new XmlPermissionsReader();
+    }
+
+    public function testCanReadAndVerify()
+    {
+        $result = $this->reader->read(__DIR__ . '/examples/permissions.xml');
+
+        $this->assertInternalType('array', $result);
+    }
+
+    public function testResultIsAsExpected()
+    {
+        $result = $this->reader->read(__DIR__ . '/examples/permissions.xml');
+
+        $this->assertArraySubset($this->result, $result);
+    }
+}

--- a/tests/Unit/Components/Plugin/examples/permissions.xml
+++ b/tests/Unit/Components/Plugin/examples/permissions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<permissions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.2/engine/Shopware/Components/Plugin/schema/permissions.xsd">
+    <permission>
+        <name>read</name>
+    </permission>
+    <permission>
+        <name>write</name>
+    </permission>
+    <permission>
+        <name>blog</name>
+    </permission>
+</permissions>


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Added a way to define plugin permissions via xml
* What does it improve?
plugin install/update simplification
* Does it have side effects?
none i am aware of




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes
| Tests pass?      | yes
| Related tickets? | none
| How to test?     | place a permissions.xml inside the PluginRoot/Resources folder and reinstall the plugin

