### PR TITLE
add missing attributes `width`, `height` and `len` (fix #SW-18181)

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -490,6 +490,9 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
             $mainData['releaseDate'] = $mainDetail->getReleaseDate();
             $mainData['shippingTime'] = $mainDetail->getShippingTime();
             $mainData['shippingFree'] = $mainDetail->getShippingFree();
+            $mainData['width'] = $mainDetail->getWidth();
+            $mainData['height'] = $mainDetail->getHeight();
+            $mainData['len'] = $mainDetail->getLen();
         }
         if ($mapping['attributes']) {
             $builder = Shopware()->Models()->createQueryBuilder();


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary? fixes a bug.
* What does it improve? Shopware.
* Does it have side effects? No.




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://issues.shopware.com/issues/SW-18181
| How to test?     | Fill out article fields width, height and length on main detail page. Use the copy from main details button to copy data from main variant. without the fix the three fields stay empty, with the fix they will be copied.

