### PR TITLE
Fix floating point rounding in sArticles::sRound()

### DIFF
--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -1351,6 +1351,9 @@ class sArticles
      */
     public function sRound($moneyfloat = null)
     {
+        if (is_numeric($moneyfloat)) {
+            $moneyfloat = sprintf('%F', $moneyfloat);
+        }
         $money_str = explode(".", $moneyfloat);
         if (empty($money_str[1])) {
             $money_str[1] = 0;

--- a/tests/Functional/Core/sArticlesTest.php
+++ b/tests/Functional/Core/sArticlesTest.php
@@ -118,4 +118,52 @@ class sArticlesTest extends Enlight_Components_Test_Controller_TestCase
         // a query to a not existing article should return 'false' and not throw an exception
         $this->assertFalse($result);
     }
+
+    /**
+     * Assert that numbers that are small enough to be represented as floating points by PHP when they are converted to
+     * string are rounded correctly by sArticles::sRound.
+     */
+    public function testsRoundWithFloatingPointRepresentation()
+    {
+        $sArticles = new sArticles();
+        $input = 0.00001; // 1.0E-5
+
+        // Round 1.0E-5
+        $result = $sArticles->sRound($input);
+
+        $this->assertEquals(0, $result);
+    }
+
+    /**
+     * Assert that negative numbers that are small enough to be represented as floating points by PHP when they are
+     * converted to string are rounded correctly by sArticles::sRound. Also assert that they are not represented as -0
+     * (negative zero)
+     */
+    public function testsRoundWithFloatingPointRepresentationNegative()
+    {
+        $sArticles = new sArticles();
+        $input = -0.00001; // -1.0E-5
+
+        // Round -1.0E-5
+        $result = $sArticles->sRound($input);
+
+        $this->assertEquals(0, $result);
+        // Make sure we don't get negative zero
+        $this->assertEquals('0', (string) $result);
+    }
+
+    /**
+     * Assert that numbers that are small enough to be represented as floating points by PHP when they are converted to
+     * string are rounded correctly by sArticles::sRound.
+     */
+    public function testsRoundWithFloatingPointRepresentationLarge()
+    {
+        $sArticles = new sArticles();
+        $input = 100000000000000.0; // 1.0E14
+
+        // Round 1.0E14
+        $result = $sArticles->sRound($input);
+
+        $this->assertEquals(100000000000000, $result);
+    }
 }


### PR DESCRIPTION
## Description
Please describe your pull request:
* _Why is it necessary?_
The method `sArticles::sRound()` "rounds" monetary amounts to two decimal places by string manipulation based on PHP's implicit type conversion of double values to string. For numbers `>= 1e14` and numbers `<= 1e-5`, PHP will use scientific notation (i.e. floating point notation) when converting those numbers to string. This breaks `sArticles::sRound()` in silly ways. In particular, `0.00001` is rounded to `1`, `-0.00001` is rounded to `-1` and `100000000000000.0` is rounded to `1`. While we have not observed the latter case in the wild, the two former cases will happen when the cart total is close to zero, which is why we discovered this case. Also see the related PR #1027.
* _What does it improve?_
It makes `sArticles::sRound()` work correctly for numbers which are small enough or large enough for PHP to stringify them using scientific notation by default.
* _Does it have side effects?_
None observed.



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://issues.shopware.com/issues/SW-17016
| How to test?     | Unit tests are enclosed with the PR.

