### PR TITLE
Fix emotion video button

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/hacks.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/hacks.less
@@ -99,3 +99,17 @@ More precise designations are commented inside the document.
         font-size: 5px;
     }
 }
+
+// hide ios video play-button
+video::-webkit-media-controls-panel {
+    display: none !important;
+    -webkit-appearance: none;
+}
+video::--webkit-media-controls-play-button {
+    display: none !important;
+    -webkit-appearance: none;
+}
+video::-webkit-media-controls-start-playback-button {
+    display: none !important;
+    -webkit-appearance: none;
+}


### PR DESCRIPTION
This PR hides iOS video-playback buttons which get distorted in emotion-widgets due to shopware's scaling of video-elements.

![image](https://cloud.githubusercontent.com/assets/765896/22296570/d8850110-e31a-11e6-9b93-0cbd6ae563a5.png)
Th white circle is the iOS-Play button. distorted due to `transform: scale`

## Description
Please describe your pull request:
* Why is it necessary? see screenshot
* What does it improve? hide the button
* Does it have side effects? no. this doesn't affect usability as it has no consequences for functionality




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | add a video-element

