### PR TITLE
Fixed pop state without state values

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -197,7 +197,9 @@
 
             $.publish('plugin/swAjaxVariant/onPopState', [ me, state ]);
 
-            me.requestData(state.values, false);
+            if (state && state.values) {
+                me.requestData(state.values, false);
+            }
         },
 
         /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | See below. |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | No. |
| How to test?            | See below. |
| Requirements met?       | Does your PR fulfil our [contribution requirements](https://developers.shopware.com/contributing/contribution-guideline/#requirements-for-a-successful-pull-request)? |

The following bug is fixed with this PR.

### Detailed bug description

Back button and anchors on product detail page not working.

*Steps to reproduce*:

Place an anchor in the product description, e.g.

```html
[...]
<a href="#anchor">anchor test</a>
[...]
<div id="anchor">
	[...]
</div>
[...]
```

Go to product detail page in frontend. Click on anchor link. Press the back button of your browser.

*Expected result*:

The last visited page is shown (the product detail page).

*Actual result*:

Infinite spinner( 
![spinner](https://user-images.githubusercontent.com/847843/27073061-d852c5fe-5022-11e7-8ead-f938ddd64200.png)
 ) and Javascript error

 - in Firefox: `TypeError: values is undefined`
 - in Chrome: `Uncaught TypeError: Cannot set property 'template' of undefined`