### PR TITLE
[BUGFIX] Set lastBacklogId after applying backlog in shop indexer

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/ShopIndexer.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/ShopIndexer.php
@@ -226,6 +226,8 @@ class ShopIndexer implements ShopIndexerInterface
             $last = array_pop($backlogs);
             $lastId = $last->getId();
         }
+
+        $this->backlogReader->setLastBacklogId($lastId);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description
After applying the Elastic Search backlog, the id of the last processed backlog entry
should be set, because otherwise the backlog entries will be processed
again every time, decreasing indexing performance big time.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | See description |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        ||
| How to test?            | `./bin/console sw:es:index:populate; mysql -e "SELECT value FROM s_core_config_elements WHERE name='lastBacklogId' "` |
| Requirements met?       | yes |