### PR TITLE
Fixed sShopUrl Url on alwaysSecure

### DIFF
--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -160,7 +160,7 @@ class Shopware_Components_TemplateMail
             $defaultContext = array(
                 'sConfig' => $config,
                 'sShop' => $config->get('shopName'),
-                'sShopURL' => 'http://' . $config->basePath,
+                'sShopURL' => 'http' . ($this->getShop()->getAlwaysSecure() ? 's' : '') .'://' . $config->basePath,
             );
             $isoCode = $this->getShop()->get('isocode');
             $translationReader = $this->getTranslationReader();

--- a/engine/Shopware/Controllers/Backend/Mail.php
+++ b/engine/Shopware/Controllers/Backend/Mail.php
@@ -179,7 +179,7 @@ class Shopware_Controllers_Backend_Mail extends Shopware_Controllers_Backend_Ext
 
         $defaultContext = array(
             'sShop'    => Shopware()->Config()->get('ShopName'),
-            'sShopURL' => 'http://'. $shop->getHost() . $shop->getBasePath(),
+            'sShopURL' => 'http' . ($shop->getAlwaysSecure() ? 's' : '') . '://'. $shop->getHost() . $shop->getBasePath(),
             'sConfig'  => Shopware()->Config(),
         );
 
@@ -409,7 +409,7 @@ class Shopware_Controllers_Backend_Mail extends Shopware_Controllers_Backend_Ext
 
         $defaultContext = array(
             'sShop'    => Shopware()->Config()->get('ShopName'),
-            'sShopURL' => 'http://' . $shop->getHost() . $shop->getBasePath(),
+            'sShopURL' => 'http' . ($shop->getAlwaysSecure() ? 's' : '') . '://'. $shop->getHost() . $shop->getBasePath(),
             'sConfig'  => Shopware()->Config(),
         );
 
@@ -457,7 +457,7 @@ class Shopware_Controllers_Backend_Mail extends Shopware_Controllers_Backend_Ext
 
         $defaultContext = array(
             'sShop'    => Shopware()->Config()->get('ShopName'),
-            'sShopURL' => 'http://' . $shop->getHost() . $shop->getBasePath(),
+            'sShopURL' => 'http' . ($shop->getAlwaysSecure() ? 's' : '') . '://'. $shop->getHost() . $shop->getBasePath(),
             'sConfig'  => Shopware()->Config(),
         );
 

--- a/engine/Shopware/Controllers/Backend/Mail.php
+++ b/engine/Shopware/Controllers/Backend/Mail.php
@@ -24,6 +24,7 @@
 
 use Shopware\Models\Mail\Mail;
 use Shopware\Models\Mail\Attachment;
+use Shopware\Models\Shop\Shop;
 
 /**
  * Backend Controller for the mail backend module
@@ -173,21 +174,15 @@ class Shopware_Controllers_Backend_Mail extends Shopware_Controllers_Backend_Ext
             return;
         }
 
-        /** @var $shop \Shopware\Models\Shop\Shop **/
-        $shop = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop')->getActiveDefault();
+        /** @var $shop Shop **/
+        $shop = Shopware()->Models()->getRepository(Shop::class)->getActiveDefault();
         $shop->registerResources();
-
-        $defaultContext = array(
-            'sShop'    => Shopware()->Config()->get('ShopName'),
-            'sShopURL' => 'http' . ($shop->getAlwaysSecure() ? 's' : '') . '://'. $shop->getHost() . $shop->getBasePath(),
-            'sConfig'  => Shopware()->Config(),
-        );
 
         $context = $mail->getContext();
         if (empty($context)) {
             $context = array();
         }
-        $data['contextPath'] = $mail->arrayGetPath(array_merge($defaultContext, $context));
+        $data['contextPath'] = $mail->arrayGetPath(array_merge($this->getDefaultMailContext($shop), $context));
 
         $this->View()->assign(array('success' => true, 'data' => $data, 'total' => 1));
     }
@@ -404,17 +399,11 @@ class Shopware_Controllers_Backend_Mail extends Shopware_Controllers_Backend_Ext
 
         $recipient = Shopware()->Config()->get('mail');
 
