### PR TITLE
Variant grid "inStock" sortable

### DIFF
--- a/themes/Backend/ExtJs/backend/article/view/variant/list.js
+++ b/themes/Backend/ExtJs/backend/article/view/variant/list.js
@@ -319,8 +319,8 @@ Ext.define('Shopware.apps.Article.view.variant.List', {
         standardColumns = [
             {
                 header: me.snippets.columns.stock,
-                dataIndex: 'inStock',
-                sortable: false,
+                dataIndex: 'details.inStock',
+                sortable: true,
                 flex: 1,
                 renderer: me.stockColumnRenderer,
                 editor: {


### PR DESCRIPTION
Improve usability by using a qualified dataIndex and enabling sortable on it.

## Description
Please describe your pull request:
* Why is it necessary?
Just a simple UX improvement
* What does it improve?
Variant listing allows sorting by stock
* Does it have side effects?
none known

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | not tested
| Tests pass?      | not tested
| Related tickets? | -
| How to test?     | Open a article with variants, to to variants tab and try sorting by stock