### PR TITLE
Added new option `showPagingToolbar` to `Shopware.DragAndDropSelector…

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.DragAndDropSelector.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.DragAndDropSelector.js
@@ -162,6 +162,11 @@ Ext.define('Shopware.DragAndDropSelector',
     gridHeight: null,
 
     /**
+     * show paging toolbar
+     */
+    showPagingToolbar: false,
+
+    /**
      * standard layout
      */
     layout:{
@@ -201,7 +206,7 @@ Ext.define('Shopware.DragAndDropSelector',
         me.refreshStore();
         me.fromStore.load();
 
-        me.fromField = me.createGrid({
+        var config = {
             title: me.fromTitle,
             store: me.fromStore,
             columns :me.fromColumns,
@@ -219,7 +224,16 @@ Ext.define('Shopware.DragAndDropSelector',
                     }
                 }
             }
-        });
+        };
+
+        if (me.showPagingToolbar) {
+            config.bbar = Ext.create('Ext.toolbar.Paging', {
+                store: me.fromStore,
+                displayInfo: true
+            });
+        }
+
+        me.fromField = me.createGrid(config);
 
         me.toField = me.createGrid({
             title : me.toTitle,

--- a/themes/Backend/ExtJs/backend/category/view/category/tabs/restriction.js
+++ b/themes/Backend/ExtJs/backend/category/view/category/tabs/restriction.js
@@ -117,6 +117,7 @@ Ext.define('Shopware.apps.Category.view.category.tabs.restriction', {
             fromStore: me.customerGroupsStore,
             buttons:[ 'add', 'remove' ],
             selectedItems: me.record.getCustomerGroups(),
+            showPagingToolbar: true,
             buttonsText:{
                 add:"{s name=tabs/restriction/button_add}Add{/s}",
                 remove:"{s name=tabs/restriction/button_remove}Remove{/s}"


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | The grid shows only the first 20 items, if a shop has more then 20 customer groups they wont be displayed |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        |  |
| How to test?            | Create 25 customer groups show in => Category => Restrict category are all available |
| Requirements met?       | Yep |