### PR TITLE
fix emotion manufacturer slider

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -875,7 +875,7 @@ class LegacyStructConverter
             'attributes' => $manufacturer->getAttributes()
         ];
 		
-		if(!empty($data['image'])) {
+		if (!empty($data['image'])) {
 			$data['image'] = $this->mediaService->getUrl($data['image']);
 		}
 

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -874,6 +874,10 @@ class LegacyStructConverter
             'image' => $manufacturer->getCoverFile(),
             'attributes' => $manufacturer->getAttributes()
         ];
+		
+		if(!empty($data['image'])) {
+			$data['image'] = $this->mediaService->getUrl($data['image']);
+		}
 
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Manufacturer', $data, [
             'manufacturer' => $manufacturer


### PR DESCRIPTION
the image / cover image of an manufacturer was not converted correctly to the new media structure in the legacy struct converter.

<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
The pull request fix the emotion manufacturer slider. The manfacturer image was not displayed, if only selected manufacturers should be displayed.

* What does it improve?
The emotion manufacturer slider for emotion sites.

* Does it have side effects?
No.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | no
| Related tickets? | https://issues.shopware.com/issues/SW-17817.
| How to test?     | Add the manufacturer slider with selected manufacturers - not all manufacturers of an category - on a emotion site.

