### PR TITLE
Fixed mysql error while using MariaDB 10.3

### DIFF
--- a/engine/Shopware/Models/Emotion/Emotion.php
+++ b/engine/Shopware/Models/Emotion/Emotion.php
@@ -247,7 +247,7 @@ class Emotion extends ModelEntity
 
     /**
      * @var int
-     * @ORM\Column(name="rows", type="integer", nullable=false)
+     * @ORM\Column(name="`rows`", type="integer", nullable=false)
      */
     private $rows;
 


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | The column name "rows" is a reserved word and must be escaped in mariadb 10.3 |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | https://forum.shopware.com/discussion/47103/mariadb-syntax-fehler-aufgrund-von-reserviertem-wort#latest |
| How to test?            | Install mariadb 10.3 and create a new shopping world |
| Requirements met?       | Yep |