### PR TITLE
Reset OPcache after extracting plugin zip

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/DownloadService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/DownloadService.php
@@ -123,6 +123,11 @@ class DownloadService
         } else {
             throw new \RuntimeException('No Plugin found in archive.');
         }
+
+        // Reset the OPcache to make sure no outdated versions of the unzipped files are loaded from the cache
+        if (extension_loaded('Zend OPcache') && ini_get('opcache.enable')) {
+            opcache_reset();
+        }
     }
 
     /**


### PR DESCRIPTION
When downloading a plugin ZIP file from the community store or manually uploading it in the plugin manager, the contents of the ZIP file are extracted and, if the same plugin is already available in the file system, replace the existing files. However, if the OPcache is enabled and [`opcache.revalidate_freq`](http://php.net/manual/de/opcache.configuration.php#ini.opcache.revalidate-freq) is set to an arbitrary long interval (e.g. 2 minutes), you most likely run into the case that outdated plugin files are executed, until the OPcache is revalidated automatically. This is particularly problematic if the user runs the plugin update directly after downloading it, because some update steps that are only present in the downloaded `Bootstrap.php` might not be executed.
This commit fixes these issues by adding a single `opcache_reset()` call just after the actual extraction of the plugin ZIP file.

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | After extracting a plugin zip file the plugin files loaded in the OPcache do not match the extracted files. |
| BC breaks?              | no |
| Tests exists & pass?    | n/a |
| Related tickets?        | n/a |
| How to test?            | Enable OPcache, set `opcache.revalidate_freq` to a long interval, change something in a plugin and upload the new version as a ZIP. |
| Requirements met?       | yes |