### PR TITLE
Remove ‘NotBlank’ assertion from ‘Shopware\Models\Order\Order::$remoteAddress’

### DIFF
--- a/engine/Shopware/Models/Order/Order.php
+++ b/engine/Shopware/Models/Order/Order.php
@@ -289,8 +289,6 @@ class Order extends ModelEntity
     private $currencyFactor;
 
     /**
-     * @Assert\NotBlank
-     *
      * @var string $remoteAddress
      *
      * @ORM\Column(name="remote_addr", type="string", length=255, nullable=true)


### PR DESCRIPTION
### Why is it necessary

Since 5ae5059fc9dd32e040dc8e9a80143d16e043542e it is not possible anymore to create an order (`s_order`) using Doctrine and validation, without setting a `remoteAddress`. However, the field `s_order.remote_addr` is nullable per definition (so is the declaration of its property in the Doctrine model) and hence it should not be enforced to set the `remoteAddress` to some non-blank value when working with Doctrine models or the REST API.

### What does it improve?

This PR removes the `NotBlank` assertion constraint from `Shopware\Models\Order\Order::$remoteAddress` to fix the validation of orders without remote address and make the model consistent with its database table again.

### Does it have any side effects?

No.

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Create an order using the REST API without setting `remoteAddress`

