### PR TITLE
Restrict access to grunt configuration

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -27,6 +27,9 @@ RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]
 
     # Restrict access to root folder files
     RedirectMatch 404 /(composer\.(json|lock)|README\.md|UPGRADE\.md)$
+    
+    # Restrict access to grunt configuration
+    RedirectMatch 404 /web/cache/config_\d+\.json$
 </IfModule>
 
 # Staging environment


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Some developers using grunt on live enviroment and they dump the config. The dump is accessible by everyone. That allows the user to see which less and js files are loaded from which plugin and can download easily all resources uncompiled |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | #995  |
| How to test?            | Dump the config and request config_[SHOP_ID].json |
| Requirements met?       | Yep! |