### PR TITLE
use DI parameters for class names

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -9,6 +9,112 @@
             <parameter key="regexp">/([^A-Za-z0-9\.]|-)+/</parameter>
             <parameter key="lowercase">false</parameter>
         </parameter>
+
+        <parameter key="bootstrap.class">Shopware_Bootstrap</parameter>
+        <parameter key="locale_factory.class">Shopware\Components\DependencyInjection\Bridge\Locale</parameter>
+        <parameter key="currency_factory.class">Shopware\Components\DependencyInjection\Bridge\Currency</parameter>
+        <parameter key="currency.class">Zend_Currency</parameter>
+        <parameter key="snippet_resource.class">Enlight_Components_Snippet_Resource</parameter>
+        <parameter key="template_factory.class">Shopware\Components\DependencyInjection\Bridge\Template</parameter>
+        <parameter key="template.class">Enlight_Template_Manager</parameter>
+        <parameter key="session_factory.class">Shopware\Components\DependencyInjection\Bridge\Session</parameter>
+        <parameter key="session.class">Enlight_Components_Session_Namespace</parameter>
+        <parameter key="mailtransport_factory.class">Shopware\Components\DependencyInjection\Bridge\MailTransport</parameter>
+        <parameter key="mailtransport.class">Zend_Mail_Transport_Abstract</parameter>
+        <parameter key="mail_factory.class">Shopware\Components\DependencyInjection\Bridge\Mail</parameter>
+        <parameter key="mail.class">Enlight_Components_Mail</parameter>
+        <parameter key="templatemail_factory.class">Shopware\Components\DependencyInjection\Bridge\TemplateMail</parameter>
+        <parameter key="templatemail.class">Shopware_Components_TemplateMail</parameter>
+        <parameter key="plugins_factory.class">Shopware\Components\DependencyInjection\Bridge\Plugins</parameter>
+        <parameter key="plugins.class">Enlight_Plugin_PluginManager</parameter>
+        <parameter key="router_factory.class">Shopware\Components\DependencyInjection\Bridge\Router</parameter>
+        <parameter key="router.class">Shopware\Components\Routing\Router</parameter>
+        <parameter key="dispatcher.class">Enlight_Controller_Dispatcher_Default</parameter>
+        <parameter key="front_factory.class">Shopware\Components\DependencyInjection\Bridge\Front</parameter>
+        <parameter key="front.class">Enlight_Controller_Front</parameter>
+        <parameter key="date.class">Zend_Date</parameter>
+        <parameter key="loader.class">Enlight_Loader</parameter>
+        <parameter key="snippets.class">Shopware_Components_Snippet_Manager</parameter>
+        <parameter key="acl.class">Shopware_Components_Acl</parameter>
+        <parameter key="cron_adapter.class">Enlight_Components_Cron_Adapter_DBAL</parameter>
+        <parameter key="cron.class">Enlight_Components_Cron_Manager</parameter>
+        <parameter key="db_factory.class">Shopware\Components\DependencyInjection\Bridge\Db</parameter>
+        <parameter key="db.class">Enlight_Components_Db_Adapter_Pdo_Mysql</parameter>
+        <parameter key="http_client_factory.class">Shopware\Components\HttpClient\GuzzleFactory</parameter>
+        <parameter key="http_client.class">Shopware\Components\HttpClient\GuzzleHttpClient</parameter>
+        <parameter key="cache_factory.class">Shopware\Components\DependencyInjection\Bridge\Cache</parameter>
+        <parameter key="cache.class">Zend_Cache_Core</parameter>
+        <parameter key="config_factory.class">Shopware\Components\DependencyInjection\Bridge\Config</parameter>
+        <parameter key="config.class">Shopware_Components_Config</parameter>
+        <parameter key="events.class">Shopware\Components\ContainerAwareEventManager</parameter>
+        <parameter key="hooks.class">Enlight_Hook_HookManager</parameter>
+        <parameter key="model_config.class">Shopware\Components\Model\Configuration</parameter>
+        <parameter key="model_factory.class">Shopware\Components\DependencyInjection\Bridge\Models</parameter>
+        <parameter key="models.class">Shopware\Components\Model\ModelManager</parameter>
+        <parameter key="models_metadata_cache.class">Doctrine\Common\Cache\Cache</parameter>
+        <parameter key="dbal_connection_factory.class">Shopware\Components\DependencyInjection\Bridge\Db</parameter>
+        <parameter key="dbal_connection.class">Doctrine\DBAL\Connection</parameter>
+        <parameter key="model_annotations_factory.class">Shopware\Components\DependencyInjection\Bridge\ModelAnnotation</parameter>
+        <parameter key="model_annotations.class">Doctrine\ORM\Mapping\Driver\AnnotationDriver</parameter>
+        <parameter key="model_event_manager.class">Doctrine\Common\EventManager</parameter>
+        <parameter key="model_repository_factory.class">Shopware\Components\Model\ProxyAwareRepositoryFactory</parameter>
+        <parameter key="event_subscriber.class">Shopware\Components\Model\EventSubscriber</parameter>
+        <parameter key="order_history_subscriber.class">Shopware\Models\Order\OrderHistorySubscriber</parameter>
+        <parameter key="category_subscriber.class">Shopware\Components\Model\CategorySubscriber</parameter>
+        <parameter key="category_duplication.class">Shopware\Components\CategoryHandling\CategoryDuplicator</parameter>
+        <parameter key="category_denormalization.class">Shopware\Components\Model\CategoryDenormalization</parameter>
+        <parameter key="shopware.holiday_table_updater.class">Shopware\Components\HolidayTableUpdater</parameter>
+        <parameter key="zend.escaper.class">Zend\Escaper\Escaper</parameter>
+        <parameter key="shopware.escaper.class">Shopware\Components\Escaper\Escaper</parameter>
+        <parameter key="shopware.snippet_database_handler.class">Shopware\Components\Snippet\DatabaseHandler</parameter>
+        <parameter key="shopware.snippet_validator.class">Shopware\Components\Snippet\SnippetValidator</parameter>
+        <parameter key="shopware.snippet_query_handler.class">Shopware\Components\Snippet\QueryHandler</parameter>
+        <parameter key="shopware.cache_manager.class">Shopware\Components\CacheManager</parameter>
+        <parameter key="media_subscriber.class">Shopware\Models\Media\MediaSubscriber</parameter>
+        <parameter key="thumbnail_generator_basic.class">Shopware\Components\Thumbnail\Generator\Basic</parameter>
+        <parameter key="thumbnail_manager.class">Shopware\Components\Thumbnail\Manager</parameter>
+        <parameter key="multi_edit.product.class">Shopware\Components\MultiEdit\Resource\Product</parameter>
+        <parameter key="multi_edit.product.value.class">Shopware\Components\MultiEdit\Resource\Product\Value</parameter>
+        <parameter key="multi_edit.product.dql_helper.class">Shopware\Components\MultiEdit\Resource\Product\DqlHelper</parameter>
+        <parameter key="multi_edit.product.backup.class">Shopware\Components\MultiEdit\Resource\Product\Backup</parameter>
+        <parameter key="multi_edit.product.filter.class">Shopware\Components\MultiEdit\Resource\Product\Filter</parameter>
+        <parameter key="multi_edit.product.queue.class">Shopware\Components\MultiEdit\Resource\Product\Queue</parameter>
+        <parameter key="multi_edit.product.batch_process.class">Shopware\Components\MultiEdit\Resource\Product\BatchProcess</parameter>
+        <parameter key="multi_edit.product.grammar.class">Shopware\Components\MultiEdit\Resource\Product\Grammar</parameter>
+        <parameter key="legacy_struct_converter.class">Shopware\Components\Compatibility\LegacyStructConverter</parameter>
+        <parameter key="legacy_event_manager.class">Shopware\Components\Compatibility\LegacyEventManager</parameter>
+        <parameter key="query_alias_mapper.class">Shopware\Components\QueryAliasMapper</parameter>
+        <parameter key="file_system.class">Symfony\Component\Filesystem\Filesystem</parameter>
+        <parameter key="first_run_wizard_plugin_store.class">Shopware\Bundle\PluginInstallerBundle\Service\FirstRunWizardPluginStoreService</parameter>
+        <parameter key="http_cache_warmer.class">Shopware\Components\HttpCache\CacheWarmer</parameter>
+        <parameter key="shop_page_menu.class">Shopware\Components\SitePageMenu</parameter>
+        <parameter key="emotion_device_configuration.class">Shopware\Components\Emotion\DeviceConfiguration</parameter>
+        <parameter key="validator.validator_factory.class">Shopware\Bundle\FormBundle\DependencyInjection\Factory\ConstraintValidatorFactory</parameter>
+        <parameter key="validator.class">Symfony\Component\Validator\Validator\ValidatorInterface</parameter>
+        <parameter key="validator.email.class">Shopware\Components\Validator\EmailValidator</parameter>
+        <parameter key="sitemapxml.repository.class">Shopware\Components\SitemapXMLRepository</parameter>
+        <parameter key="attribute_subscriber.class">Shopware\Components\AttributeSubscriber</parameter>
+        <parameter key="error_subscriber.class">Shopware\Components\ErrorSubscriber</parameter>
+        <parameter key="config_writer.class">Shopware\Components\ConfigWriter</parameter>
+        <parameter key="shopware.plugin.config_writer.class">Shopware\Components\Plugin\ConfigWriter</parameter>
+        <parameter key="shopware.plugin.cached_config_reader.class">Shopware\Components\Plugin\CachedConfigReader</parameter>
+        <parameter key="shopware.plugin.config_reader.class">Shopware\Components\Plugin\DBALConfigReader</parameter>
+        <parameter key="shopware_product_stream.criteria_factory.class">Shopware\Components\ProductStream\CriteriaFactory</parameter>
+        <parameter key="shopware_product_stream.repository.class">Shopware\Components\ProductStream\Repository</parameter>
+        <parameter key="shopware_product_stream.facet_filter.class">Shopware\Components\ProductStream\FacetFilter</parameter>
+        <parameter key="shopware.upload_max_size_validator.class">Shopware\Components\UploadMaxSizeValidator</parameter>
+        <parameter key="shopware.csrftoken_validator.class">Shopware\Components\CSRFTokenValidator</parameter>
+        <parameter key="shopware_core.license_service_subscriber.class">Shopware\Components\License\Service\LicenseServiceSubscriber</parameter>
+        <parameter key="shopware_core.local_license_unpack_service.class">Shopware\Components\License\Service\LocalLicenseUnpackService</parameter>
+        <parameter key="shopware.openssl_verificator.class">Shopware\Components\OpenSSLVerifier</parameter>
+        <parameter key="shopware.number_range_incrementer.class">Shopware\Components\NumberRangeIncrementer</parameter>
+        <parameter key="shopware.plugin_xml_plugin_info_reader.class">Shopware\Components\Plugin\XmlPluginInfoReader</parameter>
+        <parameter key="shopware.plugin_requirement_validator.class">Shopware\Components\Plugin\RequirementValidator</parameter>
+        <parameter key="slugify.class">Cocur\Slugify\Slugify</parameter>
+        <parameter key="shopware.slug.class">Shopware\Components\Slug\CocurSlugifyAdapter</parameter>
+        <parameter key="shopware.requirements.class">Shopware\Components\Check\Requirements</parameter>
+        <parameter key="shopware.emotion_component_installer.class">Shopware\Components\Emotion\ComponentInstaller</parameter>
+        <parameter key="shopware.plugin_payment_installer.class">Shopware\Components\Plugin\PaymentInstaller</parameter>
     </parameters>
 
     <services>
@@ -16,32 +122,32 @@
         <service id="PasswordEncoder" synthetic="true" />
         <service id="db_connection"   synthetic="true" />
 
-        <service id="bootstrap" class="Shopware_Bootstrap">
+        <service id="bootstrap" class="%bootstrap.class%">
             <argument type="service" id="service_container"/>
             <deprecated>The "%service_id%" service is deprecated since 5.2 and will be removed in 5.3.</deprecated>
         </service>
 
-        <service id="locale_factory" class="Shopware\Components\DependencyInjection\Bridge\Locale" />
+        <service id="locale_factory" class="%locale_factory.class%" />
         <service id="shopware.locale" alias="locale" />
         <service id="locale" class="Zend_Locale">
             <factory service="locale_factory" method="factory" />
             <argument type="service" id="service_container"/>
         </service>
 
-        <service id="currency_factory" class="Shopware\Components\DependencyInjection\Bridge\Currency"/>
-        <service id="currency" class="Zend_Currency">
+        <service id="currency_factory" class="%currency_factory.class%"/>
+        <service id="currency" class="%currency.class%">
             <factory service="currency_factory" method="factory" />
             <argument type="service" id="service_container"/>
             <argument type="service" id="shopware.locale"/>
         </service>
 
-        <service id="snippet_resource" class="Enlight_Components_Snippet_Resource">
+        <service id="snippet_resource" class="%snippet_resource.class%">
             <argument type="service" id="snippets"/>
             <argument>%shopware.snippet.showSnippetPlaceholder%</argument>
         </service>
 
