### PR TITLE
Return record on creation of the banner mapping store entry

### DIFF
--- a/themes/Backend/ExtJs/backend/emotion/view/components/banner_mapping.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/components/banner_mapping.js
@@ -529,6 +529,8 @@ Ext.define('Shopware.apps.Emotion.view.components.BannerMapping', {
                 });
             });
         }, 1000);
+
+        return record;
     }
 });
 //{/block}


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Returning the record allows plugins to modifiy the data on creation of each mapping icons, otherwise the whole function (`createMappingResizer`) has to be replaced.
* What does it improve?
Capability to modify the records after they are added to the store.
* Does it have side effects?
No

Side note: Actually the whole record creation and data assignment need to be rewritten. The model should not be created inline. But I guess this would be to big of a change, since it would break plugins which are modifying the banner mapping functionality. Would this be a suitable commit for Shopware 5.3?

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | -
| How to test?     | -

