### PR TITLE
Clear config cache after saving config forms

### DIFF
--- a/engine/Shopware/Controllers/Backend/Config.php
+++ b/engine/Shopware/Controllers/Backend/Config.php
@@ -218,6 +218,8 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
             $this->saveElement($elementData, $defaultShop);
         }
 
+        $this->get('shopware.cache_manager')->clearConfigCache();
+
         $this->View()->assign(array('success' => true));
     }
 


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
I guess everyone know it which has done plugin support. The main question to the customer is have you cleared the cache after saving plugin configuration :)
* What does it improve?
Cleares automaticly after saving form
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | #526 last comment
| How to test?     | Please describe how to best verify that this PR is correct.

