### PR TITLE
make the article shippingtime field translatable

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -32,6 +32,7 @@ View all changes from v5.3.0-RC1...v5.3.0-RC2](https://github.com/shopware/shopw
 * Added new filter event `Shopware_Controllers_Performance_filterCounts` to `engine/Shopware/Controllers/Backend/Performance.php` to add custom count of the HttpCache warmer URLs
 * Added new filter event `Shopware_Controllers_Seo_filterCounts` to `engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php` to add a custom SEO URL count
 * Added new notify event `Shopware_CronJob_RefreshSeoIndex_CreateRewriteTable` to `engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php` to be notified when the SEO URLs are generated via cronjob
+* Added translation for article `shippingtime` field
 
 ### Changes
 

--- a/_sql/migrations/944-add-article-shippingtime-translation.php
+++ b/_sql/migrations/944-add-article-shippingtime-translation.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+use Shopware\Components\Migrations\AbstractMigration;
+
+class Migrations_Migration944 extends AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+ALTER TABLE `s_articles_translations` ADD `shippingtime` MEDIUMTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL AFTER `description_clear`;
+EOD;
+        $this->addSql($sql);
+    }
+}
+
+

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/ProductHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/ProductHydrator.php
@@ -118,6 +118,7 @@ class ProductHydrator extends Hydrator
             'txtArtikel' => '__product_name',
             'txtshortdescription' => '__product_description',
             'txtlangbeschreibung' => '__product_description_long',
+            'txtshippingtime' => '__variant_shippingtime',
             'txtzusatztxt' => '__variant_additionaltext',
             'txtkeywords' => '__product_keywords',
             'txtpackunit' => '__unit_packunit',

--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -613,6 +613,7 @@ class Article extends Resource implements BatchInterface
             'name',
             'description',
             'descriptionLong',
+            'shippingTime',
             'keywords',
             'packUnit',
         ]);

--- a/engine/Shopware/Components/Translation.php
+++ b/engine/Shopware/Components/Translation.php
@@ -394,12 +394,14 @@ class Shopware_Components_Translation
                     'txtArtikel' => 'name',
                     'txtshortdescription' => 'description',
                     'txtlangbeschreibung' => 'descriptionLong',
+                    'txtshippingtime' => 'shippingTime',
                     'txtzusatztxt' => 'additionalText',
                     'txtkeywords' => 'keywords',
                     'txtpackunit' => 'packUnit',
                 ];
             case 'variant':
                 return [
+                    'txtshippingtime' => 'shippingTime',
                     'txtzusatztxt' => 'additionalText',
                     'txtpackunit' => 'packUnit',
                 ];
@@ -480,6 +482,7 @@ class Shopware_Components_Translation
             'keywords' => (isset($data['txtkeywords'])) ? (string) $data['txtkeywords'] : '',
             'description' => (isset($data['txtshortdescription'])) ? (string) $data['txtshortdescription'] : '',
             'description_long' => (isset($data['txtlangbeschreibung'])) ? (string) $data['txtlangbeschreibung'] : '',
+            'shippingtime' => (isset($data['txtshippingtime'])) ? (string) $data['txtshippingtime'] : '',
         ]);
 
         $schemaManager = Shopware()->Container()->get('dbal_connection')->getSchemaManager();

--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -2332,6 +2332,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
                 unset($coreTranslation['objectdata']['name']);
                 unset($coreTranslation['objectdata']['description']);
                 unset($coreTranslation['objectdata']['descriptionLong']);
+                unset($coreTranslation['objectdata']['shippingTime']);
                 unset($coreTranslation['objectdata']['keywords']);
                 $coreTranslation['objectkey'] = $variant->getId();
                 $coreTranslation['objecttype'] = 'variant';
@@ -3359,6 +3360,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
             unset($articleTranslation['objectdata']['name']);
             unset($articleTranslation['objectdata']['description']);
             unset($articleTranslation['objectdata']['descriptionLong']);
