### PR TITLE
Added new plugin method registerAutoloader for composer dependencies

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
@@ -92,6 +92,11 @@ class PluginInitializer
             if (!$plugin instanceof Plugin) {
                 throw new \RuntimeException(sprintf('Class %s must extend %s in file %s', get_class($plugin), Plugin::class, $pluginFile));
             }
+
+            if ($plugin->isActive()) {
+                $plugin->registerAutoloader();
+            }
+
             $plugins[$plugin->getName()] = $plugin;
         }
 

--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -159,6 +159,14 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
     }
 
     /**
+     * This method can be used to register our custom composer dependencies.
+     * It would be executed on any kernel boot, if the plugin is active
+     */
+    public function registerAutoloader()
+    {
+    }
+
+    /**
      * Sets the container.
      *
      * @param ContainerInterface|null $container A ContainerInterface instance or null


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | The Plugin bootstrap is currently also constructed, if plugin is inactive. If a plugin includes libs example from composer and use the include the autoload.php in the head, they will be loaded everytime. I have local currently 90 Plugins, and i got a issue on registration page, because a library use symfony 3.x components was loaded and broke any thing, also if all plugins are inactive. Thats totally terrible to detect which plugin does it... |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | #1152  |
| How to test?            | Require a autoload.php from registerAutoloader method and try to use this dependency while the plugin is inactive |
| Requirements met?       | Yep |