### PR TITLE
Improve input handling for the sw:rebuild:category:tree command and set correct limit

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -4,6 +4,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.23
 * Added conditional statement in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js` to prevent the jquery plugin from sending ajax requests indefinitely
+* Made the values for the optional options `limit` and `offset` mandatory, added an value check and set the default limit to 3000 as suggested by the documentation for the `sw:rebuild:category:tree` command
 
 ## 5.2.22
 * Fixed the picture implementation of the `box-emotion.tpl` to load the correct image sizes

--- a/engine/Shopware/Commands/RebuildCategoryTreeCommand.php
+++ b/engine/Shopware/Commands/RebuildCategoryTreeCommand.php
@@ -48,13 +48,15 @@ class RebuildCategoryTreeCommand extends ShopwareCommand
                 'offset',
                 'o',
                 InputOption::VALUE_REQUIRED,
-                'Offset to start with. Default: 0'
+                'Offset to start with. Default: 0',
+                0
             )
             ->addOption(
                 'limit',
                 'l',
                 InputOption::VALUE_REQUIRED,
-                'Categories to build per batch. Default: 3000'
+                'Categories to build per batch. Default: 3000',
+                3000
             )
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command will rebuild your category tree.
@@ -68,8 +70,8 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $progress = $input->getOption('offset') ?: 0;
-        $limit = $input->getOption('limit') ?: 3000;
+        $progress = $input->getOption('offset');
+        $limit = $input->getOption('limit');
 
         Assertion::integerish($progress);
         Assertion::integerish($limit);

--- a/engine/Shopware/Commands/RebuildCategoryTreeCommand.php
+++ b/engine/Shopware/Commands/RebuildCategoryTreeCommand.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Commands;
 
+use Assert\Assertion;
 use Shopware\Components\Model\CategoryDenormalization;
 use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -43,12 +44,23 @@ class RebuildCategoryTreeCommand extends ShopwareCommand
         $this
             ->setName('sw:rebuild:category:tree')
             ->setDescription('Rebuild the category tree')
-             ->addOption('offset', 'o', InputOption::VALUE_OPTIONAL, 'Offset to start with.')
-             ->addOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'Categories to build per batch. Default: 3000')
+            ->addOption(
+                'offset',
+                'o',
+                InputOption::VALUE_REQUIRED,
+                'Offset to start with. Default: 0'
+            )
+            ->addOption(
+                'limit',
+                'l',
+                InputOption::VALUE_REQUIRED,
+                'Categories to build per batch. Default: 3000'
+            )
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command will rebuild your category tree.
 EOF
-            );
+            )
+        ;
     }
 
     /**
@@ -56,8 +68,11 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $progress = $input->getOption('offset');
-        $limit = $input->getOption('limit') ?: 1000;
+        $progress = $input->getOption('offset') ?: 0;
+        $limit = $input->getOption('limit') ?: 3000;
+
+        Assertion::integerish($progress);
+        Assertion::integerish($limit);
 
         /** @var CategoryDenormalization $component */
         $component = Shopware()->Container()->get('CategoryDenormalization');


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | The current default limit is set not the same as suggested in the documentation of the command. Also the input for this command is not checked and will raise warnings, thus the behavior of the command is probably not as expected if not properly used. The options could also supplied empty, which makes no sense. |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | - |
| How to test?            | Run `php bin/console sw:rebuild:category:tree -o=123` for example and view output with and without the patch |
| Requirements met?       | yes |