### PR TITLE
fix breadcrumb-items without links

### DIFF
--- a/themes/Frontend/Bare/frontend/index/breadcrumb.tpl
+++ b/themes/Frontend/Bare/frontend/index/breadcrumb.tpl
@@ -9,10 +9,16 @@
                 <li class="breadcrumb--entry{if $breadcrumb@last} is--active{/if}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
                     {if $breadcrumb.name}
                         {block name="frontend_index_breadcrumb_entry_inner"}
-                            <a class="breadcrumb--link" href="{if $breadcrumb.link}{$breadcrumb.link}{else}#{/if}" title="{$breadcrumb.name|escape}" itemprop="item">
-                                <link itemprop="url" href="{if $breadcrumb.link}{$breadcrumb.link}{else}#{/if}" />
-                                <span class="breadcrumb--title" itemprop="name">{$breadcrumb.name}</span>
-                            </a>
+                            {if $breadcrumb.link}
+                                <a class="breadcrumb--link" href="{$breadcrumb.link}" title="{$breadcrumb.name|escape}" itemprop="item">
+                                    <link itemprop="url" href="{$breadcrumb.link}" />
+                                    <span class="breadcrumb--title" itemprop="name">{$breadcrumb.name}</span>
+                                </a>
+                            {else}
+                                <span class="breadcrumb--link" itemprop="item">
+                                    <span class="breadcrumb--title" itemprop="name">{$breadcrumb.name}</span>
+                                </span>
+                            {/if}
                             <meta itemprop="position" content="{$breadcrumb@index}" />
                         {/block}
                     {/if}


### PR DESCRIPTION
This PR prevents breadcrumb-items without link from being rendered with an `<a>`-element.

Instead items without link get rendered as spans. This doesn't break styling or semantics.

## Description
Please describe your pull request:
* Why is it necessary? Prevent customer confusion from "broken" links
* What does it improve? UX
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes/no
| Tests pass?      | yes/no
| Related tickets? | If this PR fixes an existing [Issue](https://issues.shopware.com) ticket, please add its complete issue URL.
| How to test?     | Please describe how to best verify that this PR is correct.

