### PR TITLE
Fixed numeric snippet names

### DIFF
--- a/engine/Library/Enlight/Config/Adapter/DbTable.php
+++ b/engine/Library/Enlight/Config/Adapter/DbTable.php
@@ -175,7 +175,7 @@ class Enlight_Config_Adapter_DbTable extends Enlight_Config_Adapter
         $extends = $config->getExtends();
         $currentSection = is_array($section) ? implode(':', $section) : $section;
         while ($currentSection !== null) {
-            $data = $this->readSection($name, $currentSection) + $data;
+            $data = $data + $this->readSection($name, $currentSection);
             $currentSection = isset($extends[$currentSection]) ? $extends[$currentSection] : null;
         }
 

--- a/engine/Library/Enlight/Config/Adapter/DbTable.php
+++ b/engine/Library/Enlight/Config/Adapter/DbTable.php
@@ -175,7 +175,7 @@ class Enlight_Config_Adapter_DbTable extends Enlight_Config_Adapter
         $extends = $config->getExtends();
         $currentSection = is_array($section) ? implode(':', $section) : $section;
         while ($currentSection !== null) {
-            $data = array_merge($this->readSection($name, $currentSection), $data);
+            $data = $this->readSection($name, $currentSection) + $data;
             $currentSection = isset($extends[$currentSection]) ? $extends[$currentSection] : null;
         }
 


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Numeric snippet names, will be broken my array_merge
* What does it improve?
Using "+" to merge arrays
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Create snippet like {s name=200}200 km{/s} and change the value in backend, and show the result in frontend

