### PR TITLE
Share Session between language Shops belong to the same main Shop

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
@@ -85,13 +85,13 @@ class Session
         /** @var $shop \Shopware\Models\Shop\Shop */
         $shop = $container->get('Shop');
 
-        $name = 'session-' . $shop->getId();
-        $sessionOptions['name'] = $name;
-
         $mainShop = $shop->getMain() ?: $shop;
         if ($mainShop->getAlwaysSecure()) {
             $sessionOptions['cookie_secure'] = true;
         }
+
+        $name = 'session-' . $mainShop->getId();
+        $sessionOptions['name'] = $name;
 
         if ($saveHandler) {
             session_set_save_handler($saveHandler);

--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -331,9 +331,17 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
             return;
         }
 
+        // Start session in frontend controllers
+        $session = Shopware()->Session();
+
+        if ($cookieKey !== null) {
+            $session->$cookieKey = $cookieValue;
+        }
+
         // Upgrade currency
-        if ($request->getCookie('currency') !== null) {
-            $currencyValue = $request->getCookie('currency');
+        if ( ($request->getCookie('currency') !== null) ||
+            (isset($session->sBasketCurrency) && $shop->getCurrency()->getId() != $session->sBasketCurrency && Shopware()->Modules()->Admin()->sCheckUser()) ) {
+            $currencyValue = ($request->getCookie('currency') !== null) ? $request->getCookie('currency'): $session->sBasketCurrency;
             foreach ($shop->getCurrencies() as $currency) {
                 if ($currencyValue == $currency->getId()
                     || $currencyValue == $currency->getCurrency()) {
@@ -341,13 +349,6 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
                     break;
                 }
             }
-        }
-
-        // Start session in frontend controllers
-        $session = Shopware()->Session();
-
-        if ($cookieKey !== null) {
-            $session->$cookieKey = $cookieValue;
         }
 
         // Refresh basket on currency change


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
### **Why is it necessary?**
Shopware added the ability to create a language Shops and this was so great.
but it handle the language Shops with the same logic off the sub Shop.

the language Shops used the same Template of the Main Shop and from the Name (language Shop) man suppose that he will just see the info in another language.

but when I visit for example the german Shop and I chose my products and add it to the Basket and then for some reason I chose to see something in the englisch language Shopware make a new Session and this case the following Problems:
1- I have a new Basket in the englisch Shop and if I want to continue in this Shop I must to add all the products that I have already added in the German Shop.
2- if I was already login in the German Shop. Shopware will log me out in the Englisch Shop and I must login again.

This logic is like a visiting a total different Shop but all what I wanted is to see the Shop in another language but I don want to redo all the steps again.

This logic with new Session is so gut with the subshops but make no sense with the language Shops. 

### **What does it improve?**
make just one Session for all the language Shops which belong to same main Shop by using the main Shop id as the session Name identifier. 
### **Does it have side effects?**
ja there is a side effect when we use a different  Currency for the language Shops and we have hier two case:
1- the user is not login before he change the language and in this case we have no problem the code will work without any problem.
2- the use had login the change the language hier after login the user with be connected to the customergroup (for example DE) which defined in the first Shop ( let us say that he use Euro as Currency)  and when he change the language he go to another Shop (which use USD as Currency) hier Shopware will show the pries for the user Customergroup but with a different Currency (USD in our Case).
**and Hier also we have two Cases :**
- in the backend I had configure the Currency Factor then Shopware will calculate the Preis in the new Currency and we have no problem.
- in the backend I had not configure the Currency Factor (I make the Currency Factor as 1) because I don't want the user to change the Currency and I attach the USD prices to another CustomerGroup (for example US) in this Case I will see the prices from the DE Customergroup with the USD Currency.

But I had already fixed this side effect by change the Code in the Routing Core Plugin you can find the changes in the same Comment.

with this changes I keep the original logic (for change Currency) from Shopware and add the case if some is login and change the language.


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes
| Tests pass?      | yes
| Related tickets? | NO
| How to test?     | just create a language Shop go to this shop add some product or login then change the language.

