### PR TITLE
False guess on snippet export

### DIFF
--- a/engine/Shopware/Controllers/Backend/Snippet.php
+++ b/engine/Shopware/Controllers/Backend/Snippet.php
@@ -555,8 +555,8 @@ class Shopware_Controllers_Backend_Snippet extends Shopware_Controllers_Backend_
             $stmt = Shopware()->Db()
                 ->select()
                 ->from(array('s1' => 's_core_snippets'), array('namespace', 'name', "value as $alias", "dirty as $alias-dirty"))
-                ->where('s1.localeId = ?', 1)
-                ->where('s1.shopId = ?', 1)
+                ->where('s1.localeId = ?', $baseLocale['localeId'])
+                ->where('s1.shopId = ?', $baseLocale['shopId'])
                 ->order('s1.namespace');
 
             $counter = 1;


### PR DESCRIPTION
On snippet export, shopware querys a $baseLocale for creating an alias.
A few lines further, shopware guesses that the baseLocale is a record with localeID = 1 and shopId = 1

But in some cases, this record isn't the first result on the query before. 
Like this: 
![image](https://cloud.githubusercontent.com/assets/5836639/22973406/dd892d94-f37d-11e6-9dd6-7d0de4e3674d.png)

This causes, that the german translation is put doubled either in german column and in englisch (or some other language that was the first line in BaseLocale query):
![image](https://cloud.githubusercontent.com/assets/5836639/22973531/552ac06a-f37e-11e6-9266-8607dd96db9d.png)

There is either this workaround or the sql query must be sorted after localeID = 1 and shopId = 1
I think this one is more dynamic


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | I don't know exactly how to reproduce that the german language isn't on first place. But that causes the error. Simply export snippets in csv or csvexcel.