-        <service id="template_factory" class="Shopware\Components\DependencyInjection\Bridge\Template" />
-        <service id="template" class="Enlight_Template_Manager">
+        <service id="template_factory" class="%template_factory.class%" />
+        <service id="template" class="%template.class%">
             <factory service="template_factory" method="factory" />
             <argument type="service" id="events"/>
             <argument type="service" id="snippet_resource"/>
@@ -49,38 +155,38 @@
             <argument>%shopware.template%</argument>
         </service>
 
-        <service id="session_factory" class="Shopware\Components\DependencyInjection\Bridge\Session" />
-        <service id="session" class="Enlight_Components_Session_Namespace">
+        <service id="session_factory" class="%session_factory.class%" />
+        <service id="session" class="%session.class%">
             <factory service="session_factory" method="factory" />
             <argument type="service" id="service_container"/>
         </service>
 
-        <service id="mailtransport_factory" class="Shopware\Components\DependencyInjection\Bridge\MailTransport" />
+        <service id="mailtransport_factory" class="%mailtransport_factory.class%" />
         <service id="shopware.mail_transport" alias="MailTransport" />
-        <service id="MailTransport" class="Zend_Mail_Transport_Abstract">
+        <service id="MailTransport" class="%mailtransport.class%">
             <factory service="mailtransport_factory" method="factory" />
             <argument type="service" id="Loader"/>
             <argument type="service" id="config"/>
             <argument>%shopware.mail%</argument>
         </service>
 
