### PR TITLE
Variant grid "inStock" sortable

### DIFF
--- a/themes/Backend/ExtJs/backend/article/view/variant/list.js
+++ b/themes/Backend/ExtJs/backend/article/view/variant/list.js
@@ -179,6 +179,10 @@ Ext.define('Shopware.apps.Article.view.variant.List', {
                     oldValue = e.record.get('number');
                     newValue = e.record.get('details.number') || e.record.get('number')
                 }
+                
+               if (e.field === 'details.inStock') {
+                   oldValue = e.record.get('inStock');
+               }
 
                 if(e.field === 'details.number' &&  (!newValue || !newValue.match(/^[a-zA-Z0-9-_. ]+$/))) {
                     Shopware.Notification.createGrowlMessage(me.snippets.saved.errorTitle, me.snippets.saved.ordernumberNotMatch, me.snippets.growlMessage);
@@ -193,6 +197,10 @@ Ext.define('Shopware.apps.Article.view.variant.List', {
 
                 if (e.field === 'details.number') {
                     e.record.set('number', newValue);
+                }
+                
+                if (e.field === 'details.inStock') {
+                    e.record.set('inStock', newValue);
                 }
 
                 me.fireEvent('saveVariant', e.record);

--- a/themes/Backend/ExtJs/backend/article/view/variant/list.js
+++ b/themes/Backend/ExtJs/backend/article/view/variant/list.js
@@ -319,8 +319,8 @@ Ext.define('Shopware.apps.Article.view.variant.List', {
         standardColumns = [
             {
                 header: me.snippets.columns.stock,
-                dataIndex: 'inStock',
-                sortable: false,
+                dataIndex: 'details.inStock',
+                sortable: true,
                 flex: 1,
                 renderer: me.stockColumnRenderer,
                 editor: {


### PR DESCRIPTION
Improve usability by using a qualified dataIndex and enabling sortable on it. The [orginal PR](https://github.com/shopware/shopware/pull/1086) has been closed as it broke saving stock inline in variant list view. This is now fixed.

## Description
Please describe your pull request:
* Why is it necessary?
Just a simple UX improvement
* What does it improve?
Variant listing allows sorting by stock
* Does it have side effects?
none known

| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | not tested
| Tests pass?      | not tested
| Related tickets? | [`SW-18776`](https://issues.shopware.com/issues/SW-18776)
| How to test?     | Open a article with variants, to to variants tab and try sorting by stock