### PR TITLE
Create attributes using attributes.xml

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/services.xml
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/services.xml
@@ -23,6 +23,7 @@
             <argument type="service" id="shopware.plugin_requirement_validator" />
             <argument type="service" id="db_connection" />
             <argument>%kernel.root_dir%</argument>
+            <argument type="service" id="shopware_plugininstaller.synchronizer.attribute"/>
         </service>
 
         <service id="shopware_plugininstaller.legacy_plugin_installer" class="Shopware\Bundle\PluginInstallerBundle\Service\LegacyPluginInstaller">
@@ -94,6 +95,12 @@
             <argument type="service" id="shopware_plugininstaller.store_client" />
             <argument type="service" id="models"/>
             <argument type="service" id="shopware_plugininstaller.plugin_licence_service" />
+        </service>
+
+        <service id="shopware_plugininstaller.synchronizer.attribute" class="Shopware\Components\Plugin\AttributeSynchronizer">
+            <argument type="service" id="dbal_connection" />
+            <argument type="service" id="models" />
+            <argument type="service" id="shopware_attribute.crud_service"/>
         </service>
     </services>
 </container>

--- a/engine/Shopware/Components/Plugin/AttributeSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/AttributeSynchronizer.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin;
+
+use DateTime;
+use Doctrine\DBAL\Connection;
+use Shopware\Bundle\AttributeBundle\Service\CrudService;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Models\Plugin\Plugin;
+
+/**
+ * Class AttributeSynchronizer
+ * @package Shopware\Components\Plugin
+ */
+class AttributeSynchronizer
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var ModelManager
+     */
+    private $models;
+
+    /**
+     * @var CrudService
+     */
+    private $crudService;
+
+    /**
+     * AttributeSynchronizer constructor.
+     * @param Connection $connection
+     * @param ModelManager $models
+     * @param CrudService $crudService
+     */
+    public function __construct(Connection $connection, ModelManager $models, CrudService $crudService)
+    {
+        $this->connection = $connection;
+        $this->models = $models;
+        $this->crudService = $crudService;
+    }
+
+    /**
+     * @param array $attributes
+     * @throws \InvalidArgumentException
+     */
+    public function installAttributes(array $attributes)
+    {
+        foreach ($attributes as $table => $attribute) {
+            $this->addAttributes($table, $attribute);
+        }
+
+        $this->models->generateAttributeModels(array_keys($attributes));
+    }
+
+    /**
+     * @param array $attributes
+     * @throws \InvalidArgumentException
+     */
+    public function uninstallAttributes(array $attributes)
+    {
+        foreach ($attributes as $table => $attribute) {
+            $this->removeAttributes($table, $attribute);
+        }
+
+        $this->models->generateAttributeModels(array_keys($attributes));
+    }
+
+    /**
+     * @param string $tableName
+     * @param array $attributeConfigurations
+     */
+    private function addAttributes($tableName, $attributeConfigurations)
+    {
+        foreach ($attributeConfigurations as $attributeConfiguration) {
+            $this->crudService->update(
+                $tableName,
+                $attributeConfiguration['name'],
+                $attributeConfiguration['type'],
+                $attributeConfiguration,
+                null,
+                $attributeConfiguration['updateDependingTables'],
+                $attributeConfiguration['defaultValue']
+            );
+        }
+    }
+
+    /**
+     * @param string $tableName
+     * @param array $attributeConfigurations
+     */
+    private function removeAttributes($tableName, $attributeConfigurations)
+    {
+        foreach ($attributeConfigurations as $attributeConfiguration) {
+            $this->crudService->delete(
+                $tableName,
+                $attributeConfiguration['name'],
+                $attributeConfiguration['updateDependingTables']
+            );
+        }
+    }
+}

