### PR TITLE
don't echo readfile's return

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1250,7 +1250,7 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
         $response->setHeader('Content-Length', filesize($file));
         $response->sendHeaders();
 
-        echo readfile($file);
+        readfile($file);
         exit;
     }
 


### PR DESCRIPTION
Since readfile() echoes the given file directly to the output buffer, it is not necessary to echo its return value. In addition, echoing the number of bytes read _could_ mess up the download in environments with output compression.

See http://php.net/manual/en/function.readfile.php