### PR TITLE
Added new configuration element "logMailAddress" to send shop errors …

### DIFF
--- a/_sql/migrations/816-seperate-logmail-address.php
+++ b/_sql/migrations/816-seperate-logmail-address.php
@@ -1,0 +1,31 @@
+<?php
+
+class Migrations_Migration816 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = <<<'SQL'
+SET @formId = (SELECT id FROM `s_core_config_forms` WHERE name='Log');
+SQL;
+
+        $this->addSql("SET @localeID = (SELECT `id` FROM `s_core_locales` WHERE `locale` = 'en_GB' LIMIT 1);");
+        $this->addSql($sql);
+
+        $sql = <<<'SQL'
+      INSERT IGNORE INTO `s_core_config_elements`
+                (`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`, `options`)
+                VALUES
+                (@formID, 'logMailAddress', 's:0:"";', 'Seperate Mail-Adresse für Fehlermeldungen', 'Wenn dieses Feld leer ist, wird die Shopbetreiber Mail-Adresse verwendet', 'text', 1, 0, 0, NULL)
+SQL;
+        $this->addSql($sql);
+        $this->addSql('SET @elementID = (SELECT id FROM s_core_config_elements WHERE name = "logMailAddress")');
+
+        $sql = <<<EOD
+                INSERT IGNORE INTO `s_core_config_element_translations`
+                (`element_id`, `locale_id`, `label`, `description`)
+                VALUES
+                (@elementID, @localeID, 'Alternative e-mail address for errors', 'If this field is empty, the shop e-mail address will be used');
+EOD;
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Plugins/Default/Core/ErrorHandler/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/ErrorHandler/Bootstrap.php
@@ -279,8 +279,14 @@ class Shopware_Plugins_Core_ErrorHandler_Bootstrap extends Shopware_Components_P
      */
     public function createMailHandler()
     {
+        $mail = Shopware()->Config()->get('logMailAddress');
+
+        if (empty($mail)) {
+            $mail = Shopware()->Config()->Mail;
+        }
+
         $mailer = new \Enlight_Components_Mail();
-        $mailer->addTo(Shopware()->Config()->Mail);
+        $mailer->addTo($mail);
         $mailer->setSubject('Error in shop "'.Shopware()->Config()->Shopname.'".');
         $mailHandler = new EnlightMailHandler($mailer, \Monolog\Logger::WARNING);
         $mailHandler->pushProcessor(new ShopwareEnvironmentProcessor());


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Mostly the shop owner doesnt interested in shop errors and can forward the errors easily to a technician 
* What does it improve?
Adds a alternative email address for shop errors
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Configure a alternative email receiver

