### PR TITLE
Fix url fetch in swModalbox when more than one target are available & the clicking target have child elements

### DIFF
--- a/themes/Backend/ExtJs/backend/article_list/controller/suggest.js
+++ b/themes/Backend/ExtJs/backend/article_list/controller/suggest.js
@@ -34,7 +34,7 @@
 /**
  *
  */
-//{block name="backend/article_list/controller/main"}
+//{block name="backend/article_list/controller/suggest"}
 Ext.define('Shopware.apps.ArticleList.controller.Suggest', {
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.modal.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.modal.js
@@ -755,7 +755,7 @@
             event.preventDefault();
 
             var me = this,
-                target = me.$target.length === 1 && me.$target || $(event.target);
+                target = me.$target.length === 1 && me.$target || $(event.currentTarget);
 
             $.modal.open(me.opts.content || (me.opts.mode !== 'local' ? target.attr('href') : target), me.opts);
 


### PR DESCRIPTION
Please describe your pull request:
* Why is it necessary?
It prevent getting a wrong url when clicking on a target **when** multiple target exists **and** the clicking target has child elements like `<span>` or similar.
* What does it improve?
Fixing a bug.
* Does it have side effects?
No.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | see below

You need to put two targets in the snippet `ConfirmTerms` like the following, clear the related caches and go to `/checkout/confirm` by following the default order behavior in shopware. Then you need to click on one of the targets (`<a>` by default in the `AGB`-Section) and then the wrong url will be fetched and the page breaks (the current url will be loaded and executed in the modalbox). With my fix this doesn't happen because I access the original target.
```html
Ich habe die <a href="{url controller=custom sCustom=4 forceSecure}" title="AGB"><span style="text-decoration:underline;">AGB</span></a> und  <a href="{url controller=custom sCustom=308 forceSecure}" title="Widerrufsbelehrung"><span style="text-decoration:underline">Widerrufsbelehrung</span></a> Ihres Shops gelesen und bin mit deren Geltung einverstanden.
```

