### PR TITLE
Deprecated Enlight_Controller_ActionEventArgs

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -298,6 +298,7 @@ did not work anymore because the smarty rendering is off. The string {$offerPosi
 * Deprecated `\Shopware_Controllers_Widgets_Listing::ajaxListingAction`, use `\Shopware_Controllers_Widgets_Listing::listingCountAction` instead
 * Deprecated method `sArticles::sGetAffectedSuppliers()` without replacement, to be removed with 5.5
 * Deprecated `Shopware\Models\Article\Element`, to be removed with 6.0
+* Deprecated `Enlight_Controller_ActionEventArgs` use `Enlight_Event_EventArgs` instead, to be removed with 5.4
 
 ### Backend Components
 

--- a/engine/Library/Enlight/Controller/Action.php
+++ b/engine/Library/Enlight/Controller/Action.php
@@ -124,7 +124,7 @@ abstract class Enlight_Controller_Action extends Enlight_Class implements Enligh
      */
     public function dispatch($action)
     {
-        $args = new Enlight_Controller_ActionEventArgs(array(
+        $args = new Enlight_Event_EventArgs(array(
             'subject'  => $this,
             'request'  => $this->Request(),
             'response' => $this->Response()

--- a/engine/Library/Enlight/Controller/ActionEventArgs.php
+++ b/engine/Library/Enlight/Controller/ActionEventArgs.php
@@ -18,6 +18,7 @@
  * @package    Enlight_Controller
  * @copyright  Copyright (c) 2013, shopware AG (http://www.shopware.de)
  * @license    http://enlight.de/license     New BSD License
+ * @deprecated since 5.3, to be removed with 5.4, use \Enlight_Event_EventArgs instead
  */
 class Enlight_Controller_ActionEventArgs extends Enlight_Event_EventArgs
 {

--- a/engine/Shopware/Components/CSRFTokenValidator.php
+++ b/engine/Shopware/Components/CSRFTokenValidator.php
@@ -25,8 +25,7 @@
 namespace Shopware\Components;
 
 use Enlight\Event\SubscriberInterface;
-use Enlight_Components_Session_Namespace as Session;
-use Enlight_Controller_ActionEventArgs as ActionEventArgs;
+use Enlight_Event_EventArgs as EventArgs;
 use Shopware\Components\DependencyInjection\Container;
 
 /**
@@ -93,11 +92,11 @@ class CSRFTokenValidator implements SubscriberInterface
     }
 
     /**
-     * @param ActionEventArgs $args
+     * @param EventArgs $args
      *
      * @throws CSRFTokenValidationException
      */
-    public function checkBackendTokenValidation(ActionEventArgs $args)
+    public function checkBackendTokenValidation(EventArgs $args)
     {
         if (!$this->isEnabledBackend) {
             return;

--- a/engine/Shopware/Components/LastArticlesSubscriber.php
+++ b/engine/Shopware/Components/LastArticlesSubscriber.php
@@ -66,9 +66,9 @@ class LastArticlesSubscriber implements SubscriberInterface
     }
 
     /**
-     * @param \Enlight_Controller_ActionEventArgs $args
+     * @param \Enlight_Event_EventArgs $args
      */
-    public function onRefreshStatistics(\Enlight_Controller_ActionEventArgs $args)
+    public function onRefreshStatistics(\Enlight_Event_EventArgs $args)
     {
         $request = $args->getRequest();
 
@@ -86,9 +86,9 @@ class LastArticlesSubscriber implements SubscriberInterface
     }
 
     /**
-     * @param \Enlight_Controller_ActionEventArgs $args
+     * @param \Enlight_Event_EventArgs $args
      */
-    public function onPostDispatch(\Enlight_Controller_ActionEventArgs $args)
+    public function onPostDispatch(\Enlight_Event_EventArgs $args)
     {
         $this->cleanupLastArticles();
         $config = $this->container->get('config');

--- a/engine/Shopware/Components/Plugin/Bootstrap.php
+++ b/engine/Shopware/Components/Plugin/Bootstrap.php
@@ -708,9 +708,9 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
      * Event listener of the post dispatch event of the backend and widgets emotion controller
      * to load the plugin emotion template extensions.
      *
-     * @param Enlight_Controller_ActionEventArgs $args
+     * @param Enlight_Event_EventArgs $args
      */
-    public function extendsEmotionTemplates(Enlight_Controller_ActionEventArgs $args)
+    public function extendsEmotionTemplates(Enlight_Event_EventArgs $args)
     {
         /** @var $view Enlight_View_Default */
         $view = $args->getSubject()->View();

--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Bootstrap.php
@@ -98,9 +98,9 @@ class Shopware_Plugins_Backend_SwagUpdate_Bootstrap extends Shopware_Components_
      * When index backend module was loaded, add our snippet- and template-directory
      * Also extend the template
      *
-     * @param \Enlight_Controller_ActionEventArgs $args
+     * @param \Enlight_Event_EventArgs $args
      */
-    public function onBackendIndexPostDispatch(Enlight_Controller_ActionEventArgs $args)
+    public function onBackendIndexPostDispatch(Enlight_Event_EventArgs $args)
     {
         $args->getSubject()->View()->addTemplateDir(
             __DIR__ . '/Views/'

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -300,9 +300,9 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
     /**
      * Do http caching jobs
      *
-     * @param Enlight_Controller_ActionEventArgs $args
+     * @param Enlight_Event_EventArgs $args
      */
-    public function onPreDispatch(\Enlight_Controller_ActionEventArgs $args)
+    public function onPreDispatch(\Enlight_Event_EventArgs $args)
     {
         $this->action = $args->getSubject();
         $this->request = $args->getRequest();
@@ -323,9 +323,9 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
     /**
      * On post dispatch we try to find affected articleIds displayed during this request
      *
-     * @param \Enlight_Controller_ActionEventArgs $args
+     * @param \Enlight_Event_EventArgs $args
      */
-    public function onPostDispatch(\Enlight_Controller_ActionEventArgs $args)
+    public function onPostDispatch(\Enlight_Event_EventArgs $args)
     {
         $view = $args->getSubject()->View();
 

--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
@@ -104,9 +104,9 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
     /**
      * Event listener method
      *
-     * @param Enlight_Controller_ActionEventArgs $args
+     * @param Enlight_Event_EventArgs $args
      */
-    public function onPostDispatch(Enlight_Controller_ActionEventArgs $args)
+    public function onPostDispatch(Enlight_Event_EventArgs $args)
     {
         $config = $this->Config();
 


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Enlight_Event_EventArgs can handle the same functions with magic method __call and the consts(PRE_EVENT, POST_EVENT...) are not used.

* What does it improve?
Makes typehinting of events callbacks clearer with one single class and removes enlight code :D

* Does it have side effects?
Nope, its marked as deprecated 



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | 
| How to test?     | 
