### PR TITLE
SW-19299: Fix persisting of existing article entity if only attribute…

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -15,6 +15,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 * Added new block `frontend_checkout_cart_item_details_essential_features` to `themes/Frontend/Bare/frontend/checkout/confirm_item.tpl`.
 * Added new block `frontend_checkout_confirm_product_table_content` around table in `themes/Frontend/Bare/frontend/checkout/confirm.tpl`.
 * Individual voucher codes are now searchable in voucher overview
+* Fixed saving in the backend articleDetails only (Doctrine flush issue)
 
 # 5.2.26
 

--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -2885,7 +2885,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
         $article->fromArray($data);
 
         Shopware()->Models()->persist($article);
-        Shopware()->Models()->flush();
+        Shopware()->Models()->flush($article);
         if (empty($data['id']) && !empty($data['autoNumber'])) {
             $this->increaseAutoNumber($data['autoNumber'], $article->getMainDetail()->getNumber());
         }


### PR DESCRIPTION
…s of articleDetails etc. are changed, but nothing from the article entity itselft.

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Saving of ArticleDetails in the backend fails |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | n/a |
| How to test?            | Save dimensions of an article only |
| Requirements met?       | yes |