### PR TITLE
Event which notifies about an article added to basket

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1612,6 +1612,8 @@ class sBasket
             ]
         );
 
+        $this->eventManager->notify('Shopware_Modules_Basket_AddArticle_Added', [ 'id' => $insertId]);
+
         $this->sUpdateArticle($insertId, $quantity);
 
         return $insertId;


### PR DESCRIPTION
Adds an event to the "sBasket->sAddArticle()"-method, so that it is possible to react to the insert, without hooking into the following sUpdateArticle-method.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Hooking became really ugly, the more the depending plugin grew. |
| BC breaks?              | probably not, just adds a notify event |
| Tests exists & pass?    | no |
| Related tickets?        | - |
| How to test?            | Subscribe to the emitted event and add an article to an empty basket. |
| Requirements met?       | mostly |