### PR TITLE
Do not use Default-Text for WYSIWYG-Fields

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.plugin.Translation.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.plugin.Translation.js
@@ -282,7 +282,9 @@ Ext.define('Shopware.form.plugin.Translation',
                 config.xtype = field.xtype;
             }
             if (field.getValue()) {
-                config.emptyText = field.getValue();
+                if (config.xtype != 'tinymce') {
+                    config.emptyText = field.getValue();
+                }
             }
             result.push(config)
         });


### PR DESCRIPTION
If you use WYSIWYG-Fields (tinymce) in translations, shopware will always save the default text instead of ignoring the field in this case on saveing. Removing the default text will prevent this behavior.

## Description
* Why is it necessary?
Otherwise you have to add translations for each WYSIWYG-Field.
* What does it improve?
Improve usability for multilanguage shops (e.g. french -> france, belgium, ...).
* Does it have side effects?
No.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | ?
| How to test?     | Add a WYSIWYG-Field as translatable field. Save default text and test, if the default text ist shown in translation-widget / is saved into database while saving translation.

