### PR TITLE
Added argument shopId to sw:theme:cache:generate to generate cache fo…

### DIFF
--- a/engine/Shopware/Commands/ThemeCacheGenerateCommand.php
+++ b/engine/Shopware/Commands/ThemeCacheGenerateCommand.php
@@ -69,7 +69,7 @@ class ThemeCacheGenerateCommand extends ShopwareCommand
                 AbstractQuery::HYDRATE_OBJECT
             );
         } else {
-            $shops = array_map(function($shop) use ($repository) {
+            $shops = array_map(function ($shop) use ($repository) {
                 return $repository->getActiveById($shop);
             }, $shops);
             $shops = array_filter($shops);

--- a/engine/Shopware/Commands/ThemeCacheGenerateCommand.php
+++ b/engine/Shopware/Commands/ThemeCacheGenerateCommand.php
@@ -69,7 +69,7 @@ class ThemeCacheGenerateCommand extends ShopwareCommand
                 AbstractQuery::HYDRATE_OBJECT
             );
         } else {
-            $shops = array_map(function($shop) use($repository) {
+            $shops = array_map(function($shop) use ($repository) {
                 return $repository->getActiveById($shop);
             }, $shops);
             $shops = array_filter($shops);


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Adds a argument shopId to command sw:theme:cache:generate to limit to single or multiple shops
* What does it improve?
Limit theme cache generation to shops
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | ./bin/console sw:theme:cache:generate 1