### PR TITLE
emotion viewport connection improvment

### DIFF
--- a/themes/Backend/ExtJs/backend/emotion/view/detail/designer.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/detail/designer.js
@@ -267,14 +267,7 @@ Ext.define('Shopware.apps.Emotion.view.detail.Designer', {
 
     createGridView: function() {
         var me = this,
-            stateConnections = [ 'xl' ];
-
-        /**
-         * All viewports are initially connected when the emotion has no elements.
-         */
-        if (me.emotion.getElements().getCount() === 0) {
             stateConnections = [ 'xs', 's', 'm', 'l', 'xl' ];
-        }
 
         return me.grid = Ext.create('Shopware.apps.Emotion.view.detail.Grid', {
             emotion: me.emotion,

--- a/themes/Backend/ExtJs/backend/emotion/view/detail/grid.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/detail/grid.js
@@ -432,6 +432,12 @@ Ext.define('Shopware.apps.Emotion.view.detail.Grid', {
                 } else {
                     element.render(me.hiddenElements.getEl());
                 }
+
+                me.viewportStore.each(function(viewport) {
+                    if (!element.getVisible(viewport.get('alias')) && me.stateConnections.indexOf(viewport.get('alias')) !== -1) {
+                        delete me.stateConnections[me.stateConnections.indexOf(viewport.get('alias'))];
+                    }
+                });
             }
         });
 


### PR DESCRIPTION
## Description
Changes the current emotion designer behavior on editing emotions with at least one element.
Not sure if changes like this would be applicable for 5.2 but as it changes a backend behavior I set the PR to 5.3 branch. Hope this is correct.

Old behavior:   
If an emotion contains at least one element do not automaticly connect viewports on load. 

New behavior:
Connect viewports that do not contain any hidden elements


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Create new emotion; Create element; Unconnect Tablet; Add new element on tablet; Save and reopen emotion. Tablet is not connected but all other viewports are connected.

