### PR TITLE
Fix wrong output of voucher value in the backend

### DIFF
--- a/themes/Backend/ExtJs/backend/order/view/detail/position.js
+++ b/themes/Backend/ExtJs/backend/order/view/detail/position.js
@@ -333,7 +333,7 @@ Ext.define('Shopware.apps.Order.view.detail.Position', {
                 editor: {
                     xtype: 'numberfield',
                     allowBlank: false,
-                    decimalPrecision: 2
+                    decimalPrecision: 3
                 }
             },
             {

--- a/themes/Backend/ExtJs/backend/order/view/list/position.js
+++ b/themes/Backend/ExtJs/backend/order/view/list/position.js
@@ -281,6 +281,8 @@ Ext.define('Shopware.apps.Order.view.list.Position', {
         if ( value === Ext.undefined ) {
             return value;
         }
+
+        value = this._roundPriceValue(value);
         return Ext.util.Format.currency(value);
     },
 
@@ -293,9 +295,21 @@ Ext.define('Shopware.apps.Order.view.list.Position', {
         if ( value === Ext.undefined ) {
             return value;
         }
+        value = this._roundPriceValue(value);
         return Ext.util.Format.currency(value);
-    }
+    },
 
+    _roundPriceValue: function(value) {
+        if (Math.sign(value) === -1) {
+            // Negativen Wert
+            value = Math.round(Math.abs(value) * 100);
+            value = (value * -1) / 100;
+        } else if (Math.sign(value) === 1) {
+            value = Math.round(value * 100) / 100;
+        }
+
+        return value;
+    }
 
 
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | When using a voucher in the frontend, the value has more than 2 decimal places in the database. This leads to different outputs when comparing the backend to the frontend. e.g. you have an article price of 116,70 and a 15% voucher. The cart will show -17,51 as voucher value, the backend -17,50. This is because the voucher is stored as 17,505 in the database and the backend-view does not round the output. This PR adds a rounding to the output. The documents already uses -17.51 as price,  so this is only an error of the backend view. |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | no |
| How to test?            | Please see above. Make a checkout with the suggested positions and have a look at the backend and frontend prices. With this PR there should be no difference any more. |
| Requirements met?       | possibly|

It might be a better solution to store the voucher value rounded to two decimal places to prevent this error appearing, but this is sadly to complex for me.