### PR TITLE
Fixed default value assignment for skipInit parameter

### DIFF
--- a/engine/Library/ExtJs/overrides/Ext.app.Application.js
+++ b/engine/Library/ExtJs/overrides/Ext.app.Application.js
@@ -91,7 +91,9 @@ Ext.override(Ext.app.Application, {
 	 * @param subapp
 	 */
 	addSubApplication: function(subapp, skipInit, fn, showLoadMask) {
-        skipInit = (skipInit === undefined) ? false : true;
+        if (skipInit === undefined) {
+			skipInit = false;
+		}
 		subapp.app = this;
 
         if(subapp.hasOwnProperty('showLoadMask')) {

--- a/engine/Library/ExtJs/overrides/Ext.app.Application.js
+++ b/engine/Library/ExtJs/overrides/Ext.app.Application.js
@@ -91,9 +91,7 @@ Ext.override(Ext.app.Application, {
 	 * @param subapp
 	 */
 	addSubApplication: function(subapp, skipInit, fn, showLoadMask) {
-        if (skipInit === undefined) {
-			skipInit = false;
-		}
+		skipInit = skipInit === true;
 		subapp.app = this;
 
         if(subapp.hasOwnProperty('showLoadMask')) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Right now, if you pass anything that is not `undefined` for the `skipInit`-Parameter, it'll always be true |
| BC breaks?              | yes |
| Tests exists & pass?    | no |
| Related tickets?        |  |
| How to test?            | Try to load a SubApplication into the Shopware backend with the Shopware.app.Application.addSubApplication function and set the `skipInit` parameter to false. The SubApplication will load, but nothing happens afterwards. See example below |

Example: Type this into the developer tools of your browser
```javascript
Shopware.app.Application.addSubApplication({
    name: 'Shopware.apps.Analytics',
    action: 'index'
}, false);
```

This is especially annoying if you want to use the callback parameter:

```javascript
Shopware.app.Application.addSubApplication({
    name: 'Shopware.apps.Analytics',
    action: 'index'
}, false, function () {
    console.log('callback');
});
```

What you'd have to do at the moment to actually set `skipInit` to false:

```javascript
Shopware.app.Application.addSubApplication({
    name: 'Shopware.apps.Analytics',
    action: 'index'
}, undefined);
```
