### PR TITLE
Don't load inactive plugins

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
@@ -76,6 +76,11 @@ class PluginInitializer
                 continue;
             }
 
+            $isActive = in_array($pluginName, $activePlugins, true);
+            if (!$isActive) {
+                continue;
+            }
+
             $namespace = $pluginName;
             $className = '\\' . $namespace . '\\' . $pluginName;
             $classLoader->addPrefix($namespace, $pluginDir->getPathname());
@@ -83,8 +88,6 @@ class PluginInitializer
             if (!class_exists($className)) {
                 throw new \RuntimeException(sprintf('Unable to load class %s for plugin %s in file %s', $className, $pluginName, $pluginFile));
             }
-
-            $isActive = in_array($pluginName, $activePlugins, true);
 
             /** @var Plugin $plugin */
             $plugin = new $className($isActive);


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | The Plugin bootstrap is currently also constructed, if plugin is inactive. If a plugin includes libs example from composer and use the include the autoload.php in the head, they will be loaded everytime. I have local currently 90 Plugins, and i got a issue on registration page, because a library use symfony 3.x components was loaded and broke any thing, also if all plugins are inactive. Thats totally terrible to detect which plugin does it... |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | Nopeee |
| How to test?            | Create a new plugin, make composer require symfony/options-resolver in plugin folder, include it on the plugin bootstrap header. And try a registration everything is broken |
| Requirements met?       | Yes |