### PR TITLE
Add canonical-tag to category-listing with activated seoIndexPaginationLinks

### DIFF
--- a/themes/Frontend/Bare/frontend/listing/header.tpl
+++ b/themes/Frontend/Bare/frontend/listing/header.tpl
@@ -43,6 +43,9 @@
 
 {* Canonical link *}
 {block name='frontend_index_header_canonical'}
+
+    <link rel="canonical" href="{url controller=cat sCategory=$sCategoryContent.id}" />
+
     {* Count of available product pages *}
     {$pages = ceil($sNumberArticles / $criteria->getLimit())}
 
@@ -58,8 +61,6 @@
             {$sCategoryContent.canonicalParams.sPage = $sPage + 1}
             <link rel="next" href="{url params = $sCategoryContent.canonicalParams}">
         {/if}
-    {elseif !{config name=seoIndexPaginationLinks} || !$showListing}
-        <link rel="canonical" href="{url params = $sCategoryContent.canonicalParams}" />
     {/if}
 {/block}
 


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Canonical-tag is missing in category listing when seoIndexPaginationLinks are active
* What does it improve?
Adds canonical-tag to category listing and avoids duplicate content
* Does it have side effects?
No



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | activate Prev-/Next-Tags and see that canonical-tag is gone

Patch created by @alea123 #969
