### PR TITLE
Set enddate in CronJobSynchronizer

### DIFF
--- a/engine/Shopware/Components/Plugin/CronjobSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/CronjobSynchronizer.php
@@ -86,7 +86,8 @@ class CronjobSynchronizer
             $this->connection->update('s_crontab', $cronjob, ['id' => $id]);
         } else {
             $cronjob['next'] = new DateTime();
-            $this->connection->insert('s_crontab', $cronjob, ['next' => 'datetime']);
+            $cronjob['end'] = new DateTime();
+            $this->connection->insert('s_crontab', $cronjob, ['next' => 'datetime', 'end' => 'datetime']);
         }
     }
 


### PR DESCRIPTION
## Description

At the moment Shopware will not execute newly added CronJobs which are generated with an cronjobs.xml
Shopware does not consider CronJobs with no `end`-Date as active. This PR sets the current date as `end`-Date in order to change that.
It's the same solutions that is used in the legacy PluginSystem, see: https://github.com/shopware/shopware/blob/5.2/engine/Shopware/Components/Plugin/Bootstrap.php#L399

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Because it's the same behaviour as in the old PluginSystem and newly added CronJobs should be executed if the cronjobs.xml defines them as active |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | Didn't find one, don't think there is one |
| How to test?            | Create an Plugin that creates at least one active Cronjob via cronjobs.xml. Without this fix the cronjob will not be active in the backendlist and not be executed. After this fix it get's displayed as active |
| Requirements met?       | I hope so ;) |