### PR TITLE
Accept urls with and without trailing slash

### DIFF
--- a/engine/Shopware/Components/Routing/Matchers/RewriteMatcher.php
+++ b/engine/Shopware/Components/Routing/Matchers/RewriteMatcher.php
@@ -75,6 +75,7 @@ class RewriteMatcher implements MatcherInterface
           SELECT subshopID as shopId, path, org_path as orgPath, main
           FROM s_core_rewrite_urls
           WHERE path LIKE :pathInfo
+             OR Path LIKE :pathInfoWithoutslach
           ORDER BY main DESC, subshopID = :shopId DESC
           LIMIT 1
         ';
@@ -115,10 +116,12 @@ class RewriteMatcher implements MatcherInterface
             return $pathInfo;
         }
 
-        $pathInfo = ltrim($pathInfo, '/');
+        $pathInfoWithoutslach = trim($pathInfo, '/');
+        $pathInfo = $pathInfoWithoutslach . '/';
         $statement = $this->getRouteStatement();
         $statement->bindValue(':shopId', $context->getShopId(), \PDO::PARAM_INT);
         $statement->bindValue(':pathInfo', $pathInfo, \PDO::PARAM_STR);
+        $statement->bindValue(':pathInfoWithoutslach', $pathInfoWithoutslach, \PDO::PARAM_STR);
 
         if ($statement->execute() && $statement->rowCount() > 0) {
             $route = $statement->fetch(\PDO::FETCH_ASSOC);

--- a/engine/Shopware/Components/Routing/Matchers/RewriteMatcher.php
+++ b/engine/Shopware/Components/Routing/Matchers/RewriteMatcher.php
@@ -75,7 +75,7 @@ class RewriteMatcher implements MatcherInterface
           SELECT subshopID as shopId, path, org_path as orgPath, main
           FROM s_core_rewrite_urls
           WHERE path LIKE :pathInfo
-             OR Path LIKE :pathInfoWithoutslach
+             OR path LIKE :pathInfoWithoutSlach
           ORDER BY main DESC, subshopID = :shopId DESC
           LIMIT 1
         ';
@@ -116,12 +116,12 @@ class RewriteMatcher implements MatcherInterface
             return $pathInfo;
         }
 
-        $pathInfoWithoutslach = trim($pathInfo, '/');
-        $pathInfo = $pathInfoWithoutslach . '/';
+        $pathInfoWithoutSlach = trim($pathInfo, '/');
+        $pathInfo = $pathInfoWithoutSlach . '/';
         $statement = $this->getRouteStatement();
         $statement->bindValue(':shopId', $context->getShopId(), \PDO::PARAM_INT);
         $statement->bindValue(':pathInfo', $pathInfo, \PDO::PARAM_STR);
-        $statement->bindValue(':pathInfoWithoutslach', $pathInfoWithoutslach, \PDO::PARAM_STR);
+        $statement->bindValue(':pathInfoWithoutSlach', $pathInfoWithoutSlach, \PDO::PARAM_STR);
 
         if ($statement->execute() && $statement->rowCount() > 0) {
             $route = $statement->fetch(\PDO::FETCH_ASSOC);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
### **Why is it necessary?**
if the url saved in s_core_rewrite_urls table with trailing slash for example 'womens/' then if I call it with 'womens' without slash it not find the page and redirect me to the homepage.

and the problem that the code generate the urls sometimes with trailing slash (like the categories) and sometimes without trailing slash (like the products or static pages).

so I can't do anything with .htacess to add or remove the trailing slash from the urls.

### **What does it improve?**
after this change the code will search for the page name und not the exact value with trailing slash. and that will be more senses.

### **Does it have side effects?**
No


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       |  no
| Tests pass?      |  yes
| Related tickets? | [SW-17514](https://issues.shopware.com/issues/SW-17514)
| How to test?     | simply call the Shopware demo page and then remove or add the trailing slash for example : http://www.shopwaredemo.de/beach-relax/fashion/women/ and http://www.shopwaredemo.de/beach-relax/fashion/women