### PR TITLE
Force late-calls to `asyncReady` to be async

### DIFF
--- a/themes/Frontend/Bare/frontend/index/script-async-ready.tpl
+++ b/themes/Frontend/Bare/frontend/index/script-async-ready.tpl
@@ -14,7 +14,7 @@
 
         document.asyncReady = function (callback) {
             if (typeof callback === 'function') {
-                callback.call(document);
+                setTimeout(callback.apply(document), 0);
             }
         }
     });


### PR DESCRIPTION
## Description
To stay consistent with the early call to `document.asyncReady`, the late call must also call the callback asynchronously. Otherwise Zalgo will be unleashed.

Issues arising from synchronously calling the callback may be:
```
console.log('1. before ready');

document.asyncReady(() => { console.log('3. is ready'); });

console.log('2. after ready');
```

This code has inconsistent behaviour depending on when it's executed.

If it gets executed before the page is ready, this will happen:
```
1. before ready
2. after ready
3. is ready
```

if the code instead gets called after the page is ready, this will happen:
```
1. before ready
3. is ready
2. after ready
```

See this blog post for more information, regarding this Issue:

_https://blog.ometer.com/2011/07/24/callbacks-synchronous-and-asynchronous/_

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Keep the API consistent |
| BC breaks?              | no |
| Tests exists & pass?    | - |
| How to test?            | Example given above |
| Requirements met?       | Yes |