### PR TITLE
Changed orderBy parameter to be optional

### DIFF
--- a/engine/Shopware/Models/Category/Repository.php
+++ b/engine/Shopware/Models/Category/Repository.php
@@ -98,7 +98,7 @@ class Repository extends ModelRepository
      *
      * @return \Doctrine\ORM\Query
      */
-    public function getListQuery(array $filterBy, array $orderBy, $limit = null, $offset = null, $selectOnlyActive = true)
+    public function getListQuery(array $filterBy, array $orderBy = array(), $limit = null, $offset = null, $selectOnlyActive = true)
     {
         $builder = $this->getListQueryBuilder($filterBy, $orderBy, $limit, $offset, $selectOnlyActive);
 
@@ -185,7 +185,7 @@ class Repository extends ModelRepository
      *
      * @return \Doctrine\ORM\Query
      */
-    public function getListQueryBuilder(array $filterBy, array $orderBy, $limit = null, $offset = null, $selectOnlyActive = true)
+    public function getListQueryBuilder(array $filterBy, array $orderBy = array(), $limit = null, $offset = null, $selectOnlyActive = true)
     {
         /** @var $builder \Shopware\Components\Model\QueryBuilder */
         $builder = $this->createQueryBuilder('c');


### PR DESCRIPTION
OrderBy parameter can be optional in getListQueryBuilder() of the category repository class because it already has a default order and a condition to check if the "additonal" order array is empty.

With this PR the getListQuery() method can be called without an empty array as second parameter when it is not needed.

**The error thar appeared when second param leaves unsetted just occurs on PHP 7. I'm not quite sure why.**

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | See above
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| How to test?            | Call getListQuery of Shopware\Models\Category\Category |
| Requirements met?       | Think so |