--- a/engine/Shopware/Components/Plugin/XmlAttributeReader.php
+++ b/engine/Shopware/Components/Plugin/XmlAttributeReader.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin;
+
+use Symfony\Component\Config\Util\XmlUtils;
+
+/**
+ * Class XmlAttributeReader
+ * @package Shopware\Components\Plugin
+ */
+class XmlAttributeReader
+{
+    private $boolFields = ['translatable', 'displayInBackend', 'custom', 'updateDependingTables'];
+
+    /**
+     * @param string $file
+     * @return array
+     */
+    public function read($file)
+    {
+        try {
+            $dom = XmlUtils::loadFile($file, __DIR__.'/schema/attributes.xsd');
+        } catch (\Exception $e) {
+            throw new \InvalidArgumentException(sprintf('Unable to parse file "%s".', $file), $e->getCode(), $e);
+        }
+
+        return $this->parseInfo($dom);
+    }
+
+    /**
+     * @param \DOMDocument $xml
+     * @return array
+     */
+    private function parseInfo(\DOMDocument $xml)
+    {
+        $xpath = new \DOMXPath($xml);
+
+        if (false === $entries = $xpath->query('//tables/table')) {
+            return;
+        }
+
+        $attributes = [];
+        /** @var \DOMElement $entry */
+        foreach ($entries as $entry) {
+            $attributes[$entry->getAttribute('name')] = $this->parseTable($entry);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param \DOMElement $entry
+     * @return array
+     */
+    private function parseTable(\DOMElement $entry)
+    {
+        $entries = [];
+        foreach ($this->getChildren($entry, 'attribute') as $child) {
+            $entryArray = [];
+
+            $entryArray['name'] = $child->getAttribute('name');
+            $entryArray['type'] = $child->getAttribute('type');
+            $entryArray['label'] = $this->getFirstChild($child, 'label');
+            $entryArray['supportText'] = $this->getFirstChild($child, 'supportText');
+            $entryArray['helpText'] = $this->getFirstChild($child, 'helpText');
+            $entryArray['translatable'] = $this->getFirstChild($child, 'translatable');
+            $entryArray['displayInBackend'] = $this->getFirstChild($child, 'displayInBackend');
+            $entryArray['custom'] = $this->getFirstChild($child, 'custom');
+            $entryArray['updateDependingTables'] = $this->getFirstChild($child, 'updateDependingTables');
+            $entryArray['defaultValue'] = $this->getFirstChild($child, 'defaultValue');
+            $entryArray['entity'] = $this->getFirstChild($child, 'entity');
+            $entryArray['position'] = $this->getFirstChild($child, 'position');
+
+            $arrayStore = $this->getChildren($child, 'arrayStore');
+            if ($arrayStore[0]) {
+                $entryArray['arrayStore'] = $this->parseArrayStore($this->getChildren($arrayStore[0], 'option'));
+            }
+
+            // Remove empty fields
+            foreach ($entryArray as $key => $item) {
+                if ($item === null) {
+                    unset($entryArray[$key]);
+                    continue;
+                }
+
+                if (in_array($key, $this->boolFields)) {
+                    $entryArray[$key] = XmlUtils::phpize($entryArray[$key]);
+                }
+            }
+
+            // Default fields
+
+            if (!isset($entryArray['updateDependingTables'])) {
+                $entryArray['updateDependingTables'] = false;
+            }
+
+            if (!isset($entryArray['defaultValue'])) {
+                $entryArray['defaultValue'] = null;
+            }
+
+            $entries[] = $entryArray;
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param array $entries
+     * @return array
+     */
+    private function parseArrayStore(array $entries)
+    {
+        $arrayStore = [];
+
+        /** @var \DOMElement $entry */
+        foreach ($entries as $entry) {
+            $arrayStore[] = ['key' => $entry->getAttribute('key'), 'value' => $entry->nodeValue];
+        }
+
+        return $arrayStore;
+    }
+
+    /**
+     * @param \DOMNode $node
+     * @param $name
+     * @return null|string
+     */
+    private function getFirstChild(\DOMNode $node, $name)
+    {
+        if ($children = $this->getChildren($node, $name)) {
+            return $children[0]->nodeValue;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get child elements by name.
+     *
+     * @param \DOMNode $node
+     * @param mixed    $name
+     *
+     * @return \DOMElement[]
+     */
+    private function getChildren(\DOMNode $node, $name)
+    {
+        $children = array();
+        foreach ($node->childNodes as $child) {
+            if ($child instanceof \DOMElement && $child->localName === $name) {
+                $children[] = $child;
+            }
+        }
+
+        return $children;
+    }
+}

--- a/engine/Shopware/Components/Plugin/XmlAttributeReader.php
+++ b/engine/Shopware/Components/Plugin/XmlAttributeReader.php
@@ -93,7 +93,7 @@ class XmlAttributeReader
             $entryArray['entity'] = $this->getFirstChild($child, 'entity');
             $entryArray['position'] = $this->getFirstChild($child, 'position');
 
-            $arrayStore = $this->getChildren($child, 'arrayStore');
+            $arrayStore = $this->getChildren($child, 'store');
             if ($arrayStore[0]) {
                 $entryArray['arrayStore'] = $this->parseArrayStore($this->getChildren($arrayStore[0], 'option'));
             }

--- a/engine/Shopware/Components/Plugin/schema/attributes.xsd
+++ b/engine/Shopware/Components/Plugin/schema/attributes.xsd
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+    <xsd:element name="tables" type="tablesType"/>
+
+    <xsd:complexType name="tablesType">
+        <xsd:sequence>
+            <xsd:element name="table" type="tableType" minOccurs="1" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="tableType" mixed="true">
+        <xsd:sequence>
+            <xsd:element name="attribute" type="attributeType" minOccurs="1" maxOccurs="unbounded"/>
+        </xsd:sequence>
+        <xsd:attribute name="name" type="tables" default="s_articles_attributes"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="attributeType">
+        <xsd:sequence>
+            <xsd:element name="label" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="supportText" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="helpText" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="displayInBackend" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="translatable" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="custom" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="updateDependingTables" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="defaultValue" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="entity" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="position" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="arrayStore" type="arrayStore" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+        <xsd:attribute name="name" type="xsd:string" use="required"/>
+        <xsd:attribute name="type" type="types" use="required"/>
+    </xsd:complexType>
+
+    <xsd:simpleType name="tables">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="s_article_configurator_groups_attributes"/>
+            <xsd:enumeration value="s_article_configurator_options_attributes"/>
+            <xsd:enumeration value="s_article_configurator_template_prices_attributes"/>
+            <xsd:enumeration value="s_article_configurator_templates_attributes"/>
+            <xsd:enumeration value="s_articles_attributes"/>
+            <xsd:enumeration value="s_articles_downloads_attributes"/>
+            <xsd:enumeration value="s_articles_esd_attributes"/>
+            <xsd:enumeration value="s_articles_img_attributes"/>
+            <xsd:enumeration value="s_articles_information_attributes"/>
+            <xsd:enumeration value="s_articles_prices_attributes"/>
+            <xsd:enumeration value="s_articles_supplier_attributes"/>
+            <xsd:enumeration value="s_blog_attributes"/>
+            <xsd:enumeration value="s_categories_attributes"/>
+            <xsd:enumeration value="s_cms_static_attributes"/>
+            <xsd:enumeration value="s_cms_support_attributes"/>
+            <xsd:enumeration value="s_core_auth_attributes"/>
+            <xsd:enumeration value="s_core_config_mails_attributes"/>
+            <xsd:enumeration value="s_core_countries_attributes"/>
+            <xsd:enumeration value="s_core_countries_states_attributes"/>
+            <xsd:enumeration value="s_core_customergroups_attributes"/>
+            <xsd:enumeration value="s_core_paymentmeans_attributes"/>
+            <xsd:enumeration value="s_emarketing_banners_attributes"/>
+            <xsd:enumeration value="s_emarketing_partner_attributes"/>
+            <xsd:enumeration value="s_emarketing_vouchers_attributes"/>
+            <xsd:enumeration value="s_emotion_attributes"/>
+            <xsd:enumeration value="s_export_attributes"/>
+            <xsd:enumeration value="s_filter_attributes"/>
+            <xsd:enumeration value="s_filter_options_attributes"/>
+            <xsd:enumeration value="s_filter_values_attributes"/>
+            <xsd:enumeration value="s_media_attributes"/>
+            <xsd:enumeration value="s_order_attributes"/>
+            <xsd:enumeration value="s_order_basket_attributes"/>
+            <xsd:enumeration value="s_order_billingaddress_attributes"/>
+            <xsd:enumeration value="s_order_details_attributes"/>
+            <xsd:enumeration value="s_order_documents_attributes"/>
+            <xsd:enumeration value="s_order_shippingaddress_attributes"/>
+            <xsd:enumeration value="s_premium_dispatch_attributes"/>
+            <xsd:enumeration value="s_product_streams_attributes"/>
+            <xsd:enumeration value="s_user_addresses_attributes"/>
+            <xsd:enumeration value="s_user_attributes"/>
+            <xsd:enumeration value="s_user_billingaddress_attributes"/>
+            <xsd:enumeration value="s_user_shippingaddress_attributes"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="types">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="string"/>
+            <xsd:enumeration value="text"/>
+            <xsd:enumeration value="html"/>
+            <xsd:enumeration value="integer"/>
+            <xsd:enumeration value="float"/>
+            <xsd:enumeration value="boolean"/>
+            <xsd:enumeration value="date"/>
+            <xsd:enumeration value="datetime"/>
+            <xsd:enumeration value="combobox"/>
+            <xsd:enumeration value="single_selection"/>
+            <xsd:enumeration value="multi_selection"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="arrayStore">
+        <xsd:sequence>
+            <xsd:element name="option" type="optionType" minOccurs="1" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="optionType">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute type="xsd:string" name="key" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+</xsd:schema>

--- a/engine/Shopware/Components/Plugin/schema/attributes.xsd
+++ b/engine/Shopware/Components/Plugin/schema/attributes.xsd
@@ -29,7 +29,7 @@
             <xsd:element name="defaultValue" type="xsd:string" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="entity" type="xsd:string" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="position" type="xsd:int" minOccurs="0" maxOccurs="1"/>
-            <xsd:element name="arrayStore" type="arrayStore" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="store" type="arrayStore" minOccurs="0" maxOccurs="1"/>
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" use="required"/>
         <xsd:attribute name="type" type="types" use="required"/>

--- a/tests/Unit/Components/Plugin/XmlAttributeReaderReaderTest.php
+++ b/tests/Unit/Components/Plugin/XmlAttributeReaderReaderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Shopware\Tests\Unit\Components\Plugin;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Components\Plugin\XmlAttributeReader;
+
+class XmlAttributeReaderReaderTest extends TestCase
+{
+    /**
+     * @var XmlAttributeReader
+     */
+    private $SUT;
+
+    private $result = [
+        's_articles_attributes' =>
+            [
+                0 =>
+                    [
+                        'name' => 'test',
+                        'type' => 'combobox',
+                        'label' => 'I am a checkbox',
+                        'supportText' => 'supportText',
+                        'helpText' => 'helpText',
+                        'translatable' => true,
+                        'displayInBackend' => true,
+                        'custom' => true,
+                        'updateDependingTables' => true,
+                        'arrayStore' =>
+                            [
+                                0 =>
+                                    [
+                                        'key' => '1',
+                                        'value' => 'Yes',
+                                    ],
+                                1 =>
+                                    [
+                                        'key' => '0',
+                                        'value' => 'No',
+                                    ],
+                            ],
+                        'defaultValue' => NULL,
+                    ],
+            ],
+    ];
+
+    protected function setUp()
+    {
+        $this->SUT = new XmlAttributeReader();
+    }
+
+    public function testCanReadAndVerify()
+    {
+        $result = $this->SUT->read(__DIR__.'/examples/attributes.xml');
+        $this->assertInternalType('array', $result);
+    }
+
+    public function testReadCronjob()
+    {
+        $result = $this->SUT->read(__DIR__.'/examples/attributes.xml');
+
+        $this->assertArraySubset($result, $this->result);
+    }
+}

--- a/tests/Unit/Components/Plugin/XmlAttributeReaderReaderTest.php
+++ b/tests/Unit/Components/Plugin/XmlAttributeReaderReaderTest.php
@@ -26,7 +26,7 @@ class XmlAttributeReaderReaderTest extends TestCase
                         'displayInBackend' => true,
                         'custom' => true,
                         'updateDependingTables' => true,
-                        'store' =>
+                        'arrayStore' =>
                             [
                                 0 =>
                                     [

--- a/tests/Unit/Components/Plugin/XmlAttributeReaderReaderTest.php
+++ b/tests/Unit/Components/Plugin/XmlAttributeReaderReaderTest.php
@@ -26,7 +26,7 @@ class XmlAttributeReaderReaderTest extends TestCase
                         'displayInBackend' => true,
                         'custom' => true,
                         'updateDependingTables' => true,
-                        'arrayStore' =>
+                        'store' =>
                             [
                                 0 =>
                                     [
@@ -39,7 +39,7 @@ class XmlAttributeReaderReaderTest extends TestCase
                                         'value' => 'No',
                                     ],
                             ],
-                        'defaultValue' => NULL,
+                        'defaultValue' => null,
                     ],
             ],
     ];

--- a/tests/Unit/Components/Plugin/examples/attributes.xml
+++ b/tests/Unit/Components/Plugin/examples/attributes.xml
@@ -11,10 +11,10 @@
             <translatable>true</translatable>
             <custom>true</custom>
             <updateDependingTables>true</updateDependingTables>
-            <arrayStore>
+            <store>
                 <option key="1">Yes</option>
                 <option key="0">No</option>
-            </arrayStore>
+            </store>
         </attribute>
     </table>
 </tables>

--- a/tests/Unit/Components/Plugin/examples/attributes.xml
+++ b/tests/Unit/Components/Plugin/examples/attributes.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tables xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../engine/Shopware/Components/Plugin/schema/attributes.xsd">
+
+    <table name="s_articles_attributes">
+        <attribute name="test" type="combobox">
+            <label>I am a checkbox</label>
+            <supportText>supportText</supportText>
+            <helpText>helpText</helpText>
+            <displayInBackend>true</displayInBackend>
+            <translatable>true</translatable>
+            <custom>true</custom>
+            <updateDependingTables>true</updateDependingTables>
+            <arrayStore>
+                <option key="1">Yes</option>
+                <option key="0">No</option>
+            </arrayStore>
+        </attribute>
+    </table>
+</tables>


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Added a way to create plugin attributes with xml
* What does it improve?
plugin install/update simplification
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | 

Example File:

```xml
<?xml version="1.0" encoding="utf-8"?>
<tables xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../../../../engine/Shopware/Components/Plugin/schema/attributes.xsd">

    <table name="s_articles_attributes">
        <attribute name="test" type="combobox">
            <label>I am a checkbox</label>
            <supportText>supportText</supportText>
            <helpText>helpText</helpText>
            <displayInBackend>true</displayInBackend>
            <translatable>true</translatable>
            <custom>true</custom>
            <updateDependingTables>true</updateDependingTables>
            <arrayStore>
                <option key="1">Yes</option>
                <option key="0">No</option>
            </arrayStore>
        </attribute>
    </table>
</tables>
```