-        <service id="mail_factory" class="Shopware\Components\DependencyInjection\Bridge\Mail" />
-        <service id="mail" class="Enlight_Components_Mail">
+        <service id="mail_factory" class="%mail_factory.class%" />
+        <service id="mail" class="%mail.class%">
             <factory service="mail_factory" method="factory" />
             <argument type="service" id="service_container"/>
             <argument type="service" id="config"/>
             <argument>%shopware.mail%</argument>
         </service>
 
-        <service id="templatemail_factory" class="Shopware\Components\DependencyInjection\Bridge\TemplateMail" />
-        <service id="templatemail" class="Shopware_Components_TemplateMail">
+        <service id="templatemail_factory" class="%templatemail_factory.class%" />
+        <service id="templatemail" class="%templatemail.class%">
             <factory service="templatemail_factory" method="factory" />
             <argument type="service" id="service_container"/>
         </service>
 
-        <service id="plugins_factory" class="Shopware\Components\DependencyInjection\Bridge\Plugins" />
+        <service id="plugins_factory" class="%plugins_factory.class%" />
         <service id="plugin_manager" alias="plugins" />
-        <service id="plugins" class="Enlight_Plugin_PluginManager">
+        <service id="plugins" class="%plugins.class%">
             <factory service="plugins_factory" method="factory" />
             <argument type="service" id="service_container"/>
             <argument type="service" id="Loader"/>
@@ -89,72 +195,74 @@
             <argument>%shopware.plugin_directories%</argument>
         </service>
 
-        <service id="router_factory" class="Shopware\Components\DependencyInjection\Bridge\Router" />
-        <service id="router" class="Shopware\Components\Routing\Router">
+        <service id="router_factory" class="%router_factory.class%" />
+        <service id="router" class="%router.class%">
             <factory service="router_factory" method="factory" />
             <argument type="service" id="service_container"/>
             <argument type="service" id="events"/>
         </service>
 
-        <service id="dispatcher" class="Enlight_Controller_Dispatcher_Default" />
+        <service id="dispatcher" class="%dispatcher.class%" />
 
-        <service id="front_factory" class="Shopware\Components\DependencyInjection\Bridge\Front" />
-        <service id="front" class="Enlight_Controller_Front">
+        <service id="front_factory" class="%front_factory.class%" />
+        <service id="front" class="%front.class%">
             <factory service="front_factory" method="factory" />
             <argument type="service" id="service_container"/>
             <argument type="service" id="events"/>
             <argument>%shopware.front%</argument>
         </service>
 
-        <service id="date" class="Zend_Date">
+        <service id="date" class="%date.class%">
             <argument type="service" id="locale"/>
         </service>
 
         <service id="shopware.loader" alias="Loader" />
-        <service id="Loader"     class="Enlight_Loader" />
-        <service id="snippets"   class="Shopware_Components_Snippet_Manager">
+        <service id="Loader"     class="%loader.class%" />
+        <service id="snippets"   class="%snippets.class%">
             <argument type="service" id="shopware.model_manager"/>
             <argument>%shopware.plugin_directories%</argument>
             <argument>%shopware.snippet%</argument>
         </service>
 
-        <service id="acl" class="Shopware_Components_Acl">
+        <service id="acl" class="%acl.class%">
             <argument type="service" id="models"/>
         </service>
 
-        <service id="cron_adapter" class="Enlight_Components_Cron_Adapter_DBAL">
+        <service id="cron_adapter" class="%cron_adapter.class%">
             <argument type="service" id="dbal_connection"/>
         </service>
 
-        <service id="cron" class="Enlight_Components_Cron_Manager">
+        <service id="cron" class="%cron.class%">
             <argument type="service" id="cron_adapter"/>
             <argument type="service" id="events"/>
             <argument type="string">Shopware_Components_Cron_CronJob</argument>
         </service>
 
+        <service id="db_factory" class="%db_factory.class%"/>
         <service id="shopware.db" alias="db"/>
-        <service id="db" class="Enlight_Components_Db_Adapter_Pdo_Mysql">
-            <factory class="Shopware\Components\DependencyInjection\Bridge\Db" method="createEnlightDbAdapter" />
+        <service id="db" class="%db.class%">
+            <factory service="db_factory" method="createEnlightDbAdapter" />
             <argument type="service" id="dbal_connection"/>
             <argument>%shopware.db%</argument>
         </service>
 
