### PR TITLE
SW-17675 » Fixed duplicate smarty block

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/ajax_cart.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/ajax_cart.tpl
@@ -78,7 +78,7 @@
                             </a>
                         {/block}
                     {else}
-                        {block name='frontend_checkout_ajax_cart_open_checkout'}
+                        {block name='frontend_checkout_ajax_cart_open_checkout_disabled'}
                             <span class="btn is--disabled is--primary button--checkout is--icon-right" title="{"{s name='AjaxCartLinkConfirm'}{/s}"|escape}">
                                 <i class="icon--arrow-right"></i>
                                 {s name='AjaxCartLinkConfirm'}{/s}


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
 to get the ability to modify one single block
* Does it have side effects?
other plugins which use the second block are now not able to modify the content due to other block name


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes
| Related tickets? | [SW-17675](https://issues.shopware.com/issues/SW-17675)

