### PR TITLE
Trim request value before getting article

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -4,6 +4,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.23
 * Added conditional statement in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js` to prevent the jquery plugin from sending ajax requests indefinitely
+* Trim sAdd request param before trying to get id by sGetArticleIdByOrderNumber.
 
 ## 5.2.22
 * Fixed the picture implementation of the `box-emotion.tpl` to load the correct image sizes

--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -460,7 +460,7 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action
      */
     public function addArticleAction()
     {
-        $ordernumber = $this->Request()->getParam('sAdd');
+        $ordernumber = trim($this->Request()->getParam('sAdd'));
         $quantity = $this->Request()->getParam('sQuantity');
         $articleID = Shopware()->Modules()->Articles()->sGetArticleIdByOrderNumber($ordernumber);
 


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | When entering a whitespace prefixed ordernumber into the corresponding field on the cart page, the article is not found. In order to avoid that issue with copy-pasted articlenumbers, the request param value gets trimmed before passing to sGetArticleIdByOrderNumber. |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | none |
| How to test?            | Go to http://www.shopwaredemo.de/checkout/cart and try to add a product to cart by adding a whitespace prefixed article number into the corresponding field. The product is not found. |
| Requirements met?       | yes |