### PR TITLE
Fixed API Error messages

### DIFF
--- a/engine/Shopware/Components/Api/Exception/ValidationException.php
+++ b/engine/Shopware/Components/Api/Exception/ValidationException.php
@@ -26,6 +26,7 @@ namespace Shopware\Components\Api\Exception;
 
 use Symfony\Component\Form\FormErrorIterator;
 use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
@@ -50,7 +51,7 @@ class ValidationException extends \Enlight_Exception
     {
         $this->setViolations($violations);
 
-        parent::__construct();
+        parent::__construct($this->__toString());
     }
 
     /**
@@ -60,8 +61,9 @@ class ValidationException extends \Enlight_Exception
     {
         $output = '';
 
+        /** @var ConstraintViolationInterface $violation */
         foreach ($this->violations as $violation) {
-            $output .= $violation->getMessage() . PHP_EOL;
+            $output .= $violation->getPropertyPath() . ': ' . $violation->getMessage() . PHP_EOL;
         }
 
         return $output;


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | When creating a invalid resource record with the api i get a ValidationException but i dont know why. The message would not outputted |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        |  |
| How to test?            |  |
| Requirements met?       | Yep |

Test-Code
```php
$testA = array(
            'email' => 'meier@mail.de',
            'firstname' => 'Max',
            'lastname' => 'Meier',
            'salutation' => 'blaaa',
            'billing' => array(
                'firstname' => 'Max',
                'lastname' => 'Meier',
                'salutation' => 'mr',
                'street' => 'Musterstrasse 55',
                'city' => 'Sch\u00f6ppingen',
                'zipcode' => '48624',
                'country' => 2
            )
        );

        $test = Manager::getResource('Customer');

        $test->create($testA);
````

Before:
![bildschirmfoto 2017-07-07 um 16 37 33](https://user-images.githubusercontent.com/6224096/27962569-9aa1e9b0-6332-11e7-8912-8facf8bc0655.png)

After:
![bildschirmfoto 2017-07-07 um 16 37 50](https://user-images.githubusercontent.com/6224096/27962586-a2883116-6332-11e7-8088-4eafe9909a4c.png)
