### PR TITLE
option to compile theme from current asset timestamp and skip cache clear

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -8,6 +8,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 
 ### Additions
 
+* Added command option `--current` to theme:cache:generate to compile from current asset timestamp and skip cache clear
 * Added config element `displayOnlySubShopVotes` to display only shop assigned article votes
 * Added parameter `displayProgressOnSingleDelete` to `Shopware.grid.Panel` to hide progress window on single delete action
 * Added parameter `expression` in `Shopware.listing.FilterPanel` to allow define own query expressions

--- a/engine/Shopware/Commands/ThemeCacheGenerateCommand.php
+++ b/engine/Shopware/Commands/ThemeCacheGenerateCommand.php
@@ -48,6 +48,7 @@ class ThemeCacheGenerateCommand extends ShopwareCommand
         $this
             ->setName('sw:theme:cache:generate')
             ->addOption('shopId', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The Id of the shop')
+            ->addOption('current', 'c', InputOption::VALUE_NONE, 'Compile from current asset timestamp')
             ->setDescription('Generates theme caches.')
         ;
     }
@@ -61,6 +62,7 @@ class ThemeCacheGenerateCommand extends ShopwareCommand
         $repository = $this->container->get('models')->getRepository(Shop::class);
 
         $shopIds = $input->getOption('shopId');
+        $current = (bool)$input->getOption('current');
 
         /** @var Shop[] $shopsWithThemes */
         $shopsWithThemes = $repository->getShopsWithThemes()->getResult(AbstractQuery::HYDRATE_OBJECT);
@@ -81,13 +83,23 @@ class ThemeCacheGenerateCommand extends ShopwareCommand
         $compiler = $this->container->get('theme_compiler');
 
         foreach ($shopsWithThemes as $shop) {
-            $output->writeln(sprintf('Generating theme cache for shop "%s" ...', $shop->getName()));
-            $compiler->compile($shop);
+            if (!empty($current) === true) {
+                $timestamp = Shopware()->Container()->get('theme_timestamp_persistor')->getCurrentTimestamp($shop->getId());
+                $output->writeln(sprintf('Generating theme cache for shop "%s" from current timestamp %s', $shop->getName(), $timestamp));
+                $compiler->compilecurrent($shop);
+            } else {
+                $output->writeln(sprintf('Generating new theme cache for shop "%s" ...', $shop->getName()));
+                $compiler->compile($shop);
+            }
         }
 
-        $output->writeln('Clearing HTTP cache ...');
         /** @var $cacheManager CacheManager */
         $cacheManager = $this->container->get('shopware.cache_manager');
-        $cacheManager->clearHttpCache();
+        if (!empty($current) === true) {
+            return;
+        } else {
+            $output->writeln('Clearing HTTP cache ...');
+            $cacheManager->clearHttpCache();
+        }
     }
 }

--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -154,6 +154,19 @@ class Compiler
         $this->clearThemeCache($shop, $old);
     }
 
+    public function compilecurrent(Shop\Shop $shop)
+    {
+        if ($shop->getMain()) {
+            $shop = $shop->getMain();
+        }
+
+        $timestamp = $this->getThemeTimestamp($shop);
+
+        $this->compileLess($timestamp, $shop->getTemplate(), $shop);
+        $this->compileJavascript($timestamp, $shop->getTemplate(), $shop);
+    }
+
+
     /**
      * @param Shop\Shop $shop
      *


### PR DESCRIPTION
## Description

This evolved from a need in release handling on multiple nodes.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | the `theme:cache:generate` command creates a new assetTimestamp and clears the caches by default. Multiserver setups need finer controls in rolling out new releases and nodes. Setting a new timestamp is not always neccessary and if it is, then only once per rollout. The other nodes have to build from the new stamp instead of setting it again.<br/>For building assets: the first frontend request would trigger the process if the assets do not exist on the filesystem yet. Having them ready for the new release/node prior to getting real views gives flexibility and avoids slow requests / seconds of unstyled content.  Cache invalidation/clearing should be handled by existing dedicated commands. |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | no |
| How to test?            | execute `bin/console sw:theme:cache:generate --current` |
| Requirements met?       | Upgrade.md change: ✓ <br/>PR to correct shopware version: ✓ <br/>implementation missing important parts: no<br/>provideed necessary tests: ✓ <br/>do duplicate pull request exist on the same issue: no |

To me it was cleaner to create a new function in Components/Theme/Compiler.php with a subset of compile(), since the function is already doing more than it is advertising. If you prefer to supply arguments to compile(), please make a suggestion.

If you agree on approach, please merge for 5.2 as well.