### PR TITLE
Run subgrunt-tasks for current & inherited themes

### DIFF
--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -341,6 +341,7 @@ class Compiler
     {
         $config = $this->inheritance->buildConfig($template, $shop, true);
         $config['shopware-revision'] = \Shopware::REVISION;
+        $config['shopware-theme-inheritance'] = $this->inheritance->getInheritancePath($template);
 
         $collection = new ArrayCollection();
 

--- a/engine/Shopware/Components/Theme/Inheritance.php
+++ b/engine/Shopware/Components/Theme/Inheritance.php
@@ -130,6 +130,24 @@ class Inheritance
     }
 
     /**
+     * Returns the inheritance-path of a given shop theme as an array of
+     * template-names. The names are sorted descending in priority.
+     * @param \Shopware\Models\Shop\Template $template
+     * @return array
+     */
+    public function getInheritancePath(Shop\Template $template)
+    {
+        $hierarchy = $this->buildInheritanceRecursive($template);
+        $path = [];
+
+        foreach ($hierarchy as $template) {
+            $path[] = $template->getTemplate();
+        }
+
+        return $path;
+    }
+
+    /**
      * Returns the shop theme configuration for the passed template.
      * The configuration is built recursive to include the configuration
      * of the template inheritance.

--- a/themes/Gruntfile.js
+++ b/themes/Gruntfile.js
@@ -6,7 +6,10 @@ module.exports = function (grunt) {
         jsFiles = [],
         jsTargetFile = {},
         content = '',
-        variables = {};
+        variables = {},
+        inheritancePath = config.config['shopware-theme-inheritance'],
+        themesTasks = {},
+        path = require('path');
 
     lessTargetFile['../' + config.lessTarget] = '../web/cache/all.less';
 
@@ -19,6 +22,15 @@ module.exports = function (grunt) {
         content += `@import "../${item}";`;
     });
     grunt.file.write('../web/cache/all.less', content);
+
+    inheritancePath.forEach(function (item) {
+        var folderPath = path.join('Frontend', item);
+        if (!grunt.file.exists(folderPath, 'Gruntfile.js')) {
+            return;
+        }
+        themesTasks[item] = {};
+        themesTasks[item][folderPath] = 'default';
+    });
 
     for (var key in config.config) {
         variables[key] = config.config[key];
@@ -93,15 +105,18 @@ module.exports = function (grunt) {
                 'Gruntfile.js',
                 'Frontend/Responsive/frontend/_public/src/js/*.js'
             ]
-        }
+        },
+        themes: themesTasks
     });
 
     grunt.loadNpmTasks('grunt-contrib-less');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-chokidar');
     grunt.loadNpmTasks('gruntify-eslint');
+    grunt.loadNpmTasks('grunt-subgrunt');
 
     grunt.renameTask('chokidar', 'watch');
+    grunt.renameTask('subgrunt', 'themes');
     grunt.registerTask('production', [ 'eslint', 'less:production', 'uglify:production' ]);
     grunt.registerTask('default', [ 'less:development', 'uglify:development', 'watch' ]);
 };

--- a/themes/package.json
+++ b/themes/package.json
@@ -12,6 +12,7 @@
     "grunt-chokidar": "^1.0.0",
     "grunt-contrib-less": "^1.0.1",
     "grunt-contrib-uglify": "^0.9.1",
+    "grunt-subgrunt": "^1.2.0",
     "gruntify-eslint": "^3.1.0"
   }
 }


### PR DESCRIPTION
This PR adds a new Grunt-Task called themes. This task gives the user the ability to run all available theme grunt-files through the main grunt-file.

Example (active theme is e.g. `Foobar`)
```
# run all grunt-tasks for inherited templates
grunt themes
# runs Responsive/Gruntfile.js
# runs Foobar/Gruntfile.js

# run only `Foobar` tasks
grunt themes:Foobar
```

Available Tasks are the ones in the current Theme (if available) and all the Themes it inherits from (e.g. ProprietaryBaseTheme, Responsive)


## Description
Please describe your pull request:
* Why is it necessary? To better automate a developers own theme
* What does it improve? Developer experience
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | Run `bin/console sw:theme:dump` config_X.json now contains a new key containing the inheritance-path of the current theme. Then run `grunt themes` from the themes-folder.

