### PR TITLE
Fixed color picker

### DIFF
--- a/themes/Backend/ExtJs/backend/config/view/element/color.js
+++ b/themes/Backend/ExtJs/backend/config/view/element/color.js
@@ -37,7 +37,9 @@ Ext.define('Shopware.apps.Config.view.element.Color', {
     },
 
     //invalidText: "Colors must be in a the hex format #FFFFFF.",
+    // {literal}
     regex: /^#[0-9A-F]{6}|[0-9A-F]{3}$/i,
+    // {/literal}
 
     initComponent: function () {
         this.callParent()


### PR DESCRIPTION
Without this fix, the curly braces will be removed by smarty, resulting in a regex that only validates colors ending with `3` oder `6`.

## Description
* Without this fix, the curly braces will be removed by smarty, resulting in a regex that only validates colors ending with `3` or `6`.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | -
| How to test?     | Use color picker in a config. Pick a color not ending with 3 or 6. See no validation error

