### PR TITLE
Removed unnecessary SQL for current date in seoindex refresh

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/RebuildIndex/Components/SeoIndex.php
+++ b/engine/Shopware/Plugins/Default/Core/RebuildIndex/Components/SeoIndex.php
@@ -40,9 +40,9 @@ class Shopware_Components_SeoIndex extends Enlight_Class
 
         $cache = (int) Shopware()->Config()->routerCache;
         $cache = $cache < 360 ? 86400 : $cache;
-        $currentTime = Shopware()->Db()->fetchOne('SELECT ?', array(new Zend_Date()));
+        $currentTime = date('Y-m-d H:i:s');
 
-        if (strtotime($cachedTime) < strtotime($currentTime) - $cache) {
+        if (strtotime($cachedTime) < time() - $cache) {
             $this->setCachedTime($currentTime, $elementId, $shopId);
 
             $resultTime = Shopware()->Modules()->RewriteTable()->sCreateRewriteTable($cachedTime);


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
The query to mysql server is useless :)
* What does it improve?
Replaces with php code
* Does it have side effects?
nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes/no
| Tests pass?      | yes/no
| Related tickets? | If this PR fixes an existing [Issue](https://issues.shopware.com) ticket, please add its complete issue URL.
| How to test?     | Please describe how to best verify that this PR is correct.

