### PR TITLE
Set service dbal_connection while container building

### DIFF
--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -24,6 +24,7 @@
 
 namespace Shopware;
 
+use Doctrine\DBAL\DriverManager;
 use Enlight_Controller_Request_RequestHttp as EnlightRequest;
 use Enlight_Controller_Response_ResponseHttp as EnlightResponse;
 use Shopware\Bundle\AttributeBundle\DependencyInjection\Compiler\SearchRepositoryCompilerPass;
@@ -592,6 +593,14 @@ class Kernel implements HttpKernelInterface
      */
     protected function prepareContainer(ContainerBuilder $container)
     {
+        if ($this->connection !== null) {
+            $connection = DriverManager::getConnection([
+                'pdo' => $this->connection
+            ]);
+
+            $container->set('dbal_connection', $connection);
+        }
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/Components/DependencyInjection/'));
         $loader->load('services.xml');
         $loader->load('theme.xml');


### PR DESCRIPTION
## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Register services or set parameters to container while container building from informations from database.  |
| BC breaks?              | no |
| Tests exists & pass?    | yes |
| Related tickets?        |  |
| How to test?            | See below example |
| Requirements met?       | Yes |

```php
class ShyimExample extends Plugin
{
    public function build(ContainerBuilder $container)
    {
        parent::build($container);

        $config = new Plugin\DBALConfigReader($container->get('dbal_connection'));
        $pluginConfig = $config->getByPluginName('ShyimExample');
        if ($pluginConfig['fooIntegration']) {
            $container->addCompilerPass(new FooIntegrationCompilerPass());
        }

        $container->setParameter('shyim_example.plugin_config', $pluginConfig);
    }
}
```
