### PR TITLE
Reliable fallback for popularity sorting

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/SortingHandler/PopularitySortingHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SortingHandler/PopularitySortingHandler.php
@@ -66,6 +66,6 @@ class PopularitySortingHandler implements SortingHandlerInterface
 
         /* @var PopularitySorting $sorting */
         $query->addOrderBy('topSeller.sales', $sorting->getDirection())
-              ->addOrderBy('topSeller.article_id', $sorting->getDirection());
+              ->addOrderBy('product.id', $sorting->getDirection());
     }
 }


### PR DESCRIPTION
| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | When the topseller index hasn't been generated, the order of articles sorted by popularity will be random across requests. There is also the possibility for articles being listed more than once over multiple pages.  |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | - |
| How to test?            | Reload listing with disabled cache and missing topseller index. The order of articles should stay the same. |
| Requirements met?       | Guess so |