### PR TITLE
Miss naming of classes and div in checkout steps

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/register.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/register.less
@@ -378,10 +378,6 @@ The user can see the registration steps, advantages and required information.
     .steps--content {
 
         .steps--entry {
-            &.step--payment {
-                width: 30%;
-            }
-
             .text {
                 .unitize-margin(0, 0, 0, 10);
                 width: 70%;


### PR DESCRIPTION
If you check frontend/register/steps.tpl and register.less there are one class 'step--payment' that are not used. Also in steps.tpl file, the second step payment are named with block "register".

{* Second Step - Payment *}
{block name='frontend_register_steps_register'}


This is my first comment here, can anyone more experienced can check if this needs improvement?
thanks

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Please describe *why* your change is necessary. |
| BC breaks?              | yes/no |
| Tests exists & pass?    | yes/no |
| Related tickets?        | If this PR fixes an existing issue ticket, please add there url here. |
| How to test?            | Please describe how to best verify that this PR is correct. |
| Requirements met?       | Does your PR fulfil our [contribution requirements](https://developers.shopware.com/contributing/contribution-guideline/#requirements-for-a-successful-pull-request)? |