### PR TITLE
Move 'Shopware_Modules_Export_ExportResult_Filter'

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -4,6 +4,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.23
 * Added conditional statement in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js` to prevent the jquery plugin from sending ajax requests indefinitely
+* The event `Shopware_Modules_Export_ExportResult_Filter_Fixed` was added and now filters the processed export result. Previously with `Shopware_Modules_Export_ExportResult_Filter`, an instance of `Zend_Db_Statement_Pdo` was supplied, which could not be used to filter the actual result.
 
 ## 5.2.22
 * Fixed the picture implementation of the `box-emotion.tpl` to load the correct image sizes

--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -1147,6 +1147,12 @@ class sExport
             if ($rowIndex == $count || count($rows) >= 50) {
                 @set_time_limit(30);
 
+                $rows = Shopware()->Container()->get('events')->filter(
+                    'Shopware_Modules_Export_ExportResult_Filter_Fixed',
+                    $rows,
+                    ['feedId' => $this->sFeedID, 'subject' => $this]
+                );
+
                 $this->sSmarty->assign('sArticles', $rows);
                 $rows = [];
 


### PR DESCRIPTION
The Event `Shopware_Modules_Export_ExportResult_Filter` currently supplies a `Zend_Db_Statement_Pdo` instead of the actual result. The statement can't actually be filtered, thus the event should be moved down and filter the actual result before it is assigned to Smarty.

## Description
Please describe your pull request:
* Why is it necessary?
The current implementation does not allow developers to filter the query result.
* What does it improve?
The result can be filtered.
* Does it have side effects?
If this event was previously used to manipulate the actual Statement object, that will not work anymore.


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | possibly
| Tests pass?      | yes
| Related tickets? | could not find any
| How to test?     | subscribe to the event and filter the results

