### PR TITLE
SW-17653 | $sArticle.image.description not filled properly on article detail page

### DIFF
--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -2087,7 +2087,9 @@ class sArticles
             $mainKey = 0;
 
             if (empty($sCombination)) {
-                $sArticle["image"]["description"] = is_null($sArticle["image"]["res"]["description"]) ? $sArticle["image"]["description"] : $sArticle["image"]["res"]["description"];;
+                if(!empty($sArticle["image"]["res"]["description"])) {
+                    $sArticle["image"]["description"] = $sArticle["image"]["res"]["description"];
+                }
                 $sArticle["image"]["relations"] = $sArticle["image"]["res"]["relations"];
                 foreach ($sArticle["sConfigurator"] as $key => $group) {
                     foreach ($group["values"] as $key2 => $option) {

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -2087,7 +2087,7 @@ class sArticles
             $mainKey = 0;
 
             if (empty($sCombination)) {
-                if(!empty($sArticle["image"]["res"]["description"])) {
+                if (!empty($sArticle["image"]["res"]["description"])) {
                     $sArticle["image"]["description"] = $sArticle["image"]["res"]["description"];
                 }
                 $sArticle["image"]["relations"] = $sArticle["image"]["res"]["relations"];

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -2087,7 +2087,7 @@ class sArticles
             $mainKey = 0;
 
             if (empty($sCombination)) {
-                $sArticle["image"]["description"] = $sArticle["image"]["description"] = is_null($sArticle["image"]["res"]["description"]) ? $sArticle["image"]["description"] : $sArticle["image"]["res"]["description"];;
+                $sArticle["image"]["description"] = is_null($sArticle["image"]["res"]["description"]) ? $sArticle["image"]["description"] : $sArticle["image"]["res"]["description"];;
                 $sArticle["image"]["relations"] = $sArticle["image"]["res"]["relations"];
                 foreach ($sArticle["sConfigurator"] as $key => $group) {
                     foreach ($group["values"] as $key2 => $option) {

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -2087,7 +2087,7 @@ class sArticles
             $mainKey = 0;
 
             if (empty($sCombination)) {
-                $sArticle["image"]["description"] = $sArticle["image"]["res"]["description"];
+                $sArticle["image"]["description"] = $sArticle["image"]["description"] = is_null($sArticle["image"]["res"]["description"]) ? $sArticle["image"]["description"] : $sArticle["image"]["res"]["description"];;
                 $sArticle["image"]["relations"] = $sArticle["image"]["res"]["relations"];
                 foreach ($sArticle["sConfigurator"] as $key => $group) {
                     foreach ($group["values"] as $key2 => $option) {


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
There are two issues (known bugs).
* What does it improve?
It makes sure all provided image descriptions are available on the article detail page, even if the article has configurator options
* Does it have side effects?
No.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes
| Tests pass?      | yes
| Related tickets? | [Issue 1](https://issues.shopware.com/issues/SW-14534) [Issue 2](https://issues.shopware.com/issues/SW-17653) 
| How to test?     | 2 Articles: one with variants and image description, one without variants and image description. Both descriptions must appear.

