### PR TITLE
Remove media file only if it was uploaded

### DIFF
--- a/engine/Shopware/Models/Media/Media.php
+++ b/engine/Shopware/Models/Media/Media.php
@@ -1818,7 +1818,9 @@ class Media extends ModelEntity
             }
 
             $mediaService->write($this->path, file_get_contents($this->file->getRealPath()));
-            unlink($this->file->getPathname());
+            if (is_uploaded_file($this->file->getPathname())) {
+                unlink($this->file->getPathname());
+            }
         }
         return true;
     }


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary? When you use the `Media` Resource class for a local media import for article images e.g. the source image will be removed.
* What does it improve? The source image will only be removed if it was uploaded via HTTP.
* Does it have side effects? No.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | no
| How to test?     | Write an image import using the `Media` resource and import a file with `file:///path/to/my/file.jpg`. The image should remain in the path after the import in Shopware.