-        <service id="guzzle_http_client_factory" class="Shopware\Components\HttpClient\GuzzleFactory" />
+        <service id="guzzle_http_client_factory" alias="http_client_factory"/>
+        <service id="http_client_factory" class="%http_client_factory.class%" />
 
-        <service id="http_client" class="Shopware\Components\HttpClient\GuzzleHttpClient">
-            <argument type="service" id="guzzle_http_client_factory"/>
+        <service id="http_client" class="%http_client.class%">
+            <argument type="service" id="http_client_factory"/>
         </service>
 
-        <service id="cache_factory" class="Shopware\Components\DependencyInjection\Bridge\Cache"/>
-        <service id="cache" class="Zend_Cache_Core">
+        <service id="cache_factory" class="%cache_factory.class%"/>
+        <service id="cache" class="%cache.class%">
             <factory service="cache_factory" method="factory" />
             <argument>%shopware.cache.backend%</argument>
             <argument>%shopware.cache.frontendOptions%</argument>
             <argument>%shopware.cache.backendOptions%</argument>
         </service>
 
-        <service id="config_factory" class="Shopware\Components\DependencyInjection\Bridge\Config" />
-        <service id="config" class="Shopware_Components_Config">
+        <service id="config_factory" class="%config_factory.class%" />
+        <service id="config" class="%config.class%">
             <factory service="config_factory" method="factory" />
             <argument type="service" id="cache" />
             <argument type="service" id="db" on-invalid="ignore"/>
@@ -162,28 +270,28 @@
          </service>
 
         <service id="shopware.event_manager" alias="events" />
-        <service id="events" class="Shopware\Components\ContainerAwareEventManager">
+        <service id="events" class="%events.class%">
             <argument type="service" id="service_container"/>
         </service>
 
         <service id="shopware.hook_manager" alias="Hooks" />
-        <service id="Hooks" class="Enlight_Hook_HookManager">
+        <service id="Hooks" class="%hooks.class%">
             <argument type="service" id="shopware.event_manager" />
             <argument type="service" id="shopware.loader" />
             <argument>%shopware.hook%</argument>
         </service>
 
         <service id="shopware.model_config" alias="ModelConfig" />
-        <service id="ModelConfig" class="Shopware\Components\Model\Configuration">
+        <service id="ModelConfig" class="%model_config.class%">
             <argument>%shopware.Model%</argument>
             <argument type="service" id="cache" />
             <argument type="service" id="model_repository_factory" />
         </service>
 
-        <service id="model_factory" class="Shopware\Components\DependencyInjection\Bridge\Models" />
+        <service id="model_factory" class="%model_factory.class%" />
         <service id="shopware.model_manager" alias="models" />
 
-        <service id="models" class="Shopware\Components\Model\ModelManager">
+        <service id="models" class="%models.class%">
             <factory service="model_factory" method="factory" />
             <argument type="service" id="model_event_manager" />
             <argument type="service" id="shopware.model_config" />
@@ -192,103 +300,104 @@
             <argument type="service" id="shopware.model_annotations" />
          </service>
 
-        <service id="models_metadata_cache" class="Doctrine\Common\Cache\Cache">
+        <service id="models_metadata_cache" class="%models_metadata_cache.class%">
             <factory service="ModelConfig" method="getMetadataCacheImpl" />
         </service>
 
-        <service id="dbal_connection" class="Doctrine\DBAL\Connection">
-            <factory class="Shopware\Components\DependencyInjection\Bridge\Db" method="createDbalConnection" />
+        <service id="dbal_connection_factory" class="%dbal_connection_factory.class%" />
+        <service id="dbal_connection" class="%dbal_connection.class%">
+            <factory service="dbal_connection_factory" method="createDbalConnection" />
             <argument>%shopware.db%</argument>
             <argument type="service" id="ModelConfig"/>
             <argument type="service" id="model_event_manager"/>
             <argument type="service" id="db_connection"/>
         </service>
 
-        <service id="model_annotations_factory" class="Shopware\Components\DependencyInjection\Bridge\ModelAnnotation" />
+        <service id="model_annotations_factory" class="%model_annotations_factory.class%" />
         <service id="shopware.model_annotations" alias="ModelAnnotations" />
-        <service id="ModelAnnotations" class="Doctrine\ORM\Mapping\Driver\AnnotationDriver">
+        <service id="ModelAnnotations" class="%model_annotations.class%">
             <factory service="model_annotations_factory" method="factory" />
             <argument type="service" id="shopware.model_config" />
             <argument>%kernel.root_dir%/engine/Shopware/Models</argument>
         </service>
 
-        <service id="model_event_manager" class="Doctrine\Common\EventManager" public="false" />
+        <service id="model_event_manager" class="%model_event_manager.class%" public="false" />
 
