### PR TITLE
Do not round voucher net values

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2086,14 +2086,14 @@ class sBasket
             }
         } else {
             if ($voucherDetails['taxconfig'] == 'default' || empty($voucherDetails['taxconfig'])) {
-                $tax = round($voucherDetails['value'] / (100 + $this->config->get('sVOUCHERTAX')) * 100, 3) * -1;
+                $tax = $voucherDetails['value'] / (100 + $this->config->get('sVOUCHERTAX')) * 100 * -1;
                 $taxRate = $this->config->get('sVOUCHERTAX');
                 // Pre 3.5.4 behaviour
             } elseif ($voucherDetails['taxconfig'] == 'auto') {
                 // Check max. used tax-rate from basket
                 $tax = $this->getMaxTax();
                 $taxRate = $tax;
-                $tax = round($voucherDetails['value'] / (100 + $tax) * 100, 3) * -1;
+                $tax = $voucherDetails['value'] / (100 + $tax) * 100 * -1;
             } elseif (intval($voucherDetails['taxconfig'])) {
                 // Fix defined tax
                 $temporaryTax = $voucherDetails['taxconfig'];
@@ -2102,7 +2102,7 @@ class sBasket
                     [$temporaryTax]
                 );
                 $taxRate = $getTaxRate;
-                $tax = round($voucherDetails['value'] / (100 + (intval($getTaxRate))) * 100, 3) * -1;
+                $tax = $voucherDetails['value'] / (100 + (intval($getTaxRate))) * 100 * -1;
             } else {
                 // No tax
                 $tax = $voucherDetails['value'] * -1;

--- a/tests/Functional/Core/sBasketTest.php
+++ b/tests/Functional/Core/sBasketTest.php
@@ -775,6 +775,74 @@ class sBasketTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers \sBasket::calculateVoucherValues
+     */
+    public function testsAddVoucherWithPercentageVoucher()
+    {
+        // Create percentage voucher
+        $voucherData = array(
+            'vouchercode' => 'testOne',
+            'description' => 'testOne description',
+            'numberofunits' => 1,
+            'value' => 10,
+            'minimumcharge' => 10,
+            'ordercode' => uniqid(rand()),
+            'modus' => 0,
+            'percental' => 1
+        );
+        $this->db->insert(
+            's_emarketing_vouchers',
+            $voucherData
+        );
+
+        // Setup session
+        $this->module->sSYSTEM->sSESSION_ID = uniqid(rand());
+        $this->session->offsetSet('sessionId', $this->module->sSYSTEM->sSESSION_ID);
+
+        // Add one article to the basket with specified value
+        $randomArticle = $this->db->fetchRow(
+            'SELECT * FROM s_articles_details detail
+            INNER JOIN s_articles article
+              ON article.id = detail.articleID
+            WHERE detail.active = 1
+            ORDER BY RAND() LIMIT 1'
+        );
+        $this->db->insert(
+            's_order_basket',
+            array(
+                'price' => 99.99,
+                'quantity' => 1,
+                'sessionID' => $this->session->get('sessionId'),
+                'ordernumber' => $randomArticle['ordernumber'],
+                'articleID' => $randomArticle['articleID'],
+            )
+        );
+
+        // Add voucher to basket
+        $this->assertTrue($this->module->sAddVoucher('testOne'));
+
+        // Retrieve voucher values from basket
+        $discount = $this->db->fetchRow(
+            'SELECT * FROM s_order_basket WHERE modus = 2 and sessionID = ?',
+            array($this->module->sSYSTEM->sSESSION_ID)
+        );
+
+        $this->assertEquals(-9.999, $discount['price'], '', 0.00001);
+        // Test that more than 3 decimal places are present for net prices
+        $this->assertEquals(-8.4025210084034, $discount['netprice'], '', 0.00001);
+
+        // Housekeeping
+        $this->db->delete(
+            's_order_basket',
+            array('sessionID = ?' => $this->session->get('sessionId'))
+        );
+        $this->db->delete(
+            's_emarketing_vouchers',
+            array('vouchercode = ?' => 'testOne')
+        );
+    }
+
+    /**
      * @covers \sBasket::sAddVoucher
      */
     public function testsAddVoucherWithLimitedVoucher()


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

Updated version of #915 against Shopware 5.3, please also see the discussion there.

Before this PR the net prices of vouchers were rounded to three decimal places in the basket. Articles in contrast have an exact net price, where the precisions is just limited by PHP itself.

This might seem like a minor thing, as only prices rounded to two decimal places are displayed to the customer. However this breaks the [PAYONE plugin](http://store.shopware.com/payone00261/payone-payment-fuer-shopware.html) for certain baskets which calculates the gross value itself. The calculation itself is correct but is off by one cent with some constellations because of the missing precisions of the vouchers net value and PHPs imperfect internal float handling.

Example basket with 7 % VAT:

| Position        | Quantity           | Value  |
| ------------- |:-------------:| -----:|
| Sample Article      | 1 | 112,50 € |
| Voucher 5 %      |      |   -5,63 €|
|      |     **SUM** |   106,87 €|

But the PAYONE plugin takes the rounded net value of the voucher `-5.257` and recomputes it to `-5.62499` which is then then rounded to the incorrect value of `-5.62` (off by 0,01 €). The code doing this can be found [here](https://github.com/PAYONE-GmbH/shopware-5/blob/v3.4.7/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php#L1046) and is correct, it's just not fed with enough precision in case of vouchers.

Orders like this are rejected by the PAYONE API as the summed basket value displayed to the user is transmitted as well and cross checked against the sum of the individual positions. The error returned is `1610: Article list faulty or incomplete` in this case.

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | see above |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        | - |
| How to test?            | Test case is included in the PR. |
| Requirements met?       | sure |