### PR TITLE
Fixed paging count in account: orders and downloads ($sPage was not d…

### DIFF
--- a/themes/Frontend/Bare/frontend/account/downloads.tpl
+++ b/themes/Frontend/Bare/frontend/account/downloads.tpl
@@ -120,6 +120,7 @@
                             {foreach $sPages.numbers as $page}
                                 {if $page.markup}
                                     <a class="paging--link is--active">{$page.value}</a>
+                                    {$sPage=$page.value}
                                 {else}
                                     <a href="{$page.link}" class="paging--link">{$page.value}</a>
                                 {/if}

--- a/themes/Frontend/Bare/frontend/account/orders.tpl
+++ b/themes/Frontend/Bare/frontend/account/orders.tpl
@@ -81,6 +81,7 @@
                             {foreach $sPages.numbers as $page}
                                 {if $page.markup}
                                     <a class="paging--link is--active">{$page.value}</a>
+                                    {$sPage=$page.value}
                                 {else}
                                     <a href="{$page.link}" class="paging--link">{$page.value}</a>
                                 {/if}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary? -> $sPage not defined - current page number is always 1
* What does it improve? -> Change the current page number to the correct one
* Does it have side effects? -> no

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes
| Tests pass?      | yes
| Related tickets? | No ticket
| How to test?     | Login into frontend, visit: account/downloads & account/orders