-        <service id="model_repository_factory" class="Shopware\Components\Model\ProxyAwareRepositoryFactory" public="false">
+        <service id="model_repository_factory" class="%model_repository_factory.class%" public="false">
             <argument type="service" id="Hooks" />
         </service>
 
-        <service id="EventSubscriber" class="Shopware\Components\Model\EventSubscriber" public="false">
+        <service id="EventSubscriber" class="%event_subscriber.class%" public="false">
             <argument type="service" id="shopware.event_manager" />
             <tag name="doctrine.event_subscriber" />
         </service>
 
-        <service id="OrderHistorySubscriber" class="Shopware\Models\Order\OrderHistorySubscriber" public="false">
+        <service id="OrderHistorySubscriber" class="%order_history_subscriber.class%" public="false">
             <tag name="doctrine.event_subscriber" />
         </service>
 
-        <service id="CategorySubscriber" class="Shopware\Components\Model\CategorySubscriber">
+        <service id="CategorySubscriber" class="%category_subscriber.class%">
             <argument type="service" id="service_container" />
             <tag name="doctrine.event_subscriber" />
         </service>
 
-        <service id="CategoryDuplicator" class="Shopware\Components\CategoryHandling\CategoryDuplicator">
+        <service id="CategoryDuplicator" class="%category_duplication.class%">
             <argument type="service" id="db_connection" />
             <argument type="service" id="CategoryDenormalization" />
             <argument type="service" id="shopware_attribute.data_persister" />
         </service>
 
-        <service id="CategoryDenormalization" class="Shopware\Components\Model\CategoryDenormalization">
+        <service id="CategoryDenormalization" class="%category_denormalization.class%">
             <argument type="service" id="db_connection" />
         </service>
 
-        <service id="shopware.holiday_table_updater" class="Shopware\Components\HolidayTableUpdater">
+        <service id="shopware.holiday_table_updater" class="%shopware.holiday_table_updater.class%">
             <argument type="service" id="dbal_connection" />
         </service>
 
-        <service id="zend.escaper" class="Zend\Escaper\Escaper" public="false">
+        <service id="zend.escaper" class="%zend.escaper.class%" public="false">
             <argument type="string">utf-8</argument>
         </service>
 
-        <service id="shopware.escaper" class="Shopware\Components\Escaper\Escaper">
+        <service id="shopware.escaper" class="%shopware.escaper.class%">
             <argument type="service" id="zend.escaper" />
         </service>
 
-        <service id="shopware.snippet_database_handler" class="Shopware\Components\Snippet\DatabaseHandler">
+        <service id="shopware.snippet_database_handler" class="%shopware.snippet_database_handler.class%">
             <argument type="service" id="shopware.model_manager" />
             <argument type="service" id="db" />
             <argument>%kernel.root_dir%</argument>
         </service>
 
-        <service id="shopware.snippet_validator" class="Shopware\Components\Snippet\SnippetValidator">
+        <service id="shopware.snippet_validator" class="%shopware.snippet_validator.class%">
             <argument type="service" id="dbal_connection" />
         </service>
 
-        <service id="shopware.snippet_query_handler" class="Shopware\Components\Snippet\QueryHandler">
+        <service id="shopware.snippet_query_handler" class="%shopware.snippet_query_handler.class%">
             <argument>%kernel.root_dir%/snippets/</argument>
         </service>
-        <service id="shopware.cache_manager" class="Shopware\Components\CacheManager">
+        <service id="shopware.cache_manager" class="%shopware.cache_manager.class%">
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="MediaSubscriber" class="Shopware\Models\Media\MediaSubscriber" public="false">
+        <service id="MediaSubscriber" class="%media_subscriber.class%" public="false">
             <tag name="doctrine.event_subscriber" />
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="thumbnail_generator_basic" class="Shopware\Components\Thumbnail\Generator\Basic">
+        <service id="thumbnail_generator_basic" class="%thumbnail_generator_basic.class%">
             <argument type="service" id="config" />
             <argument type="service" id="shopware_media.media_service" />
         </service>
 
-        <service id="thumbnail_manager" class="Shopware\Components\Thumbnail\Manager">
+        <service id="thumbnail_manager" class="%thumbnail_manager.class%">
             <argument type="service" id="thumbnail_generator_basic" />
             <argument>%kernel.root_dir%</argument>
             <argument type="service" id="events" />
             <argument type="service" id="shopware_media.media_service" />
         </service>
 
-        <service id="multi_edit.product" class="Shopware\Components\MultiEdit\Resource\Product">
+        <service id="multi_edit.product" class="%multi_edit.product.class%">
             <argument type="service" id="multi_edit.product.dql_helper" />
             <argument type="service" id="multi_edit.product.grammar" />
             <argument type="service" id="multi_edit.product.value" />
