### PR TITLE
Fix InvalidArgumentException if plugin services are empty

### DIFF
--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -167,7 +167,11 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
             new FileLocator()
         );
 
-        $loader->load($this->getPath().'/Resources/services.xml');
+        try {
+            $loader->load($this->getPath().'/Resources/services.xml');
+        } catch (\InvalidArgumentException $e) {
+            error_log($e);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary? an empty plugin services.xml leads after installation to an InvalidArgumentException and the whole system gets "503 Service Unavailable" as shop owner there is no non technical way to get rid of that
* What does it improve? the shop is not corrupted after plugin installation and the exception gets logged
* Does it have side effects? no

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes/no
| How to test?     | install plugin [LubischTest_services_empty.zip](https://github.com/shopware/shopware/files/740292/LubischTest_services_empty.zip) and go to frontend or reload backend



