### PR TITLE
Check if javascript files exist before compiling

### DIFF
--- a/themes/Gruntfile.js
+++ b/themes/Gruntfile.js
@@ -10,12 +10,12 @@ module.exports = function (grunt) {
 
     lessTargetFile['../' + config.lessTarget] = '../web/cache/all.less';
 
-    config['js'].forEach(function (item) {
+    config.js.forEach(function (item) {
         jsFiles.push('../' + item);
     });
     jsTargetFile['../' + config.jsTarget] = jsFiles;
 
-    config['less'].forEach(function (item) {
+    config.less.forEach(function (item) {
         content += `@import "../${item}";`;
     });
     grunt.file.write('../web/cache/all.less', content);
@@ -93,6 +93,9 @@ module.exports = function (grunt) {
                 'Gruntfile.js',
                 'Frontend/Responsive/frontend/_public/src/js/*.js'
             ]
+        },
+        fileExists: {
+            js: jsFiles
         }
     });
 
@@ -100,8 +103,9 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-chokidar');
     grunt.loadNpmTasks('gruntify-eslint');
+    grunt.loadNpmTasks('grunt-file-exists');
 
     grunt.renameTask('chokidar', 'watch');
     grunt.registerTask('production', [ 'eslint', 'less:production', 'uglify:production' ]);
-    grunt.registerTask('default', [ 'less:development', 'uglify:development', 'watch' ]);
+    grunt.registerTask('default', [ 'fileExists:js', 'less:development', 'uglify:development', 'watch' ]);
 };

--- a/themes/package.json
+++ b/themes/package.json
@@ -12,6 +12,7 @@
     "grunt-chokidar": "^1.0.0",
     "grunt-contrib-less": "^1.0.1",
     "grunt-contrib-uglify": "^0.9.1",
+    "grunt-file-exists": "^0.1.4",
     "gruntify-eslint": "^3.1.0"
   }
 }


### PR DESCRIPTION
This PR adds a check to see if all given javascript-files exist before compiling.

This check only runs in development.

The check runs in under 200ms on my machine which is nothing compared to the compilation of the assets.

## Description
Please describe your pull request:
* Why is it necessary?
Uglify doesn't check whether or not the given files exist, so if there's a spelling error in someones Theme.php they're left to wonder why e.g. their javascript-plugin is not available.

* What does it improve?
Developer experience

* Does it have side effects?
No



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | run `grunt`

