### PR TITLE
Process more than 50 manufacturer seo urls

### DIFF
--- a/engine/Shopware/Core/sRewriteTable.php
+++ b/engine/Shopware/Core/sRewriteTable.php
@@ -995,10 +995,8 @@ class sRewriteTable
         if ($offset !== null) {
             $criteria->offset = $offset;
         }
-        if ($limit !== null) {
-            $criteria->limit = $limit;
-        }
-
+        
+        $criteria->limit = $limit;
         $result = $repo->search($criteria);
         $suppliers = $result->getData();
         $ids = array_column($suppliers, 'id');


### PR DESCRIPTION
The SearchCriteria's limit property has to be set to NULL to process more than 50 manufacturer seo urls. :)