### PR TITLE
Changing the PriceFacetHandler to save filterloading time

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/PriceFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/PriceFacetHandler.php
@@ -126,22 +126,18 @@ class PriceFacetHandler implements FacetHandlerInterface
         $selection = $this->priceHelper->getSelection($context);
         $this->priceHelper->joinPrices($query, $context);
 
-        $query->select('MIN('. $selection .') as cheapest_price');
-
-        /**@var $statement \Doctrine\DBAL\Driver\ResultStatement */
-        $statement = $query->execute();
-
-        $min = $statement->fetch(\PDO::FETCH_COLUMN);
+        $query->select('MIN(' . $selection . ') as cheapest_price');
 
         $query->groupBy('product.id')
-            ->orderBy('cheapest_price', 'DESC')
-            ->setFirstResult(0)
-            ->setMaxResults(1);
+            ->orderBy('cheapest_price', 'DESC');
 
         /**@var $statement \Doctrine\DBAL\Driver\ResultStatement */
         $statement = $query->execute();
 
-        $max = $statement->fetch(\PDO::FETCH_COLUMN);
+        $result = $statement->fetchAll(\PDO::FETCH_COLUMN);
+
+        $min = end($result);
+        $max = reset($result);
 
         $activeMin = $min;
         $activeMax = $max;


### PR DESCRIPTION
## Description
Please describe your pull request:

This pull request changes the PriceFacet, so that only one query is send to the Database.

* Why is it necessary? The two querys can be executed in one.
* What does it improve? It saves about 30-50% of the time the PriceFilter needs.
* Does it have side effects? No it doesn't.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       |no
| Tests pass?      | yes
| Related tickets? | -
| How to test?     | The functional tests should test if the right values where show. For testing the time saving you need to disable the Http-Cache, fill the category with about 1000-3000 articles and measure the category loading time with and without the changes.

