### PR TITLE
Fix typo in block name in ArticleList suggest controller

### DIFF
--- a/themes/Backend/ExtJs/backend/article_list/controller/suggest.js
+++ b/themes/Backend/ExtJs/backend/article_list/controller/suggest.js
@@ -34,7 +34,7 @@
 /**
  *
  */
-//{block name="backend/article_list/controller/main"}
+//{block name="backend/article_list/controller/suggest"}
 Ext.define('Shopware.apps.ArticleList.controller.Suggest', {
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
This pull requests fixes a typo in a block name of a backend controller of the module ArticleList.

* Why is it necessary?
It duplicates an overriding controller by an plugin in the code when you append the block.
* What does it improve?
Less duplicated code when extending the current (non-fixed) block.
* Does it have side effects?
No



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | no test needed
| How to test?     | no test needed

