### PR TITLE
Make loading attributes consistent

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Service/DataLoader.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/DataLoader.php
@@ -82,7 +82,7 @@ class DataLoader
             ->setFirstResult(0)
             ->setMaxResults(1);
 
-        return $query->execute()->fetch(\PDO::FETCH_ASSOC);
+        return $query->execute()->fetch(\PDO::FETCH_ASSOC) ?: [];
     }
 
     /**


### PR DESCRIPTION
Due to inconsistencies within the shopware core, some db items which should have an empty attribute by default, just have no attribute at all. This change makes sure that loading an attribute always returns an array.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Due to inconsistencies within the shopware core, some db items which should have an empty attribute by default, just have no attribute at all. This change makes sure that loading an attribute always returns an array. |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | none |
| How to test?            | load an order attribute which doesnt exist |
| Requirements met?       | yes |