### PR TITLE
Round basket total before checking whether it is less than zero

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1137,7 +1137,7 @@ class sBasket
             $totalAmountNet
         ) = $this->getBasketArticles($getArticles);
 
-        if ($totalAmount < 0 || empty($totalCount)) {
+        if (static::roundTotal($totalAmount)  < 0 || empty($totalCount)) {
             if (!$this->eventManager->notifyUntil('Shopware_Modules_Basket_sGetBasket_AllowEmptyBasket', array(
                 'articles' => $getArticles,
                 'totalAmount' => $totalAmount,
@@ -1212,6 +1212,26 @@ class sBasket
 
         return $result;
     }
+
+    /**
+     * Round a total to two decimal places. Also make sure to round to positive zero instead of negative zero.
+     *
+     * @param float|double $total a number to round
+     * @return double the number rounded to two decimal places, with -0.0 replaced with 0.0
+     */
+    private static function roundTotal($total)
+    {
+        $roundedTotal = round($total, 2);
+
+        // -0.0 == 0.0 in PHP
+        if (((float) $roundedTotal) == 0.0) {
+            // prevent -0.0 (FP negative zero) from being returned from this function
+            return 0.0;
+        }
+
+        return $roundedTotal;
+    }
+
 
     /**
      * Add product to wishlist


### PR DESCRIPTION
## Description
Please describe your pull request:

* _Why is it necessary?_
We have use cases where the entire remaining value of the basket needs to be discounted. Shopware computes the basket total using double (i.e. binary floating point) arithmetic. A lot of common decimal fractions are periodic in binary, which means they cannot be represented exactly by doubles. Because of this, the result of adding a few simple decimal fractions may be off from the expected result by a small margin. In some particular constellations, this leads to the basket total being infinitesimally less than zero when it should be exactly zero, which leads to Shopware rejecting the basket as invalid.

* _What does it improve?_
The pull request adds code that rounds the total that is returned from `sBasket::sGetBasketArticles()` to two decimal places and coerces its value to be `0.0` when the FPU computes it to `-0.0` before doint the `< 0` check. This rounding is only applied within that check itself, so it does not modify the values that are used for showing the cart total to the user, since rounding prices correctly for display is the job of `sArticles::sRound()`.

* _Does it have side effects?_
This PR only fixes the basket validity check. There is another problem that causes very small (`|x| <= 0.00001`) totals to be rounded to nonsensical values, which will become visible for the sort of case described in this PR. Because of this, #1029 should be merged at the same time as this PR. 

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://issues.shopware.com/issues/SW-17016
| How to test?     | A unit test is enclosed with the PR.

**Edit**: simplified the PR to not touch the values that flow out from `sGetBasket` and edited the description accordingly.

