### PR TITLE
Remove old syntax to enable support shop-struct

### DIFF
--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -164,7 +164,22 @@ class Shopware_Components_TemplateMail
             );
             $isoCode = $this->getShop()->getId();
             $translationReader = $this->getTranslationReader();
-            $translation = $translationReader->read($isoCode, 'config_mails', $mailModel->getId());
+            
+            if ($this->getShop() instanceof \Shopware\Models\Shop\Shop) {
+                $fallbackId = $this->getShop()->getFallback()->getId();
+            } else {
+                $shopStruct = $this->getShop();
+                /* @var $shopStruct \Shopware\Bundle\StoreFrontBundle\Struct\Shop */
+                $fallbackId = $shopStruct->getFallbackId();
+            }
+            
+            $translation = $translationReader->readWithFallback(
+                $isoCode,
+                $fallbackId,
+                'config_mails',
+                $mailModel->getId()
+            );
+            
             $mailModel->setTranslation($translation);
         } else {
             $defaultContext = array(

--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -162,7 +162,7 @@ class Shopware_Components_TemplateMail
                 'sShop' => $config->get('shopName'),
                 'sShopURL' => 'http://' . $config->basePath,
             );
-            $isoCode = $this->getShop()->get('isocode');
+            $isoCode = $this->getShop()->getId();
             $translationReader = $this->getTranslationReader();
             $translation = $translationReader->read($isoCode, 'config_mails', $mailModel->getId());
             $mailModel->setTranslation($translation);


### PR DESCRIPTION
The call $this->getShop()->get('isocode') does nothing else than $this->getShop()->getId() - but the old syntax does not support the shop-struct, which is returned using the ShopContextService. So this line should be changed.

## Description
Please describe your pull request:
* Why is it necessary? Support shop-struct
* What does it improve? Performance (because you can use the struct)
* Does it have side effects? No

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes


