### PR TITLE
Add order ID to Order_SaveOrder_ProcessDetails event

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -765,6 +765,7 @@ class sOrder
         $this->eventManager->notify('Shopware_Modules_Order_SaveOrder_ProcessDetails', [
             'subject' => $this,
             'details' => $this->sBasketData['content'],
+            'orderId' => $orderID,
         ]);
 
         // Save Billing and Shipping-Address to retrace in future


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | You need the order ID if you want to modify the order(s attributes) based on the details. |
| BC breaks?              | no |
| Tests exists & pass?    | no/yes |
| Related tickets?        | no |
| How to test?            | Write a subscriber to the event `Shopware_Modules_Order_SaveOrder_ProcessDetails` |
| Requirements met?       | yes |