### PR TITLE
Added config to toggle backend menu hover

### DIFF
--- a/_sql/migrations/812-add-backend-config-menu-hover.php
+++ b/_sql/migrations/812-add-backend-config-menu-hover.php
@@ -1,0 +1,17 @@
+<?php
+
+class Migrations_Migration812 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('SET @formId = (SELECT id FROM `s_core_config_forms` WHERE `label` = \'Backend\');');
+
+        $this->addSql('INSERT IGNORE INTO `s_core_config_elements` (`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`) VALUES
+            (@formId, \'useBackendMenuHoverButton\', \'b:1;\', \'Hover im Menü aktiv?\', null, \'checkbox\', 0, 0, 0);');
+
+        $this->addSql('SET @elementId = (SELECT id FROM `s_core_config_elements` WHERE `name` = \'useBackendMenuHoverButton\' LIMIT 1)');
+
+        $this->addSql('INSERT IGNORE INTO `s_core_config_element_translations` (`element_id`, `locale_id`, `label`)
+        VALUES (@elementId, \'2\', \'Enable Hover Menu items?\');');
+    }
+}

--- a/themes/Backend/ExtJs/backend/index/menu.tpl
+++ b/themes/Backend/ExtJs/backend/index/menu.tpl
@@ -3,7 +3,7 @@
         [{foreach $menu as $category}
             {if ($category['onclick'] || $category['action'] || $category['children']) && {acl_is_allowed privilege=read resource=$category['controller']|lower}}
                 {
-                {if $level === 0}{if $category['children']}xtype: 'hoverbutton',{else}xtype: 'button',{/if}{/if}
+                {if $level === 0}{if $category['children']}xtype: '{if {config name="useBackendMenuHoverButton"}}hoverbutton{else}button{/if}',{else}xtype: 'button',{/if}{/if}
                 {$name = null}
                 {if $category['controller']}{$name = $category['controller']}{/if}
                 {if $category['action'] && $category['action'] != 'Index'}{$name = "{$category['controller']}/{$category['action']}"}{/if}


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Some customers hate the hovering of the menu in backend
* What does it improve?
Adds a config to disable it
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Switch the config and clear the cache