### PR TITLE
remove eslint-task from watch:less

### DIFF
--- a/themes/Gruntfile.js
+++ b/themes/Gruntfile.js
@@ -79,7 +79,7 @@ module.exports = function (grunt) {
                     '../custom/plugins/**/*.less',
                     '../custom/plugins/**/*.css'
                 ],
-                tasks: ['less:development', 'eslint'],
+                tasks: ['less:development'],
                 options: {
                     spawn: false
                 }


### PR DESCRIPTION
This PR removes the eslint task from the `watch:less`-task.

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | eslint has nothing to do with compiling less |
| BC breaks?              | no |
| Tests exists & pass?    | no tests |
| How to test?            | Run `grunt watch:less`, update a less file and see, that eslint won't run |
| Requirements met?       | Yes |