### PR TITLE
Load attributes of product exports in backend

### DIFF
--- a/themes/Backend/ExtJs/backend/product_feed/view/feed/window.js
+++ b/themes/Backend/ExtJs/backend/product_feed/view/feed/window.js
@@ -78,6 +78,7 @@ Ext.define('Shopware.apps.ProductFeed.view.feed.Window', {
             if(me.record.data.formatId == 0) me.record.data.formatId = 1;
 
             me.formPanel.loadRecord(me.record);
+            me.attributeForm.loadAttribute(me.record.get('id'));
         }
     },
 


### PR DESCRIPTION
This will load attributes of a product export if it's dialog was opened in the backend.
Currently after you save a product export with it's attributes the attributes will be lost after you open the dialog (and save the export) a second time - because all attribute fields will be empty again.

