### PR TITLE
fix rewrite for authorization headers in fpm/fcgi setups

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,9 @@
 <IfModule mod_rewrite.c>
 RewriteEngine on
 
+# Fix missing authorization-header on fast_cgi installations
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
 #RewriteBase /shopware/
 
 # Https config for the backend
@@ -17,8 +20,7 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ shopware.php [PT,L,QSA]
 
-# Fix missing authorization-header on fast_cgi installations
-RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]
+
 </IfModule>
 
 <IfModule mod_alias.c>


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Currently the api is not usable with apache 2.4 using php-fpm with a RewriteRule-setup, defined in the vhost-config. The .htaaccess rule for rewriting ``HTTP_AUTHORIZATION`` comes to late and never gets executed. Therefore the api returns always ``{"success":false,"message":"Invalid or missing auth"}``.

* What does it improve?
It makes the api, using the setup above, usable again.

* Does it have side effects?
No, if it did work with other setups, nothing will change.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | setup apache 2.4 with php-fpm and use the api

