### PR TITLE
Don't loose array type hints when hooking methods

### DIFF
--- a/engine/Library/Enlight/Hook/ProxyFactory.php
+++ b/engine/Library/Enlight/Hook/ProxyFactory.php
@@ -282,6 +282,7 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
                     $proxy_params .= '$';
                     $array_param .= '&';
                 }
+                $params .= $rp->isArray() ? 'array ' : '';
                 $params .= '$' . $rp->getName();
                 $proxy_params .= '$' . $rp->getName();
                 $array_param .= '$' . $rp->getName();


### PR DESCRIPTION
If a method with type hints is hooked (e.g. 'Shopware\Models\Category\Repository::getListQueryBuilder::after' => 'myAwesomeFunc') the ProxyFactory will generate: 
public function getListQueryBuilder( $filterBy,  $orderBy, $limit = NULL, $offset = NULL, $selectOnlyActive = true)

But the original function is declared via
public function getListQueryBuilder(array $filterBy, array $orderBy, $limit = NULL, $offset = NULL, $selectOnlyActive = true)

This will result in
PHP Strict Standards:  Declaration of Shopware_Proxies_ShopwareModelsCategoryRepositoryProxy::getListQueryBuilder() should be compatible with Shopware\Models\Category\Repository::getListQueryBuilder(array $filterBy, array $orderBy, $limit = NULL, $offset = NULL, $selectOnlyActive = true)

<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
See above
* What does it improve?
See above
* Does it have side effects?
Did not test deeply



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes/no
Dont know
| Tests pass?      | yes/no
Dont know
| Related tickets? | If this PR fixes an existing [Issue](https://issues.shopware.com) ticket, please add its complete issue URL.
Private Support Ticket
| How to test?     | Please describe how to best verify that this PR is correct.
See Description
