### PR TITLE
Replaced file_get_contents with Guzzle in Widget Controller

### DIFF
--- a/engine/Shopware/Controllers/Backend/Widgets.php
+++ b/engine/Shopware/Controllers/Backend/Widgets.php
@@ -743,11 +743,7 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
         $result = [];
 
         try {
-            $xml = new \SimpleXMLElement(file_get_contents('https://' . $lang . '.shopware.com/news/?sRss=1', false, stream_context_create([
-                'http' => [
-                    'timeout' => 20
-                ]
-            ])));
+            $xml = new \SimpleXMLElement($this->container->get('http_client')->get('https://' . $lang . '.shopware.com/news/?sRss=1')->getBody());
         } catch (\Exception $e) {
             return [];
         }


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
allow_url_fopen is not required to see shopware news
* What does it improve?
Replaced file_get_contents with Guzzle
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Set allow_url_fopen to 0 in php.ini and show shopware news widget in backend
