### PR TITLE
remove a obsolete debug = false statement inside the kernel constructor

### DIFF
--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -138,8 +138,6 @@ class Kernel implements HttpKernelInterface
      */
     public function __construct($environment, $debug)
     {
-        $debug = false;
-
         $this->environment = $environment;
         $this->debug = (bool) $debug;
         $this->name = 'Shopware';


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | the debug parameter is ignored |
| BC breaks?              | no|
| Tests exists & pass?    | yes|
| Related tickets?        | none |
| How to test?            | it's a one liner |
| Requirements met?       | yes |