### PR TITLE
fix a php notice if no child menus are present

### DIFF
--- a/engine/Shopware/Components/Plugin/XmlMenuReader.php
+++ b/engine/Shopware/Components/Plugin/XmlMenuReader.php
@@ -97,6 +97,7 @@ class XmlMenuReader
             $menuEntry['position'] = (int)$position[0]->nodeValue;
         }
 
+        $menuEntry['children'] = [];
         if ($children = $this->getChildren($entry, 'children')) {
             foreach ($this->getChildren($children[0], 'entry') as $child) {
                 $menuEntry['children'][] = $this->parseEntry($child);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
it fixes a notice inside the MenuSynchronizer.php on line 66 as no children are present in my current testcase
* What does it improve?
removes a notice
* Does it have side effects?
none i am aware of



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | none
| How to test?     | create a plugin and use the following menu.xml before and after applying my change

```
<?xml version="1.0" encoding="utf-8"?>
<menu xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.2/engine/Shopware/Components/Plugin/schema/menu.xsd">
    <entries>
        <entry>
            <name>Test</name>
            <label lang="en">Test</label>
            <controller>Test</controller>
            <action>index</action>
            <class>sprite-metronome</class>
            <parent identifiedBy="controller">ConfigurationMenu</parent>
        </entry>
    </entries>
</menu>
```

