### PR TITLE
Renamed block for comment count in frontend_blog_detail_comments_count

### DIFF
--- a/themes/Frontend/Bare/frontend/blog/detail.tpl
+++ b/themes/Frontend/Bare/frontend/blog/detail.tpl
@@ -50,7 +50,7 @@
                                 {block name='frontend_blog_detail_category'}{/block}
 
                                 {* Comments *}
-                                {block name='frontend_blog_detail_comments'}
+                                {block name='frontend_blog_detail_comments_count'}
                                     <span class="blog--metadata-comments blog--metadata">
                                         <a data-scroll="true" data-scrollTarget="#blog--comments-start" href="#blog--comments-start" title="{"{s name="BlogLinkComments"}{/s}"|escape}">{$sArticle.comments|count|default:0} {s name="BlogInfoComments"}{/s}</a>
                                     </span>


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
The old blockname was duplicate in same file. I can't choose which block i can really override
* What does it improve?
Renames duplicate block to frontend_blog_detail_comments_count
* Does it have side effects?




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes/no
| Tests pass?      | yes/no
| Related tickets? | If this PR fixes an existing [Issue](https://issues.shopware.com) ticket, please add its complete issue URL.
| How to test?     | Please describe how to best verify that this PR is correct.

