### PR TITLE
take displayDate for documentDate

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -580,7 +580,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         if (!empty($checkForExistingDocument['ID'])) {
             // Document already exist. Update date and amount!
             $update = '
-            UPDATE `s_order_documents` SET `date` = now(),`amount` = ?
+            UPDATE `s_order_documents` SET `date` = ?,`amount` = ?
             WHERE `type` = ? AND userID = ? AND orderID = ? LIMIT 1
             ';
             $amount = ($this->_order->order->taxfree ? true : $this->_config['netto']) ? round($this->_order->amountNetto, 2) : round($this->_order->amount, 2);
@@ -588,6 +588,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
                 $amount *= -1;
             }
             Shopware()->Db()->query($update, [
+                    DateTime::createFromFormat('d.m.Y', $this->_config['date'])->format('Y-m-d'),
                     $amount,
                     $typID,
                     $this->_order->userID,


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | It's a wrong way to ignore displayDate while saving a document. For sample: If a customer wanted to change his name in the created Invoice, you have to regenerate the Invoice. in Backend you can set "displayDate" but any interface for the accountancy cannot see this date, so every generated Invoice will get a new date. For accountancy it will be a new invoice. So there would be 2 options. 1. this OR 2. make it impossible to update a invoice in backend :-) |
| BC breaks?              |  |
| Tests exists & pass?    | no |
| Related tickets?        |  |
| How to test?            | Create a invoice, generate a new invoice after a day with the displayDate of yesterday. Now the date of the document will be the date of update, recarding this commit it'll be the displayDate. |
| Requirements met?       | hope so |