### PR TITLE
Fix payment instance created_at column

### DIFF
--- a/_sql/migrations/919-fix-payment-instance-created-at-column-type.php
+++ b/_sql/migrations/919-fix-payment-instance-created-at-column-type.php
@@ -1,0 +1,19 @@
+<?php
+
+use Shopware\Components\Migrations\AbstractMigration;
+
+class Migrations_Migration919 extends AbstractMigration
+{
+    /**
+     * @inheritdoc
+     */
+    public function up($modus)
+    {
+        $sql = <<<SQL
+ALTER TABLE `s_core_payment_instance`
+  CHANGE `created_at` `created_at` DATETIME NOT NULL;
+SQL;
+
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Models/Payment/PaymentInstance.php
+++ b/engine/Shopware/Models/Payment/PaymentInstance.php
@@ -162,7 +162,7 @@ class PaymentInstance extends ModelEntity
     /**
      * @var \DateTime $createdAt
      *
-     * @ORM\Column(name="created_at", type="date", nullable=false)
+     * @ORM\Column(name="created_at", type="datetime", nullable=false)
      */
     protected $createdAt;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
It sets the correct sql column type for the creation date of payment instances in order to save the exact time of payments (not just the date).
* What does it improve?
Improved analysis and ERP order processing due to accurate timestamps.
* Does it have side effects?
No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | -
| How to test?     | Running tests.

