### PR TITLE
Add smarty-block for first image / preview image

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/images.tpl
+++ b/themes/Frontend/Bare/frontend/detail/images.tpl
@@ -8,26 +8,28 @@
         <div class="image-slider--thumbnails-slide">
             {block name='frontend_detail_image_thumbnail_items'}
 
-                {* Thumbnail - Main image *}
-                {if $sArticle.image.thumbnails}
+                {block name='frontend_detail_image_thumbnail_preview_image'}
+                    {* Thumbnail - Main image *}
+                    {if $sArticle.image.thumbnails}
 
-                    {$alt = $sArticle.articleName|escape}
+                        {$alt = $sArticle.articleName|escape}
 
-                    {if $sArticle.image.description}
-                        {$alt = $sArticle.image.description|escape}
+                        {if $sArticle.image.description}
+                            {$alt = $sArticle.image.description|escape}
+                        {/if}
+
+                        <a href="{$sArticle.image.src.1}"
+                           title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt}"
+                           class="thumbnail--link is--active">
+                            {block name='frontend_detail_image_thumbs_main_img'}
+                                <img srcset="{$sArticle.image.thumbnails[0].sourceSet}"
+                                     alt="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt}"
+                                     title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt|truncate:160}"
+                                     class="thumbnail--image" />
+                            {/block}
+                        </a>
                     {/if}
-
-                    <a href="{$sArticle.image.src.1}"
-                       title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt}"
-                       class="thumbnail--link is--active">
-                        {block name='frontend_detail_image_thumbs_main_img'}
-                            <img srcset="{$sArticle.image.thumbnails[0].sourceSet}"
-                                 alt="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt}"
-                                 title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt|truncate:160}"
-                                 class="thumbnail--image" />
-                        {/block}
-                    </a>
-                {/if}
+                {/block}
 
                 {* Thumbnails *}
                 {foreach $sArticle.images as $image}


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | We need to implement a video-link after the first preview-image. Currently we have to copy the whole block instead of using `$smarty.block.parent`. |
| BC breaks?              | no |
| Tests exists & pass?    | No tests exist for smarty template block yet  |
| Related tickets?        | none |
| How to test?            | Add a new theme based on the Bare-theme, add a `images.tpl`-file and extend the newly block `frontend_detail_image_thumbnail_preview_image`.  |
| Requirements met?       | hope so |