### PR TITLE
Fixed plugin cronjob.xml boolean evaluation

### DIFF
--- a/engine/Shopware/Components/Plugin/XmlCronjobReader.php
+++ b/engine/Shopware/Components/Plugin/XmlCronjobReader.php
@@ -77,9 +77,9 @@ class XmlCronjobReader
 
         $cronjobEntry['name'] = $this->getFirstChild($entry, 'name');
         $cronjobEntry['action'] = $this->getFirstChild($entry, 'action');
-        $cronjobEntry['active'] = $this->toBool($this->getFirstChild($entry, 'active'));
+        $cronjobEntry['active'] = XmlUtils::phpize($this->getFirstChild($entry, 'active'));
         $cronjobEntry['interval'] = $this->getFirstChild($entry, 'interval');
-        $cronjobEntry['disable_on_error'] = $this->toBool($this->getFirstChild($entry, 'disableOnError'));
+        $cronjobEntry['disable_on_error'] = XmlUtils::phpize($this->getFirstChild($entry, 'disableOnError'));
 
         return $cronjobEntry;
     }
@@ -116,14 +116,5 @@ class XmlCronjobReader
         }
 
         return $children;
-    }
-
-    /**
-     * @param string $string
-     * @return bool
-     */
-    private function toBool($string)
-    {
-        return $string == 'true' ? true : false;
     }
 }


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary? if an boolean value equals integer 1 the value got evaluated as false
* What does it improve? boolean evaluation
* Does it have side effects? no

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes/no
| How to test?     |  install plugin [LubischTest_cronjob_bool.zip](https://github.com/shopware/shopware/files/740228/LubischTest_cronjob_bool.zip) - the configured "disableOnError" with 1 gets evaluated and saved as 0.

Reference: https://www.w3.org/TR/xmlschema11-2/#boolean


