### PR TITLE
Media converter fix

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -659,10 +659,10 @@ class LegacyStructConverter
     }
 
     /**
-     * @param StoreFrontBundle\Struct\Media $media
+     * @param $media
      * @return array
      */
-    public function convertMediaStruct(StoreFrontBundle\Struct\Media $media)
+    public function convertMediaStruct($media)
     {
         if (!$media instanceof StoreFrontBundle\Struct\Media) {
             return [];

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -664,6 +664,7 @@ class LegacyStructConverter
      */
     public function convertMediaStruct($media)
     {
+        /** @var \Shopware\Bundle\StoreFrontBundle\Struct\Media $media */
         if (!$media instanceof StoreFrontBundle\Struct\Media) {
             return [];
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
Under PHP 7 if NULL is passed to convertMediaStruct, e.g. if the image is missing, an unrecoverable fatal error is thrown. If this happens inside digital publishing, it can cause whole shopping worlds to fail to load. The first line of the function checks that $media is an instance of StoreFrontBundle\Struct\Media meaning the type declaration isn't strictly necessary.

* What does it improve?
Fixes a bug.

* Does it have side effects?
IDE auto-complete.



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | no
| Related tickets? | n/a
| How to test?     | Set up a digital publishing banner with a broken image, migrate from local image storage to s3 then try and load the digital publishing banner

