### PR TITLE
count orders after eventFilter

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -1279,7 +1279,6 @@ class sAdmin
                 $mainShop->getId(),
             ]
         );
-        $foundOrdersCount = (int) Shopware()->Db()->fetchOne('SELECT FOUND_ROWS()');
 
         foreach ($getOrders as $orderKey => $orderValue) {
             $getOrders[$orderKey]['invoice_amount'] = $this->moduleManager->Articles()
@@ -1302,7 +1301,9 @@ class sAdmin
                 'subshopID' => $this->contextService->getShopContext()->getShop()->getId(),
             ]
         );
-
+        
+        
+        $foundOrdersCount = count($getOrders);
         $orderData['orderData'] = $getOrders;
 
         if ($limitEnd != 0) {


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Adding orders from foreign source wouldn't have a nice result, cause getPagerStructure just looks for own orders. In our sample, we add orders live from out ERP and the pager is broken :-) |
| BC breaks?              | hope not |
| Tests exists & pass?    |  |
| Related tickets?        |  |
| How to test?            | Manipulate the result in Event Shopware_Modules_Admin_GetOpenOrderData_FilterResult with more orders and see what's happening with the pager |
| Requirements met?       | yes |