### PR TITLE
Fixed document meta if articlenumber is numeric

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -342,7 +342,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         $articleModule = Shopware()->Modules()->Articles();
         foreach ($positions as &$position) {
             if ($position['modus'] == 0) {
-                $position['meta'] = $articleModule->sGetPromotionById('fix', 0, $position['articleordernumber']);
+                $position['meta'] = $articleModule->sGetPromotionById('fix', 0, $position['articleID']);
             }
         }
 


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
If the articlenumber is numeric, shopware will load the article by article ID
See: https://github.com/shopware/shopware/blob/5.2/engine/Shopware/Core/sArticles.php#L1442
* What does it improve?
Uses articleID
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://issues.shopware.com/issues/SW-17829
| How to test?     | Create a article with numeric ordernumber and create a document

