### PR TITLE
Use QueryBuilderFactoryInterface instead of QueryBuilderFactory implementation as parameter type.

### DIFF
--- a/engine/Shopware/Bundle/SearchBundle/README.md
+++ b/engine/Shopware/Bundle/SearchBundle/README.md
@@ -164,10 +164,10 @@ The following FacetHandler wants to display the total count of products which so
 class PluginFacetHandler implements \Shopware\Bundle\SearchBundleDBAL\FacetHandlerInterface
 {
     /**
-     * @param QueryBuilderFactory $queryBuilderFactory
+     * @param QueryBuilderFactoryInterface $queryBuilderFactory
      */
     public function __construct(
-        \Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory\QueryBuilderFactory $queryBuilderFactory
+        \Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface $queryBuilderFactory
     ) {
         $this->queryBuilderFactory = $queryBuilderFactory;
     }

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/CategoryFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/CategoryFacetHandler.php
@@ -29,10 +29,10 @@ use Shopware\Bundle\SearchBundle\Condition\CategoryCondition;
 use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\SearchBundle\FacetResult\TreeFacetResult;
 use Shopware\Bundle\SearchBundle\FacetResult\TreeItem;
-use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory;
 use Shopware\Bundle\SearchBundle\Facet;
 use Shopware\Bundle\SearchBundle\FacetInterface;
 use Shopware\Bundle\SearchBundleDBAL\FacetHandlerInterface;
+use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\Category;
 use Shopware\Bundle\StoreFrontBundle\Service\CategoryServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
@@ -51,7 +51,7 @@ class CategoryFacetHandler implements FacetHandlerInterface
     private $categoryService;
 
     /**
-     * @var QueryBuilderFactory
+     * @var QueryBuilderFactoryInterface
      */
     private $queryBuilderFactory;
 
@@ -71,14 +71,14 @@ class CategoryFacetHandler implements FacetHandlerInterface
 
     /**
      * @param CategoryServiceInterface $categoryService
-     * @param QueryBuilderFactory $queryBuilderFactory
+     * @param QueryBuilderFactoryInterface $queryBuilderFactory
      * @param \Shopware_Components_Snippet_Manager $snippetManager
      * @param QueryAliasMapper $queryAliasMapper
      * @param Connection $connection
      */
     public function __construct(
         CategoryServiceInterface $categoryService,
-        QueryBuilderFactory $queryBuilderFactory,
+        QueryBuilderFactoryInterface $queryBuilderFactory,
         \Shopware_Components_Snippet_Manager $snippetManager,
         QueryAliasMapper $queryAliasMapper,
         Connection $connection

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ImmediateDeliveryFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ImmediateDeliveryFacetHandler.php
@@ -28,9 +28,9 @@ use Shopware\Bundle\SearchBundle\FacetResult\BooleanFacetResult;
 use Shopware\Bundle\SearchBundleDBAL\ConditionHandler\ImmediateDeliveryConditionHandler;
 use Shopware\Bundle\SearchBundleDBAL\FacetHandlerInterface;
 use Shopware\Bundle\SearchBundle\Criteria;
-use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory;
 use Shopware\Bundle\SearchBundle\Facet;
 use Shopware\Bundle\SearchBundle\FacetInterface;
+use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Components\QueryAliasMapper;
 
@@ -42,7 +42,7 @@ use Shopware\Components\QueryAliasMapper;
 class ImmediateDeliveryFacetHandler implements FacetHandlerInterface
 {
     /**
-     * @var QueryBuilderFactory
+     * @var QueryBuilderFactoryInterface
      */
     private $queryBuilderFactory;
 
@@ -57,12 +57,12 @@ class ImmediateDeliveryFacetHandler implements FacetHandlerInterface
     private $fieldName;
 
     /**
-     * @param QueryBuilderFactory $queryBuilderFactory
+     * @param QueryBuilderFactoryInterface $queryBuilderFactory
      * @param \Shopware_Components_Snippet_Manager $snippetManager
      * @param QueryAliasMapper $queryAliasMapper
      */
     public function __construct(
-        QueryBuilderFactory $queryBuilderFactory,
+        QueryBuilderFactoryInterface $queryBuilderFactory,
         \Shopware_Components_Snippet_Manager $snippetManager,
         QueryAliasMapper $queryAliasMapper
     ) {

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ManufacturerFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ManufacturerFacetHandler.php
@@ -27,10 +27,10 @@ namespace Shopware\Bundle\SearchBundleDBAL\FacetHandler;
 use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\SearchBundle\FacetResult\ValueListFacetResult;
 use Shopware\Bundle\SearchBundle\FacetResult\ValueListItem;
-use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory;
 use Shopware\Bundle\SearchBundle\Facet;
 use Shopware\Bundle\SearchBundle\Condition;
 use Shopware\Bundle\SearchBundle\FacetInterface;
+use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Bundle\SearchBundleDBAL\FacetHandlerInterface;
 use Shopware\Bundle\StoreFrontBundle\Service\ManufacturerServiceInterface;
@@ -50,7 +50,7 @@ class ManufacturerFacetHandler implements FacetHandlerInterface
     private $manufacturerService;
 
     /**
-     * @var QueryBuilderFactory
+     * @var QueryBuilderFactoryInterface
      */
     private $queryBuilderFactory;
 
@@ -66,13 +66,13 @@ class ManufacturerFacetHandler implements FacetHandlerInterface
 
     /**
      * @param ManufacturerServiceInterface $manufacturerService
-     * @param QueryBuilderFactory $queryBuilderFactory
+     * @param QueryBuilderFactoryInterface $queryBuilderFactory
      * @param \Shopware_Components_Snippet_Manager $snippetManager
      * @param QueryAliasMapper $queryAliasMapper
      */
     public function __construct(
         ManufacturerServiceInterface $manufacturerService,
-        QueryBuilderFactory $queryBuilderFactory,
+        QueryBuilderFactoryInterface $queryBuilderFactory,
         \Shopware_Components_Snippet_Manager $snippetManager,
         QueryAliasMapper $queryAliasMapper
     ) {

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/PriceFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/PriceFacetHandler.php
@@ -26,12 +26,12 @@ namespace Shopware\Bundle\SearchBundleDBAL\FacetHandler;
 
 use Shopware\Bundle\SearchBundle\Condition\PriceCondition;
 use Shopware\Bundle\SearchBundle\FacetResult\RangeFacetResult;
-use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory;
 use Shopware\Bundle\SearchBundle\FacetInterface;
 use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\SearchBundleDBAL\PriceHelperInterface;
 use Shopware\Bundle\SearchBundleDBAL\FacetHandlerInterface;
 use Shopware\Bundle\SearchBundle\Facet;
+use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Components\QueryAliasMapper;
 
@@ -48,7 +48,7 @@ class PriceFacetHandler implements FacetHandlerInterface
     private $priceHelper;
 
     /**
-     * @var QueryBuilderFactory
+     * @var QueryBuilderFactoryInterface
      */
     private $queryBuilderFactory;
 
@@ -69,13 +69,13 @@ class PriceFacetHandler implements FacetHandlerInterface
 
     /**
      * @param PriceHelperInterface $priceHelper
-     * @param QueryBuilderFactory $queryBuilderFactory
+     * @param QueryBuilderFactoryInterface $queryBuilderFactory
      * @param \Shopware_Components_Snippet_Manager $snippetManager
      * @param QueryAliasMapper $queryAliasMapper
      */
     public function __construct(
         PriceHelperInterface $priceHelper,
-        QueryBuilderFactory $queryBuilderFactory,
+        QueryBuilderFactoryInterface $queryBuilderFactory,
         \Shopware_Components_Snippet_Manager $snippetManager,
         QueryAliasMapper $queryAliasMapper
     ) {

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ProductAttributeFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ProductAttributeFacetHandler.php
@@ -33,9 +33,9 @@ use Shopware\Bundle\SearchBundle\FacetResult\ValueListFacetResult;
 use Shopware\Bundle\SearchBundle\FacetResult\ValueListItem;
 use Shopware\Bundle\SearchBundleDBAL\FacetHandlerInterface;
 use Shopware\Bundle\SearchBundleDBAL\QueryBuilder;
-use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory;
 use Shopware\Bundle\SearchBundle\Facet\ProductAttributeFacet;
 use Shopware\Bundle\SearchBundle\FacetInterface;
+use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct;
 
 /**
@@ -46,7 +46,7 @@ use Shopware\Bundle\StoreFrontBundle\Struct;
 class ProductAttributeFacetHandler implements FacetHandlerInterface
 {
     /**
-     * @var QueryBuilderFactory
+     * @var QueryBuilderFactoryInterface
      */
     private $queryBuilderFactory;
 
@@ -56,11 +56,11 @@ class ProductAttributeFacetHandler implements FacetHandlerInterface
     private $snippetNamespace;
 
     /**
-     * @param QueryBuilderFactory $queryBuilderFactory
+     * @param QueryBuilderFactoryInterface $queryBuilderFactory
      * @param \Shopware_Components_Snippet_Manager $snippetManager
      */
     public function __construct(
-        QueryBuilderFactory $queryBuilderFactory,
+        QueryBuilderFactoryInterface $queryBuilderFactory,
         \Shopware_Components_Snippet_Manager $snippetManager
     ) {
         $this->queryBuilderFactory = $queryBuilderFactory;

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/PropertyFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/PropertyFacetHandler.php
@@ -29,12 +29,12 @@ use Shopware\Bundle\SearchBundle\FacetResult\FacetResultGroup;
 use Shopware\Bundle\SearchBundle\FacetResult\MediaListFacetResult;
 use Shopware\Bundle\SearchBundle\FacetResult\MediaListItem;
 use Shopware\Bundle\SearchBundle\FacetResult\ValueListFacetResult;
-use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory;
 use Shopware\Bundle\SearchBundle\FacetInterface;
 use Shopware\Bundle\SearchBundleDBAL\QueryBuilder;
 use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\SearchBundle\Facet;
 use Shopware\Bundle\SearchBundleDBAL\FacetHandlerInterface;
+use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct;
 use Shopware\Bundle\StoreFrontBundle\Gateway\PropertyGatewayInterface;
 use Shopware\Components\QueryAliasMapper;
@@ -52,7 +52,7 @@ class PropertyFacetHandler implements FacetHandlerInterface
     private $propertyGateway;
 
     /**
-     * @var QueryBuilderFactory
+     * @var QueryBuilderFactoryInterface
      */
     private $queryBuilderFactory;
 
@@ -63,12 +63,12 @@ class PropertyFacetHandler implements FacetHandlerInterface
 
     /**
      * @param PropertyGatewayInterface $propertyGateway
-     * @param QueryBuilderFactory $queryBuilderFactory
+     * @param QueryBuilderFactoryInterface $queryBuilderFactory
      * @param QueryAliasMapper $queryAliasMapper
      */
     public function __construct(
         PropertyGatewayInterface $propertyGateway,
-        QueryBuilderFactory $queryBuilderFactory,
+        QueryBuilderFactoryInterface $queryBuilderFactory,
         QueryAliasMapper $queryAliasMapper
     ) {
         $this->propertyGateway = $propertyGateway;

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ShippingFreeFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ShippingFreeFacetHandler.php
@@ -27,9 +27,9 @@ namespace Shopware\Bundle\SearchBundleDBAL\FacetHandler;
 use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\SearchBundle\FacetResult\BooleanFacetResult;
 use Shopware\Bundle\SearchBundleDBAL\FacetHandlerInterface;
-use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory;
 use Shopware\Bundle\SearchBundle\Facet;
 use Shopware\Bundle\SearchBundle\FacetInterface;
+use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Components\QueryAliasMapper;
 
@@ -41,7 +41,7 @@ use Shopware\Components\QueryAliasMapper;
 class ShippingFreeFacetHandler implements FacetHandlerInterface
 {
     /**
-     * @var QueryBuilderFactory
+     * @var QueryBuilderFactoryInterface
      */
     private $queryBuilderFactory;
 
@@ -56,12 +56,12 @@ class ShippingFreeFacetHandler implements FacetHandlerInterface
     private $fieldName;
 
     /**
-     * @param QueryBuilderFactory $queryBuilderFactory
+     * @param QueryBuilderFactoryInterface $queryBuilderFactory
      * @param \Shopware_Components_Snippet_Manager $snippetManager
      * @param QueryAliasMapper $queryAliasMapper
      */
     public function __construct(
-        QueryBuilderFactory $queryBuilderFactory,
+        QueryBuilderFactoryInterface $queryBuilderFactory,
         \Shopware_Components_Snippet_Manager $snippetManager,
         QueryAliasMapper $queryAliasMapper
     ) {

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/VoteAverageFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/VoteAverageFacetHandler.php
@@ -33,6 +33,7 @@ use Shopware\Bundle\SearchBundleDBAL\FacetHandlerInterface;
 use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory;
 use Shopware\Bundle\SearchBundle\Facet\VoteAverageFacet;
 use Shopware\Bundle\SearchBundle\FacetInterface;
+use Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct;
 use Shopware\Components\QueryAliasMapper;
 
@@ -44,7 +45,7 @@ use Shopware\Components\QueryAliasMapper;
 class VoteAverageFacetHandler implements FacetHandlerInterface
 {
     /**
-     * @var QueryBuilderFactory
+     * @var QueryBuilderFactoryInterface
      */
     private $queryBuilderFactory;
 
@@ -64,13 +65,13 @@ class VoteAverageFacetHandler implements FacetHandlerInterface
     private $fieldName;
 
     /**
-     * @param QueryBuilderFactory $queryBuilderFactory
+     * @param QueryBuilderFactoryInterface $queryBuilderFactory
      * @param \Doctrine\DBAL\Connection $connection
      * @param \Shopware_Components_Snippet_Manager $snippetManager
      * @param QueryAliasMapper $queryAliasMapper
      */
     public function __construct(
-        QueryBuilderFactory $queryBuilderFactory,
+        QueryBuilderFactoryInterface $queryBuilderFactory,
         Connection $connection,
         \Shopware_Components_Snippet_Manager $snippetManager,
         QueryAliasMapper $queryAliasMapper

--- a/engine/Shopware/Bundle/SearchBundleDBAL/ProductNumberSearch.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/ProductNumberSearch.php
@@ -39,7 +39,7 @@ use Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\Hydrator\AttributeHydrator;
 class ProductNumberSearch implements SearchBundle\ProductNumberSearchInterface
 {
     /**
-     * @var \Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory
+     * @var \Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface
      */
     private $queryBuilderFactory;
 
@@ -55,12 +55,12 @@ class ProductNumberSearch implements SearchBundle\ProductNumberSearchInterface
     private $eventManager;
 
     /**
-     * @param QueryBuilderFactory $queryBuilderFactory
+     * @param QueryBuilderFactoryInterface $queryBuilderFactory
      * @param \Enlight_Event_EventManager $eventManager
      * @param FacetHandlerInterface[] $facetHandlers
      */
     public function __construct(
-        QueryBuilderFactory $queryBuilderFactory,
+        QueryBuilderFactoryInterface $queryBuilderFactory,
         \Enlight_Event_EventManager $eventManager,
         $facetHandlers = []
     ) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

Currently many/all FacetHandlers are implemented to receive the actual `Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory` instead of the interface `Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactoryInterface`. This leads to fatal errors in PHP 7 when decorating `shopware_searchdbal.dbal_query_builder_factory`.

This PR changes the parameters to assume the `QueryBuilderFactoryInterface`.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? |
| How to test?     | Decorate `shopware_searchdbal.dbal_query_builder_factory` and load a listing page. You will see a fatal error. Apply the patch, you will not see a fatal error.

