### PR TITLE
Show the correct filter value of RadioFacets on filter change

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.listing-actions.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.listing-actions.js
@@ -887,6 +887,9 @@
                     labelText = $label.prev('span').html() + $label.html();
                 } else if ($label.find('img').length) {
                     labelText = $label.find('img').attr('alt');
+                } else if ($label.closest(me.opts.filterComponentSelector).is('[data-filter-type="radio"]')) {
+                    var activeRadioId = $label.closest(me.opts.filterComponentSelector).find('input:checked').attr('id');
+                    labelText = me.$filterForm.find('label[for="'+me.escapeDoubleQuotes(activeRadioId)+'"]').html();
                 } else if (value > 0 || valueString.length > 0) {
                     labelText = $label.html();
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary? 
When having a radio facet in the frontend and the customer changes the selection, the label of the group is shown, not the selection
* What does it improve?
Shows the right label
* Does it have side effects?
No



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | -
| How to test?     | Create a radio facet and change the value in the listing or search

