### PR TITLE
Moved table_entity_mapping in container as parameter

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/DependencyInjection/Compiler/StaticResourcesCompilerPass.php
+++ b/engine/Shopware/Bundle/AttributeBundle/DependencyInjection/Compiler/StaticResourcesCompilerPass.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\AttributeBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class StaticResourcesCompilerPass implements CompilerPassInterface
+{
+
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $container->setParameter('shopware_attribute.table_entity_mapping', include __DIR__ . '/../Resources/table_entity_mapping.php');
+    }
+}

--- a/engine/Shopware/Bundle/AttributeBundle/Service/TableMapping.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/TableMapping.php
@@ -47,11 +47,12 @@ class TableMapping
     /**
      * TableMapping constructor.
      * @param Connection $connection
+     * @param array      $tableMapping
      */
-    public function __construct(Connection $connection)
+    public function __construct(Connection $connection, array $tableMapping)
     {
         $this->connection = $connection;
-        $this->tables = include __DIR__ . '/../DependencyInjection/Resources/table_entity_mapping.php';
+        $this->tables = $tableMapping;
     }
 
     /**

--- a/engine/Shopware/Bundle/AttributeBundle/services.xml
+++ b/engine/Shopware/Bundle/AttributeBundle/services.xml
@@ -28,6 +28,7 @@
 
         <service id="shopware_attribute.table_mapping" class="Shopware\Bundle\AttributeBundle\Service\TableMapping">
             <argument type="service" id="dbal_connection" />
+            <argument>%shopware_attribute.table_entity_mapping%</argument>
         </service>
 
         <service id="shopware_attribute.type_mapping" class="Shopware\Bundle\AttributeBundle\Service\TypeMapping">

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -25,6 +25,7 @@
 namespace Shopware;
 
 use Shopware\Bundle\AttributeBundle\DependencyInjection\Compiler\SearchRepositoryCompilerPass;
+use Shopware\Bundle\AttributeBundle\DependencyInjection\Compiler\StaticResourcesCompilerPass;
 use Shopware\Bundle\ControllerBundle\DependencyInjection\Compiler\RegisterControllerCompilerPass;
 use Shopware\Bundle\ESIndexingBundle\DependencyInjection\CompilerPass\SettingsCompilerPass;
 use Shopware\Bundle\ESIndexingBundle\DependencyInjection\CompilerPass\SynchronizerCompilerPass;
@@ -584,6 +585,7 @@ class Kernel implements HttpKernelInterface
         $container->addCompilerPass(new FormPass());
         $container->addCompilerPass(new AddConstraintValidatorsPass());
         $container->addCompilerPass(new SearchRepositoryCompilerPass());
+        $container->addCompilerPass(new StaticResourcesCompilerPass());
         $container->addCompilerPass(new AddConsoleCommandPass());
         $container->addCompilerPass(new MediaAdapterCompilerPass());
         $container->addCompilerPass(new MediaOptimizerCompilerPass());


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Easier editable with plugins.
* What does it improve?
Plugins could do add a new CompilerPass which modifies the container parameter "shopware_attribute.table_entity_mapping"
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | 

