### PR TITLE
Allow listing limit only on available values

### DIFF
--- a/engine/Shopware/Bundle/SearchBundle/CriteriaRequestHandler/CoreCriteriaRequestHandler.php
+++ b/engine/Shopware/Bundle/SearchBundle/CriteriaRequestHandler/CoreCriteriaRequestHandler.php
@@ -340,8 +340,14 @@ class CoreCriteriaRequestHandler implements CriteriaRequestHandlerInterface
      */
     private function addLimit(Request $request, Criteria $criteria)
     {
+        $pageSizes = explode("|", $this->config->get('numberArticlesToShow'));
         $limit = (int) $request->getParam('sPerPage', $this->config->get('articlesPerPage'));
         $limit = $limit >= 1 ? $limit: 1;
+
+        if (!in_array($limit, $pageSizes)) {
+            $limit = (int)$this->config->get('articlesPerPage');
+        }
+
         $criteria->limit($limit);
     }
 

--- a/engine/Shopware/Bundle/SearchBundle/CriteriaRequestHandler/CoreCriteriaRequestHandler.php
+++ b/engine/Shopware/Bundle/SearchBundle/CriteriaRequestHandler/CoreCriteriaRequestHandler.php
@@ -344,7 +344,7 @@ class CoreCriteriaRequestHandler implements CriteriaRequestHandlerInterface
         $limit = (int) $request->getParam('sPerPage', $this->config->get('articlesPerPage'));
         $limit = $limit >= 1 ? $limit: 1;
 
-        if (!in_array($limit, $pageSizes) && $request->getControllerName() == 'listing' && $request->getModuleName() == 'frontend') {
+        if (!in_array($limit, $pageSizes) && in_array($request->getControllerName(), ['listing', 'search']) && $request->getModuleName() == 'frontend') {
             $limit = (int)$this->config->get('articlesPerPage');
         }
 

--- a/engine/Shopware/Bundle/SearchBundle/CriteriaRequestHandler/CoreCriteriaRequestHandler.php
+++ b/engine/Shopware/Bundle/SearchBundle/CriteriaRequestHandler/CoreCriteriaRequestHandler.php
@@ -344,7 +344,7 @@ class CoreCriteriaRequestHandler implements CriteriaRequestHandlerInterface
         $limit = (int) $request->getParam('sPerPage', $this->config->get('articlesPerPage'));
         $limit = $limit >= 1 ? $limit: 1;
 
-        if (!in_array($limit, $pageSizes)) {
+        if (!in_array($limit, $pageSizes) && $request->getControllerName() == 'listing' && $request->getModuleName() == 'frontend') {
             $limit = (int)$this->config->get('articlesPerPage');
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
I can go to very big shops with big categories and call the listing page with 99999 limit and use useless cpu and space(http-caching)
* What does it improve?
Sets the default listing limit, if limit value is not available
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Use limit 9999 or something else in listing page

