### PR TITLE
[FEATURE] last seen products cache busting

### DIFF
--- a/themes/Frontend/Bare/frontend/index/index.tpl
+++ b/themes/Frontend/Bare/frontend/index/index.tpl
@@ -153,6 +153,8 @@
         {block name="frontend_index_header_javascript_inline"}
             var timeNow = {time() nocache};
 
+            var cacheCreated = '{themeTimestamp}';
+
             var controller = controller || {ldelim}
                 'vat_check_enabled': '{config name='vatcheckendabled'}',
                 'vat_check_required': '{config name='vatcheckrequired'}',

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.last-seen-products.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.last-seen-products.js
@@ -171,7 +171,7 @@
             }
 
             $.each(products, function(i, product) {
-                if (product.articleId === opts.currentArticle.articleId) {
+                if (product.cacheCreated !== window.cacheCreated || product.articleId === opts.currentArticle.articleId) {
                     return;
                 }
 
@@ -282,6 +282,7 @@
                 itemKey = 'lastSeenProducts-' + opts.shopId + '-' + opts.baseUrl,
                 productsJson = me.storage.getItem(itemKey),
                 products = productsJson ? $.parseJSON(productsJson) : [],
+                newProducts = [],
                 linkDetailsQuery = '',
                 len = products.length,
                 i = 0,
@@ -315,13 +316,16 @@
                 newProduct.linkDetailsRewritten = url.substring(0, url.indexOf('?')) + linkDetailsQuery;
             }
 
-            products.splice(0, 0, newProduct);
+            newProduct.cacheCreated = window.cacheCreated;
+            newProducts.push(newProduct);
 
-            while (products.length > opts.productLimit + 1) {
-                products.pop();
-            }
+            $.each(products, function (i, product) {
+                if (newProducts.length <= opts.productLimit && product.cacheCreated === window.cacheCreated) {
+                    newProducts.push(product);
+                }
+            });
 
-            me.storage.setItem(itemKey, JSON.stringify(products));
+            me.storage.setItem(itemKey, JSON.stringify(newProducts));
 
             $.publish('plugin/swLastSeenProducts/onCollectProduct', [ me, newProduct ]);
         },


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
Currently if you decide to change information or layout in last seen products you have no way to ensure that past visitors don't get broken layouts or unstyled information.
* What does it improve?
Adds an cache identifier {themeTimestamp} (currently also used for css cache busting) to the products in localStorage and just displays them if this identifier matches with the current one.
* Does it have side effects?
Last seen products get cleared for all visitors upon theme compilation as themeTimestamp changes.


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | -
| How to test?     | Test visiting product pages and check if last seen products disappear after theme compilation.

