### PR TITLE
[BUGFIX] Use encodeURIComponent to encode semicolons

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-manager.js
@@ -60,7 +60,7 @@
                     expires = '; expires=' + date.toGMTString();
                 }
 
-                value = encodeURI(value);
+                value = encodeURIComponent(value);
 
                 document.cookie = name + '=' + value + expires + '; path=/';
             }
@@ -86,7 +86,7 @@
                     }
 
                     if (cookie.indexOf(nameEq) == 0) {
-                        return decodeURI(cookie.substring(nameEq.length, cookie.length));
+                        return decodeURIComponent(cookie.substring(nameEq.length, cookie.length));
                     }
                 }
                 return null;


### PR DESCRIPTION
## Description
encodeURI does not encode semicolons, which are not allowed in cookie values. encodeURIComponents does. Using encodeURI, the cookie will only be stored up to the first semicolon and thus cannot be completely retrieved afterwards.


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | [SW-17497](https://issues.shopware.com/issues/SW-17497) 
| How to test?     | On javascript console: <br/><code>StorageManager.getLocalStorage().setItem("Foo", "Bar; Baz"); </code><br/>reload the page;  <br/><code>StorageManager.getLocalStorage().getItem("Foo"); // -> JSON decoding exception</code>

