### PR TITLE
[BUGFIX] check client IP against REMOTE_ADDR rather than SERVER_ADDR …

### DIFF
--- a/engine/Shopware/Components/HttpCache/AppCache.php
+++ b/engine/Shopware/Components/HttpCache/AppCache.php
@@ -287,8 +287,8 @@ class AppCache extends HttpCache
      */
     protected function isPurgeRequestAllowed(Request $request)
     {
-        if ($request->server->has('SERVER_ADDR')) {
-            if ($request->server->get('SERVER_ADDR') == $request->getClientIp()) {
+        if ($request->server->has('REMOTE_ADDR')) {
+            if ($request->server->get('REMOTE_ADDR') == $request->getClientIp()) {
                 return true;
             }
         }


### PR DESCRIPTION
…on BAN Request

BAN requests for cache invalidation fail because of a comparison between client IP and SERVER_ADDR. In almost all average hosting environments SERVER_ADDR will be the internal server IP. But the client IP will be the external IP (like REMOTE_ADDR). Shopware will answer that request with 504, because the internal IP is in most cases not equal to the external IP. This causes exceptions on cache invalidation BAN requests "core.ERROR: Reverse proxy returned invalid status code". 

We have modified this check to match average hosting environments by checking REMOTE_ADDR and not SERVER_ADDR.

See also: https://forum.shopware.com/discussion/40903/reverse-proxy-error 