### PR TITLE
Restore removeAttribute backwards compatibility

### DIFF
--- a/engine/Shopware/Components/Model/ModelManager.php
+++ b/engine/Shopware/Components/Model/ModelManager.php
@@ -361,7 +361,7 @@ class ModelManager extends EntityManager
 
         /** @var CrudService $crudService */
         $crudService = Shopware()->Container()->get('shopware_attribute.crud_service');
-        $crudService->delete($table, $prefixedColumn, true);
+        $crudService->delete($table, $prefixedColumn, false);
     }
 
     /**


### PR DESCRIPTION
## Description

SW 5.3 includes a compatibility layer that maps the old `\Shopware\Components\Model\ModelManager::*Attribute` methods onto the newer `\Shopware\Bundle\AttributeBundle\Service\CrudService`. However, the delegate for `\Shopware\Components\Model\ModelManager::removeAttribute` behaves in a backwards-incompatible way: When deleting an attribute, it will also traverse the "`dependingTables`" and try to delete the attribute there. If any of the `dependingTables` does not have that attribute, the called `CrudService` method will throw. This is inconsistent with the original method's behaviour and causes existing plugins to break for no good reason. This PR makes `removeAttribute()` behave in a backwards-compatible way again.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | See above |
| BC breaks?              | BC is actually _improved_ ;) |
| Tests exists & pass?    | yes |
| Related tickets?        |  |
| How to test?            | Here is a [minimal test plugin](https://gist.github.com/fixpunkt/6c5310cdd38a1adf925ab6753f82e3c9) that shows the problem this PR fixes |
| Requirements met?       | yeah |

Props for finding this issue go to @mihaiplasoianu.