### PR TITLE
Use di for router generators, matchers, pre/postfilters

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Router.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Router.php
@@ -4,9 +4,8 @@ namespace Shopware\Components\DependencyInjection\Bridge;
 use Shopware\Components\DependencyInjection\Container;
 use Enlight_Event_EventManager as EnlightEventManager;
 use Shopware\Components\Routing\Context;
-use Shopware\Components\Routing\Matchers;
-use Shopware\Components\Routing\Generators;
-use Shopware\Components\Routing\GeneratorFilters;
+use Shopware\Components\Routing\Router as RoutingRouter;
+use Shopware\Components\Routing\RouterInterface;
 
 /**
  * @category  Shopware
@@ -16,38 +15,21 @@ use Shopware\Components\Routing\GeneratorFilters;
 class Router
 {
     /**
-     * @param Container $container
      * @param EnlightEventManager $eventManager
-     * @return \Shopware\Components\Routing\RouterInterface
-     * @throws \Exception
+     * @param array $matchers
+     * @param array $generators
+     * @param array $preFilters
+     * @param array $postFilters
+     * @return RouterInterface
      */
     public function factory(
-        Container $container, EnlightEventManager $eventManager
+        EnlightEventManager $eventManager,
+        array $matchers,
+        array $generators,
+        array $preFilters,
+        array $postFilters
     ) {
-        $queryAliasMapper = $container->get('query_alias_mapper');
-
-        $matchers = [
-            new Matchers\RewriteMatcher($container->get('dbal_connection'), $queryAliasMapper),
-            new Matchers\EventMatcher($eventManager),
-            new Matchers\DefaultMatcher($container->get('dispatcher'))
-        ];
-
-        $generators = [
-            new Generators\RewriteGenerator($container->get('dbal_connection'), $queryAliasMapper, $eventManager),
-            new Generators\DefaultGenerator($container->get('dispatcher'))
-        ];
-
-        $preFilters = [
-            new GeneratorFilters\DefaultPreFilter(),
-            new GeneratorFilters\FrontendPreFilter(),
-        ];
-
-        $postFilters = [
-            new GeneratorFilters\FrontendPostFilter(),
-            new GeneratorFilters\DefaultPostFilter(),
-        ];
-
-        $router = new \Shopware\Components\Routing\Router(
+        $router = new RoutingRouter(
             Context::createEmpty(), // Request object will created on dispatch :/
             $matchers,
             $generators,
@@ -78,7 +60,7 @@ class Router
     {
         /** @var $container Container */
         $container = $args->getSubject();
-        /** @var $router \Shopware\Components\Routing\RouterInterface  */
+        /** @var $router RouterInterface  */
         $router = $container->get('router');
         /** @var $shop \Shopware\Models\Shop\Shop */
         $shop = $container->get('shop');
@@ -113,7 +95,7 @@ class Router
         /** @var $front \Enlight_Controller_Front */
         $front = $args->getSubject();
         $request = $front->Request();
-        /** @var $router \Shopware\Components\Routing\RouterInterface  */
+        /** @var $router RouterInterface  */
         $router = $front->Router();
         // Fix context on forward
         $context = $router->getContext();

--- a/engine/Shopware/Components/DependencyInjection/Compiler/RouterCompilerPass.php
+++ b/engine/Shopware/Components/DependencyInjection/Compiler/RouterCompilerPass.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+namespace Shopware\Components\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * @category  Shopware
+ * @package   Shopware\Components\DependencyInjection\Compiler
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class RouterCompilerPass implements CompilerPassInterface
+{
+    Use TagReplaceTrait;
+
+    public function process(ContainerBuilder $container)
+    {
+        $this->replaceArgumentWithTaggedServices($container, 'router', 'router.matcher', 1);
+        $this->replaceArgumentWithTaggedServices($container, 'router', 'router.generator', 2);
+        $this->replaceArgumentWithTaggedServices($container, 'router', 'router.prefilter', 3);
+        $this->replaceArgumentWithTaggedServices($container, 'router', 'router.postfilter', 4);
+    }
+}

--- a/engine/Shopware/Components/DependencyInjection/Compiler/RouterCompilerPass.php
+++ b/engine/Shopware/Components/DependencyInjection/Compiler/RouterCompilerPass.php
@@ -33,7 +33,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
  */
 class RouterCompilerPass implements CompilerPassInterface
 {
-    Use TagReplaceTrait;
+    use TagReplaceTrait;
 
     public function process(ContainerBuilder $container)
     {

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -97,8 +97,11 @@
         <service id="router_factory" class="Shopware\Components\DependencyInjection\Bridge\Router" />
         <service id="router" class="Shopware\Components\Routing\Router">
             <factory service="router_factory" method="factory" />
-            <argument type="service" id="service_container"/>
             <argument type="service" id="events"/>
+            <argument type="collection"/>
+            <argument type="collection"/>
+            <argument type="collection"/>
+            <argument type="collection"/>
         </service>
 
         <service id="dispatcher" class="Enlight_Controller_Dispatcher_Default" />
@@ -512,5 +515,47 @@
         <service id="shopware.api.shop" class="Shopware\Components\Api\Resource\Shop" shared="false" />
         <service id="shopware.api.translation" class="Shopware\Components\Api\Resource\Translation" shared="false" />
         <service id="shopware.api.variant" class="Shopware\Components\Api\Resource\Variant" shared="false" />
+
+        <service id="shopware.routing.matchers.rewrite_matcher" class="Shopware\Components\Routing\Matchers\RewriteMatcher">
+            <argument type="service" id="dbal_connection"/>
+            <argument type="service" id="query_alias_mapper"/>
+            <tag name="router.matcher"/>
+        </service>
+
+        <service id="shopware.routing.matchers.event_matcher" class="Shopware\Components\Routing\Matchers\EventMatcher">
+            <argument type="service" id="events"/>
+            <tag name="router.matcher"/>
+        </service>
+
+        <service id="shopware.routing.matchers.default_matcher" class="Shopware\Components\Routing\Matchers\DefaultMatcher">
+            <argument type="service" id="dispatcher"/>
+            <tag name="router.matcher"/>
+        </service>
+
+        <service id="shopware.routing.generators.rewrite_generator" class="Shopware\Components\Routing\Generators\RewriteGenerator">
+            <argument type="service" id="dbal_connection"/>
+            <argument type="service" id="query_alias_mapper"/>
+            <argument type="service" id="events"/>
+            <tag name="router.generator"/>
+        </service>
+
+        <service id="shopware.routing.generators.default_generator" class="Shopware\Components\Routing\Generators\DefaultGenerator">
+            <argument type="service" id="dispatcher"/>
+            <tag name="router.generator"/>
+        </service>
+
+        <service id="shopware.routing.prefilter.default_prefilter" class="Shopware\Components\Routing\GeneratorFilters\DefaultPreFilter">
+            <tag name="router.prefilter"/>
+        </service>
+        <service id="shopware.routing.prefilter.frontend_prefilter" class="Shopware\Components\Routing\GeneratorFilters\FrontendPreFilter">
+            <tag name="router.prefilter"/>
+        </service>
+
+        <service id="shopware.routing.postfilter.default_prefilter" class="Shopware\Components\Routing\GeneratorFilters\DefaultPostFilter">
+            <tag name="router.postfilter"/>
+        </service>
+        <service id="shopware.routing.postfilter.frontend_prefilter" class="Shopware\Components\Routing\GeneratorFilters\FrontendPostFilter">
+            <tag name="router.postfilter"/>
+        </service>
     </services>
 </container>

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -43,6 +43,7 @@ use Shopware\Components\DependencyInjection\Compiler\DoctrineEventSubscriberComp
 use Shopware\Components\DependencyInjection\Compiler\EventListenerCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EventSubscriberCompilerPass;
 use Shopware\Components\ConfigLoader;
+use Shopware\Components\DependencyInjection\Compiler\RouterCompilerPass;
 use Shopware\Components\DependencyInjection\Container;
 use Shopware\Components\Plugin;
 use Symfony\Component\ClassLoader\Psr4ClassLoader;
@@ -590,6 +591,7 @@ class Kernel implements HttpKernelInterface
         $container->addCompilerPass(new AddConsoleCommandPass());
         $container->addCompilerPass(new MediaAdapterCompilerPass());
         $container->addCompilerPass(new MediaOptimizerCompilerPass());
+        $container->addCompilerPass(new RouterCompilerPass());
 
         if ($this->isElasticSearchEnabled()) {
             $container->addCompilerPass(new SearchHandlerCompilerPass());


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
There are no events to add or replace matcher/generator or pre/postfilter
* What does it improve?
Gets generator, matchers pre/postfilter from di. That can be extended with tags router.matcher, router.generator, router.prefilter, router.postfilter
* Does it have side effects?
No



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | 

