### PR TITLE
external links not working in mobile menu

### DIFF
--- a/themes/Frontend/Bare/widgets/listing/get_category.tpl
+++ b/themes/Frontend/Bare/widgets/listing/get_category.tpl
@@ -64,7 +64,13 @@
                         {if $children.active}
                             <li class="navigation--entry" role="menuitem">
                                 {block name="widgets_listing_get_category_categories_item_link"}
-                                    <a href="{$children.link}" title="{$children.name|escape}"
+                                
+                                    {$link = $children.link}
+                                    {if $children.external}
+                                        {$link = $children.external}
+                                    {/if}
+                                    
+                                    <a href="{$link}" title="{$children.name|escape}"
                                        class="navigation--link{if $children.childrenCount} link--go-forward{/if}"
                                        data-category-id="{$children.id}"
                                        data-fetchUrl="{url module=widgets controller=listing action=getCategory categoryId={$children.id}}">


### PR DESCRIPTION
In the ajax mobile menu, external links are not working correctly.

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | not working |
| BC breaks?              | yes/no |
| Tests exists & pass?    | yes/no |
| Related tickets?        | If this PR fixes an existing issue ticket, please add there url here. |
| How to test?            | Please describe how to best verify that this PR is correct. |
| Requirements met?       | Does your PR fulfil our [contribution requirements](https://developers.shopware.com/contributing/contribution-guideline/#requirements-for-a-successful-pull-request)? |