### PR TITLE
Better HTTP cache id distribution and invalidation for static shop pages

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -17,7 +17,7 @@ View all changes from v5.3.0-RC1...v5.3.0-RC2](https://github.com/shopware/shopw
 * Added new search builder class `Shopware\Components\Model\SearchBuilder`
 * Added new search builder as __construct parameter in `Shopware\Bundle\AttributeBundle\Repository\Searcher\GenericSearcher`
 * Added new `FunctionNode` for IF-ELSE statements in ORM query builder
-* Added `/address` to robots.txt 
+* Added `/address` to robots.txt
 * Added snippet `DetailBuyActionAddName` in `snippets/frontend/detail/buy.ini`
 * Added `Shopware\Components\Template\Security` class for all requests.
 * Added whitelist for allowed php functions and php modifiers in smarty
@@ -28,6 +28,8 @@ View all changes from v5.3.0-RC1...v5.3.0-RC2](https://github.com/shopware/shopw
 * Added new filter event `Shopware_Controllers_Performance_filterCounts` to `engine/Shopware/Controllers/Backend/Performance.php` to add custom count of the HttpCache warmer URLs
 * Added new filter event `Shopware_Controllers_Seo_filterCounts` to `engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php` to add a custom SEO URL count
 * Added new notify event `Shopware_CronJob_RefreshSeoIndex_CreateRewriteTable` to `engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php` to be notified when the SEO URLs are generated via cronjob
+* Added cache ids for static shop pages `s<id>` and HTTP cache invalidation for those
+* Added the cache id `c<id>` for category pages
 
 ### Changes
 
@@ -40,11 +42,13 @@ View all changes from v5.3.0-RC1...v5.3.0-RC2](https://github.com/shopware/shopw
 * Merged `account/sidebar.tpl` and `account/sidebar_personal.tpl`
 * Moved snippets from `account/sidebar_personal.ini` to `account/sidebar.ini`
 * Changed `Enlight_Hook_ProxyFactory` to use `ocramius/proxy-manager` for generating proxy classes
+* Changed the cache ids for the listing back to a<id> instead of <id>
 
 ### Removals
 
 * Removed event `Shopware_Plugins_HttpCache_ShouldNotCache`
 * Removed `eval` from block `frontend_forms_index_headline` in `index.tpl` of `themes\Frontend\Bare\frontend\forms` for `$sSupport.text`
+* Removed ambiguous variant cache ids from the emotion pages (`a<variantId>`)
 
 ## 5.3.0 - RC1
 
@@ -145,7 +149,7 @@ View all changes from v5.3.0-RC1...v5.3.0-RC2](https://github.com/shopware/shopw
     * `Shopware\Components\Emotion\EmotionImporter` - handle emotion imports
     * `Shopware\Components\Emotion\EmotionExporter` - handle emotion exports
     * `Shopware\Components\Emotion\Preset\EmotionToPresetDataTransformer` - transform emotion to preset
-    * `Shopware\Components\Emotion\Preset\PresetDataSynchronizer` - uses component handlers to support import / export of emotions  
+    * `Shopware\Components\Emotion\Preset\PresetDataSynchronizer` - uses component handlers to support import / export of emotions
     * `Shopware\Components\Emotion\Preset\PresetInstaller` - installer for preset plugins
     * `Shopware\Components\Emotion\Preset\PresetLoader` - loads presets and refreshes preset data to match current database
     * `Shopware\Components\Emotion\Preset\PresetMetaDataInterface` - interface to use for preset plugin development

--- a/_sql/migrations/943-add-http-cache-events-for-site.php
+++ b/_sql/migrations/943-add-http-cache-events-for-site.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration943 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+SET @plugin_id = (SELECT id FROM s_core_plugins WHERE name='HttpCache');
+INSERT IGNORE INTO `s_core_subscribes` (`subscribe`, `type`, `listener`, `pluginID`, `position`) VALUES ('Shopware\\Models\\Site\\Site::postPersist', '0', 'Shopware_Plugins_Core_HttpCache_Bootstrap::onPostPersist', @plugin_id, '0');
+INSERT IGNORE INTO `s_core_subscribes` (`subscribe`, `type`, `listener`, `pluginID`, `position`) VALUES ('Shopware\\Models\\Site\\Site::postUpdate', '0', 'Shopware_Plugins_Core_HttpCache_Bootstrap::onPostPersist', @plugin_id, '0');
+EOD;
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -143,6 +143,9 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
         $this->subscribeEvent('Shopware\Models\Emotion\Emotion::postPersist', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Emotion\Emotion::postUpdate', 'onPostPersist');
 
+        $this->subscribeEvent('Shopware\Models\Site\Site::postPersist', 'onPostPersist');
+        $this->subscribeEvent('Shopware\Models\Site\Site::postUpdate', 'onPostPersist');
+
         $this->installForm();
 
         return true;
@@ -683,6 +686,9 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
                 break;
             case Shopware\Models\Emotion\Emotion::class:
                 $cacheIds[] = 'e' . $entity->getId();
+                break;
+            case Shopware\Models\Site\Site::class:
+                $cacheIds[] = 's' . $entity->getId();
                 break;
         }
 

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/CacheIdCollector.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/CacheIdCollector.php
@@ -52,7 +52,7 @@ class CacheIdCollector
                 return $this->getBlogCacheIds($request, $view);
 
             case 'widgets/listing':
-                return $this->getAjaxListingCacheIds($context, $request, $view);
+                return $this->getAjaxListingCacheIds($request, $view);
 
             case 'frontend/index':
                 return $this->getHomePageCacheIds($context);
@@ -66,9 +66,11 @@ class CacheIdCollector
             case 'widgets/emotion':
                 return $this->getEmotionCacheIds($view);
 
-                break;
             case 'frontend/listing':
-                return $this->getListingCacheIds($view);
+                return $this->getListingCacheIds($request, $view);
+
+            case 'frontend/custom':
+                return $this->getStaticSiteCacheIds($request);
 
             default:
                 return [];
@@ -103,13 +105,11 @@ class CacheIdCollector
         return $cacheIds;
     }
 
