### PR TITLE
Fixing bug with ambiguous columns

### DIFF
--- a/engine/Shopware/Core/sRewriteTable.php
+++ b/engine/Shopware/Core/sRewriteTable.php
@@ -453,8 +453,8 @@ class sRewriteTable
     public function getSeoArticleQuery()
     {
         return "
-            SELECT a.*, d.ordernumber, d.suppliernumber, s.name as supplier, datum as date,
-                d.releasedate, changetime as changed, metaTitle, ct.objectdata, ctf.objectdata as objectdataFallback, at.attr1, at.attr2,
+            SELECT a.*, d.ordernumber, d.suppliernumber, s.name as supplier, a.datum as date,
+                d.releasedate, a.changetime as changed, ct.objectdata, ctf.objectdata as objectdataFallback, at.attr1, at.attr2,
                 at.attr3, at.attr4, at.attr5, at.attr6, at.attr7, at.attr8, at.attr9,
                 at.attr10,at.attr11, at.attr12, at.attr13, at.attr14, at.attr15, at.attr16,
                 at.attr17, at.attr18, at.attr19, at.attr20


### PR DESCRIPTION
If an attribute has the name 'metaTitle, 'datum' or 'changetime' the seo index throwing an ambiguous column error because the columns in the statement are not prefixed. metaTitle is unnecessary anyway, because it comes with the a.* request as well.

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | no seo index |
| BC breaks?              | yes/no |
| Tests exists & pass?    | yes/no |
| Related tickets?        | If this PR fixes an existing issue ticket, please add there url here. |
| How to test?            | Please describe how to best verify that this PR is correct. |
| Requirements met?       | Does your PR fulfil our [contribution requirements](https://developers.shopware.com/contributing/contribution-guideline/#requirements-for-a-successful-pull-request)? |