### PR TITLE
Fix calculation in Order::calculateInvoiceAmount

### DIFF
--- a/engine/Shopware/Models/Order/Order.php
+++ b/engine/Shopware/Models/Order/Order.php
@@ -1066,7 +1066,9 @@ class Order extends ModelEntity
         //iterate order details to recalculate the amount.
         /**@var $detail Detail*/
         foreach ($this->getDetails() as $detail) {
-            $invoiceAmount += $detail->getPrice() * $detail->getQuantity();
+            $price = round($detail->getPrice(), 2);
+
+            $invoiceAmount += $price * $detail->getQuantity();
 
             $tax = $detail->getTax();
 
@@ -1078,9 +1080,9 @@ class Order extends ModelEntity
             }
 
             if ($this->net) {
-                $invoiceAmountNet += round(($detail->getPrice() * $detail->getQuantity()) / 100 * (100 + $taxValue), 2);
+                $invoiceAmountNet += round(($price * $detail->getQuantity()) / 100 * (100 + $taxValue), 2);
             } else {
-                $invoiceAmountNet += ($detail->getPrice() * $detail->getQuantity()) / (100 + $taxValue) * 100;
+                $invoiceAmountNet += round(($price * $detail->getQuantity()) / (100 + $taxValue) * 100, 2);
             }
         }
 

--- a/tests/Functional/Controllers/Frontend/CheckoutTest.php
+++ b/tests/Functional/Controllers/Frontend/CheckoutTest.php
@@ -76,13 +76,134 @@ class Shopware_Tests_Controllers_Frontend_CheckoutTest extends Enlight_Component
     /**
      * fires the add article request with the given user agent
      * @param $userAgent
+     * @param int $quantity
      * @return String | session id
      */
-    private function addBasketArticle($userAgent)
+    private function addBasketArticle($userAgent, $quantity = 1)
     {
         $this->reset();
         $this->Request()->setHeader('User-Agent', $userAgent);
+        $this->Request()->setParam('sQuantity', $quantity);
         $this->dispatch('/checkout/addArticle/sAdd/'.self::ARTICLE_NUMBER);
         return Shopware()->Container()->get('SessionID');
+    }
+
+    /**
+     * Tests that price calculations of the basket do not differ from the price calculation in the Order
+     * for customer group
+     */
+    public function testCheckoutForNetOrders()
+    {
+        $net = true;
+        $this->runCheckoutTest($net);
+    }
+
+    /**
+     * Tests that price calculations of the basket do not differ from the price calculation in the Order
+     * for customer group
+     */
+    public function testCheckoutForGrossOrders()
+    {
+        $net = false;
+        $this->runCheckoutTest($net);
+    }
+
+    /**
+     * Compares the calculated price from a basket with the calculated price from Order/Order::calculateInvoiceAmount
+     * It does so by creating via the frontend controllers, and comparing the amount (net & gross) with the values provided by
+     * Order/Order::calculateInvoiceAmount (Which will be called when one changes / saves the order in the backend).
+     *
+     * Also covers a complete checkout process
+     * @param bool $net
+     */
+    public function runCheckoutTest($net = false)
+    {
+        $tax = $net == true ? 0 : 1;
+
+        // Set net customer group
+        $defaultShop = Shopware()->Models()->getRepository(\Shopware\Models\Shop\Shop::class)->find(1);
+        $previousCustomerGroup = $defaultShop->getCustomerGroup()->getKey();
+        $netCustomerGroup = Shopware()->Models()->getRepository(\Shopware\Models\Customer\Group::class)->findOneBy(['tax' => $tax])->getKey();
+        $this->assertNotEmpty($netCustomerGroup);
+        Shopware()->Db()->query(
+            'UPDATE s_user SET customergroup = ? WHERE id = 1',
+            array($netCustomerGroup)
+        );
+
+        // Simulate checkout in frontend
+
+        // Login
+        $this->loginFrontendUser();
+
+        // Add article to basket
+        $this->addBasketArticle(self::USER_AGENT, 5);
+
+        // Confirm checkout
+        $this->reset();
+        $this->Request()->setHeader('User-Agent', self::USER_AGENT);
+        $this->dispatch('/checkout/confirm');
+
+        // Finish checkout
+        $this->reset();
+        $this->Request()->setHeader('User-Agent', self::USER_AGENT);
+        $this->Request()->setParam('sAGB', 'on');
+        $this->dispatch('/checkout/finish');
+
+        // Logout frontend user
+        Shopware()->Modules()->Admin()->logout();
+
+        // Revert customer group
+        Shopware()->Db()->query(
+            'UPDATE s_user SET customergroup = ? WHERE id = 1',
+            array($previousCustomerGroup)
+        );
+
+        // Fetch created order
+        $orderId = Shopware()->Db()->fetchOne(
+            'SELECT id FROM s_order ORDER BY ID DESC LIMIT 1'
+        );
+        /** @var \Shopware\Models\Order\Order $order */
+        $order = Shopware()->Models()->getRepository(\Shopware\Models\Order\Order::class)->find($orderId);
+
+        // Save invoiceAmounts for comparison
+        $previousInvoiceAmount = $order->getInvoiceAmount();
+        $previousInvoiceAmountNet = $order->getInvoiceAmountNet();
+
+        // Simulate backend order save
+        $order->calculateInvoiceAmount();
+
+        // Assert messages
+        $message = 'InvoiceAmount' . ($net ? ' (net shop)' : '') . ': ' . $previousInvoiceAmount .' from sBasket, '. $order->getInvoiceAmount() . ' from getInvoiceAmount';
+        $messageNet = 'InvoiceAmountNet' . ($net ? ' (net shop)' : '') . ': ' . $previousInvoiceAmountNet.' from sBasket, '. $order->getInvoiceAmountNet() . ' from getInvoiceAmountNet';
+
+        // Test that sBasket calculation matches calculateInvoiceAmount
+        $this->assertEquals($order->getInvoiceAmount(), $previousInvoiceAmount, $message);
+        $this->assertEquals($order->getInvoiceAmountNet(), $previousInvoiceAmountNet, $messageNet);
+    }
+
+    /**
+     * Login as a frontend user
+     * @throws Enlight_Exception
+     * @throws Exception
+     */
+    public function loginFrontendUser()
+    {
+        Shopware()->Front()->setRequest(new Enlight_Controller_Request_RequestHttp());
+        $user = Shopware()->Db()->fetchRow(
+            'SELECT id, email, password, subshopID, language FROM s_user WHERE id = 1'
+        );
+
+        /** @var $repository Shopware\Models\Shop\Repository */
+        $repository = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop');
+        $shop = $repository->getActiveById($user['language']);
+
+        $shop->registerResources();
+
+        Shopware()->Session()->Admin = true;
+        Shopware()->System()->_POST = array(
+            'email' => $user['email'],
+            'passwordMD5' => $user['password'],
+        );
+        Shopware()->Modules()->Admin()->sLogin(true);
     }
 }


