### PR TITLE
[BUGFIX] Fixed replaced name for JPG files in media model

### DIFF
--- a/engine/Shopware/Models/Media/Media.php
+++ b/engine/Shopware/Models/Media/Media.php
@@ -2156,9 +2156,9 @@ class Media extends ModelEntity
         }
 
         // make sure that the name don't contains the file extension.
-        $name = str_replace('.' . $extension, '', $name);
+        $name = str_ireplace('.' . $extension, '', $name);
         if ($extension === 'jpeg') {
-            $name = str_replace('.jpg', '', $name);
+            $name = str_ireplace('.jpg', '', $name);
         }
 
         //set the file type using the type mapping


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary? Because actually you can't use the media API resource to import local files with an uppercase JPG extension.
* What does it improve? This PR makes sure that the name of the file does not contain the extension if the extension is an uppercase JGP, too
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | Write an image import using the media API resource and import an image called `image.JPG`

