### PR TITLE
Dump theme config typo

### DIFF
--- a/engine/Shopware/Commands/ThemeDumpConfigurationCommand.php
+++ b/engine/Shopware/Commands/ThemeDumpConfigurationCommand.php
@@ -62,7 +62,7 @@ class ThemeDumpConfigurationCommand extends ShopwareCommand
             $configuration = $compiler->getThemeConfiguration($shop);
             $file = $this->dumpConfiguration($shop, $configuration);
             $file = str_replace($rootDir, '', $file);
-            $output->writeln("file : " . $file . " generated");
+            $output->writeln("file: " . $file . " generated");
         }
     }
 


### PR DESCRIPTION
This PR fixes a typo

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | run `bin/console sw:theme:dump:config`

