### PR TITLE
Do not trigger_error in production environment when refreshing the pl…

### DIFF
--- a/engine/Library/Enlight/Event/Handler/Plugin.php
+++ b/engine/Library/Enlight/Event/Handler/Plugin.php
@@ -141,9 +141,11 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
     {
         $plugin = $this->Plugin();
         if (!method_exists($plugin, $this->listener)) {
-            $name = $this->plugin instanceof Enlight_Plugin_Bootstrap ? $this->plugin->getName() : $this->plugin;
-            trigger_error('Listener "' . $this->listener . '" in "' . $name . '" is not callable.', E_USER_ERROR);
-            //throw new Enlight_Exception('Listener "' . $this->listener . '" in "' . $name . '" is not callable.');
+            if (Shopware()->Kernel()->getEnvironment() !== 'production') {
+                $name = $this->plugin instanceof Enlight_Plugin_Bootstrap ? $this->plugin->getName() : $this->plugin;
+                trigger_error('Listener "' . $this->listener . '" in "' . $name . '" is not callable.', E_USER_ERROR);
+                //throw new Enlight_Exception('Listener "' . $this->listener . '" in "' . $name . '" is not callable.');
+            }
             return;
         }
         return $this->Plugin()->{$this->listener}($args);


### PR DESCRIPTION
| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | When you want to deploy code with a ci server to different servers without any user interaction in the backend you need to refresh the plugins during the deployment (php bin/console sw:plugin:refresh). When you delete a plugin that registers a cli command from your code it is not possible to refresh the plugins to force a database cleanup (Event Subscribers etc.).   So instead of removing the code completely, I thinks it is a good compromise to not trigger the error in a production environment. If you refresh the plugin list in the backend there is not error or warning and everything is working as expected. |
| BC breaks?              | in some cases maybe |
| Tests exists & pass?    | no |
| Related tickets?        |  |
| How to test?            | Install and activate a plugin that registers a cli command (SwagImportExport). Remove the code of the plugin and call the `php bin/console sw:plugin:refresh` command.  |
| Requirements met?       | yes |