### PR TITLE
Normalized view settings in the media manager, now we can use the sam…

### DIFF
--- a/snippets/backend/media_manager/view/main.ini
+++ b/snippets/backend/media_manager/view/main.ini
@@ -100,6 +100,7 @@ move/media/title = "Moving media files"
 move/indicator/snippet = "[0] of [1]"
 move/media/cancel = "Cancel"
 move/media/cancel_message = "Cancelling process..."
+previewSizeFieldLabel = "Preview size"
 
 [de_DE]
 addAlbum/add = "Album hinzufügen"
@@ -203,3 +204,5 @@ move/media/title = "Medien verschieben"
 move/indicator/snippet = "[0] von [1]"
 move/media/cancel = "Abbrechen"
 move/media/cancel_message = "Breche Vorgang ab..."
+
+previewSizeFieldLabel = "Preview-Größe"

--- a/themes/Backend/ExtJs/backend/media_manager/app.js
+++ b/themes/Backend/ExtJs/backend/media_manager/app.js
@@ -71,7 +71,7 @@ Ext.define('Shopware.apps.MediaManager', {
      * Requires models for sub-application
      * @array
      */
-    models:['Album', 'Media'],
+    models:['Album', 'Media','Setting'],
 
     /**
      * Required views for this sub-application
@@ -82,7 +82,7 @@ Ext.define('Shopware.apps.MediaManager', {
      * Required stores for sub-application
      * @array
      */
-    stores:['Album', 'Media' ],
+    stores:['Album', 'Media', 'Setting'],
     /**
      * Returns the main application window for this is expected
      * by the Enlight.app.SubApplication class.

--- a/themes/Backend/ExtJs/backend/media_manager/model/setting.js
+++ b/themes/Backend/ExtJs/backend/media_manager/model/setting.js
@@ -1,0 +1,42 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    MediaManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
+
+//{block name="backend/media_manager/model/setting"}
+Ext.define('Shopware.apps.MediaManager.model.Setting', {
+    fields: ['DisplayType', 'ItemsPerPage','ThumbnailSize'],
+    extend: 'Ext.data.Model',
+    proxy: {
+        type: 'localstorage',
+        id  : 'media-manager-settings'
+    }
+});
+
+
+
+//{/block}

--- a/themes/Backend/ExtJs/backend/media_manager/store/setting.js
+++ b/themes/Backend/ExtJs/backend/media_manager/store/setting.js
@@ -1,0 +1,36 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    MediaManager
+ * @subpackage Store
+ * @version    $Id$
+ * @author shopware AG
+ */
+
+//{block name="backend/media_manager/store/setting"}
+Ext.define('Shopware.apps.MediaManager.store.Setting', {
+    extend: 'Ext.data.Store',
+    model: 'Shopware.apps.MediaManager.model.Setting'
+
+});
+//{/block}

--- a/themes/Backend/ExtJs/backend/media_manager/view/main/window.js
+++ b/themes/Backend/ExtJs/backend/media_manager/view/main/window.js
@@ -59,7 +59,8 @@ Ext.define('Shopware.apps.MediaManager.view.main.Window', {
             store: me.albumStore
         }, {
             xtype: 'mediamanager-media-view',
-            mediaStore: me.mediaStore
+            mediaStore: me.mediaStore,
+            settingRecord: this.settingRecord
         }];
 
         me.callParent(arguments);

--- a/themes/Backend/ExtJs/backend/media_manager/view/media/view.js
+++ b/themes/Backend/ExtJs/backend/media_manager/view/media/view.js
@@ -47,14 +47,18 @@ Ext.define('Shopware.apps.MediaManager.view.media.View', {
     createInfoPanel: true,
     createDeleteButton: true,
     createMediaQuantitySelection: true,
+    /**
+     * Button section
+     */
     deleteBtn: null,
+    displayTypeBtn: null,
     selectedLayout: 'grid',
-
     snippets: {
         noMediaFound: '{s name=noMediaFound}No Media found{/s}',
         uploadDataDragDrop: '{s name=uploadDataDragDrop}Upload your Data via <strong>Drag & Drop</strong> here{/s}',
         noAdditionalInfo: '{s name=noAdditionalInfo}No additional informations found{/s}',
         moreInfoTitle:'{s name=moreInfoTitle}More information{/s}',
+        previewSize: '{s name=previewSizeFieldLabel}Preview size{/s}',
         mediaInfo: {
             name: '{s name=mediaInfo/name}Name:{/s}',
             uploadedon: '{s name=mediaInfo/uploadedOn}Uploaded on:{/s}',
@@ -487,9 +491,13 @@ Ext.define('Shopware.apps.MediaManager.view.media.View', {
         }
         /* {/if} */
 
-        toolbar.add({
+        /**
+         * Initialize the display type button
+         */
+
+        me.displayTypeBtn = Ext.create('Ext.button.Cycle',{
+
             showText: true,
-            xtype: 'cycle',
             prependText: '{s name=toolbar/view}Display as{/s} ',
             action: 'mediamanager-media-view-layout',
             menu: {
@@ -505,6 +513,8 @@ Ext.define('Shopware.apps.MediaManager.view.media.View', {
                 }]
             }
         });
+
+        toolbar.add(me.displayTypeBtn);
 
         toolbar.add(
             '->',
@@ -528,6 +538,7 @@ Ext.define('Shopware.apps.MediaManager.view.media.View', {
             labelWidth: 110,
             cls: Ext.baseCSSPrefix + 'page-size',
             queryMode: 'local',
+            action: 'perPageComboBox',
             width: 210,
             listeners: {
                 scope: me,
@@ -549,6 +560,7 @@ Ext.define('Shopware.apps.MediaManager.view.media.View', {
             displayField: 'name',
             valueField: 'value'
         });
+
         pageSize.setValue(me.mediaStore.pageSize + '');
 
         var toolbar = Ext.create('Ext.toolbar.Paging', {
@@ -559,6 +571,8 @@ Ext.define('Shopware.apps.MediaManager.view.media.View', {
             toolbar.add('->', pageSize, { xtype: 'tbspacer', width: 6 });
         }
 
+        me.pageSize = pageSize;
+
         // Create the data for the preview image size
         var imageSizeData = [], i = 1;
         for( ; i < 9; i++) {
@@ -568,7 +582,7 @@ Ext.define('Shopware.apps.MediaManager.view.media.View', {
 
         // Preview image size selection, especially for the list view
         me.imageSize = Ext.create('Ext.form.field.ComboBox', {
-            fieldLabel: 'Preview-Größe',
+            fieldLabel: me.snippets.previewSize,
             queryMode: 'local',
             labelWidth: 90,
             width: 190,
@@ -650,6 +664,7 @@ Ext.define('Shopware.apps.MediaManager.view.media.View', {
      * @return void
      */
     onChangeMediaQuantity: function(combo, records) {
+
         var record = records[0],
             me = this;
 


### PR DESCRIPTION
…e settings (icon size, paging limit, display type table/grid among the different media panels. For achieveing this feature, we have opted to use the extjs localStorage proxy to save said settings.

<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* To normalize all the view settings (Paging limit, Icon Size, Display type (table/grid)
* Usability / End user experience
* No




| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://issues.shopware.com/issues/SW-17809
| How to test?     | Open the up the media manager in the backend, change the display type, change the paging limit, change the icon size. Reload the page, open up the media manager again, all the previous settings will stay in place.

