### PR TITLE
Normalized the grid and table views in the media manager, removed rel…

### DIFF
--- a/themes/Backend/ExtJs/backend/media_manager/app.js
+++ b/themes/Backend/ExtJs/backend/media_manager/app.js
@@ -71,7 +71,7 @@ Ext.define('Shopware.apps.MediaManager', {
      * Requires models for sub-application
      * @array
      */
-    models:['Album', 'Media'],
+    models:['Album', 'Media','Setting'],
 
     /**
      * Required views for this sub-application
@@ -82,7 +82,7 @@ Ext.define('Shopware.apps.MediaManager', {
      * Required stores for sub-application
      * @array
      */
-    stores:['Album', 'Media' ],
+    stores:['Album', 'Media', 'Setting'],
     /**
      * Returns the main application window for this is expected
      * by the Enlight.app.SubApplication class.

--- a/themes/Backend/ExtJs/backend/media_manager/controller/media.js
+++ b/themes/Backend/ExtJs/backend/media_manager/controller/media.js
@@ -44,7 +44,6 @@ Ext.define('Shopware.apps.MediaManager.controller.Media', {
      * @string
      */
     extend: 'Ext.app.Controller',
-
     snippets: {
         confirmMsgBox: {
             deleteTitle: '{s name=confirmMsgBox/deleteTitle}Delete media files{/s}',
@@ -76,6 +75,9 @@ Ext.define('Shopware.apps.MediaManager.controller.Media', {
      */
     init: function() {
         var me = this;
+
+        me.settingRecord = me.getSettings();
+        me.restoreSettings();
 
         me.control({
             'mediamanager-album-tree': {
@@ -110,6 +112,9 @@ Ext.define('Shopware.apps.MediaManager.controller.Media', {
             'mediamanager-selection-window textfield[action=mediamanager-selection-window-searchfield]': {
                 change: me.onSearchMedia
             },
+            'mediamanager-media-view combobox[action=perPageComboBox]': {
+                select: me.onSelectPerPage
+            },
             'mediamanager-media-grid': {
                 'showDetail': me.onShowDetails,
                 'edit': me.onGridEditLabel
@@ -117,6 +122,89 @@ Ext.define('Shopware.apps.MediaManager.controller.Media', {
         });
 
         me.callParent(arguments);
+    },
+
+    getSettings:function() {
+        var me = this,
+            settingStore = me.subApplication.getStore('Setting'),
+            settingRecord = null,
+            grid = me.getMediaGrid(),
+            view = me.getMediaView();
+
+        settingStore.load(function() {
+            if(!settingStore.getAt(0)) {
+                /**
+                 * Initialize the record with default values provided by the view and the mediaGrid.
+                 */
+                settingRecord = Ext.create('Shopware.apps.MediaManager.model.Setting', {
+                    DisplayType: view.selectedLayout,
+                    ItemsPerPage: view.mediaStore.pageSize,
+                    ThumbnailSize:  grid.selectedPreviewSize
+                });
+                settingStore.add(settingRecord);
+            }
+        });
+
+        return settingStore.getAt(0);
+    },
+
+    restoreSettings: function() {
+        var me = this,
+            view = me.getMediaView(),
+            grid = me.getMediaGrid(),
+            displayTypeValue = me.settingRecord.get('DisplayType'),
+            pageSizeCombo = view.pageSize,
+            thumbnailSize = me.settingRecord.get('ThumbnailSize'),
+            itemsPerPage = me.settingRecord.get('ItemsPerPage');
+
+        view.mediaStore.pageSize = itemsPerPage;
+        view.thumbnailSize = thumbnailSize;
+        view.mediaViewContainer.add(view.createMediaView());
+
+        /**
+         * Find the item which matches the settingRecord value
+         */
+        view.displayTypeBtn.menu.items.each(function(item) {
+            if(item.layout == displayTypeValue) {
+                view.displayTypeBtn.setActiveItem(item);
+
+                return false;
+            }
+        });
+
+        /**
+         * Fire the onChangeLayout event
+         */
+
+        me.onChangeLayout(null, {
+            layout: displayTypeValue
+        });
+
+        grid.columns[1].setWidth(thumbnailSize+10);
+        grid.selectedPreviewSize = thumbnailSize;
+
+        view.imageSize.reset();
+        view.imageSize.setValue(grid.selectedPreviewSize);
+
+        // ItemsPerPage
+        pageSizeCombo.store.each(function(item) {
+            if(item.raw.value == itemsPerPage) {
+                pageSizeCombo.reset();
+                pageSizeCombo.setValue(item.raw.name);
+
+                return false;
+            }
+        });
+    },
+
+    onSelectPerPage: function(combo) {
+        var me = this,
+            settingRecord = me.settingRecord;
+
+        settingRecord.set({
+            'ItemsPerPage': parseInt(combo.getValue())
+        });
+        settingRecord.save();
     },
 
     moveMedias: function(view, medias) {
@@ -133,7 +221,7 @@ Ext.define('Shopware.apps.MediaManager.controller.Media', {
      */
     onReload: function() {
         var me = this, validTypes = me.subApplication.validTypes,
-            store = me.getStore('Media');
+        store = me.getStore('Media');
 
         if(validTypes) {
             var proxy = store.getProxy();
@@ -419,18 +507,26 @@ Ext.define('Shopware.apps.MediaManager.controller.Media', {
      * Event listener method which will be fired when the user clicks
      * on the `change layout` button.
      *
-     * The method sets the correct active item and shows / hides the
-     * preview size combobox.
+     * The method sets the correct active item.
      *
      * @param { Ext.button.Button } button - The clicked button
      * @param { Object } item - The configuration of the active layout
      * @returns { Void }
      */
     onChangeLayout: function(button, item) {
-        var me = this, view = me.getMediaView();
+        var me = this,
+            view = me.getMediaView(),
+            grid = me.getMediaGrid();
+
         view.selectedLayout = item.layout;
         view.cardContainer.getLayout().setActiveItem((item.layout === 'grid') ? 0 : 1);
-        view.imageSize[(item.layout === 'grid') ? 'hide' : 'show']();
+        view.thumbnailSize = me.settingRecord.get('ThumbnailSize');
+
+        me.settingRecord.set({
+            'DisplayType':item.layout
+        });
+
+        me.settingRecord.save();
     },
 
     /**
@@ -462,7 +558,11 @@ Ext.define('Shopware.apps.MediaManager.controller.Media', {
      *          the selected item. Otherwise `void`
      */
     onChangePreviewSize: function(field, newValue, value) {
-        var me = this, view = me.getMediaGrid();
+        var me = this,
+            grid = me.getMediaGrid(),
+            view = me.getMediaView(),
+            displayType = me.settingRecord.get('DisplayType'),
+            iconSize = null;
 
         // Prevents the first event to re-render the list view
         if(!value || newValue === value) {
@@ -470,15 +570,26 @@ Ext.define('Shopware.apps.MediaManager.controller.Media', {
         }
 
         // Cast the passed value to a number
-        view.selectedPreviewSize = ~~(1 * newValue);
+        iconSize = ~~(1 * newValue);
 
-        // Reload the store and resize the preview column
-        view.getStore().load({
-            callback: function() {
-                // We need to hard-code the preview column
-                view.columns[1].setWidth((view.selectedPreviewSize < 50) ? 50 : view.selectedPreviewSize + 10);
-            }
+        me.settingRecord.set({
+            ThumbnailSize: iconSize
         });
+
+        me.settingRecord.save();
+
+        //Change the thumbnail size for the table view, sadly we need to recreate the view.
+        view.thumbnailSize = iconSize;
+        view.mediaViewContainer.removeAll();
+        view.mediaViewContainer.add(view.createMediaView());
+
+        // 1) Set the icon preview size on the grid
+        // 2) Refresh the view
+        // 3) Resize the first column to fit the new icon size
+        grid.selectedPreviewSize = iconSize;
+        grid.getView().refresh();
+        grid.columns[1].setWidth((iconSize < 50) ? 50 : iconSize + 10);
+
     }
 });
 //{/block}

--- a/themes/Backend/ExtJs/backend/media_manager/model/setting.js
+++ b/themes/Backend/ExtJs/backend/media_manager/model/setting.js
@@ -1,0 +1,42 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    MediaManager
+ * @subpackage Model
+ * @version    $Id$
+ * @author shopware AG
+ */
+
+//{block name="backend/media_manager/model/setting"}
+Ext.define('Shopware.apps.MediaManager.model.Setting', {
+    fields: ['DisplayType', 'ItemsPerPage','ThumbnailSize'],
+    extend: 'Ext.data.Model',
+    proxy: {
+        type: 'localstorage',
+        id  : 'media-manager-settings'
+    }
+});
+
+
+
+//{/block}

--- a/themes/Backend/ExtJs/backend/media_manager/store/setting.js
+++ b/themes/Backend/ExtJs/backend/media_manager/store/setting.js
@@ -1,0 +1,36 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    MediaManager
+ * @subpackage Store
+ * @version    $Id$
+ * @author shopware AG
+ */
+
+//{block name="backend/media_manager/store/setting"}
+Ext.define('Shopware.apps.MediaManager.store.Setting', {
+    extend: 'Ext.data.Store',
+    model: 'Shopware.apps.MediaManager.model.Setting'
+
+});
+//{/block}

--- a/themes/Backend/ExtJs/backend/media_manager/view/main/window.js
+++ b/themes/Backend/ExtJs/backend/media_manager/view/main/window.js
@@ -59,7 +59,8 @@ Ext.define('Shopware.apps.MediaManager.view.main.Window', {
             store: me.albumStore
         }, {
             xtype: 'mediamanager-media-view',
-            mediaStore: me.mediaStore
+            mediaStore: me.mediaStore,
+            settingRecord: this.settingRecord
         }];
 
         me.callParent(arguments);


### PR DESCRIPTION
…oading the contents all over again from the store when the table display type is selected

<!--
Thank you for contributing to Shopware!

Please take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
Please describe your pull request:
* Why is it necessary?
There was a need to normalize both types of displays in the media manager, icon size, paging, and so on.
* What does it improve?
Overall end user experience, expected behaviour from the end user side.
* Does it have side effects?
No



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://issues.shopware.com/issues/SW-17808
| How to test?     | Login in the backend, open up the media manager, switch the icon size, the icon size will be reflected in both views, grid and table.

