### PR TITLE
[BUGFIX] SW-18001 Prefer get parameter 'template' when requesting art…

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Detail.php
+++ b/engine/Shopware/Controllers/Frontend/Detail.php
@@ -113,13 +113,15 @@ class Shopware_Controllers_Frontend_Detail extends Enlight_Controller_Action
             return $this->forward('error');
         }
 
-        $template = trim($article['template']);
-        if (!empty($template)) {
-            $this->View()->loadTemplate('frontend/detail/' . $article['template']);
-        } elseif (!empty($article['mode'])) {
-            $this->View()->loadTemplate('frontend/blog/detail.tpl');
-        } elseif ($tpl === 'ajax') {
+        if ($tpl && $tpl === 'ajax') {
             $this->View()->loadTemplate('frontend/detail/ajax.tpl');
+        } else {
+            $template = trim($article['template']);
+            if (!empty($template)) {
+                $this->View()->loadTemplate('frontend/detail/' . $template);
+            } elseif (!empty($article['mode'])) {
+                $this->View()->loadTemplate('frontend/blog/detail.tpl');
+            }
         }
 
         $article = Shopware()->Modules()->Articles()->sGetConfiguratorImage($article);


### PR DESCRIPTION
## The detail controller should prefer the GET parameter "template"
If the detail view of an article is requested with the GET parameter "template" and value "ajax", but the requested article has another template than the default template selected, then the GET parameter "template" is ignored. In this case, there is no way to get an ajax optimized result.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no, don't think so
| Tests pass?      | yes, but only tested manually
| Related tickets? | https://issues.shopware.com/issues/SW-18001
| How to test?     | Create an additional article template and select it for an article of your choice. Request the article detail view at the storefront and add the get param "template=ajax" to it's url. Without this bugfix, you cannot use the template /frontend/detail/ajax.tpl, it will be ignored.

