### PR TITLE
fixed NaN-bug in custom date field when value is 0000-00-00

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/element/date.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/date.js
@@ -41,7 +41,12 @@ Ext.define('Shopware.apps.Base.view.element.Date', {
         if(!value) {
             return null;
         } else if (typeof(value) == 'string') {
-            return new Date(value);
+            var date = new Date(value);
+            if (!isNaN(date)) {
+                return date;
+            } else {
+                return null;
+            }
         } else {
             return value;
         }

--- a/themes/Backend/ExtJs/backend/base/component/element/date.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/date.js
@@ -41,12 +41,7 @@ Ext.define('Shopware.apps.Base.view.element.Date', {
         if(!value) {
             return null;
         } else if (typeof(value) == 'string') {
-            var date = new Date(value);
-            if (!isNaN(date)) {
-                return date;
-            } else {
-                return null;
-            }
+            return new Date(value);
         } else {
             return value;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* When article has a custom field of date-type and is saved without an input in said field, the value '0000-00-00' is saved. When article is opened again in backend, it shows 'NaN.NaN.0NaN'. This 'value' however can not be saved in the date-type-field since this is not valide input.
* This fix checks if the value creates a NaN-Output. If it does, null is returned. If not, the valid date is returned.
* No known side effects.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | unknown
| Tests pass?      | unknown
| Related tickets? | unknown
| How to test?     | Create custom field for article of type "date". Create new article and leave said field empty. Reopen the new article: the custom field displays NaN. Now article can't be saved until NaN is deleted from the field. With this fix however, the NaN-output is catched and null is returned instead.

