### PR TITLE
nesting level too deep

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Resource.php
+++ b/engine/Shopware/Components/Api/Resource/Resource.php
@@ -424,7 +424,7 @@ abstract class Resource
                 );
                 continue;
             }
-            if ($entity->$method() == $value) {
+            if ($entity->$method() === $value) {
                 return $entity;
             }
         }


### PR DESCRIPTION
changing from the equal to the identical operator

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | the system is running into a nesting level too deep or memory exhausted error sometimes when using the equal operator |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | |
| How to test?            | running the generateVariantImages API request with a product with a lot of variants and images |
| Requirements met?       |  |