### PR TITLE
Fix translation handling of s_filter_values_attributes

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/PropertyHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/PropertyHydrator.php
@@ -145,7 +145,7 @@ class PropertyHydrator extends Hydrator
         $option->setPosition((int) $data['__propertyOption_position']);
 
         if ($data['__propertyOptionAttribute_id']) {
-            $this->attributeHydrator->addAttribute($option, $data, 'propertyOptionAttribute');
+            $this->attributeHydrator->addAttribute($option, $data, 'propertyOptionAttribute', 'core', 'propertyOption');
         }
 
         if (isset($data['__media_id']) && $data['__media_id']) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Translation of s_filter_values_attributes are not loaded on article detail page |
| BC breaks?              | no |
| Tests exists & pass?    | no (Did not find any test for the PropertyHydrator) |
| Related tickets?        |  |
| How to test?            | Add a new attribute to the s_filter_values_attributes. Translate this attribute. Assign that value to an article. Go to the detail page of that article. The value of the attribute is not translated |
| Requirements met?       | yes |