### PR TITLE
[BUGFIX] Added padding to unordered lists in custom pages

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/custom.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/custom.less
@@ -6,6 +6,11 @@ Defines the layout for the custom pages.
 The styling defines the basic layout of the Shopware 5 custom pages that can be created and customized for multiple purposes.
 */
 
+.is--ctl-custom {
+    ul {
+        .unitize(padding-left, 20);
+    }
+}
 
 .custom-page--content {
     .unitize(margin-top, 10);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Styling looks bugged on custom pages when unordered lists are used. Cause is, that ul styling receives padding: 0.



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | Add list to static page.

