### PR TITLE
SW-16471 | API addresses - Customer Info fehlt

### DIFF
--- a/engine/Shopware/Models/Customer/AddressRepository.php
+++ b/engine/Shopware/Models/Customer/AddressRepository.php
@@ -158,6 +158,7 @@ class AddressRepository extends ModelRepository
 
         $builder->select([
             'address',
+            'customer',
             'attribute',
             'country',
             'state'
@@ -166,7 +167,8 @@ class AddressRepository extends ModelRepository
         $builder->from('Shopware\Models\Customer\Address', 'address')
             ->leftJoin('address.country', 'country')
             ->leftJoin('address.state', 'state')
-            ->leftJoin('address.attribute', 'attribute');
+            ->leftJoin('address.attribute', 'attribute')
+            ->join('address.customer', 'customer');
 
         if (!empty($filterBy)) {
             $builder->addFilter($filterBy);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
[the Address API Documentation](https://developers.shopware.com/developers-guide/rest-api/api-resource-address/) in Get ( list )  said:

> This API call returns an array of elements, one for each address. Each of these elements has the same structure like a single element above.

but when you call this API you can't find the Customer info.

* What does it improve?
add the Customer Info to the returned list.
* Does it have side effects?
NO



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | [SW-16471](http://issues.shopware.com/issues/SW-16471).
| How to test?     | just call the API.

