### PR TITLE
Changed the generation of the document path

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -252,7 +252,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
                 $mpdf->Output();
                 exit;
             } else {
-                $path = Shopware()->DocPath()."files/documents"."/".$this->_documentHash.".pdf";
+                $path = Shopware()->DocPath("files/documents").$this->_documentHash.".pdf";
                 $mpdf = new mPDF("utf-8", "A4", "", "", $this->_document["left"], $this->_document["right"], $this->_document["top"], $this->_document["bottom"]);
                 $mpdf->WriteHTML($data);
                 $mpdf->Output($path, "F");

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -252,7 +252,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
                 $mpdf->Output();
                 exit;
             } else {
-                $path = Shopware()->DocPath("files/documents").$this->_documentHash.".pdf";
+                $path = sprintf('%s%s.pdf', Shopware()->DocPath("files_documents"), $this->_documentHash);
                 $mpdf = new mPDF("utf-8", "A4", "", "", $this->_document["left"], $this->_document["right"], $this->_document["top"], $this->_document["bottom"]);
                 $mpdf->WriteHTML($data);
                 $mpdf->Output($path, "F");


### PR DESCRIPTION
With this change, Shopware()->DocPath() will be used to generate the path to ./files/documents. That makes it consistent with the other calls of DocPath().

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes