### PR TITLE
confirm_item.tpl should reuse cart_item.tpl details

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/confirm_item.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/confirm_item.tpl
@@ -19,6 +19,7 @@
 
 {* Additional product relevant information *}
 {block name='frontend_checkout_cart_item_details_inline'}
+    {$smarty.block.parent}
     <div class="product--essential-features">
         {include file="string:{config name=mainfeatures}"}
     </div>


### PR DESCRIPTION
## Description
The confirm_item.tpl should use the additional info already provided by extending templates (if there are any) from e.g. checkout/items/product.tpl. This should be intuitive.

This is done by adding getting the parents template-data in the block `frontend_checkout_cart_item_details_inline`.

This prevents the duplication of code if the theme-developer adds additional info in this block, as it's supposed to be `{* Additional product information *}`.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Saving developers pain, by making the template more intuitive |
| BC breaks?              | no |
| Tests exists & pass?    | no tests |
| How to test?            | Add custom info data to frontend/checkout/items/product.tpl, in the `frontend_checkout_cart_item_details_inline` block and see it showing up in checkout/confirm. |
| Requirements met?       | Yas |