### PR TITLE
Make all attributes from s_articles_attributes available to productfeed

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -8,6 +8,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 * Fixed article api resource when creating a new article with new configurator options and an image mapping for this new options
 * Added cronjob registration via `Resources/cronjob.xml` file
+* Make all custom attributes available to productfeed
 
 ## 5.2.14
 

--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -750,6 +750,7 @@ class sExport
         $sql_add_join   = array();
         $sql_add_select = array();
         $sql_add_where  = array();
+        $sql_select_attributes = array();
 
         $skipBackend = $this->shop->get('skipbackend');
         $isoCode = $this->shop->get('isocode');
@@ -836,6 +837,18 @@ class sExport
             $sql_add_group_by = "d.id";
             $sql_add_article_detail_join_condition ='';
         }
+
+        $tableColumns = Shopware()->Container()->get('models')->getConnection()->getSchemaManager()->listTableDetails('s_articles_attributes')->getColumns();
+        foreach ($tableColumns as $column) {
+            $columnName = $column->getName();
+            if (
+                $columnName !== 'id'
+                && $columnName !== 'articleID'
+                && $columnName !== 'articledetailsID') {
+                $sql_select_attributes[] = 'at.' . $columnName;
+            }
+        }
+        $sql_select_attributes = implode(", ", $sql_select_attributes);
 
         $grouppricefield = "gp.price";
         if (
@@ -947,8 +960,7 @@ class sExport
                 d.weight,
                 d.position,
 
-                at.attr1, at.attr2, at.attr3, at.attr4, at.attr5, at.attr6, at.attr7, at.attr8, at.attr9, at.attr10,
-                at.attr11, at.attr12, at.attr13, at.attr14, at.attr15, at.attr16, at.attr17, at.attr18, at.attr19, at.attr20,
+                $sql_select_attributes,
 
                 s.name as supplier,
                 u.unit,

--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -750,7 +750,7 @@ class sExport
         $sql_add_join   = array();
         $sql_add_select = array();
         $sql_add_where  = array();
-        $sql_select_attributes = array();
+        $sql_select_article_attributes = array();
 
         $skipBackend = $this->shop->get('skipbackend');
         $isoCode = $this->shop->get('isocode');
@@ -845,10 +845,14 @@ class sExport
                 $columnName !== 'id'
                 && $columnName !== 'articleID'
                 && $columnName !== 'articledetailsID') {
-                $sql_select_attributes[] = 'at.' . $columnName;
+                if (substr($columnName, 0, 4) === "attr") {
+                    $sql_select_article_attributes[] = 'at.' . $columnName;
+                } else {
+                    $sql_select_article_attributes[] = 'at.' . $columnName . ' as "attribute.' . $columnName . '"';
+                }
             }
         }
-        $sql_select_attributes = implode(", ", $sql_select_attributes);
+        $sql_select_article_attributes = implode(", ", $sql_select_article_attributes);
 
         $grouppricefield = "gp.price";
         if (
@@ -960,7 +964,7 @@ class sExport
                 d.weight,
                 d.position,
 
-                $sql_select_attributes,
+                $sql_select_article_attributes,
 
                 s.name as supplier,
                 u.unit,


### PR DESCRIPTION
## Description
As for now, only attr1-attr20 are added to the SQL query and therefore are available to a productfeed. This PR adds all non-id fields of s_articles_attributes to the SQL query. That way custom attributes from plugins are available as well.
No other fields of the query are overwritten, attr1-attr20 are accessed the same way as before `{sArticle.attr1} `, plugin attributes are accessed via `{sArticle.["attribute.someplugin_someattribute"]} `
This PR does not introduce any breaking changes.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
|Related tickets?| -
|How to test?| Add a custom attribute of any installed plugin to any template of a ProductFeed `{sArticle.["attribute.someplugin_someattribute"]} `and export it. It now appears in the export document.

