### PR TITLE
RestApi-Plugin also checks for raw JSON post, on FrontPreDispatch

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -7,6 +7,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 [View all changes from v5.2.26...v5.2.27](https://github.com/shopware/shopware/compare/v5.2.26...v5.2.27)
 
 * Fixed id collision in `themes/Backend/ExtJs/backend/base/component/Shopware.ModuleManager.js`
+* Added check for JSON data in POST parameter, when processing RestApi requests
 
 # 5.2.26
 

--- a/engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
@@ -146,7 +146,12 @@ class Shopware_Plugins_Core_RestApi_Bootstrap extends Shopware_Components_Plugin
             if ($rawBody != '') {
                 $input = Zend_Json::decode($rawBody);
             } else {
-                $input = null;
+                $rawPost = $request->getPost('application/json');
+                if ($rawPost != '') {
+                    $input = Zend_Json::decode($rawPost);
+                } else {
+                    $input = null;
+                }
             }
         } catch (Zend_Json_Exception $e) {
             $response->setHttpResponseCode(400);


### PR DESCRIPTION
## Description
 This PR allows JSON data to be sent as a POST parameter.
When processing RestApi requests, the plugin now checks for raw JSON in POST, if nothing was found in the body.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | The current media endpoint allows file uploads in the body, but restricts the remaining data request to pure POST parameters. |
| BC breaks?              | no |
| Tests exists & pass?    | - |
| Related tickets?        | - |
| How to test?            | Send JSON as POST parameter with 'application/json' as name. |
| Requirements met?       | mostly |