-    private function getAjaxListingCacheIds(ShopContextInterface $context, Request $request, View $view)
+    private function getAjaxListingCacheIds(Request $request, View $view)
     {
         $cacheIds = [];
+
         $categoryId = (int) $request->getParam('sCategory');
-        if (empty($categoryId)) {
-            $categoryId = $context->getShop()->getCategory()->getId();
-        }
         $cacheIds[] = 'c' . $categoryId;
 
         foreach ($view->getAssign('sArticles') as $article) {
@@ -186,13 +186,11 @@ class CacheIdCollector
                         continue;
                     }
                     $cacheIds[] = 'a' . $product->getId();
-                    $cacheIds[] = 'a' . $product->getVariantId();
                 } elseif ($element['component']['type'] === ArticleSliderComponentHandler::COMPONENT_NAME) {
                     /** @var \Shopware\Bundle\StoreFrontBundle\Struct\ListProduct[] $products */
                     $products = $element['data']['products'];
                     foreach ($products as $product) {
                         $cacheIds[] = 'a' . $product->getId();
-                        $cacheIds[] = 'a' . $product->getVariantId();
                     }
                 }
             }
@@ -202,18 +200,34 @@ class CacheIdCollector
     }
 
     /**
-     * @param View $view
+     * @param Request $request
+     * @param View    $view
      *
      * @return array
      */
-    private function getListingCacheIds(View $view)
+    private function getListingCacheIds(Request $request, View $view)
     {
         $cacheIds = [];
+
+        $categoryId = (int) $request->getParam('sCategory');
+        $cacheIds[] = 'c' . $categoryId;
 
         foreach ($view->getAssign('sArticles') as $article) {
             $cacheIds[] = 'a' . $article['articleID'];
         }
 
         return $cacheIds;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return array
+     */
+    private function getStaticSiteCacheIds(Request $request)
+    {
+        $staticSiteId = $request->getParam('sCustom');
+
+        return ['s' . $staticSiteId];
     }
 }


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | There were some inconsistencies with the cache ids, the exact changes are in the `UPGRADE-5.3.md` |
| BC breaks?              | no |
| Tests exists & pass?    | - |
| Related tickets?        | - |
| How to test?            | Activate the HTTP Cache and look at the cache ids |
| Requirements met?       | - |