### PR TITLE
Fix missing zipcode for shipping adresses

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/finish.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/finish.tpl
@@ -238,7 +238,7 @@
                                                 {if $sAddresses.shipping.additional_address_line1}<span class="address--additional-one">{$sAddresses.shipping.additional_address_line1|escapeHtml}</span><br />{/if}
                                                 {if $sAddresses.shipping.additional_address_line2}<span class="address--additional-two">{$sAddresses.shipping.additional_address_line2|escapeHtml}</span><br />{/if}
                                                 {if {config name=showZipBeforeCity}}
-                                                    <span class="address--zipcode">{$sAddresses.shipping.zipcod|escapeHtml}</span> <span class="address--city">{$sAddresses.shipping.city|escapeHtml}</span>
+                                                    <span class="address--zipcode">{$sAddresses.shipping.zipcode|escapeHtml}</span> <span class="address--city">{$sAddresses.shipping.city|escapeHtml}</span>
                                                 {else}
                                                     <span class="address--city">{$sAddresses.shipping.city|escapeHtml}</span> <span class="address--zipcode">{$sAddresses.shipping.zipcode|escapeHtml}</span>
                                                 {/if}<br />


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | See https://forum.shopware.com/discussion/46594/postleitzahl-fehlt-bei-abweichender-lieferadresse#latest for more information.
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        |  |
| How to test?            | Just do a simple checkout with a shippingaddress. The zipcode is currently missing for the shippingaddress on the finish page, because the variable was misspelled. With this PR the zipcode of the shippingaddress should be displayed. |
| Requirements met?       | / |