### PR TITLE
Added the possibility to ignore url parameters for the cache key gene…

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -17,7 +17,7 @@ View all changes from v5.3.0-RC1...v5.3.0-RC2](https://github.com/shopware/shopw
 * Added new search builder class `Shopware\Components\Model\SearchBuilder`
 * Added new search builder as __construct parameter in `Shopware\Bundle\AttributeBundle\Repository\Searcher\GenericSearcher`
 * Added new `FunctionNode` for IF-ELSE statements in ORM query builder
-* Added `/address` to robots.txt 
+* Added `/address` to robots.txt
 * Added snippet `DetailBuyActionAddName` in `snippets/frontend/detail/buy.ini`
 * Added `Shopware\Components\Template\Security` class for all requests.
 * Added whitelist for allowed php functions and php modifiers in smarty
@@ -28,6 +28,7 @@ View all changes from v5.3.0-RC1...v5.3.0-RC2](https://github.com/shopware/shopw
 * Added new filter event `Shopware_Controllers_Performance_filterCounts` to `engine/Shopware/Controllers/Backend/Performance.php` to add custom count of the HttpCache warmer URLs
 * Added new filter event `Shopware_Controllers_Seo_filterCounts` to `engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php` to add a custom SEO URL count
 * Added new notify event `Shopware_CronJob_RefreshSeoIndex_CreateRewriteTable` to `engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php` to be notified when the SEO URLs are generated via cronjob
+* Added possibility for the shopware http cache to ignore url parameters for the cache key, the default ignored parameters are `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `gclid`, `cx`, `ie`, `cof`, `siteurl`, `_ga`
 
 ### Changes
 
@@ -145,7 +146,7 @@ View all changes from v5.3.0-RC1...v5.3.0-RC2](https://github.com/shopware/shopw
     * `Shopware\Components\Emotion\EmotionImporter` - handle emotion imports
     * `Shopware\Components\Emotion\EmotionExporter` - handle emotion exports
     * `Shopware\Components\Emotion\Preset\EmotionToPresetDataTransformer` - transform emotion to preset
-    * `Shopware\Components\Emotion\Preset\PresetDataSynchronizer` - uses component handlers to support import / export of emotions  
+    * `Shopware\Components\Emotion\Preset\PresetDataSynchronizer` - uses component handlers to support import / export of emotions
     * `Shopware\Components\Emotion\Preset\PresetInstaller` - installer for preset plugins
     * `Shopware\Components\Emotion\Preset\PresetLoader` - loads presets and refreshes preset data to match current database
     * `Shopware\Components\Emotion\Preset\PresetMetaDataInterface` - interface to use for preset plugin development

--- a/engine/Shopware/Components/HttpCache/AppCache.php
+++ b/engine/Shopware/Components/HttpCache/AppCache.php
@@ -287,7 +287,12 @@ class AppCache extends HttpCache
             return new $class($this->options, $this->kernel);
         }
 
-        return new Store($this->cacheDir ? $this->cacheDir : $this->kernel->getCacheDir() . '/http_cache', $this->options['cache_cookies'], $this->options['lookup_optimization']);
+        return new Store(
+            $this->cacheDir ? $this->cacheDir : $this->kernel->getCacheDir() . '/http_cache',
+            $this->options['cache_cookies'],
+            $this->options['lookup_optimization'],
+            $this->options['ignored_url_parameters']
+        );
     }
 
     /**

--- a/engine/Shopware/Components/HttpCache/Store.php
+++ b/engine/Shopware/Components/HttpCache/Store.php
@@ -58,9 +58,9 @@ class Store extends BaseStore
      * @param array    $ignoredUrlParameters
      */
     public function __construct(
-        string $root,
+        $root,
         array $cacheCookies,
-        bool $lookupOptimization,
+        $lookupOptimization,
         array $ignoredUrlParameters
     ) {
         $this->cacheCookies = $cacheCookies;
@@ -249,12 +249,12 @@ class Store extends BaseStore
         $queryParts = [];
         parse_str($queryString, $queryParts);
 
-        $queryParts = $this->sortQueryStringParameters($queryParts);
         $queryParts = $this->removeIgnoredParameters($queryParts);
+        $queryParts = $this->sortQueryStringParameters($queryParts);
 
         $queryString = http_build_query($queryParts);
 
-        return $urlPath . $queryString;
+        return rtrim($urlPath . $queryString, '?');
     }
 
     /**

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -150,6 +150,18 @@ return array_replace_recursive([
         'stale_if_error' => false,
         'cache_dir' => $this->getCacheDir() . '/html',
         'cache_cookies' => ['shop', 'currency', 'x-cache-context-hash'],
+        'ignored_url_parameters' => [
+            'utm_source',
+            'utm_medium',
+            'utm_campaign',
+            'utm_content',
+            'gclid',
+            'cx',
+            'ie',
+            'cof',
+            'siteurl',
+            '_ga',
+        ],
     ],
     'session' => [
         'cookie_lifetime' => 0,

--- a/tests/Unit/Components/HttpCache/StoreTest.php
+++ b/tests/Unit/Components/HttpCache/StoreTest.php
@@ -56,7 +56,7 @@ class StoreTest extends TestCase
     {
         $object = $this->createPartialMock(Store::class, []);
         $class = new \ReflectionClass($object);
-        $method = $class->getMethod('sortQueryStringParameters');
+        $method = $class->getMethod('processQueryStringParameters');
         $method->setAccessible(true);
 
         $this->assertSame($expected, $method->invokeArgs($object, [$url]));

--- a/tests/Unit/Components/HttpCache/StoreTest.php
+++ b/tests/Unit/Components/HttpCache/StoreTest.php
@@ -25,7 +25,7 @@
 namespace Shopware\Tests\Unit\Components\HttpCache;
 
 use PHPUnit\Framework\TestCase;
-use Shopware\Components\HttpCache\Store;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @category  Shopware
@@ -34,15 +34,39 @@ use Shopware\Components\HttpCache\Store;
  */
 class StoreTest extends TestCase
 {
+    public function setUp()
+    {
+        $this->httpCacheStore = new \Shopware\Components\HttpCache\Store(
+            'test',
+            [],
+            true,
+            [
+                'foo',
+                '_foo',
+                '__foo',
+            ]
+        );
+    }
+
     public function provideUrls()
     {
         return [
-            ['http://example.com', 'http://example.com'],
-            ['http://example.com?a=a', 'http://example.com?a=a'],
-            ['http://example.com?z=a&a=a', 'http://example.com?a=a&z=a'],
-            ['http://example.com?z=a&z=b', 'http://example.com?z=b'], // duplicate parameters
-            ['http://example.com?Z=a&z=a', 'http://example.com?Z=a&z=a'], // case sensitive
-            ['http://example.com/?colors[]=red&cars[]=Saab&cars[]=Audi&colors[]=red&colors[]=blue', 'http://example.com/?cars%5B0%5D=Saab&cars%5B1%5D=Audi&colors%5B0%5D=red&colors%5B1%5D=red&colors%5B2%5D=blue'],
+            ['http://example.com', 'http://example.com/'],
+            ['http://example.com?a=a', 'http://example.com/?a=a'],
+            ['http://example.com?z=a&a=a', 'http://example.com/?a=a&z=a'],
+            ['http://example.com?z=a&z=b', 'http://example.com/?z=b'], // duplicate parameters
+            ['http://example.com?Z=a&z=a', 'http://example.com/?Z=a&z=a'], // case sensitive
+            ['http://example.com/?colors[]=red&cars[]=Saab&cars[]=Audi&colors[]=red&colors[]=blue', 'http://example.com/?cars%5B0%5D=Audi&cars%5B1%5D=Saab&colors%5B0%5D=blue&colors%5B1%5D=red&colors%5B2%5D=red'],
+            ['http://example.com?foo', 'http://example.com/'],
+            ['http://example.com?foo=bar', 'http://example.com/'],
+            ['http://example.com?_foo=bar', 'http://example.com/'],
+            ['http://example.com?__foo=bar', 'http://example.com/'],
+            ['http://example.com?foo&z=a&a=a', 'http://example.com/?a=a&z=a'],
+            ['http://example.com?foo=bar&z=a&a=a', 'http://example.com/?a=a&z=a'],
+            ['http://example.com?_foo=bar&z=a&a=a', 'http://example.com/?a=a&z=a'],
+            ['http://example.com?__foo=bar&z=a&a=a', 'http://example.com/?a=a&z=a'],
+            ['http://example.com?z=a&foo=bar&a=a', 'http://example.com/?a=a&z=a'],
+            ['http://example.com?z=a&a=a&foo=bar', 'http://example.com/?a=a&z=a'],
         ];
     }
 
@@ -54,11 +78,15 @@ class StoreTest extends TestCase
      */
     public function testSortQueryParams($url, $expected)
     {
-        $object = $this->createPartialMock(Store::class, []);
-        $class = new \ReflectionClass($object);
-        $method = $class->getMethod('processQueryStringParameters');
+        $request = Request::create($url);
+
+        $class = new \ReflectionClass($this->httpCacheStore);
+        $method = $class->getMethod('generateCacheKey');
         $method->setAccessible(true);
 
-        $this->assertSame($expected, $method->invokeArgs($object, [$url]));
+        $this->assertSame(
+            'md' . hash('sha256', $expected),
+            $method->invokeArgs($this->httpCacheStore, [$request])
+        );
     }
 }


### PR DESCRIPTION
## Description

The problem is, that often additional query parameters are added to the url (e.g. from Google Adwords). With this, often unique, parameters a new HTTP Cache version is generated, although these parameters are only needed by some JavaScript tracking scripts. This PR adds the possibility to ignore such parameters. I have taken the parameters from the varnish cache documentation, which we use in several projects and added the parameter `_ga`. See here: https://www.varnish-software.com/wiki/content/tutorials/varnish/sample_vclTemplate.html#removing-google-analytics-added-parameters

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | See above |
| BC breaks?              | not sure |
| Tests exists & pass?    | yes |
| Related tickets?        | - |
| How to test?            | Activate HTTP Cache and try to load the page with a parameter like gclid=123123, the `x-content-digest` should be the same for each value of the parameter and without the parameter |
| Requirements met?       | yes |