@@ -298,44 +407,44 @@
             <argument type="service" id="multi_edit.product.backup" />
         </service>
 
-        <service id="multi_edit.product.value" class="Shopware\Components\MultiEdit\Resource\Product\Value">
+        <service id="multi_edit.product.value" class="%multi_edit.product.value.class%">
             <argument type="service" id="multi_edit.product.dql_helper" />
         </service>
 
-        <service id="multi_edit.product.dql_helper" class="Shopware\Components\MultiEdit\Resource\Product\DqlHelper">
+        <service id="multi_edit.product.dql_helper" class="%multi_edit.product.dql_helper.class%">
             <argument type="service" id="shopware.db" />
             <argument type="service" id="models" />
             <argument type="service" id="events" />
         </service>
 
-        <service id="multi_edit.product.backup" class="Shopware\Components\MultiEdit\Resource\Product\Backup">
+        <service id="multi_edit.product.backup" class="%multi_edit.product.backup.class%">
             <argument type="service" id="multi_edit.product.dql_helper" />
             <argument type="service" id="config" />
         </service>
 
-        <service id="multi_edit.product.filter" class="Shopware\Components\MultiEdit\Resource\Product\Filter">
+        <service id="multi_edit.product.filter" class="%multi_edit.product.filter.class%">
             <argument type="service" id="multi_edit.product.dql_helper" />
         </service>
 
-        <service id="multi_edit.product.queue" class="Shopware\Components\MultiEdit\Resource\Product\Queue">
+        <service id="multi_edit.product.queue" class="%multi_edit.product.queue.class%">
             <argument type="service" id="multi_edit.product.dql_helper" />
             <argument type="service" id="multi_edit.product.filter" />
             <argument type="service" id="multi_edit.product.backup" />
         </service>
 
-        <service id="multi_edit.product.batch_process" class="Shopware\Components\MultiEdit\Resource\Product\BatchProcess">
+        <service id="multi_edit.product.batch_process" class="%multi_edit.product.batch_process.class%">
             <argument type="service" id="multi_edit.product.dql_helper" />
             <argument type="service" id="multi_edit.product.filter" />
             <argument type="service" id="multi_edit.product.queue" />
             <argument type="service" id="config" />
         </service>
 
-        <service id="multi_edit.product.grammar" class="Shopware\Components\MultiEdit\Resource\Product\Grammar">
+        <service id="multi_edit.product.grammar" class="%multi_edit.product.grammar.class%">
             <argument type="service" id="multi_edit.product.dql_helper" />
             <argument type="service" id="events" />
         </service>
 
-        <service id="legacy_struct_converter" class="Shopware\Components\Compatibility\LegacyStructConverter">
+        <service id="legacy_struct_converter" class="%legacy_struct_converter.class%">
             <argument type="service" id="config" />
             <argument type="service" id="shopware_storefront.context_service" />
             <argument type="service" id="events" />
@@ -346,99 +455,99 @@
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="legacy_event_manager" class="Shopware\Components\Compatibility\LegacyEventManager">
+        <service id="legacy_event_manager" class="%legacy_event_manager.class%">
             <argument type="service" id="events" />
             <argument type="service" id="config" />
             <argument type="service" id="shopware_storefront.context_service" />
         </service>
 
-        <service id="query_alias_mapper" class="Shopware\Components\QueryAliasMapper">
+        <service id="query_alias_mapper" class="%query_alias_mapper.class%">
             <factory class="Shopware\Components\QueryAliasMapper" method="createFromConfig" />
             <argument type="service" id="config" />
         </service>
 
-        <service id="file_system" class="Symfony\Component\Filesystem\Filesystem" />
+        <service id="file_system" class="%file_system.class%" />
 
-        <service id="first_run_wizard_plugin_store" class="Shopware\Bundle\PluginInstallerBundle\Service\FirstRunWizardPluginStoreService">
+        <service id="first_run_wizard_plugin_store" class="%first_run_wizard_plugin_store.class%">
             <argument type="service" id="shopware_plugininstaller.plugin_installer_struct_hydrator" />
             <argument type="service" id="shopware_plugininstaller.plugin_service_local" />
             <argument type="service" id="shopware_plugininstaller.store_client" />
         </service>
 
-        <service id="http_cache_warmer" class="Shopware\Components\HttpCache\CacheWarmer">
+        <service id="http_cache_warmer" class="%http_cache_warmer.class%">
             <argument type="service" id="dbal_connection" />
             <argument type="service" id="corelogger" />
             <argument type="service" id="guzzle_http_client_factory" />
         </service>
 
-        <service id="shop_page_menu" class="Shopware\Components\SitePageMenu">
+        <service id="shop_page_menu" class="%shop_page_menu.class%">
             <argument type="service" id="dbal_connection" />
         </service>
 
