### PR TITLE
Use install email address for forms

### DIFF
--- a/recovery/install/src/Service/ShopService.php
+++ b/recovery/install/src/Service/ShopService.php
@@ -101,6 +101,7 @@ EOT;
         }
 
         $this->updateMailAddress($shop);
+        $this->updateFormMailAddress($shop);
         $this->updateShopName($shop);
     }
 
@@ -118,6 +119,16 @@ EOT;
     private function updateShopName(Shop $shop)
     {
         $this->updateConfigValue('shopName', $shop->name);
+    }
+
+    /**
+     * @param Shop $shop
+     */
+    private function updateFormMailAddress(Shop $shop)
+    {
+        $this->connection
+            ->prepare('UPDATE s_cms_support SET email = ? WHERE email = ?')
+            ->execute([$shop->email, 'info@example.com']);
     }
 
     /**


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Saves time when installing a new shopware installation
* What does it improve?
Uses install shop email for forms
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | There are not documented how to build the installation sqls... which are required for installer
| Related tickets? | 
| How to test?     | 