### PR TITLE
Add theme synchronize command

### DIFF
--- a/engine/Shopware/Commands/ThemeSynchronizeCommand.php
+++ b/engine/Shopware/Commands/ThemeSynchronizeCommand.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Components\Console\Command
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class ThemeSynchronizeCommand extends ShopwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sw:theme:synchronize')
+            ->setDescription('Synchronizes theme configurations with the database')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var \Shopware\Components\Theme\Installer $themeService */
+        $themeService = $this->container->get('theme_installer');
+        $themeService->synchronize();
+
+        $output->writeln('synchronized successfully');
+    }
+}


### PR DESCRIPTION
This PR adds a command to automatically synchronize the theme-config in the database with the ones from the Theme.php.

## Description
Please describe your pull request:
* Why is it necessary? User is wondering why there is a field missing from the Theme-Config – He doesn't know he has to reload the config
* What does it improve? Automatic Theme-Deployment. Now there's a command for adding the missing fields
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | run `bin/console sw:theme:synchronize`

