### PR TITLE
Fix category cacheIds for articles

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/HttpCache/CacheIdCollector.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/CacheIdCollector.php
@@ -210,7 +210,7 @@ class CacheIdCollector
         $cacheIds = [];
 
         foreach ($view->getAssign('sArticles') as $article) {
-            $cacheIds[] = $article['articleID'];
+            $cacheIds[] = 'a' . $article['articleID'];
         }
 
         return $cacheIds;


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Otherwise the category pages wont get invalidated in SW5.3 if an article changed |
| BC breaks?              | no |
| Tests exists & pass?    | - |
| Related tickets?        | - |
| How to test?            | Activate HTTP Cache, cache category page, change an article in this category, save the article, see what happens |
| Requirements met?       | yes |