### PR TITLE
Add empty condition

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -407,7 +407,9 @@ class Repository extends ModelRepository
                 ->where($builder->expr()->eq('history.orderId', '?1'))
                 ->setParameter(1, $orderId);
 
-        $builder->addOrderBy($orderBy);
+        if (!empty($orderBy)) {
+            $builder->addOrderBy($orderBy);
+        }
         return $builder;
     }
 


### PR DESCRIPTION
The getOrderStatusHistoryListQueryBuilder() Method throws an Doctrine exception when $orderBy is not set as parameter although it's optional.


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | Use getOrderStatusHistoryListQueryBuilder() Method without second param.

