### PR TITLE
Fix PHP notice in ShopPageService for shop pages without shop assignment

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/ShopPageHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/ShopPageHydrator.php
@@ -90,13 +90,17 @@ class ShopPageHydrator extends Hydrator
             $shopPage->setChanged(\DateTime::createFromFormat('Y-m-d H:i:s', $data['__page_changed']));
         }
 
+        $shopIds = [];
+
         if (isset($data['__page_shop_ids'])) {
             $shopIds = explode('|', $data['__page_shop_ids']);
             $shopIds = array_keys(array_flip($shopIds));
             $shopIds = array_filter($shopIds);
             $shopIds = array_map('intval', $shopIds);
-            $shopPage->setShopIds($shopIds);
+            
         }
+
+        $shopPage->setShopIds($shopIds);
 
         $this->attributeHydrator->addAttribute($shopPage, $data, 'pageAttribute');
     }


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | The service will produce the following error for shop pages without shop assignment: `PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in engine/Shopware/Bundle/StoreFrontBundle/Service/Core/ShopPageService.php on line 86`  |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | no |
| How to test?            | Create a shop page without shop assignment and reindex with the SwagEnterpriseSearch plugin. |
| Requirements met?       | yes |