### PR TITLE
Capability to use Namespaces in Controllers

### DIFF
--- a/engine/Library/Enlight/Controller/Dispatcher/Default.php
+++ b/engine/Library/Enlight/Controller/Dispatcher/Default.php
@@ -445,7 +445,7 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
             return true;
         }
         $path = $this->getControllerPath($request);
-        return Enlight_Loader::isReadable($path);
+        return Enlight_Loader::isReadable($path) || class_exists($path);
     }
 
     /**
@@ -491,6 +491,11 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
 
         $class = $this->getControllerClass($request);
         $path = $this->getControllerPath($request);
+
+        if (class_exists($path)) {
+            $class = $path;
+            $path = null;
+        }
 
         try {
             Shopware()->Loader()->loadClass($class, $path);

--- a/engine/Library/Enlight/Controller/Dispatcher/Default.php
+++ b/engine/Library/Enlight/Controller/Dispatcher/Default.php
@@ -445,7 +445,7 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
             return true;
         }
         $path = $this->getControllerPath($request);
-        return Enlight_Loader::isReadable($path) || class_exists($path);
+        return class_exists($path) || Enlight_Loader::isReadable($path);
     }
 
     /**


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Default benefits of namespacing
* What does it improve?
Allows "Enlight_Controller_Dispatcher_ControllerPath_X_X" Event to return a Class name, which should be used
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     |

Example Plugin:

Plugin:
```php
<?php


namespace Test;

use Shopware\Components\Plugin;

class Test extends Plugin
{
    public static function getSubscribedEvents()
    {
        return [
            'Enlight_Controller_Dispatcher_ControllerPath_Frontend_Test' => 'onTest'
        ];
    }

    public function onTest(\Enlight_Event_EventArgs $args)
    {
        return \Test\Controllers\Test::class;
    }
}
```

Controller:
```php
<?php


namespace Test\Controllers;

class Test extends \Enlight_Controller_Action
{
    public function indexAction()
    {
    }
}