### PR TITLE
Rest api basic auth support

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -106,6 +106,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 * Added new route `Shopware_Controllers_Frontend_Listing::listingAction` which loads the category product listing.This route is called over {action ..} in case that the category contains an emotion with customer streams
 * Added new entity `Shopware\Models\Customer\CustomerStream` for attribute single and multi selection.
 * Added new components for customer stream handling in `Shopware\Components\CustomerStream`
+* Added basic auth support for rest api
 
 ### Changes
 

--- a/engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
@@ -21,6 +21,8 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
+use ShopwarePlugins\RestApi\Components\BasicAuthResolver;
+use ShopwarePlugins\RestApi\Components\StaticResolver;
 
 /**
  * @category  Shopware
@@ -177,14 +179,18 @@ class Shopware_Plugins_Core_RestApi_Bootstrap extends Shopware_Components_Plugin
         }
 
         $adapter = new Zend_Auth_Adapter_Http([
-            'accept_schemes' => 'digest',
+            'accept_schemes' => 'basic digest',
             'realm' => 'Shopware REST-API',
             'digest_domains' => '/',
             'nonce_timeout' => 3600,
         ]);
 
+        $adapter->setBasicResolver(new BasicAuthResolver(
+            $this->get('models')
+        ));
+
         $adapter->setDigestResolver(
-            new \ShopwarePlugins\RestApi\Components\StaticResolver(
+            new StaticResolver(
                 $this->get('models')
             )
         );

--- a/engine/Shopware/Plugins/Default/Core/RestApi/Components/BasicAuthResolver.php
+++ b/engine/Shopware/Plugins/Default/Core/RestApi/Components/BasicAuthResolver.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace ShopwarePlugins\RestApi\Components;
+
+use Shopware\Components\Model\ModelManager;
+use Shopware\Models\User\User;
+
+/**
+ * @category  Shopware
+ *
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class BasicAuthResolver implements \Zend_Auth_Adapter_Http_Resolver_Interface
+{
+    /**
+     * Contains the shopware model manager
+     *
+     * @var ModelManager
+     */
+    protected $modelManager;
+
+    /**
+     * @param ModelManager $modelManager
+     */
+    public function __construct(ModelManager $modelManager)
+    {
+        $this->modelManager = $modelManager;
+    }
+
+    /**
+     * Resolve username/realm to password/hash/etc.
+     *
+     * @param string $username Username
+     * @param string $realm    Authentication Realm
+     *
+     * @return string|false user's shared secret, if the user is found in the
+     *                      realm, false otherwise
+     */
+    public function resolve($username, $realm)
+    {
+        $repository = $this->modelManager->getRepository(User::class);
+        $user = $repository->findOneBy(['username' => $username, 'active' => true]);
+
+        if (!$user) {
+            return false;
+        }
+
+        if ($user->getApiKey() === null) {
+            return false;
+        }
+
+        $apiKey = $user->getApiKey();
+
+        return $apiKey;
+    }
+}


### PR DESCRIPTION
## Description
Please describe your pull request:
* Why is it necessary?
Digest auth is not supported by any clients
* What does it improve?
Adds basic auth support for rest api
* Does it have side effects?
Nope



| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | no
| Tests pass?      | yes
| Related tickets? | https://issues.shopware.com/issues/SW-16133
| How to test?     | Use postman and create a api request with basic auth

