### PR TITLE
fix slideup on collapse-panel if panel is initially collapsed

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.collapse-panel.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.collapse-panel.js
@@ -137,19 +137,19 @@
             var me = this,
                 opts = me.opts,
                 $targetEl = me.$targetEl,
-                siblings = $('.' + opts.collapseTargetCls).not($targetEl),
+                $siblings = $('.' + opts.collapseTargetCls).not($targetEl),
                 tabId = $targetEl.parent().attr('data-tab-id');
 
             me.$el.addClass(opts.activeTriggerCls);
 
-            $targetEl.slideDown(opts.animationSpeed, function () {
+            $targetEl.finish().slideDown(opts.animationSpeed, function () {
                 $.publish('plugin/swCollapsePanel/onOpen', [ me ]);
             }).addClass(opts.collapsedStateCls);
 
             if (opts.closeSiblings) {
-                siblings.slideUp(opts.animationSpeed, function () {
-                    siblings.removeClass(opts.collapsedStateCls);
-                    siblings.prev().removeClass(opts.activeTriggerCls);
+                $siblings.finish().slideUp(opts.animationSpeed, function () {
+                    $siblings.removeClass(opts.collapsedStateCls);
+                    $siblings.prev().removeClass(opts.activeTriggerCls);
                 });
             }
 
@@ -171,9 +171,10 @@
                 opts = me.opts;
 
             me.$el.removeClass(opts.activeTriggerCls);
-            me.$targetEl.slideUp(opts.animationSpeed, function() {
+            me.$targetEl.finish().slideUp(opts.animationSpeed, function() {
+                me.$target.removeClass(opts.collapsedStateCls);
                 $.publish('plugin/swCollapsePanel/onClose', [ me ]);
-            }).removeClass(opts.collapsedStateCls);
+            });
 
             $.publish('plugin/swCollapsePanel/onClosePanel', [ me ]);
         },


### PR DESCRIPTION
This PR fixes the slideup-animation not occuring in initially collapsed panels.

If the panel-content is visible per default (by adding the correct classes to the element) the first slideUp won't animate. The reason is that the target-element is missing an inline-style with `display: block`. That inline-style would guarantee that the target-element stays visible, even if the `collapsedStateCls` is removed.

The workaround for this is manually adding an inline-style yourself, but that's pretty ugly. So this PR fixes this problem by removing the `collapsedStateCls` only once the slideUp-animation is done.

*Notice, that it's already done this way when closing siblings*

## Description
Please describe your pull request:
* Why is it necessary? Fixing a feature that should have been tested
* What does it improve? The jquery.collapse-panel plugin
* Does it have side effects? No.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | create a collapsed panel with the following markup and try to close it:

```html
<div class="tab">
    <div class="tab--header">
        <div class="tab--title is--active" data-collapse-panel="true" data-collapsetarget=".js--collapse-test-target">
            Title
        </div>
    </div>
    <div class="tab--content js--collapse-test-target is--collapsed">
        Content
    </div>
</div>
```

