### PR TITLE
Prevent Javascript and Smarty Error with IndexNoCookiesNotice if single or doubl…

### DIFF
--- a/themes/Frontend/Bare/frontend/index/index.tpl
+++ b/themes/Frontend/Bare/frontend/index/index.tpl
@@ -169,7 +169,8 @@
             {rdelim};
 
             var snippets = snippets || {ldelim}
-                'noCookiesNotice': '{"{s name='IndexNoCookiesNotice'}{/s}"|escape}'
+                {capture name="IndexNoCookiesNotice"}{s name='IndexNoCookiesNotice'}{/s}{/capture}
+                'noCookiesNotice': '{$smarty.capture.IndexNoCookiesNotice|escape:"javascript"}'
             {rdelim};
 
             var themeConfig = themeConfig || {ldelim}


### PR DESCRIPTION
…e quote is used

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | this [PR](https://github.com/shopware/shopware/pull/899) fixed the single quote error but not fix the all problem now if we used a double quote inside the text we have Smarty error  |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | __ |
| How to test?            | just open the snippets manger search for IndexNoCookiesNotice and add a double quote to the text |
| Requirements met?       | ja |