### PR TITLE
Remove Warning Messages on command line

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/OptimizerService.php
+++ b/engine/Shopware/Bundle/MediaBundle/OptimizerService.php
@@ -47,6 +47,9 @@ class OptimizerService implements OptimizerServiceInterface
      */
     public function optimize($filepath)
     {
+        if(!file_exists($filepath)) {
+            return;
+        }
         $mime = $this->getMimeTypeByFile($filepath);
 
         $optimizer = $this->getOptimizerByMimeType($mime);


### PR DESCRIPTION
If the building thumbnails on the command line warning messages a printed if the file does not exists.

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | command line not readable |
| BC breaks?              | yes/no |
| Tests exists & pass?    | yes |
| Related tickets?        | none |
| How to test?            | execute console sw:thumbnail:generate white missing thumbs |
| Requirements met?       | don't know|