### PR TITLE
add guzzle config array optional param in factory

### DIFF
--- a/engine/Shopware/Components/HttpClient/GuzzleFactory.php
+++ b/engine/Shopware/Components/HttpClient/GuzzleFactory.php
@@ -30,11 +30,12 @@ use GuzzleHttp\ClientInterface;
 class GuzzleFactory
 {
     /**
+     * @param array $guzzleConfig
      * @return ClientInterface
      */
-    public function createClient()
+    public function createClient(array $guzzleConfig = [])
     {
-        $client = new Client();
+        $client = new Client($guzzleConfig);
 
         $certPath = __DIR__.'/cacert.pem';
         if (is_file($certPath)) {


### PR DESCRIPTION
Makes initializing a guzzle client much simpler, and eliminates the
requirement to make consecutive calls to set default options, and
provides a convenient way to set other options in the Guzzle HTTP
client.

<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary? Convenience
* What does it improve? Initialization of the Guzzle HTTP Client instance through the factory class
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | Not that I am aware of.
| How to test?     | Pass a config array to the *->createClient* method as you would to the *Client* class of the Guzzle Library

