### PR TITLE
PluginCollection: Correcting PHPDoc annotation

### DIFF
--- a/engine/Library/Enlight/Plugin/PluginCollection.php
+++ b/engine/Library/Enlight/Plugin/PluginCollection.php
@@ -76,7 +76,7 @@ abstract class Enlight_Plugin_PluginCollection extends Enlight_Class implements 
     /**
      * Getter method for the plugin list.
      *
-     * @return  ArrayIterator
+     * @return ArrayObject
      */
     public function getIterator()
     {


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Will fix problems with IDEs such as PHPStorm. The current return type annotation, `ArrayIterator`, is not correct. `$this->plugins`is of type `ArrayObject` which is defined by the PHPDoc type annotation of this property (line 43). This is really misleading.  |
| BC breaks?              | No  |
| Tests exists & pass?    | No |
| Related tickets?        |   |
| How to test?            |   |
| Requirements met?       | I hope so :) |

## Versions ## 
The issue exists in v5.3 and in the v5.4 branch as well.

## Further Notes ## 
The name of the corresponding method, `getIterator`, is confusing. Take a look at this code:
```php
/** @var Enlight_Plugin_PluginCollection $pluginCollection */
$plugins = $pluginCollection->getIterator();
/** @var \ArrayObject $plugins */
$pluginsIterator = $plugins->getIterator();
```
The naming of the methods is not intuitive. Maybe it should be changed.