### PR TITLE
Added plugin config element type button

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -17,6 +17,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
     * `document_index_address_sender`
     * `document_index_address_base`
 * Added `s_article_configurator_options_attributes` and `s_article_configurator_groups_attributes`
+* Added plugin config element type `button`
 
 ### Media Optimizer
 

--- a/engine/Shopware/Components/Plugin/MenuSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/MenuSynchronizer.php
@@ -63,10 +63,14 @@ class MenuSynchronizer
 
         $items = [];
         foreach ($menu as $menuItem) {
-            $childMenuNames = array_column($menuItem['children'], 'name');
-            if ($childMenuNames) {
-                $menuNames = array_merge($menuNames, $childMenuNames);
+            if (isset($menuItem['children'])) {
+                $childMenuNames = array_column($menuItem['children'], 'name');
+
+                if ($childMenuNames) {
+                    $menuNames = array_merge($menuNames, $childMenuNames);
+                }
             }
+
             if ($menuItem['isRootMenu']) {
                 $parent = null;
             } else {

--- a/engine/Shopware/Components/Plugin/schema/config.xsd
+++ b/engine/Shopware/Components/Plugin/schema/config.xsd
@@ -59,6 +59,7 @@
             <xsd:enumeration value="number"/>
             <xsd:enumeration value="select"/>
             <xsd:enumeration value="combo"/>
+            <xsd:enumeration value="button"/>
         </xsd:restriction>
     </xsd:simpleType>
 


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary? to allow buttons in plugin config form
* Does it have side effects? no

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | Install attached [LubischTest.zip](https://github.com/shopware/shopware/files/739894/LubischTest.zip)

The docs for this are ready and only need to be edited because of the shopware version.
-> https://github.com/shopware/devdocs/pull/497

There is also a little fix for a notice with following warning in the MenuSynchronizer.

PHP Notice:  Undefined index: children in /home/vagrant/www/engine/Shopware/Components/Plugin/MenuSynchronizer.php on line 66
PHP Warning:  array_column() expects parameter 1 to be array, null given in /home/vagrant/www/engine/Shopware/Components/Plugin/MenuSynchronizer.php on line 66