+            unset($articleTranslation['objectdata']['shippingTime']);
             unset($articleTranslation['objectdata']['keywords']);
             $articleTranslation['objectkey'] = $template->getId();
             $articleTranslation['objecttype'] = 'configuratorTemplate';

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -1650,6 +1650,7 @@ class sArticles
                 $map = [
                     'txtshortdescription' => 'description',
                     'txtlangbeschreibung' => 'description_long',
+                    'txtshippingtime' => 'shippingtime',
                     'txtArtikel' => 'articleName',
                     'txtzusatztxt' => 'additionaltext',
                     'txtkeywords' => 'keywords',
@@ -1741,6 +1742,7 @@ class sArticles
                 $map = [
                     'txtshortdescription' => 'description',
                     'txtlangbeschreibung' => 'description_long',
+                    'txtshippingtime' => 'shippingtime',
                     'txtArtikel' => 'articleName',
                     'txtzusatztxt' => 'additionaltext',
                     'txtkeywords' => 'keywords',
@@ -1748,7 +1750,7 @@ class sArticles
                 ];
                 break;
             case 'variant':
-                $map = ['txtzusatztxt' => 'additionaltext', 'txtpackunit' => 'packunit'];
+                $map = ['txtshippingtime' => 'shippingtime', 'txtzusatztxt' => 'additionaltext', 'txtpackunit' => 'packunit'];
                 break;
             case 'link':
                 $map = ['linkname' => 'description'];

--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -619,6 +619,7 @@ class sExport
                 $map = [
                     'txtshortdescription' => 'description',
                     'txtlangbeschreibung' => 'description_long',
+                    'txtshippingtime' => 'shippingtime',
                     'txtArtikel' => 'name',
                     'txtzusatztxt' => 'additionaltext',
                 ];

--- a/engine/Shopware/Core/sRewriteTable.php
+++ b/engine/Shopware/Core/sRewriteTable.php
@@ -807,6 +807,7 @@ class sRewriteTable
                 'name' => 'txtArtikel',
                 'description_long' => 'txtlangbeschreibung',
                 'description' => 'txtshortdescription',
+                'shippingtime' => 'txtshippingtime',
                 'keywords' => 'txtkeywords',
                 'metaTitle' => 'metaTitle',
             ]);

--- a/tests/Functional/Bundle/StoreFrontBundle/Helper.php
+++ b/tests/Functional/Bundle/StoreFrontBundle/Helper.php
@@ -1279,6 +1279,7 @@ class Helper
             'txtArtikel' => 'Dummy Translation',
             'txtshortdescription' => 'Dummy Translation',
             'txtlangbeschreibung' => 'Dummy Translation',
+            'txtshippingtime' => 'Dummy Translation',
             'txtzusatztxt' => 'Dummy Translation',
             'txtkeywords' => 'Dummy Translation',
             'txtpackunit' => 'Dummy Translation',

--- a/tests/Functional/Bundle/StoreFrontBundle/TranslationTest.php
+++ b/tests/Functional/Bundle/StoreFrontBundle/TranslationTest.php
@@ -49,6 +49,7 @@ class TranslationTest extends TestCase
         $this->assertEquals('Dummy Translation', $listProduct->getName());
         $this->assertEquals('Dummy Translation', $listProduct->getShortDescription());
         $this->assertEquals('Dummy Translation', $listProduct->getLongDescription());
+        $this->assertEquals('Dummy Translation', $listProduct->getShippingTime());
         $this->assertEquals('Dummy Translation', $listProduct->getAdditional());
         $this->assertEquals('Dummy Translation', $listProduct->getKeywords());
         $this->assertEquals('Dummy Translation', $listProduct->getMetaTitle());

