### PR TITLE
Fixed opcache check when opcache is disabled with php.ini

### DIFF
--- a/engine/Shopware/Controllers/Backend/Performance.php
+++ b/engine/Shopware/Controllers/Backend/Performance.php
@@ -505,7 +505,7 @@ class Shopware_Controllers_Backend_Performance extends Shopware_Controllers_Back
                 'id' => 1,
                 'name' => Shopware()->Snippets()->getNamespace('backend/performance/main')->get('cache/apc'),
                 'value' => extension_loaded('apcu'),
-                'valid' => extension_loaded('apcu') === true ? self::PERFORMANCE_VALID : self::PERFORMANCE_INVALID
+                'valid' => extension_loaded('apcu') === true && ini_get('opcache.enable') === '1' ? self::PERFORMANCE_VALID : self::PERFORMANCE_INVALID
             ),
             array(
                 'id' => 3,


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Backend Module shows opcache is everything ok, but it is not enabled..
* What does it improve?
Checks opcache is also enabled in php.ini
* Does it have side effects?
Nope

PS: I have done also cosmetic changes



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | [SW-17721](https://issues.shopware.com/issues/SW-17721)
| How to test?     | 

