### PR TITLE
Fix empty form field clear data in record

### DIFF
--- a/engine/Library/ExtJs/overrides/Ext.form.Base.js
+++ b/engine/Library/ExtJs/overrides/Ext.form.Base.js
@@ -55,6 +55,7 @@ Ext.override(Ext.form.Basic, {
      */
     updateRecord: function(record) {
         record = record || this._record;
+        var me = this;
 
         var values = this.getValues(),
             fields = record.fields,
@@ -101,6 +102,12 @@ Ext.override(Ext.form.Basic, {
             var name = field.name;
             if (name in values) {
                 data[name] = values[name];
+            } else {
+                if (me.findField(name)) {
+                    // form field exists but is empty.
+                    // set empty string as "null" will be filtered server side
+                    data[name] = "";
+                }
             }
         });
 

--- a/engine/Library/ExtJs/overrides/Ext.form.Base.js
+++ b/engine/Library/ExtJs/overrides/Ext.form.Base.js
@@ -103,7 +103,7 @@ Ext.override(Ext.form.Basic, {
             if (name in values) {
                 data[name] = values[name];
             } else {
-                if (me.findField(name)) {
+                if (me.findField(name) && !me.findField(name).disabled) {
                     // form field exists but is empty.
                     // set empty string as "null" will be filtered server side
                     data[name] = "";


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
Unable to clear form fields like comboboxes. Empty combobox does not return any value thus the data in the record is never removed
* What does it improve?
If a form field exists and is empty the data in the record will be cleared as well
* Does it have side effects?
no



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Create new backend CRUD; Add e.g. combobox as form element. Select a value from the store. Remove value from combobox. Save. 

