### PR TITLE
Patch smarty recursive mkdir race condition

### DIFF
--- a/engine/Library/Smarty/sysplugins/smarty_internal_write_file.php
+++ b/engine/Library/Smarty/sysplugins/smarty_internal_write_file.php
@@ -36,8 +36,9 @@ class Smarty_Internal_Write_File {
 
         $_dirpath = dirname($_filepath);
         // if subdirs, create dir structure
-        if ($_dirpath !== '.' && !file_exists($_dirpath)) {
-            mkdir($_dirpath, $smarty->_dir_perms === null ? 0777 : $smarty->_dir_perms, true);
+        if ($_dirpath !== '.' && !@self::ensureDirectoryExists($_dirpath, $smarty->_dir_perms)) {
+            error_reporting($_error_reporting);
+            throw new SmartyException("unable to create directory {$_dirpath}");
         }
 
         // write to tmp file, then move to overt file lock race condition
@@ -83,5 +84,27 @@ class Smarty_Internal_Write_File {
 
         error_reporting($_error_reporting);
         return $success;
+    }
+
+    /**
+     * Recursively creates the missing parts of a directory path in a manner that is concurrency-safe.
+     *
+     * @see https://bugs.php.net/bug.php?id=35326
+     *
+     * @param string $pathname a (nested) directory path to create
+     * @param integer $mode the permission to use
+     * @return bool true iff the directory path was successfully created
+     */
+    private static function ensureDirectoryExists($pathname, $mode)
+    {
+        $path_segments = explode(DIRECTORY_SEPARATOR, $pathname);
+
+        $current_pathname = '';
+        foreach ($path_segments as $path_segment) {
+            $current_pathname = $current_pathname . $path_segment . DIRECTORY_SEPARATOR;
+            @mkdir($current_pathname, $mode);
+        }
+
+        return is_dir($pathname);
     }
 }


### PR DESCRIPTION
**This issue is affecting multiple customers, rendering the backend unusable after a cache clear for some of them. Because if this, we would really appreciate this patch being backported to 5.2 soon.**

This is a backport of the code in https://github.com/smarty-php/smarty/pull/379 to Shopware's vendored Smarty 3.1.8.

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | PHP's recursive `mkdir()` implementation is not concurrency-safe, which means smarty compilation on multiple requests is not concurrency safe, which has been causing significant problems for Shopware ERP customers in the last few weeks. See description below for details.|
| BC breaks?              | No. |
| Tests exists & pass?    | not really unit-testable |
| Related tickets?        | dunno |
| How to test?            | Clear the cache and reload the backend. Repeat a couple of times. |
| Requirements met?       | Yes. |

## Gory details

PHP's recursive `mkdir()` implementation may fail to create a nested directory structure when another process tries to create a nested directory structure that shares a prefix with the original process at the same time. This is a known issue (cf. https://bugs.php.net/bug.php?id=35326), but the PHP maintainers have decided that providing concurrency-safe behaviour is out of scope for PHP and should be handled by the application instead.

Here is [a small demonstrator script](https://gist.github.com/fixpunkt/5881bfeba51d64926c99d0339d3b8c02) that triggers the race condition in PHP's recursive `mkdir()` implementation and shows that my PHP reimplementation of recursive `mkdir()` behaves correctly even in the concurrent scenario.

Smarty as used in shopware uses a nested directory structures for its template cache. This directory structure is created on-the-fly here: https://github.com/shopware/shopware/blob/5.3/engine/Library/Smarty/sysplugins/smarty_internal_write_file.php#L40. When multiple requests try to compile the same template after a cache has been cleared, the race condition within `mkdir()`-recursive may cause both requests to fail, resulting in a template compilation error, which is shown as an error in the backend and prevents some Subapplications from loading correctly.

Some changes in ERP have resulted in this bug being triggered much more frequently over the last few weeks. Some of our customers have been hitting this issue with increasing frequency lately, which made the backend completely unusable for them.

Props to Sebastian Grüny (intoCommerce) and @stefanheppenheimer for their help in figuring out this issue!