### PR TITLE
Replace File with UploadedFile

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Media.php
+++ b/engine/Shopware/Components/Api/Resource/Media.php
@@ -30,6 +30,7 @@ use Shopware\Components\Thumbnail\Manager;
 use Shopware\Models\Media\Album;
 use Shopware\Models\Media\Media as MediaModel;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
  * Media API Resource
@@ -244,7 +245,7 @@ class Media extends Resource
         $name = $name . '.' . $ext;
         $path = $this->load($link, $name);
         $name = pathinfo($path, PATHINFO_FILENAME);
-        $file = new File($path);
+        $file = new UploadedFile($path, $link);
 
         $media = new MediaModel();
 

--- a/themes/Backend/ExtJs/backend/customer/view/address/list.js
+++ b/themes/Backend/ExtJs/backend/customer/view/address/list.js
@@ -159,7 +159,7 @@ Ext.define('Shopware.apps.Customer.view.address.List', {
 
         return {
             columns: columns,
-            searchField: false,
+            searchField: true,
             detailWindow: 'Shopware.apps.Customer.view.address.detail.Window'
         }
     },


### PR DESCRIPTION
*Why*
To keep the file-ending and treat every file as an uploaded file.
If you are using `File` for files added via API, Shopware tries to guess the file-extension. This is sometimes wrong.
It's better to treat the files as `UploadedFile` instead of `File` so Shopware will use the given file-extension.

*What*
Use `UploadedFile` instead of `File`

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | To keep the file-ending and treat every file as an uploaded file.
If you are using File for files added via API, Shopware tries to guess the file-extension. This is sometimes wrong.
It's better to treat the files as UploadedFile instead of File so Shopware will use the given file-extension. |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | If this PR fixes an existing issue ticket, please add there url here. |
| How to test?            | Upload a file via API.
Before: If you upload a `.stp` file, it will be saved as `.txt`
After: If you upload a `.stp` file, it will be saved as `.stp` |
| Requirements met?       | Yes |