### PR TITLE
Adds smarty block around the table in confirm.tpl

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/confirm.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/confirm.tpl
@@ -648,33 +648,35 @@
 
     {block name='frontend_checkout_confirm_product_table'}
         <div class="product--table">
-            <div class="panel has--border">
-                <div class="panel--body is--rounded">
+            {block name="frontend_checkout_confirm_product_table_content"}
+                <div class="panel has--border">
+                    <div class="panel--body is--rounded">
 
-                    {* Product table header *}
-                    {block name='frontend_checkout_confirm_confirm_head'}
-                        {include file="frontend/checkout/confirm_header.tpl"}
-                    {/block}
+                        {* Product table header *}
+                        {block name='frontend_checkout_confirm_confirm_head'}
+                            {include file="frontend/checkout/confirm_header.tpl"}
+                        {/block}
 
-                    {block name='frontend_checkout_confirm_item_before'}{/block}
+                        {block name='frontend_checkout_confirm_item_before'}{/block}
 
-                    {* Basket items *}
-                    {block name='frontend_checkout_confirm_item_outer'}
-                        {foreach $sBasket.content as $sBasketItem}
-                            {block name='frontend_checkout_confirm_item'}
-                                {include file='frontend/checkout/confirm_item.tpl' isLast=$sBasketItem@last}
-                            {/block}
-                        {/foreach}
-                    {/block}
+                        {* Basket items *}
+                        {block name='frontend_checkout_confirm_item_outer'}
+                            {foreach $sBasket.content as $sBasketItem}
+                                {block name='frontend_checkout_confirm_item'}
+                                    {include file='frontend/checkout/confirm_item.tpl' isLast=$sBasketItem@last}
+                                {/block}
+                            {/foreach}
+                        {/block}
 
-                    {block name='frontend_checkout_confirm_item_after'}{/block}
+                        {block name='frontend_checkout_confirm_item_after'}{/block}
 
-                    {* Table footer *}
-                    {block name='frontend_checkout_confirm_confirm_footer'}
-                        {include file="frontend/checkout/confirm_footer.tpl"}
-                    {/block}
+                        {* Table footer *}
+                        {block name='frontend_checkout_confirm_confirm_footer'}
+                            {include file="frontend/checkout/confirm_footer.tpl"}
+                        {/block}
+                    </div>
                 </div>
-            </div>
+            {/block}
 
             {* Table actions *}
             {block name='frontend_checkout_confirm_confirm_table_actions'}


### PR DESCRIPTION
A new block to encapsulate the product-table from the table-actions.

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | I wanted to edit the product-table without affecting the table-actions in the checkout/confirm.tpl template. |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | None. |
| How to test?            | Don't. It's just a template block. |
| Requirements met?       | Yes |