### PR TITLE
Remove the delete folder at the end, when clearing the cache

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -4,6 +4,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.23
 * Added conditional statement in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js` to prevent the jquery plugin from sending ajax requests indefinitely
+* Moved the removal of the whole cache folder after the removal of the `.js` and `.css` files for better handling of huge caches in the `clear_cache.sh` script
 
 ## 5.2.22
 * Fixed the picture implementation of the `box-emotion.tpl` to load the correct image sizes

--- a/var/cache/clear_cache.sh
+++ b/var/cache/clear_cache.sh
@@ -11,10 +11,10 @@ echo "Clearing caches"
 mkdir $DIR/delete
 find $DIR -mindepth 1 -maxdepth 1 -type d ! -name delete -print0 | xargs -I{} -0 mv {} $DIR/delete/
 
-rm -Rf $DIR/delete/
-
 rm -f $DIR/../../web/cache/*.js > /dev/null
 rm -f $DIR/../../web/cache/*.css
 rm -f $DIR/../../web/cache/*.txt
 
 $DIR/../../bin/console sw:generate:attributes
+
+rm -Rf $DIR/delete/


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | When the cache folder gets very big, the `rm` command to delete the old cache folder can take several time, in our case it happend that some sites were already in the http cache and after that the `.css` and `.js` files got removed, so we had some pages without any css and JavaScript files |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | - |
| How to test?            | Have a big cache folder and run the clear cache script |
| Requirements met?       | yes |