### PR TITLE
fix checkout header generation not uniform

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/shipping_payment.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/shipping_payment.tpl
@@ -1,55 +1,4 @@
-{extends file="frontend/index/index.tpl"}
-
-{* Shop header *}
-{block name='frontend_index_navigation'}
-    {if !$theme.checkoutHeader}
-        {$smarty.block.parent}
-    {else}
-        {include file="frontend/checkout/header.tpl"}
-    {/if}
-{/block}
-
-{* Back to the shop button *}
-{block name='frontend_index_logo_trusted_shops' append}
-    {if $theme.checkoutHeader}
-        <a href="{url controller='index'}"
-           class="btn is--small btn--back-top-shop is--icon-left"
-           title="{"{s name='FinishButtonBackToShop' namespace='frontend/checkout/finish'}{/s}"|escape}">
-            <i class="icon--arrow-left"></i>
-            {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish"}{/s}
-        </a>
-    {/if}
-{/block}
-
-{* Hide sidebar left *}
-{block name='frontend_index_content_left'}
-    {if !$theme.checkoutHeader}
-        {$smarty.block.parent}
-    {/if}
-{/block}
-
-{* Hide breadcrumb *}
-{block name='frontend_index_breadcrumb'}{/block}
-
-{* Step box *}
-{block name='frontend_index_navigation_categories_top'}
-    {if !$theme.checkoutHeader}
-        {$smarty.block.parent}
-    {/if}
-
-    {include file="frontend/register/steps.tpl" sStepActive="paymentShipping"}
-{/block}
-
-{* Footer *}
-{block name="frontend_index_footer"}
-    {if !$theme.checkoutFooter}
-        {$smarty.block.parent}
-    {else}
-        {block name="frontend_index_checkout_shipping_payment_footer"}
-            {include file="frontend/index/footer_minimal.tpl"}
-        {/block}
-    {/if}
-{/block}
+{extends file="parent:frontend/checkout/confirm.tpl"}
 
 {* Main content *}
 {block name="frontend_index_content"}
@@ -57,3 +6,4 @@
         {include file="frontend/checkout/shipping_payment_core.tpl"}
     </div>
 {/block}
+


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
Headers are not generated uniformly
* What does it improve?
Uses the header generation from confirm in shipping_payment to have a single base
* Does it have side effects?
none that i can think of




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | --
| How to test?     |

