### PR TITLE
fix combobox set null value on suggest

### DIFF
--- a/themes/Backend/ExtJs/backend/emotion/view/components/base.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/components/base.js
@@ -186,12 +186,18 @@ Ext.define('Shopware.apps.Emotion.view.components.Base', {
                 constructedItem.queryMode = 'local';
                 constructedItem.listeners = {
                     boxready: function(combo) {
-                        this.relayEvents(combo.getStore(), ['load'], 'store');
-                        combo.getStore().load();
-                    },
-                    storeload: function(store) {
-                        var record = store.findRecord(this.valueField, this.getValue());
-                        this.setValue(record);
+                        combo.relayEvents(combo.getStore(), ['load'], 'store');
+                        var store = combo.getStore();
+                        store.load();
+                        // on initial load read displayField from store
+                        store.addListener('load', function() {
+                            var record = store.findRecord(this.valueField, this.getValue());
+                            if (record) {
+                                this.setValue(record);
+                            }
+                        }, combo, {
+                            single: true
+                        });
                     }
                 };
             } else if (xtype === 'datefield') {


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
There is a bug in comboxes in emotion widgets if the store has a remote data source.
If you start typing one of the choices the store loads matching entries from the backend. That triggers the "load" event on the store. The event handler changed in this commit is used to select the saved value on initial load. But it is triggered every time and so the event tries to find a record with the typed search query as the ID witch fails and then "null" is set as selected value 
* What does it improve?
Fixes bug
* Does it have side effects?
No. The combobox will still relay the load event so there is no BC break.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Create emotion widget. Add combobox with store that loads data from the backend. Create widget and try to select an option by typing.

