### PR TITLE
Fix null being a string when persisting a date attribute and the value is empty.

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Service/DataPersister.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/DataPersister.php
@@ -227,7 +227,7 @@ class DataPersister
             $value = $data[$column->getName()];
 
             if ($this->isDateColumn($column) && empty($value)) {
-                $result[$column->getName()] = 'NULL';
+                $result[$column->getName()] = null;
             } else {
                 $result[$column->getName()] = $value;
             }


### PR DESCRIPTION
## Description

Fixes an issue when saving a date attribute with an empty value.
Currently this leads to "0000-00-00" being saved to the Database which then ExtJS cannot render correctly: https://i.imgur.com/Tnhqrqg.png

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Fixes a bug where ExtJS cannot render a field value correctly. |
| BC breaks?              | No |
| Tests exists & pass?    | Cannot find tests. |
| Related tickets?        |  |
| How to test?            | Add a new date attribute, enter an empty value and save. Check the value in the DB, it should be NULL not 0000-00-00. |
| Requirements met?       | Yes |