### PR TITLE
Fixed saving of empty dates

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Service/DataPersister.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/DataPersister.php
@@ -155,7 +155,7 @@ class DataPersister
             $query->setValue($key, ':' . $key);
             $query->setParameter(':' . $key, $value);
         }
-        
+
         $query->execute();
     }
 
@@ -220,7 +220,7 @@ class DataPersister
             $value = $data[$column->getName()];
 
             if ($this->isDateColumn($column) && empty($value)) {
-                $result[$column->getName()] = 'NULL';
+                $result[$column->getName()] = null;
             } else {
                 $result[$column->getName()] = $value;
             }


### PR DESCRIPTION
## Description
When clearing a custom attribute date field, the database contains "0000-00-00" instead of null, leading to the value of "Nan.Nan.0Nan" in the edit form. This PR fixes it to be reseted to NULL.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | To remove a date in a custom field |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        |  |
| How to test?            | Create a Custom field of type Date. Select a date and save. Clear the field an save again. The field now stays empty and does not display "Nan.Nan.0Nan". The database field contains now NULL instead of "0000-00-00" |
| Requirements met?       | Maybe |