### PR TITLE
Abort pending ajax requests when the search word is updated

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.search.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.search.js
@@ -384,10 +384,16 @@
 
             $.publish('plugin/swSearch/onSearchRequest', [ me, searchTerm ]);
 
-            $.ajax({
+            me.triggerSearchRequest.xhr =  $.ajax({
                 'url': me.requestURL,
                 'data': {
                     'sSearch': me.lastSearchTerm
+                },
+                'beforeSend': function() {
+                    // Abort any pending request before starting a new one
+                    if (me.triggerSearchRequest.xhr != null) {
+                       me.triggerSearchRequest.xhr.abort();
+                    }
                 },
                 'success': function (response) {
                     me.showResult(response);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
When you type in the search field, a result preview is fetched via ajax as soon as you stop typing. When you start typing again, while the first ajax request is still pending, a second ajax request is executed, but the first one is not aborted. That can lead to the situation, (especially when the server is under high load) where the second ajax request is finished before the first one. In this case, the preview shown does not match the current search term, but the one from the first request.
Solution: Abort the pending search request as soon as you start a new one.



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | Have a slow server, type in the search field, and see how the search results are not updated properly

