### PR TITLE
Fix doc type base store store id

### DIFF
--- a/themes/Backend/ExtJs/backend/base/store/doc_type.js
+++ b/themes/Backend/ExtJs/backend/base/store/doc_type.js
@@ -34,7 +34,7 @@ Ext.define('Shopware.apps.Base.store.DocType', {
     extend: 'Ext.data.Store',
 
     alternateClassName: 'Shopware.store.DocType',
-    storeId: 'base.Payment',
+    storeId: 'base.DocType',
     model : 'Shopware.apps.Base.model.DocType',
     pageSize: 1000,
     remoteFilter: true,


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | I made a copy-paste mistake as part of #1120, giving the new base store the same store ID as the existing `base.Payment` store. Depending on store loading order, this could lead to issues as soon as someone starts using this store. |
| BC breaks?              | no |
| Tests exists & pass?    | none exist |
| Related tickets?        | https://issues.shopware.com/issues/SW-18668 |
| How to test?            | See #1120 |
| Requirements met?       | yes |