### PR TITLE
Remove unnecessary string concatenation in plugin path configuration

### DIFF
--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -96,10 +96,10 @@ return array_replace_recursive([
         'apiEndpoint' => 'https://api.shopware.com',
     ],
     'plugin_directories' => [
-        'Default'            => $this->AppPath('Plugins_' . 'Default'),
-        'Local'              => $this->AppPath('Plugins_' . 'Local'),
-        'Community'          => $this->AppPath('Plugins_' . 'Community'),
-        'ShopwarePlugins'    => $this->DocPath('custom_plugins')
+        'Default' => $this->AppPath('Plugins_Default'),
+        'Local' => $this->AppPath('Plugins_Local'),
+        'Community' => $this->AppPath('Plugins_Community'),
+        'ShopwarePlugins' => $this->DocPath('custom_plugins'),
     ],
     'template' => [
         'compileCheck' => true,


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary? 
Cleaner code and less string operations 
* What does it improve?
See above
* Does it have side effects?
No

I also fixed the coding style although this is already done in the 5.3 branch, but the merge will be less painful

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | -
| How to test?     | Apply patch, nothing should change.

