### PR TITLE
Fix comparison due to which all snippets are being overwritten

### DIFF
--- a/engine/Shopware/Components/Snippet/Writer/DatabaseWriter.php
+++ b/engine/Shopware/Components/Snippet/Writer/DatabaseWriter.php
@@ -214,7 +214,7 @@ class DatabaseWriter
     {
         $hasSameValue = $name === $row['name'] && $value === $row['value'];
 
-        $isDirty = $row['dirty'] === 1;
+        $isDirty = $row['dirty'] == 1;
 
         // snippet was never touched after insert
         if (!$this->force && $hasSameValue && !$isDirty) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | All snippets are overwritten, regardless whether _dirty_ is set or not. |
| BC breaks?              | no |
| Tests exists & pass?    | - |
| Related tickets?        | none of which I know |
| How to test?            | Mark a snippet as _dirty_ and run the _sw:snippets:to:db_ CLI command. Without this commit, the snippet is being overwritten. |
| Requirements met?       | yes |

This bug has been introduced with 97f9cb3ead4b850fd984a37ced007e1597f89f97 and has been released since v5.2.23. Because _fetchAll_ only returns strings, the comparison without type casting (===) between a string and an integer can never be true. This is a major bug, we already had multiple customers complaining about wrong snippets.