### PR TITLE
Removed the default option touchControls of the swImageSlider plugin

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -4,6 +4,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.23
 * Added conditional statement in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js` to prevent the jquery plugin from sending ajax requests indefinitely
+* Removed the default option `touchControls: true` from the instantiation of the `swImageSlider`, since it is default by the plugin itself and caused reinstantiation of the plugin when updated by the StateManager without this particular option
 
 ## 5.2.22
 * Fixed the picture implementation of the `box-emotion.tpl` to load the correct image sizes

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -139,7 +139,7 @@
                     $(me.opts.footerJavascriptInlineSelector).replaceWith($response.filter(me.opts.footerJavascriptInlineSelector));
 
                     StateManager.addPlugin('select:not([data-no-fancy-select="true"])', 'swSelectboxReplacement')
-                        .addPlugin('*[data-image-slider="true"]', 'swImageSlider', { touchControls: true })
+                        .addPlugin('*[data-image-slider="true"]', 'swImageSlider')
                         .addPlugin('.product--image-zoom', 'swImageZoom', 'xl')
                         .addPlugin('*[data-image-gallery="true"]', 'swImageGallery')
                         .addPlugin('*[data-add-article="true"]', 'swAddArticle')

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.shopware-responsive.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.shopware-responsive.js
@@ -44,7 +44,7 @@
         .addPlugin('#new-customer-action', 'swCollapsePanel', ['xs', 's'])
 
         // Image slider
-        .addPlugin('*[data-image-slider="true"]', 'swImageSlider', { touchControls: true })
+        .addPlugin('*[data-image-slider="true"]', 'swImageSlider')
 
         // Image zoom
         .addPlugin('.product--image-zoom', 'swImageZoom', 'xl')


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | The image slider will be destroyed and reinstantiated. In our case it sometimes came to a race condition where `trackThumbnailControls` was already executed but the plugin was "destroyed" and thus the function resulted in an error `Uncaught TypeError: Cannot read property 'position' of null`. Where the line of failure was `pos = $slide.position(),`. This is probably a deeper issue which should also be looked into. |
| BC breaks?              | No |
| Tests exists & pass?    | None exist |
| Related tickets?        | - |
| How to test?            | Create a template with an image slider (instantiated by `data-image-slider="true"`) and then for example load an shopping world. |
| Requirements met?       | Yes |