--- a/tests/Functional/Components/Api/ArticleTest.php
+++ b/tests/Functional/Components/Api/ArticleTest.php
@@ -1825,6 +1825,7 @@ class ArticleTest extends TestCase
                 'name' => 'English-Name',
                 'description' => 'English-Description',
                 'descriptionLong' => 'English-DescriptionLong',
+                'shippingTime' => 'English-ShippingTime',
                 'keywords' => 'English-Keywords',
                 'packUnit' => 'English-PackUnit',
             ],
@@ -1845,6 +1846,7 @@ class ArticleTest extends TestCase
         $this->assertEquals($definedTranslation['name'], $savedTranslation['name']);
         $this->assertEquals($definedTranslation['description'], $savedTranslation['description']);
         $this->assertEquals($definedTranslation['descriptionLong'], $savedTranslation['descriptionLong']);
+        $this->assertEquals($definedTranslation['shippingTime'], $savedTranslation['shippingTime']);
         $this->assertEquals($definedTranslation['keywords'], $savedTranslation['keywords']);
         $this->assertEquals($definedTranslation['packUnit'], $savedTranslation['packUnit']);
 

--- a/tests/Functional/Components/Api/TranslationTest.php
+++ b/tests/Functional/Components/Api/TranslationTest.php
@@ -1023,12 +1023,14 @@ class TranslationTest extends TestCase
                     'name' => 'Dummy Translation',
                     'description' => 'Dummy Translation',
                     'descriptionLong' => 'Dummy Translation',
+                    'shippingTime' => 'Dummy Translation',
                     'additionalText' => 'Dummy Translation',
                     'keywords' => 'Dummy Translation',
                     'packUnit' => 'Dummy Translation',
                 ];
             case 'variant':
                 return [
+                    'shippingTime' => 'Dummy Translation',
                     'additionalText' => 'Dummy Translation',
                     'packUnit' => 'Dummy Translation',
                 ];

--- a/themes/Backend/ExtJs/backend/article/view/detail/settings.js
+++ b/themes/Backend/ExtJs/backend/article/view/detail/settings.js
@@ -209,6 +209,8 @@ Ext.define('Shopware.apps.Article.view.detail.Settings', {
             }, {
                 xtype: 'textfield',
                 name: 'mainDetail[shippingTime]',
+                translationName: 'shippingTime',
+                translatable: true,
                 fieldLabel: me.snippets.deliveryTime
             }, {
                 xtype: 'numberfield',

--- a/themes/Backend/ExtJs/backend/article/view/variant/configurator/template.js
+++ b/themes/Backend/ExtJs/backend/article/view/variant/configurator/template.js
@@ -531,6 +531,7 @@ Ext.define('Shopware.apps.Article.view.variant.configurator.Template', {
             items: [{
                 xtype: 'textfield',
                 name: 'shippingTime',
+                translatable: true,
                 fieldLabel: me.snippets.settings.deliveryTime
             }, {
                 xtype: 'checkboxfield',

--- a/themes/Backend/ExtJs/backend/article/view/variant/detail.js
+++ b/themes/Backend/ExtJs/backend/article/view/variant/detail.js
@@ -585,6 +585,7 @@ Ext.define('Shopware.apps.Article.view.variant.Detail', {
             items: [{
                 xtype: 'textfield',
                 name: 'shippingTime',
+                translatable: true,
                 fieldLabel: me.snippets.settings.deliveryTime
             }, {
                 xtype: 'checkboxfield',


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | At the moment the article shipping time is the same for every sub shop. If you deliver products to different countries you usually want to set a different shipping time for each sub shop. |
| BC breaks?              | no |
| Tests exists & pass?    | yes/hope so |
| Related tickets?        | https://issues.shopware.com/issues/SW-19279 |
| How to test?            | Open article details in backend. The field `Delivery time (days)` is now translatable (also for variants). Click on the globe and insert a shippingtime for another language. Set the article `Stock` value to `0` for displaying the custom shipping time. open article in store frontend for this language.  |
| Requirements met?       | yes |