### PR TITLE
New filter-event in PriceCalculationService.

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/PriceCalculationService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/PriceCalculationService.php
@@ -201,6 +201,12 @@ class PriceCalculationService implements Service\PriceCalculationServiceInterfac
          * we have to calculate the the price for the other currency.
          */
         $price = $price * $context->getCurrency()->getFactor();
+        
+        $price = Shopware()->Events()->filter('Shopware_StoreFrontBundle_PriceCalculationService_Filter_Price', $price, [
+            'tax' => $tax,
+            'context' => $context,
+            'customerGroup' => $customerGroup,
+        ]);
 
         /*
          * check if the customer group should see gross prices.


### PR DESCRIPTION
Puts the price through a filter-event to let subscribers alter it.

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | With the PriceCalculationService we have a central place for all price-calculations in the system (except the basket). It would make sense to give plugins the ability to alter the prices there. |
| BC breaks?              | no |
| Tests exists & pass?    | not yet |
| Related tickets?        | Not that I know of any. |
| How to test?            | Use the new event in a plugin and alter the price there. |
| Requirements met?       | yes |