### PR TITLE
jquery.search - abort previous ajax-requests

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.search.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.search.js
@@ -384,7 +384,11 @@
 
             $.publish('plugin/swSearch/onSearchRequest', [ me, searchTerm ]);
 
-            $.ajax({
+            if(me.lastSearchAjax){
+                me.lastSearchAjax.abort();
+            }
+
+            me.lastSearchAjax = $.ajax({
                 'url': me.requestURL,
                 'data': {
                     'sSearch': me.lastSearchTerm


### PR DESCRIPTION
Backport for 5.2 (https://github.com/shopware/shopware/pull/1010)

This PR modifies the jquery.search plugin to abort any previous (still-running) ajax-requests to the search controller. This prevents multiple ajax-request coming in at the same time. Also it prevents an older request from superseeding a new request, in case it takes longer (for whatever reason).

## Description
Please describe your pull request:
* Why is it necessary? Performance improvement, preventing possible bugs
* What does it improve? Ajax-Search
* Does it have side effects? No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| How to test?     | Open up the browsers dev-tools, throttle the network-speed and start typing into the search-box. See screenshot below for what it should look like.

![image](https://cloud.githubusercontent.com/assets/765896/23355965/65c43010-fcd8-11e6-9eba-43e70a19b557.png)