### PR DESCRIPTION
## Description

* Why is it necessary?
  * The amount calculated by `Order/Order::calculateInvoiceAmount()` differs from the basket,
     this might lead to inconsistent prices calculations if the order is saved later in the backend.
     (Can be tested by changing shipping costs, saving and reverting to old value) 
* What does it improve?
  * Consistency of price calculation
* Does it have side effects?
  * No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | This PR is a subset of #847
| How to test?     | Run the tests before applying fix in calculateInvoiceAmount

## Detailed writeup
While we originally tried to test/fix the first issue, the second issue emerged after we finished the tests and needed to be fixed as well, even though the implications weren't as extensive as with the first issue.

**First Issue:**
  * **Line 1069** in Order.php (here it's irrelevant if shop is in net mode or not)
  * Values rounded to 3 decimal places In s_order_details result in deviations, rounding them to two places will match the sBasket behaviour.
  * Solution: Extract `getPrice()` to `$price = round($detail->getPrice(), 2);` in all 3 occurrences.
  * Reproduce: Buy **5 x "SW10239"** in Frontend (shop in net mode), change shipping costs in backend and save and revert shipping costs back to old value. The amount now has changed from 96.48 to 96.47.

### Screenshot basket: amount = 96.48
![bildschirmfoto 2017-03-23 um 15 14 05](https://cloud.githubusercontent.com/assets/7721625/24251939/26bceb0c-0fdc-11e7-89da-78325e7a242c.png)

### After `calculateInvoiceAmount` was triggered by changing shipping costs.
![bildschirmfoto 2017-03-23 um 15 16 06](https://cloud.githubusercontent.com/assets/7721625/24251956/319bf9aa-0fdc-11e7-8f38-f3ccc3ab5296.png)


**Second Issue:**
  * **Line 1085** in Order.php
  * Missing rounding after calculation will result in unrounded values in the database.
  * Solution: round result to two decimal places.
  * Reproduce: Buy article in Frontend, change quantity in Backend and save, check s_order table for amount. The amount now stored in the database is not rounded at all. (Shop must not be in net mode to reproduce)


## What has been tested ?
* That `Order/Order::calculateInvoiceAmount()` calculation matches `sBasket`
* Checkout process (via frontend controllers)

<img width="654" alt="pr-01" src="https://cloud.githubusercontent.com/assets/7721625/24248040/1a4c3ae8-0fce-11e7-8cb3-7700c4eb4220.png">

Edit: extract $detail->getPrice(), update PR message

