### PR TITLE
[BUGFIX][SW-18218] Fixed error using getId function with articleorder…

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -342,7 +342,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         $articleModule = Shopware()->Modules()->Articles();
         foreach ($positions as &$position) {
             if ($position['modus'] == 0) {
-                $position['meta'] = $articleModule->sGetPromotionById('fix', 0, $position['articleordernumber']);
+                $position['meta'] = $articleModule->sGetPromotionById('fix', 0, $position['articleID']);
             }
         }
 


### PR DESCRIPTION
…number instead id

<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
This pull requests fixes the wrong data in meta array of order position in pdf document template.



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://issues.shopware.com/issues/SW-18218
| How to test?     | Add meta.ordernumber to PDF in document template and check if the ordernumber is the same as position

