### PR TITLE
Add empty block to body-element

### DIFF
--- a/themes/Frontend/Bare/frontend/index/index.tpl
+++ b/themes/Frontend/Bare/frontend/index/index.tpl
@@ -17,7 +17,7 @@
     {if $sTarget} is--target-{$sTarget|escapeHtml}{/if}
     {if $theme.checkoutHeader && (({controllerName|lower} == "checkout" && {controllerAction|lower} != "cart") || ({controllerName|lower} == "register" && $sTarget != "account"))} is--minimal-header{/if}
     {if !$theme.displaySidebar} is--no-sidebar{/if}
-    {/strip}{/block}">
+    {/strip}{/block}" {block name="frontend_index_body_attributes"}{/block}>
 
     {block name='frontend_index_after_body'}{/block}
 


### PR DESCRIPTION
This PR adds a new empty block to the body-element in order to add custom attributes to the `body`-element.

## Description
Please describe your pull request:
* Why is it necessary? Developer Experience 
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | In a custom theme use the `frontend_index_body_attributes` block to add new attributes to the body-element

