### PR TITLE
Added new option to Shopware.attribute.Form showSaveButton to show a …

### DIFF
--- a/snippets/backend/attributes/main.ini
+++ b/snippets/backend/attributes/main.ini
@@ -124,6 +124,7 @@ define_value = "define value"
 define_key = "define key"
 error_name_check_title = "Duplicate column name"
 error_name_check_message = "The name already exists in table [0]. Please choose an unique column name."
+attributes_has_been_saved = "Attributes has been saved"
 
 [de_DE]
 table/s_articles_attributes = "Artikel"
@@ -251,3 +252,4 @@ define_key = "Key definieren"
 error_name_check_title = "Doppelter Spaltenname"
 error_name_check_message = "Der Spaltenname existiert bereits in Tabelle [0]. Bitte wählen Sie einen eindeutigen Spaltennamen."
 table/s_customer_streams_attributes = "Customer Streams"
+attributes_has_been_saved = "Die Attribute wurden gespeichert"

--- a/themes/Backend/ExtJs/backend/article/view/image/info.js
+++ b/themes/Backend/ExtJs/backend/article/view/image/info.js
@@ -113,7 +113,8 @@ Ext.define('Shopware.apps.Article.view.image.Info', {
             table: 's_articles_img_attributes',
             allowTranslation: false,
             translationForm: me,
-            margin: '10 0 0'
+            margin: '10 0 0',
+            showSaveButton: true
         });
 
         me.items = [

--- a/themes/Backend/ExtJs/backend/base/attribute/Shopware.attribute.Form.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/Shopware.attribute.Form.js
@@ -77,6 +77,16 @@ Ext.define('Shopware.attribute.Form', {
      */
     translationPlugin: null,
 
+    /**
+     * @var boolean
+     */
+    showSaveButton: true,
+
+    /**
+     * @var integer
+     */
+    currentId: null,
+
     initComponent: function() {
         var me = this;
 
@@ -133,6 +143,8 @@ Ext.define('Shopware.attribute.Form', {
             callback();
             return;
         }
+
+        me.currentId = foreignKey;
 
         if (!me.configLoaded) {
             me.on('config-loaded', function() {
@@ -356,6 +368,21 @@ Ext.define('Shopware.attribute.Form', {
                 fields.push(handler.create(field, attribute));
             }
         });
+
+        if (me.showSaveButton) {
+            fields.push({
+                xtype: 'button',
+                text: '{s name="save_button" namespace="backend/attributes/main"}{/s}',
+                cls: 'secondary',
+                handler: function () {
+                    if (me.currentId) {
+                        me.saveAttribute(me.currentId, function () {
+                            Shopware.Notification.createGrowlMessage('Attribute', '{s name="attributes_has_been_saved" namespace="backend/attributes/main"}{/s}')
+                        });
+                    }
+                }
+            })
+        }
 
         return fields;
     },


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Article images attributes are saving until i click on a another image. Nobody will understand that, without a notice. My idea was a simple save button inside the attribute form |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        |  |
| How to test?            | Go to a article and open the images tab|
| Requirements met?       | Yep |

Image:
![bildschirmfoto 2017-07-11 um 16 01 00](https://user-images.githubusercontent.com/6224096/28072138-61fffaca-6652-11e7-8b9d-338d7da5b520.png)
