### PR TITLE
Allow opening single voucher

### DIFF
--- a/themes/Backend/ExtJs/backend/voucher/controller/main.js
+++ b/themes/Backend/ExtJs/backend/voucher/controller/main.js
@@ -66,10 +66,20 @@ Ext.define('Shopware.apps.Voucher.controller.Main', {
      */
     init: function() {
         var me = this;
-        me.mainWindow = me.getView('main.Window').create({
-            listStore: me.getStore('List')
-        });
-        me.getStore('List').load();
+
+        if (me.subApplication && me.subApplication.params && Ext.isNumeric(me.subApplication.params.voucherId)) {
+            var voucherController = me.subApplication.getController('Voucher');
+            voucherController.openVoucher(me.subApplication.params.voucherId)
+
+            // me.subApplication.getController creates the same controller multiple time, so the controller listen multiple
+            me.subApplication.removeController(voucherController);
+        } else {
+            me.mainWindow = me.getView('main.Window').create({
+                listStore: me.getStore('List')
+            });
+            me.getStore('List').load();
+        }
+
         me.callParent(arguments);
     }
 });

--- a/themes/Backend/ExtJs/backend/voucher/controller/voucher.js
+++ b/themes/Backend/ExtJs/backend/voucher/controller/voucher.js
@@ -147,11 +147,22 @@ Ext.define('Shopware.apps.Voucher.controller.Voucher', {
      */
     onEditVoucher:function (view, rowIndex) {
         var me = this,
-            store = me.getStore('Detail'),
             record = me.getStore('List').getAt(rowIndex);
 
+        me.openVoucher(record.data.id);
+    },
+
+    /**
+     * Opens voucher detail with voucherId
+     * @param [integer] voucherId
+     * @return void
+     */
+    openVoucher: function (voucherId) {
+        var me = this,
+            store = me.getStore('Detail');
+
         store.getProxy().extraParams = {
-            voucherID:record.data.id
+            voucherID: voucherId
         };
 
         store.load({
@@ -174,6 +185,7 @@ Ext.define('Shopware.apps.Voucher.controller.Voucher', {
             }
         });
     },
+
     /**
      * Opens the Ext.window.window which displays
      * the Ext.form.Panel to duplicate an existing voucher


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Decreasing developing time of voucher extensions, allows other backend modules open a single voucher
* What does it improve?
If a application param voucherId is passed, only the voucher detail will be opend
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | /backend/?app=Voucher&params[voucherId]=1
