### PR TITLE
add woff- and svg-compression

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -55,7 +55,7 @@ DirectoryIndex shopware.php
 
 # Enable gzip compression
 <IfModule mod_deflate.c>
-    AddOutputFilterByType DEFLATE text/html text/xml text/plain text/css text/javascript application/javascript application/json
+    AddOutputFilterByType DEFLATE text/html text/xml text/plain text/css text/javascript application/javascript application/json application/x-font-woff
 </IfModule>
 
 <Files ~ "\.(jpe?g|png|gif|css|js|woff|eot)$">

--- a/.htaccess
+++ b/.htaccess
@@ -55,7 +55,7 @@ DirectoryIndex shopware.php
 
 # Enable gzip compression
 <IfModule mod_deflate.c>
-    AddOutputFilterByType DEFLATE text/html text/xml text/plain text/css text/javascript application/javascript application/json application/x-font-woff
+    AddOutputFilterByType DEFLATE text/html text/xml text/plain text/css text/javascript application/javascript application/json application/x-font-woff image/svg+xml
 </IfModule>
 
 <Files ~ "\.(jpe?g|png|gif|css|js|woff|eot)$">


### PR DESCRIPTION
##Sample shopware.woff
Original-size: 69,4 KB
After Compression-Sample: 33,5 KB

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Saving traffic |
| BC breaks?              | no |
| Tests exists & pass?    |  |
| Related tickets?        |  |
| How to test?            | have a look in Developer Tools, before and after implementation |
| Requirements met?       | hope so |