### PR TITLE
Fix typo "nocache" in AppCache.php

### DIFF
--- a/engine/Shopware/Components/HttpCache/AppCache.php
+++ b/engine/Shopware/Components/HttpCache/AppCache.php
@@ -114,7 +114,7 @@ class AppCache extends HttpCache
         $response = parent::handle($request, $type, $catch);
 
         $response->headers->remove('cache-control');
-        $response->headers->addCacheControlDirective('nocache');
+        $response->headers->addCacheControlDirective('no-cache');
 
         return $response;
     }


### PR DESCRIPTION
Fix default CacheControlDirective to "no-cache"  instead of "nocache" (see https://developer.mozilla.org/en/docs/Web/HTTP/Headers/Cache-Control#Cacheability )

<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
In its current form browsers won't recognise the no-cache directive
* What does it improve?
Shopware sends the correct no-cache directive (if not otherwise changed)
* Does it have side effects?
None


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | not tested
| Related tickets? | none
| How to test?     | Check any page with default Cache-Control headers set by Shopware. In combination with a high max-age set this would result in not checking for changes by the browser until max-age is reached.

