### PR TITLE
Use default stream context options for RssFeed widget

### DIFF
--- a/engine/Shopware/Controllers/Backend/Widgets.php
+++ b/engine/Shopware/Controllers/Backend/Widgets.php
@@ -759,12 +759,17 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
 
         $result = [];
 
+        $streamContextOptions = stream_context_get_options(stream_context_get_default());
+        $streamContextOptions['http']['timeout'] = 20;
+
         try {
-            $xml = new \SimpleXMLElement(file_get_contents('https://' . $lang . '.shopware.com/news/?sRss=1', false, stream_context_create([
-                'http' => [
-                    'timeout' => 20,
-                ],
-            ])));
+            $xml = new \SimpleXMLElement(
+                file_get_contents(
+                    'https://' . $lang . '.shopware.com/news/?sRss=1',
+                    false,
+                    stream_context_create($streamContextOptions)
+                )
+            );
         } catch (\Exception $e) {
             return [];
         }


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | To add a possibility to set default stream context option (e.g. for using a proxy) via plugin  |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | - |
| How to test?            | Set default options via plugin and check if they where used |
| Requirements met?       | Yes |