### PR TITLE
Changed the check for mod rewrite

### DIFF
--- a/recovery/install/index.php
+++ b/recovery/install/index.php
@@ -63,7 +63,7 @@ if (PHP_SAPI === 'cli') {
 ini_set('max_execution_time', 120);
 
 // Redirect to no mod rewrite path
-if (!isset($_SERVER['MOD_REWRITE']) && isset($_SERVER['SCRIPT_NAME']) && isset($_SERVER['REQUEST_URI'])) {
+if (!in_array('mod_rewrite', apache_get_modules()) && isset($_SERVER['SCRIPT_NAME']) && isset($_SERVER['REQUEST_URI'])) {
     if (empty($_SERVER['PATH_INFO']) && strpos($_SERVER['REQUEST_URI'], $_SERVER['SCRIPT_NAME']) !== 0) {
         header('Location: ' . $_SERVER['SCRIPT_NAME'], true);
 

--- a/recovery/install/src/Requirements.php
+++ b/recovery/install/src/Requirements.php
@@ -214,7 +214,7 @@ class Requirements
      */
     private function checkModRewrite()
     {
-        return isset($_SERVER['MOD_REWRITE']);
+        return in_array('mod_rewrite', apache_get_modules());
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | I could not install shopware because according to it I didn't have mod_rewrite on. After some digging I found out that the $_SERVER variable doesn't have a mod_rewrite and the correct way to check for it is the apache modules function. |
| BC breaks?              | no, works with PHP 4.3.2 and greater|
| Tests exists & pass?    | no need. |
| Related tickets?        | If this PR fixes an existing issue ticket, please add there url here. |
| How to test?            | If unset the $_SERVER['mod_rewrite'] and it will still work (as you have the rewrite mod already installed). |
| Requirements met?       | yes |