### PR TITLE
Fix sArticles core for article without images

### DIFF
--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -2424,7 +2424,7 @@ class sArticles
             }
 
             if ($this->config->get('forceArticleMainImageInListing') && $configurator->getType() !== ConfiguratorService::CONFIGURATOR_TYPE_STANDARD && empty($selection)) {
-                $data['image'] = $this->legacyStructConverter->convertMediaStruct($product->getCover());
+                $data['image'] = (!is_null($product->getCover())) ? $this->legacyStructConverter->convertMediaStruct($product->getCover()) : '';
                 $data['images'] = [];
                 foreach ($product->getMedia() as $image) {
                     if ($image->getId() !== $product->getCover()->getId()) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | If an article has no images, it caused an error 503 on the frontend. error message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Shopware\Components\Compatibility\LegacyStructConverter::convertMediaStruct() must be an instance of Shopware\Bundle\StoreFrontBundle\Struct\Media, null given, called in /var/www/genxtreme/htdocs/shop/engine/Shopware/Core/sArticles.php on line x |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | no |
| How to test?            | Delete all images of an article, save it and show it on the frontend. A error 503 will be shown. After adding this commit, the article page will be displayed with an empty article image. |
| Requirements met?       | yes |