### PR TITLE
SW-18675 - Remove erroneous call to `Shopware()->Models()->clear()`

### DIFF
--- a/engine/Shopware/Components/Test/Plugin/TestCase.php
+++ b/engine/Shopware/Components/Test/Plugin/TestCase.php
@@ -113,7 +113,6 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     private static function restorePluginStates()
     {
-        Shopware()->Models()->clear();
         foreach (self::$pluginStates as $pluginName => $status) {
             self::restorePluginState($pluginName, $status);
         }


### PR DESCRIPTION
This commit fixes an unhandled exception being thrown when a test case has installed plugins and tries to restore their state afterwards.

## License

Actually I believe the removal of one line does not require a license. In case it matters though: My intellectual property is hereby provided under the MIT license.

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | When a test case that inherits from `\Shopware\Components\Test\Plugin\TestCase` has to install plugins, as they were added to the protected static array `$ensureLoadedPlugins`, then a `\Doctrine\ORM\ORMInvalidArgumentException` is being thrown during the execution of `TestCase::tearDownAfterClass()`. That is because `Shopware()->Models()->clear()` is being called before the loop in `TestCase::restorePluginStates()` – though there is also a call after everything is done. This fix is necessary to enable developers to perform automated testing. |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | https://issues.shopware.com/issues/SW-18675 |
| How to test?            | Build a test that inherits from TestCase and let the test install a plugin. |
| Requirements met?       | Yes |