-        <service id="emotion_device_configuration" class="Shopware\Components\Emotion\DeviceConfiguration">
+        <service id="emotion_device_configuration" class="%emotion_device_configuration.class%">
             <argument type="service" id="dbal_connection" />
         </service>
 
-        <service id="validator.validator_factory" class="Shopware\Bundle\FormBundle\DependencyInjection\Factory\ConstraintValidatorFactory" public="false">
+        <service id="validator.validator_factory" class="%validator.validator_factory.class%" public="false">
             <argument type="service" id="service_container" />
             <argument type="collection" />
         </service>
 
-        <service id="validator" class="Symfony\Component\Validator\Validator\ValidatorInterface" >
+        <service id="validator" class="%validator.class%" >
             <factory class="Shopware\Components\DependencyInjection\Bridge\Validator" method="create" />
             <argument type="service" id="ModelConfig" />
             <argument type="service" id="validator.validator_factory" />
         </service>
 
-        <service id="validator.email" class="Shopware\Components\Validator\EmailValidator" />
+        <service id="validator.email" class="%validator.email.class%" />
 
-        <service id="sitemapxml.repository" class="Shopware\Components\SitemapXMLRepository">
+        <service id="sitemapxml.repository" class="%sitemapxml.repository.class%">
             <argument type="service" id="models" />
             <argument type="service" id="shopware_storefront.context_service" />
         </service>
 
-        <service id="AttributeSubscriber" class="Shopware\Components\AttributeSubscriber">
+        <service id="AttributeSubscriber" class="%attribute_subscriber.class%">
             <argument type="service" id="service_container" />
             <tag name="shopware.event_subscriber" />
         </service>
 
-        <service id="ErrorSubscriber" class="Shopware\Components\ErrorSubscriber">
+        <service id="ErrorSubscriber" class="%error_subscriber.class%">
             <tag name="shopware.event_subscriber" />
         </service>
 
-        <service id="config_writer" class="Shopware\Components\ConfigWriter">
+        <service id="config_writer" class="%config_writer.class%">
             <argument type="service" id="dbal_connection" />
         </service>
 
-        <service id="shopware.plugin.config_writer" class="Shopware\Components\Plugin\ConfigWriter">
+        <service id="shopware.plugin.config_writer" class="%shopware.plugin.config_writer.class%">
             <argument type="service" id="models" />
         </service>
 
-        <service id="shopware.plugin.cached_config_reader" class="Shopware\Components\Plugin\CachedConfigReader">
+        <service id="shopware.plugin.cached_config_reader" class="%shopware.plugin.cached_config_reader.class%">
             <argument type="service" id="shopware.plugin.config_reader" />
         </service>
 
-        <service id="shopware.plugin.config_reader" class="Shopware\Components\Plugin\DBALConfigReader">
+        <service id="shopware.plugin.config_reader" class="%shopware.plugin.config_reader.class%">
             <argument type="service" id="dbal_connection" />
         </service>
 
-        <service id="shopware_product_stream.criteria_factory" class="Shopware\Components\ProductStream\CriteriaFactory">
+        <service id="shopware_product_stream.criteria_factory" class="%shopware_product_stream.criteria_factory.class%">
             <argument type="service" id="shopware_search.store_front_criteria_factory" />
         </service>
 
-        <service id="shopware_product_stream.repository" class="Shopware\Components\ProductStream\Repository">
+        <service id="shopware_product_stream.repository" class="%shopware_product_stream.repository.class%">
             <argument type="service" id="dbal_connection" />
         </service>
 
-        <service id="shopware_product_stream.facet_filter" class="Shopware\Components\ProductStream\FacetFilter" >
+        <service id="shopware_product_stream.facet_filter" class="%shopware_product_stream.facet_filter.class%" >
             <argument type="service" id="config" />
         </service>
 
-        <service id="shopware.upload_max_size_validator" class="Shopware\Components\UploadMaxSizeValidator">
+        <service id="shopware.upload_max_size_validator" class="%shopware.upload_max_size_validator.class%">
             <tag name="shopware.event_subscriber" />
         </service>
 
-        <service id="shopware.csrftoken_validator" class="Shopware\Components\CSRFTokenValidator">
+        <service id="shopware.csrftoken_validator" class="%shopware.csrftoken_validator.class%">
             <argument type="service" id="service_container" />
             <argument>%shopware.csrfProtection.frontend%</argument>
             <argument>%shopware.csrfProtection.backend%</argument>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?

For some services a decorator pattern is not viable for changing/extending service implementations.
* What does it improve?

Using parameters to propagate class names for all services allow 3rd parties to change the class to use for a service. New implementation can extend the original class.
* Does it have side effects?

No



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | 

