### PR TITLE
Save grid user preferences also in customers, orders

### DIFF
--- a/themes/Backend/ExtJs/backend/article_list/view/main/grid.js
+++ b/themes/Backend/ExtJs/backend/article_list/view/main/grid.js
@@ -31,6 +31,7 @@ Ext.define('Shopware.apps.ArticleList.view.main.Grid', {
      * Make the grid statefull
      */
     stateful: true,
+
     /**
      * StateId (used in the cookiename later)
      */
@@ -126,8 +127,6 @@ Ext.define('Shopware.apps.ArticleList.view.main.Grid', {
     initComponent: function () {
         var me = this;
 
-        this.setupStateManager();
-
         me.columns = me.getColumns();
 
         me.tbar = me.getToolbar();
@@ -193,13 +192,6 @@ Ext.define('Shopware.apps.ArticleList.view.main.Grid', {
                 window.setTimeout(function() { col.setVisible(false); }, 0);
             }
         });
-    },
-
-    setupStateManager: function () {
-        var me = this;
-        me.stateManager = new Ext.state.LocalStorageProvider({ });
-
-        Ext.state.Manager.setProvider(me.stateManager);
     },
 
     /**

--- a/themes/Backend/ExtJs/backend/customer/view/list/list.js
+++ b/themes/Backend/ExtJs/backend/customer/view/list/list.js
@@ -97,6 +97,16 @@ Ext.define('Shopware.apps.Customer.view.list.List', {
     },
 
     /**
+     * Make the grid statefull
+     */
+    stateful: true,
+
+    /**
+     * StateId (used in the cookiename later)
+     */
+    stateId: 'customer-grid',
+
+    /**
      * Initialize the Shopware.apps.Customer.view.main.List and defines the necessary
      * default configuration
      * @return void

--- a/themes/Backend/ExtJs/backend/index/header.tpl
+++ b/themes/Backend/ExtJs/backend/index/header.tpl
@@ -18,7 +18,10 @@ iframe { border: 0 none !important; width: 100%; height: 100%; }
     var userName = '{$user->name}',
         maxParameterLength = '{$maxParameterLength}';
 
-    Ext.define('Shopware.app.Application', {
+        var stateManager = new Ext.state.LocalStorageProvider({ });
+        Ext.state.Manager.setProvider(stateManager);
+
+        Ext.define('Shopware.app.Application', {
         extend: 'Ext.app.Application',
         name: 'Shopware',
         singleton: true,

--- a/themes/Backend/ExtJs/backend/order/view/list/list.js
+++ b/themes/Backend/ExtJs/backend/order/view/list/list.js
@@ -103,6 +103,16 @@ Ext.define('Shopware.apps.Order.view.list.List', {
         }
     },
 
+    /**
+     * Make the grid statefull
+     */
+    stateful: true,
+
+    /**
+     * StateId (used in the cookiename later)
+     */
+    stateId: 'order-grid',
+
     viewConfig: {
         enableTextSelection: true
     },

--- a/themes/Backend/ExtJs/backend/order/view/list/position.js
+++ b/themes/Backend/ExtJs/backend/order/view/list/position.js
@@ -93,6 +93,16 @@ Ext.define('Shopware.apps.Order.view.list.Position', {
     },
 
     /**
+     * Make the grid statefull
+     */
+    stateful: true,
+
+    /**
+     * StateId (used in the cookiename later)
+     */
+    stateId: 'order-position-grid',
+
+    /**
      * The initComponent template method is an important initialization step for a Component.
      * It is intended to be implemented by each subclass of Ext.Component to provide any needed constructor logic.
      * The initComponent method of the class being created is called first,


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
User can customize columns of orders, customers
* What does it improve?
User grid preferences in orders and customers will be also saved like article list 
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | 

