### PR TITLE
Removed extends from box-emotion.tpl

### DIFF
--- a/themes/Frontend/Bare/frontend/listing/product-box/box-emotion.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/box-emotion.tpl
@@ -1,5 +1,3 @@
-{extends file="frontend/listing/product-box/box-basic.tpl"}
-
 {namespace name="frontend/listing/box_article"}
 
 {block name="frontend_listing_box_article"}


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | The extends in the file doesn't have a effect, because the file overwrite the entire box-basic.tpl. It reduces the confusion why my box-basic doesnt have a effect :D |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        |  |
| How to test?            | Remove it and see nothing happens |
| Requirements met?       | Yes |