### PR TITLE
Escape search headline to prevent XSS attacks

### DIFF
--- a/snippets/frontend/search/fuzzy.ini
+++ b/snippets/frontend/search/fuzzy.ini
@@ -1,13 +1,13 @@
 [en_GB]
 SearchFuzzyHeadlineNoResult = "No products matching your search"
 SearchFuzzyInfoShortTerm = "The entered search term is too short."
-SearchHeadline = "The following products have been found matching your search \"{$sRequests.sSearch}\":  {$sSearchResults.sArticlesCount} "
+SearchHeadline = "The following products have been found matching your search \"{$sRequests.sSearch|escape}\":  {$sSearchResults.sArticlesCount} "
 SearchResultsFor = "Search results for {$sRequests.sSearch}"
 SearchResultsEmpty = "Search results"
 
 [de_DE]
 SearchFuzzyHeadlineNoResult = "Leider wurden zu Ihrer Suchanfrage keine Artikel gefunden"
 SearchFuzzyInfoShortTerm = "Der eingegebene Suchbegriff ist leider zu kurz."
-SearchHeadline = "Zu \"{$sRequests.sSearch}\" wurden {$sSearchResults.sArticlesCount} Artikel gefunden!"
+SearchHeadline = "Zu \"{$sRequests.sSearch|escape}\" wurden {$sSearchResults.sArticlesCount} Artikel gefunden!"
 SearchResultsFor = "Suchergebnis für {$sRequests.sSearch}"
 SearchResultsEmpty = "Suchergebnisse"


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Without the `escape` modifier the search term from the request will be printed in the frontend. This enables XSS attacks. |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | no |
| How to test?            | Perform a search: http://www.shopwaredemo.de/search?sSearch=%22%2F%3Edies+ist+ein+XSS-Test+ |
| Requirements met?       | yes |