### PR TITLE
Add Smarty-blocks in the document template for the address

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -2,6 +2,15 @@
 
 This changelog references changes done in Shopware 5.2 patch versions.
 
+## 5.2.17
+
+[View all changes from v5.2.14...v5.2.15](https://github.com/shopware/shopware/compare/v5.2.16...v5.2.17)
+
+* Added new Smarty blocks to `documents/index.tpl`
+    * `document_index_address`
+    * `document_index_address_sender`
+    * `document_index_address_base`
+
 ## 5.2.15
 
 [View all changes from v5.2.14...v5.2.15](https://github.com/shopware/shopware/compare/v5.2.14...v5.2.15)

--- a/themes/Frontend/Bare/documents/index.tpl
+++ b/themes/Frontend/Bare/documents/index.tpl
@@ -85,31 +85,37 @@ td.head  {
                 {assign var="address" value="billing"}
             {/block}
             <div id="head_sender">
-                <p class="sender">{$Containers.Header_Sender.value}</p>
-                {$User.$address.company}<br />
-                {$User.$address.salutation|salutation}
-                {if {config name="displayprofiletitle"}}
-                    {$User.$address.title}<br/>
-                {/if}
-                {$User.$address.firstname} {$User.$address.lastname}<br />
-                {$User.$address.street}<br />
-                {block name="document_index_address_additionalAddressLines"}
-                    {if {config name=showAdditionAddressLine1}}
-                        {$User.$address.additional_address_line1}<br />
-                    {/if}
-                    {if {config name=showAdditionAddressLine2}}
-                        {$User.$address.additional_address_line2}<br />
-                    {/if}
-                {/block}
-                {block name="document_index_address_cityZip"}
-                    {if {config name=showZipBeforeCity}}
-                        {$User.$address.zipcode} {$User.$address.city}<br />
-                    {else}
-                        {$User.$address.city} {$User.$address.zipcode}<br />
-                    {/if}
-                {/block}
-                {block name="document_index_address_countryData"}
-                    {if $User.$address.state.shortcode}{$User.$address.state.shortcode} - {/if}{$User.$address.country.countryen}<br />
+                {block name="document_index_address"}
+                    {block name="document_index_address_sender"}
+                        <p class="sender">{$Containers.Header_Sender.value}</p>
+                    {/block}
+                    {block name="document_index_address_base"}
+                        {$User.$address.company}<br />
+                        {$User.$address.salutation|salutation}
+                        {if {config name="displayprofiletitle"}}
+                            {$User.$address.title}<br/>
+                        {/if}
+                        {$User.$address.firstname} {$User.$address.lastname}<br />
+                        {$User.$address.street}<br />
+                    {/block}
+                    {block name="document_index_address_additionalAddressLines"}
+                        {if {config name=showAdditionAddressLine1}}
+                            {$User.$address.additional_address_line1}<br />
+                        {/if}
+                        {if {config name=showAdditionAddressLine2}}
+                            {$User.$address.additional_address_line2}<br />
+                        {/if}
+                    {/block}
+                    {block name="document_index_address_cityZip"}
+                        {if {config name=showZipBeforeCity}}
+                            {$User.$address.zipcode} {$User.$address.city}<br />
+                        {else}
+                            {$User.$address.city} {$User.$address.zipcode}<br />
+                        {/if}
+                    {/block}
+                    {block name="document_index_address_countryData"}
+                        {if $User.$address.state.shortcode}{$User.$address.state.shortcode} - {/if}{$User.$address.country.countryen}<br />
+                    {/block}
                 {/block}
             </div>
         {/if}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
Without these blocks, when changing something at the address in the document templates, the whole template has to be copied 
* What does it improve?
Add blocks for better customization 
* Does it have side effects?
No

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | --
| How to test?     | Render documents with custom templates