### PR TITLE
[FEATURE] make mixin output optional

### DIFF
--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/border-radius.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/border-radius.less
@@ -19,12 +19,13 @@ Resetting border radius:<br/>
 `.reset-border-radius();`
 */
 
-.border-radius(@radius: 3px) {
+.border-radius(@radius: 3px) when (@enableBorderRadiusMixin = true) {
+
 	border-radius: @radius;
 	// Prevent the background color leaks out
 	background-clip: padding-box;
 }
-.border-radius-multi(@leftTop: 0, @rightTop:0, @rightBottom: 0, @leftBottom: 0) {
+.border-radius-multi(@leftTop: 0, @rightTop:0, @rightBottom: 0, @leftBottom: 0) when (@enableBorderRadiusMixin = true) {
 	border-top-left-radius: @leftTop;
 	border-top-right-radius:  @rightTop;
 	border-bottom-right-radius: @rightBottom;

--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/linear-gradient.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/linear-gradient.less
@@ -20,14 +20,17 @@ Shopware 5 also provides gradient mixins based on the basic color variables that
 
 .linear-gradient(@start, @end) {
 	background-color: @start;
-	background-image: -ms-linear-gradient(top, @start, @end);
-	background-image: linear-gradient(to bottom, @start 0%, @end 100%);
+    .linear-gradient-vertical(@start, @end);
 }
-.linear-gradient-horizontal(@start, @end) {
+.linear-gradient-vertical(@start, @end) when (@enableGradientMixin = true) {
+    background-image: -ms-linear-gradient(top, @start, @end);
+    background-image: linear-gradient(to bottom, @start 0%, @end 100%);
+}
+.linear-gradient-horizontal(@start, @end) when (@enableGradientMixin = true) {
 	background-image: -ms-linear-gradient(left, @start, @end);
 	background-image: linear-gradient(to right, @start 0%, @end 100%);
 }
-.linear-gradient-multi(@firstPos, @firstColor, @secondPos, @secondColor, @thirdPos, @thirdColor, @startFrom: top, @endTo: bottom) {
+.linear-gradient-multi(@firstPos, @firstColor, @secondPos, @secondColor, @thirdPos, @thirdColor, @startFrom: top, @endTo: bottom) when (@enableGradientMixin = true) {
 	background-image: -ms-linear-gradient(@startFrom, @firstColor @firstPos,@secondColor @secondPos,@thirdColor @thirdPos);
 	background-image: linear-gradient(to @endTo, @firstColor @firstPos,@secondColor @secondPos,@thirdColor @thirdPos);
 }

--- a/themes/Frontend/Bare/frontend/_public/src/less/variables.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/variables.less
@@ -1,2 +1,5 @@
 // Used for the `.unitize()` mixin as the scale factor
 @remScaleFactor: 16;
+
+@enableBorderRadiusMixin: true;
+@enableGradientMixin: true;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
It was impossible to overwrite mixin output when extending from Bare template
* What does it improve?
Makes simple adjustments like removing all rounded borders and all gradients as easy as setting two variables to false.
* Does it have side effects?
no



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes
| Tests pass?      | yes
| Related tickets? |
| How to test?     | Check frontend output with @enableBorderRadiusMixin and @enableGradientMixin set either to true or false in variables.less

