### PR TITLE
Remove swf support in banner and blog

### DIFF
--- a/themes/Backend/ExtJs/backend/banner/view/main/banner_form_add.js
+++ b/themes/Backend/ExtJs/backend/banner/view/main/banner_form_add.js
@@ -172,7 +172,7 @@ Ext.define('Shopware.apps.Banner.view.main.BannerFormAdd', {
      * @return array of strings
      */
     getAllowedExtensions : function() {
-        return [ 'gif', 'png', 'jpeg', 'jpg', 'swf' ]
+        return [ 'gif', 'png', 'jpeg', 'jpg' ]
     },
 
     /**

--- a/themes/Backend/ExtJs/backend/blog/view/blog/detail/sidebar/options.js
+++ b/themes/Backend/ExtJs/backend/blog/view/blog/detail/sidebar/options.js
@@ -234,7 +234,7 @@ Ext.define('Shopware.apps.Blog.view.blog.detail.sidebar.Options', {
      * @return array of strings
      */
     getAllowedExtensions : function() {
-        return [ 'gif', 'png', 'jpeg', 'jpg', 'swf' ]
+        return [ 'gif', 'png', 'jpeg', 'jpg' ]
     },
     /**
      * Creates the template for the media view panel

--- a/themes/Frontend/Bare/frontend/listing/banner.tpl
+++ b/themes/Frontend/Bare/frontend/listing/banner.tpl
@@ -2,12 +2,7 @@
     {if $sBanner}
         <div class="banner--container">
 
-            {if $sBanner.extension=="swf"}
-
-                {* @deprecated Flash banner *}
-                {block name='frontend_listing_swf_banner'}{/block}
-
-            {elseif $sBanner.media.thumbnails}
+            {if $sBanner.media.thumbnails}
                 {if !$sBanner.link || $sBanner.link == "#" || $sBanner.link == ""}
 
                     {* Image only banner *}


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Everyone hates adobe flash player see: https://www.golem.de/news/browser-chrome-beginnt-mit-dem-ende-von-flash-1612-125010.html
* What does it improve?
Removed swf support in blog and banner element
* Does it have side effects?
Nope when use html5 pls..



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | 

