### PR TITLE
Add missing classes-block to content-main element

### DIFF
--- a/themes/Frontend/Bare/frontend/index/index.tpl
+++ b/themes/Frontend/Bare/frontend/index/index.tpl
@@ -82,7 +82,7 @@
             {/block}
 
             {block name='frontend_index_content_main'}
-                <section class="content-main container block-group">
+                <section class="{block name="frontend_index_content_main_classes"}content-main container block-group{/block}">
 
                     {* Breadcrumb *}
                     {block name='frontend_index_breadcrumb'}


### PR DESCRIPTION
This PR adds a missing block to change the classes of the `.content-main`-element.

This provides an easy way to remove the `.container`-class from the element, which prevents the page from going full-width. Otherwise one would have to use javascript to remove the class or overwrite the whole containing block `frontend_index_content_main`. Both is cumbersome.

## Description
Please describe your pull request:
* Why is it necessary? Make creating full-width pages easier
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | In a custom theme, modify the `frontend_index_content_main_classes`-block

