### PR TITLE
Reset selection free text field values correctly for new entities

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -4,6 +4,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.23
 * Added conditional statement in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js` to prevent the jquery plugin from sending ajax requests indefinitely
+* Fixed resetting of the values of single/multi-selection free text fields of new entities
 
 ## 5.2.22
 * Fixed the picture implementation of the `box-emotion.tpl` to load the correct image sizes

--- a/themes/Backend/ExtJs/backend/base/attribute/field/Shopware.form.field.Grid.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field/Shopware.form.field.Grid.js
@@ -320,6 +320,9 @@ Ext.define('Shopware.form.field.Grid', {
     },
 
     getSubmitData: function() {
+        if (this.disabled) {
+            return null;
+        }
         var value = { };
         value[this.name] = this.getValue();
         return value;

--- a/themes/Backend/ExtJs/backend/base/attribute/field/Shopware.form.field.SingleSelection.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field/Shopware.form.field.SingleSelection.js
@@ -176,6 +176,9 @@ Ext.define('Shopware.form.field.SingleSelection', {
     },
 
     getSubmitData: function() {
+        if (this.disabled) {
+            return null;
+        }
         var value = { };
         value[this.name] = this.getValue();
         return value;


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | When creating new entities of some types - a new payment method, for example - the attribute form is disabled, but its controls are not reset. When the entity is saved, the attribute form's values are queried using `getSubmitData()`. For both classes modified in this document, a value is returned even when the control is disabled, which causes values from the previously selected entity to be written to the new entity's attributes. This PR fixes that bug.|
| BC breaks?              | no |
| Tests exists & pass?    | no tests exist |
| Related tickets?        ||
| How to test?            |1. Create single-selection and multiple-selection free text fields for payment methods.|
||2. Open an existing payment method and make selections for both attributes you've just created. Saving changes is not required at this point.|
||3. Press the button to add a new payment method.|
||4. Enter a name and description and hit "Save.".|
||5. Select the newly-created payment method and observe that the attribute values that were chosen for the pre-existing payment method were saved for the newly-created one. These changes were also written to the database.|
| Requirements met?       | yeah | 