### PR TITLE
Pass actual basket structure to basket signature generator during payment.

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -1880,7 +1880,7 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action
         /** @var BasketSignatureGeneratorInterface $generator */
         $generator = $this->get('basket_signature_generator');
         $basket = $this->session->offsetGet('sOrderVariables')->getArrayCopy();
-        $signature = $generator->generateSignature($basket, $this->session->get('sUserId'));
+        $signature = $generator->generateSignature($basket['sBasket'], $this->session->get('sUserId'));
 
         /** @var BasketPersister $persister */
         $persister = $this->get('basket_persister');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Fix basket signature generation during paymentAction

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Currently the basket is not passed correctly during custom payments to the signature generator. |
| BC breaks?              | no|
| Tests exists & pass?    | no&yes :-) |
| Related tickets?        | no |
| How to test?            | Use any custom payment plugin that utilizes the `Shopware_Controllers_Frontend_Checkout::paymentAction` and try to finish checkout. You will get a fatal error stating `Uncaught TypeError: Argument 1 passed to Shopware\Components\BasketSignature\BasketSignatureGenerator::sortItems() must be of the type array, null given`. After the fix this error does not occur and the signature is generated correctly. |
| Requirements met?       | yup |