### PR TITLE
Update ongr/elasticsearch-dsl to 2.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "guzzlehttp/guzzle": "5.3.1",
         "egulias/email-validator": "1.2.12",
         "elasticsearch/elasticsearch": "2.2.0",
-        "ongr/elasticsearch-dsl": "2.0.2",
+        "ongr/elasticsearch-dsl": "2.2.2",
         "league/flysystem": "1.0.22",
         "paragonie/random_compat": "1.4.1",
         "cocur/slugify": "2.2",


### PR DESCRIPTION
We need this for our ElasticSearch plugin since it uses a Function Scrore Query and the DSL had a bug with this until 2.2.1 when using ES 2.x

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | Use a function score query and ES 2.4.x

