### PR TITLE
Add missing JS CartRefresh event

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.shopware-responsive.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.shopware-responsive.js
@@ -187,6 +187,8 @@
                 return;
             }
 
+            $.publish('plugin/swResponsive/onCartRefresh');
+
             $.ajax({
                 'url': ajaxCartRefresh,
                 'dataType': 'jsonp',
@@ -203,6 +205,8 @@
                     if (cart.quantity == 0) {
                         $cartQuantity.addClass('is--hidden');
                     }
+
+                    $.publish('plugin/swResponsive/onCartRefreshSuccess', [ cart ]);
                 }
             });
         }


### PR DESCRIPTION
The Shopware cartRefresh-method is missing event-emitters. there's currently no clean way to get the result of this ajax-call

## Description
Please describe your pull request:
* Why is it necessary? Developer Experience
* What does it improve? Missing event added
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | Subscribe to the `plugin/swResponsive/onCartRefresh` or the `plugin/swResponsive/onCartRefreshSuccess` event

