### PR TITLE
Fixed issue with PHP notice when no id for an option is defined

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -1843,7 +1843,7 @@ class Article extends Resource implements BatchInterface
             foreach ($mappingData as $option) {
                 $conditions = [];
 
-                if ($option['id']) {
+                if (isset($option['id']) && $option['id']) {
                     $conditions['id'] = $option['id'];
                 }
 


### PR DESCRIPTION
## Why
When creating or upgrading an article via API resources a PHP notice if thrown if the $option['id'] key is not set (which is no required field).

## How to test
Send an array like the following to article resource for update operation:

```
$params = array(
                'images' => array(
                    array(
                        'mediaId' => $media->getId(),
                        'options' => array(
                            array(
                                array(
                                    'name' => '60 Stück'
                                )
                            )
                        )
                    )
                )
            );

$articleResource->update($article->getId(), $params);
```
This operation throws the following notice:
**Notice: Undefined index: id in /engine/Shopware/Components/Api/Resource/Article.php on line 1846**

## Fix
The fix ensures that the key "id" exists in the option array.