### PR TITLE
Fix proxy generation for classes implementing type-hinted interfaces

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -5,6 +5,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 ## 5.2.25
 * Added notify event `Shopware_Modules_Basket_AddArticle_Added` in `engine/Shopware/Core/sBasket.php`
 * The event `Shopware_Modules_Export_ExportResult_Filter_Fixed` was added and now filters the processed export result. Previously with `Shopware_Modules_Export_ExportResult_Filter`, an instance of `Zend_Db_Statement_Pdo` was supplied, which could not be used to filter the actual result.
+* Fixes a fatal error caused by `Enlight_Hook_ProxyFactory::generateMethods()` generating proxy method sigantures that are not compatible with an interface implemented by the hooked class
 
 ## 5.2.23
 * Added conditional statement in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js` to prevent the jquery plugin from sending ajax requests indefinitely

--- a/engine/Library/Enlight/Hook/ProxyFactory.php
+++ b/engine/Library/Enlight/Hook/ProxyFactory.php
@@ -276,6 +276,20 @@ class <namespace>_<proxyClassName> extends <className> implements Enlight_Hook_P
                     $array_params .= ', ';
                 }
 
+                // Add parameter type/class for interface compliance
+                if (method_exists($rp, 'hasType') && $rp->hasType()) {
+                    // PHP >= 7.0 only
+                    $params .= $rp->getType() . ' ';
+                } elseif ($rp->isArray()) {
+                    // PHP < 7.0 fallback
+                    $params .= 'array ';
+                } elseif ($rp->isCallable()) {
+                    // PHP < 7.0 fallback
+                    $params .= 'callable ';
+                } elseif ($rp->getClass()) {
+                    $params .= $rp->getClass()->getName() . ' ';
+                }
+
                 $array_param = '';
                 if ($rp->isPassedByReference()) {
                     $params .= '&';

--- a/tests/Unit/Enlight/Hook/ProxyFactoryTest.php
+++ b/tests/Unit/Enlight/Hook/ProxyFactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Unit\Enlight\Hook;
+
+use Shopware\Tests\Unit\Enlight\Hook\ProxyFactoryTestSamples\HookManagerMock;
+use Shopware\Tests\Unit\Enlight\Hook\ProxyFactoryTestSamples\TestClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class ProxyFactoryTest extends TestCase
+{
+    public function testGenerateMethods()
+    {
+        // Create a proxy factory instance for testing
+        $proxyFactory = new \Enlight_Hook_ProxyFactory(
+            new HookManagerMock(),
+            '',
+            __DIR__
+        );
+
+        // Call its protected 'generateMethods' method for the TestClass
+        $reflectionProxyFactory = new \ReflectionClass($proxyFactory);
+        $method = $reflectionProxyFactory->getMethod('generateMethods');
+        $method->setAccessible(true);
+        list($generatedMethods, $generatedCode) = array_values($method->invokeArgs($proxyFactory, [TestClass::class]));
+
+        // Check the results
+        $this->assertCount(4, $generatedMethods);
+        $this->assertNotEquals(false, strpos($generatedCode, 'public function methodWithOptionalParameter($a = NULL)'));
+        $this->assertNotEquals(false, strpos($generatedCode, 'public function methodWithOptionalArrayParameter(array $a = NULL)'));
+        $this->assertNotEquals(false, strpos($generatedCode, 'public function methodWithOptionalCallableParameter(callable $a = NULL)'));
+        $this->assertNotEquals(false, strpos($generatedCode, 'public function methodWithOptionalObjectParameter(Shopware\Tests\Unit\Enlight\Hook\ProxyFactoryTestSamples\TestClass $a = NULL)'));
+    }
+}

--- a/tests/Unit/Enlight/Hook/ProxyFactoryTestSamples/HookManagerMock.php
+++ b/tests/Unit/Enlight/Hook/ProxyFactoryTestSamples/HookManagerMock.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Unit\Enlight\Hook\ProxyFactoryTestSamples;
+
+/**
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class HookManagerMock
+{
+    /**
+     * Always returns true to simulate that any method of any class has hooks.
+     *
+     * @param string $class
+     * @param string $method
+     * @param boolean
+     */
+    public function hasHooks($class, $method)
+    {
+        return true;
+    }
+}

--- a/tests/Unit/Enlight/Hook/ProxyFactoryTestSamples/TestClass.php
+++ b/tests/Unit/Enlight/Hook/ProxyFactoryTestSamples/TestClass.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Unit\Enlight\Hook\ProxyFactoryTestSamples;
+
+/**
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class TestClass implements TestInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function methodWithOptionalParameter($a = null)
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function methodWithOptionalArrayParameter(array $a = null)
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function methodWithOptionalCallableParameter(callable $a = null)
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function methodWithOptionalObjectParameter(TestClass $a = null)
+    {
+    }
+}

--- a/tests/Unit/Enlight/Hook/ProxyFactoryTestSamples/TestInterface.php
+++ b/tests/Unit/Enlight/Hook/ProxyFactoryTestSamples/TestInterface.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Unit\Enlight\Hook\ProxyFactoryTestSamples;
+
+/**
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+interface TestInterface
+{
+    /**
+     * @param mixed $a
+     */
+    public function methodWithOptionalParameter($a = null);
+
+    /**
+     * @param array|null $a
+     */
+    public function methodWithOptionalArrayParameter(array $a = null);
+
+    /**
+     * @param callable|null $a
+     */
+    public function methodWithOptionalCallableParameter(callable $a = null);
+
+    /**
+     * @param TestClass|null $a
+     */
+    public function methodWithOptionalObjectParameter(TestClass $a = null);
+}


### PR DESCRIPTION
## Description

When [`Enlight_Hook_ProxyFactory`](https://github.com/shopware/shopware/blob/74c0df5115eb7d79935372c1f34b3fa508da962a/engine/Library/Enlight/Hook/ProxyFactory.php) generates a proxy class, all hooked methods of the original class are implemented, defining all parameters defined in the original method signatures. However, only the parameter and optionally a default value is read from the original signature and added to the proxy method signature. That is, no parameter type hints are copied over, e.g.:

```php
interface FooInterface
{
    /** 
     * @param array $a
     */
    public function bar(array $a = null);
}

class Foo implements FooInterface
{
    /** 
     * @inheritdoc
     */
    public function bar(array $a = null)
    {
        // ...
    }
}

class FooProxy
{
    public function bar($a = null)
    {
        // ...
    }
}
```

As the example shows, the generated method signature for `FooProxy::bar()` does not match the signature defined in the interface `FooInterface` 100%, because of the missing type hint of parameter `$a`. This results in a fatal error, as also stated in a note in the [PHP docs on interfaces](http://php.net/manual/en/language.oop5.interfaces.php#language.oop5.interfaces.implements):

> The class implementing the interface must use the exact same method signatures as are defined in the interface. Not doing so will result in a fatal error.

This PR fixes `Enlight_Hook_ProxyFactory::generateMethods()` to check all added parameters for a type hint and, if present, adds it to the respective parameter declaration in the proxy method signature:

```php
class FooProxy
{
    public function bar(array $a = null)
    {
        // ...
    }
}
```

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Currently `Enlight_Hook_ProxyFactory::generateMethods()` generates code that results in a fatal error when hooking a method defined in an interface (see above). |
| BC breaks?              | no |
| Tests exists & pass?    | This PR adds unit test for `Enlight_Hook_ProxyFactory::generateMethods()` |
| Related tickets?        | #1065 |
| How to test?            | Run the unit test |
| Requirements met?       | yes |