-        $shop = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop')->getActiveDefault();
+        $shop = Shopware()->Models()->getRepository(Shop::class)->getActiveDefault();
         $shop->registerResources();
 
-        $defaultContext = array(
-            'sShop'    => Shopware()->Config()->get('ShopName'),
-            'sShopURL' => 'http' . ($shop->getAlwaysSecure() ? 's' : '') . '://'. $shop->getHost() . $shop->getBasePath(),
-            'sConfig'  => Shopware()->Config(),
-        );
-
         try {
-            $templateMail = Shopware()->TemplateMail()->createMail($mail, array_merge($defaultContext, $mail->getContext()), $shop);
+            $templateMail = Shopware()->TemplateMail()->createMail($mail, array_merge($this->getDefaultMailContext($shop), $mail->getContext()), $shop);
             $templateMail->addTo($recipient);
             $templateMail->send();
         } catch (\Exception $e) {
@@ -452,16 +441,10 @@ class Shopware_Controllers_Backend_Mail extends Shopware_Controllers_Backend_Ext
 
         $compiler = new Shopware_Components_StringCompiler($this->View()->Engine());
 
-        $shop = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop')->getActiveDefault();
+        $shop = Shopware()->Models()->getRepository(Shop::class)->getActiveDefault();
         $shop->registerResources();
 
-        $defaultContext = array(
-            'sShop'    => Shopware()->Config()->get('ShopName'),
-            'sShopURL' => 'http' . ($shop->getAlwaysSecure() ? 's' : '') . '://'. $shop->getHost() . $shop->getBasePath(),
-            'sConfig'  => Shopware()->Config(),
-        );
-
-        $compiler->setContext(array_merge($defaultContext, $mail->getContext()));
+        $compiler->setContext(array_merge($this->getDefaultMailContext($shop), $mail->getContext()));
 
         try {
             $template = $compiler->compileString($value);
@@ -562,7 +545,7 @@ class Shopware_Controllers_Backend_Mail extends Shopware_Controllers_Backend_Ext
         if ($shopId == 0) {
             $shop = null;
         } else {
-            /* @var $shop \Shopware\Models\Shop\Shop */
+            /* @var $shop Shop */
             $shop = Shopware()->Models()->getRepository('\Shopware\Models\Shop\Shop')->find($shopId);
             if (!$shop) {
                 $this->View()->assign(array('success' => false, 'message' => 'Shop not found'));
@@ -607,7 +590,7 @@ class Shopware_Controllers_Backend_Mail extends Shopware_Controllers_Backend_Ext
 
         $nodes = array();
 
-        /** @var $shop \Shopware\Models\Shop\Shop */
+        /** @var $shop Shop */
         $shops = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop')->findAll();
         foreach ($shops as $shop) {
             $shopNode = array(
@@ -666,5 +649,14 @@ class Shopware_Controllers_Backend_Mail extends Shopware_Controllers_Backend_Ext
         $nodes[] = $all;
 
         $this->View()->assign(array('success' => true, 'data' => $nodes));
+    }
+
+    private function getDefaultMailContext(Shop $shop)
+    {
+        return [
+            'sShop'    => $this->container->get('config')->get('ShopName'),
+            'sShopURL' => 'http' . ($shop->getAlwaysSecure() ? 's' : '') . '://'. $shop->getHost() . $shop->getBasePath(),
+            'sConfig'  => $this->container->get('config'),
+        ];
     }
 }

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -1139,10 +1139,11 @@ class sAdmin
             return false;
         }
 
+        $shop = $this->contextService->getShopContext()->getShop();
         $context = array(
             'sMAIL'     => $email,
             'sShop'     => $this->config->get('ShopName'),
-            'sShopURL'  => 'http://' . $this->config->get('BasePath'),
+            'sShopURL'  => 'http' . ($shop->getSecure() ? 's' : '') . '://' . $this->config->get('BasePath'),
             'sConfig'   => $this->config,
         );
 


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
When always ssl enabled in shop, it should be also in mails
* What does it improve?
Uses https url in mails
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Enable always secure and show the sShopUrl link in mail template

