### PR TITLE
Fixed typo in cart and confirm less (from camelcase to lowercase)

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/cart.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/cart.less
@@ -34,7 +34,7 @@ Shopware offers two different shopping cart element options that can be selected
     }
 }
 
-.is--act-shippingPayment {
+.is--act-shippingpayment {
     .add-product--form {
         display: none;
     }
@@ -936,7 +936,7 @@ Shopware offers two different shopping cart element options that can be selected
         }
     }
 
-    .is--act-shippingPayment {
+    .is--act-shippingpayment {
         .product--table .table--actions {
             .unitize(margin-top, 20);
         }
@@ -1303,7 +1303,7 @@ Shopware offers two different shopping cart element options that can be selected
         .unitize-margin(45, 0, 0, 0);
     }
 
-    .is--act-shippingPayment .product--table {
+    .is--act-shippingpayment .product--table {
         .unitize(margin-top, 25);
     }
 

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/confirm.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/confirm.less
@@ -249,7 +249,7 @@ It is displayed as the third step of the checkout process of Shopware and shows 
 
 @media screen and (min-width: @tabletViewportWidth) {
 
-    .is--act-shippingPayment .basket--footer {
+    .is--act-shippingpayment .basket--footer {
         .border-radius();
     }
 


### PR DESCRIPTION
Fixes typos in cart.less and confirm.less. The styles were not applied, so I changed the classes from camelcase to lowercase.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Styles from this css class were not applied (typo) |
| BC breaks?              | No |
| Tests exists & pass?    | No tests required |
| Related tickets?        | No |
| How to test?            | Add lowercase instead of camelcase to these classes |
| Requirements met?       | Yes |