### PR TITLE
Renamed Shopware.model.AttributeConfig to Shopware.apps.Base.model.AttributeConfig

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -2,6 +2,9 @@
 
 This changelog references changes done in Shopware 5.2 patch versions.
 
+## 5.2.24
+* Renamed `Shopware.model.AttributeConfig` to `Shopware.apps.Base.model.AttributeConfig`
+
 ## 5.2.23
 * Added conditional statement in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js` to prevent the jquery plugin from sending ajax requests indefinitely
 * Added `limit` parameter to `createQuery` and `createOptionQuery` in `engine/Shopware/Bundle/ESIndexingBundle/Property/PropertyQueryFactory`

--- a/themes/Backend/ExtJs/backend/base/model/attribute_config.js
+++ b/themes/Backend/ExtJs/backend/base/model/attribute_config.js
@@ -1,7 +1,8 @@
 
 //{namespace name="backend/attributes/main"}
 
-Ext.define('Shopware.model.AttributeConfig', {
+Ext.define('Shopware.apps.Base.model.AttributeConfig', {
+    alternateClassName: 'Shopware.model.AttributeConfig',
     extend: 'Shopware.data.Model',
 
     fields: [


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | This fixes a consistency flaw. The class now follows the same naming scheme as all other classes in this directory. |
| BC breaks?              | no, old class name is still defined as alternateClassName |
| Tests exists & pass?    | yes |
| Related tickets?        |  |
| How to test?            | see below |
| Requirements met?       | yes |

### How to test
Test, if new class name works:
```javascript
// In developer console
Ext.create('Shopware.apps.Base.model.AttributeConfig');
```

Test, if old class name still works
```javascript
// In developer console
Ext.create('Shopware.model.AttributeConfig');
```