### PR TITLE
Make article links editable after creating

### DIFF
--- a/themes/Backend/ExtJs/backend/article/view/resources/links.js
+++ b/themes/Backend/ExtJs/backend/article/view/resources/links.js
@@ -210,11 +210,17 @@ Ext.define('Shopware.apps.Article.view.resources.Links', {
                 {
                     header: me.snippets.name,
                     dataIndex: 'name',
-                    flex: 2
+                    flex: 2,
+                    editor: {
+                        xtype: 'textfield'
+                    }
                 }, {
                     header: me.snippets.link,
                     dataIndex: 'link',
-                    flex: 2
+                    flex: 2,
+                    editor: {
+                        xtype: 'textfield'
+                    }
                 }, {
                     xtype: 'booleancolumn',
                     header: me.snippets.grid.external,


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Build a typo in article link and you must delete the complete row. Thats stupid...
* What does it improve?
Makes link and name editable with double click
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | .
| How to test?     | .

