### PR TITLE
Add document type base store

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -4,6 +4,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.23
 * Added conditional statement in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js` to prevent the jquery plugin from sending ajax requests indefinitely
+* Added a base store for `Shopware.apps.Base.model.DocType`
 
 ## 5.2.22
 * Fixed the picture implementation of the `box-emotion.tpl` to load the correct image sizes

--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -940,6 +940,39 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
     }
 
     /**
+     * Returns a list of document types. Supports store paging, sorting and filtering over the standard ExtJs store
+     * parameters. Each document type has the following fields:
+     * <code>
+     *    [int]      id
+     *    [string]   name
+     *    [string]   template
+     *    [string]   numbers
+     *    [int]      left
+     *    [int]      right
+     *    [int]      top
+     *    [int]      bottom
+     *    [int]      pageBreak
+     * </code>
+     */
+    public function getDocTypesAction()
+    {
+        $repository = Shopware()->Models()->getRepository('Shopware\Models\Document\Document');
+        $builder = $repository->createQueryBuilder('d');
+
+        $builder->select('d')
+            ->addFilter((array) $this->Request()->getParam('filter', []))
+            ->addOrderBy((array) $this->Request()->getParam('sort', []))
+            ->setFirstResult($this->Request()->getParam('start'))
+            ->setMaxResults($this->Request()->getParam('limit'));
+
+        $query = $builder->getQuery();
+        $total = Shopware()->Models()->getQueryCount($query);
+        $data = $query->getArrayResult();
+
+        $this->View()->assign(['success' => true, 'data' => $data, 'total' => $total]);
+    }
+
+    /**
      * Add the table alias to the passed filter and sort parameters.
      *
      * @param array $properties

--- a/themes/Backend/ExtJs/backend/base/bootstrap.js
+++ b/themes/Backend/ExtJs/backend/base/bootstrap.js
@@ -133,6 +133,7 @@
 {include file='backend/base/store/category_tree.js'}
 {include file='backend/base/store/customer_group.js'}
 {include file='backend/base/store/dispatch.js'}
+{include file='backend/base/store/doc_type.js'}
 {include file='backend/base/store/payment.js'}
 {include file='backend/base/store/shop.js'}
 {include file='backend/base/store/shop_language.js'}

--- a/themes/Backend/ExtJs/backend/base/store/doc_type.js
+++ b/themes/Backend/ExtJs/backend/base/store/doc_type.js
@@ -1,0 +1,52 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    Base
+ * @subpackage Store
+ * @version    $Id$
+ * @author shopware AG
+ */
+
+/**
+ * The base store for document types.
+ */
+Ext.define('Shopware.apps.Base.store.DocType', {
+    extend: 'Ext.data.Store',
+
+    alternateClassName: 'Shopware.store.DocType',
+    storeId: 'base.Payment',
+    model : 'Shopware.apps.Base.model.DocType',
+    pageSize: 1000,
+    remoteFilter: true,
+
+    proxy:{
+        type:'ajax',
+        url:'{url action="getDocTypes"}',
+        reader:{
+            type: 'json',
+            root: 'data',
+            totalProperty: 'total'
+        }
+    }
+}).create();
+


### PR DESCRIPTION
## Description

Right now, in order to let users specify arbitrary document types as part of a plugin's configuration, the user has to enter the document types' ids in a plain text field. This is not user-friendly at all. After this PR is merged, plugins can allow the user to choose document types from a select element.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Right now, no base store exists for doc types. This means that it cannot be used inside plugin settings, for example.|
| BC breaks?              | no |
| Tests exists & pass?    | none exist for the affected controller |
| Related tickets?        | None that I know of |
| How to test?            | In a Plugin, create a form select element that is backed by the store `Shopware.apps.Base.store.DocType` (see below). Load the plugin's settings and observe that the store is loaded. Test saving and loading. |
| Requirements met?       | hope so |

Example config field:

```php
$form->setElement(
    'select',
    'selectDocument',
    [
        'label' => 'Choose a document type',
        'value' => [],
        'store' => 'Shopware.apps.Base.store.DocType',
        'displayField' => 'name',
        'editable' => false
    ]
);
```