### PR TITLE
fix emotion manufacturer slider

### DIFF
--- a/engine/Shopware/Controllers/Widgets/Emotion.php
+++ b/engine/Shopware/Controllers/Widgets/Emotion.php
@@ -595,22 +595,26 @@ class Shopware_Controllers_Widgets_Emotion extends Enlight_Controller_Action
             $ids = array_column($data["selected_manufacturers"], 'supplierId');
             $context = $this->get('shopware_storefront.context_service')
                 ->getShopContext();
+			
+			$mediaService = Shopware()->Container()->get('shopware_media.media_service');
 
             $manufacturers = $this->get('shopware_storefront.manufacturer_service')
                 ->getList($ids, $context);
-
-            $values = array_map(function (Manufacturer $manufacturer) {
-                return $this->get('legacy_struct_converter')
+			
+			$data['values'] = [];
+			
+			foreach($manufacturers as &$manufacturer) {
+				$value = $this->get('legacy_struct_converter')
                     ->convertManufacturerStruct($manufacturer);
-            }, $manufacturers);
-
-            if (!empty($category) && $category != Shopware()->Shop()->getCategory()->getId()) {
-                foreach ($values as &$value) {
-                    $value['link'] = $value['link'] . '?c=' . (int) $category;
-                }
-            }
-
-            $data['values'] = $values;
+				
+				if (!empty($category) && $category != Shopware()->Shop()->getCategory()->getId()) {
+					$value['link'] .= '?c=' . (int) $category;
+				}
+				
+				$value['image'] = $mediaService->getUrl($value['image']);
+				
+				$data['values'][] = $value;
+			}
         }
 
         return $data;


### PR DESCRIPTION
the image / cover image of an manufacturer was not converted correct to the new media structure.

<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
The pull request fix the emotion manufacturer slider. The manfacturer image was not displayed, if only selected manufacturers should be displayed.

* What does it improve?
The emotion manufacturer slider for emotion sites.

* Does it have side effects?
No.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | no
| Related tickets? | https://issues.shopware.com/issues/SW-17817.
| How to test?     | Add the manufacturer slider with selected manufacturers - not all manufacturers of an category - on a emotion site. 

