### PR TITLE
Cascade persist parent image

### DIFF
--- a/engine/Shopware/Models/Article/Image.php
+++ b/engine/Shopware/Models/Article/Image.php
@@ -163,10 +163,10 @@ class Image extends ModelEntity
     private $mediaId = null;
 
     /**
-     * The parent category
+     * The parent image
      *
-     * @var Category
-     * @ORM\ManyToOne(targetEntity="Image", inversedBy="children")
+     * @var Image
+     * @ORM\ManyToOne(targetEntity="Image", inversedBy="children", cascade={"persist"})
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id")
      */
     private $parent;


### PR DESCRIPTION
| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | While using the Article API it is under certain circumstances possible to get Doctrine exceptions because of unmanaged parent image objects. |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        |  |
| How to test?            |  |
| Requirements met?       | I think so |