### PR TITLE
Respect defaultValue on Checkbox Attributes

### DIFF
--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.BooleanFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.BooleanFieldHandler.js
@@ -38,6 +38,11 @@ Ext.define('Shopware.attribute.BooleanFieldHandler', {
         field.xtype = 'checkbox';
         field.uncheckedValue = 0;
         field.inputValue = 1;
+
+        if (attribute.get('defaultValue') !== null) {
+            field.checked = parseInt(attribute.get('defaultValue')) === 1;
+        }
+
         return field;
     }
 });


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | I created a checkbox attribute on articles, while creating a new article the checkbox doesn't respect the defaultValue and was anytime unchecked. So the option is currently useless |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        |  |
| How to test?            | $this->get('shopware_attribute.crud_service')->update('s_articles_attributes', 'singlearticle', 'boolean', [
            'displayInBackend' => true,
            'label' => 'Artikel nur einmal bestellbar'
        ], null, false, 1); |
| Requirements met?       | Yep |