### PR TITLE
Remove jquery plugin event listeners on destroy

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.address-editor.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.address-editor.js
@@ -169,7 +169,7 @@
                             addressId: addressId
                         });
 
-                        $.unsubscribe(me.getEventName(me.getEventName('plugin/swModal/onOpen')));
+                        $.unsubscribe(me.getEventName('plugin/swModal/onOpen'));
                     });
 
                     $.publish('plugin/swAddressEditor/onAddressFetchSuccess', [ me, data ]);

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.address-editor.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.address-editor.js
@@ -169,7 +169,7 @@
                             addressId: addressId
                         });
 
-                        $.unsubscribe(me.getEventName('plugin/swModal/onOpen'));
+                        $.unsubscribe(me.getEventName(me.getEventName('plugin/swModal/onOpen')));
                     });
 
                     $.publish('plugin/swAddressEditor/onAddressFetchSuccess', [ me, data ]);

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.collapse-cart.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.collapse-cart.js
@@ -542,6 +542,9 @@
         destroy: function () {
             var me = this;
 
+            $.unsubscribe('plugin/swAddArticle/onAddArticle');
+            $.unsubscribe('plugin/swAddArticle/onBeforeAddArticle');
+
             me.off(me.eventSuffix);
 
             me._destroy();

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.collapse-cart.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.collapse-cart.js
@@ -163,8 +163,8 @@
             if (me.isDisplayMode('offcanvas')) {
                 me._on(me._$triggerEl, 'click touchstart', $.proxy(me.onMouseEnter, me));
 
-                $.subscribe('plugin/swAddArticle/onAddArticle', $.proxy(me.onArticleAdded, me));
-                $.subscribe('plugin/swAddArticle/onBeforeAddArticle', $.proxy(me.onBeforeAddArticle, me));
+                $.subscribe(me.getEventName('plugin/swAddArticle/onAddArticle'), $.proxy(me.onArticleAdded, me));
+                $.subscribe(me.getEventName('plugin/swAddArticle/onBeforeAddArticle'), $.proxy(me.onBeforeAddArticle, me));
             } else {
                 me._on('.container--ajax-cart,' + me.opts.triggerElSelector, 'mousemove', $.proxy(me.onMouseHover, me));
                 me._on(me._$triggerEl, 'mouseenter touchstart', $.proxy(me.onMouseEnter, me));
@@ -542,8 +542,8 @@
         destroy: function () {
             var me = this;
 
-            $.unsubscribe('plugin/swAddArticle/onAddArticle');
-            $.unsubscribe('plugin/swAddArticle/onBeforeAddArticle');
+            $.unsubscribe(me.getEventName('plugin/swAddArticle/onAddArticle'));
+            $.unsubscribe(me.getEventName('plugin/swAddArticle/onBeforeAddArticle'));
 
             me.off(me.eventSuffix);
 

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
@@ -657,8 +657,8 @@
             window.StateManager.on('resize', $.proxy(me.onResize, me));
 
             if (me.opts.fullscreen) {
-                $.subscribe('plugin/swEmotionLoader/onShowEmotion', $.proxy(me.onShow, me));
-                $.subscribe('plugin/swEmotionLoader/onHideEmotion', $.proxy(me.onHide, me));
+                $.subscribe(me.getEventName('plugin/swEmotionLoader/onShowEmotion'), $.proxy(me.onShow, me));
+                $.subscribe(me.getEventName('plugin/swEmotionLoader/onHideEmotion'), $.proxy(me.onHide, me));
             }
 
             $.publish('plugin/swEmotion/onRegisterEvents', [ me ]);
@@ -802,8 +802,8 @@
             var me = this;
 
             if (me.opts.fullscreen) {
-                $.unsubscribe('plugin/swEmotionLoader/onShowEmotion');
-                $.unsubscribe('plugin/swEmotionLoader/onHideEmotion');
+                $.unsubscribe(me.getEventName('plugin/swEmotionLoader/onShowEmotion'));
+                $.unsubscribe(me.getEventName('plugin/swEmotionLoader/onHideEmotion'));
             }
 
             me._destroy();

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
@@ -801,6 +801,11 @@
         destroy: function() {
             var me = this;
 
+            if (me.opts.fullscreen) {
+                $.unsubscribe('plugin/swEmotionLoader/onShowEmotion');
+                $.unsubscribe('plugin/swEmotionLoader/onHideEmotion');
+            }
+
             me._destroy();
         }
     });

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
@@ -275,8 +275,8 @@
 
             me._on(me._$imageContainer.find(me.opts.imageSlideSelector), 'click', $.proxy(me.onClick, me));
 
-            $.subscribe('plugin/swImageSlider/onSlide', $.proxy(me.onImageUpdate, me));
-            $.subscribe('plugin/swImageSlider/onUpdateTransform', $.proxy(me.onImageUpdate, me));
+            $.subscribe(me.getEventName('plugin/swImageSlider/onSlide'), $.proxy(me.onImageUpdate, me));
+            $.subscribe(me.getEventName('plugin/swImageSlider/onUpdateTransform'), $.proxy(me.onImageUpdate, me));
 
             me._on(window, 'keydown', $.proxy(me.onKeyDown, me));
 
@@ -598,8 +598,8 @@
                 plugin.destroy();
             }
 
-            $.unsubscribe('plugin/swImageSlider/onSlide');
-            $.unsubscribe('plugin/swImageSlider/onUpdateTransform');
+            $.unsubscribe(me.getEventName('plugin/swImageSlider/onSlide'));
+            $.unsubscribe(me.getEventName('plugin/swImageSlider/onUpdateTransform'));
 
             me.$template.remove();
             me.$template = null;

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
@@ -598,6 +598,9 @@
                 plugin.destroy();
             }
 
+            $.unsubscribe('plugin/swImageSlider/onSlide');
+            $.unsubscribe('plugin/swImageSlider/onUpdateTransform');
+
             me.$template.remove();
             me.$template = null;
 

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-zoom.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-zoom.js
@@ -448,6 +448,11 @@
         destroy: function () {
             var me = this;
 
+            $.unsubscribe('plugin/swImageSlider/onRightArrowClick');
+            $.unsubscribe('plugin/swImageSlider/onLeftArrowClick');
+            $.unsubscribe('plugin/swImageSlider/onClick');
+            $.unsubscribe('plugin/swImageSlider/onLightbox');
+
             me.$lens.remove();
             me.$flyout.remove();
             me.$container.removeClass(me.opts.containerCls);

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-zoom.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-zoom.js
@@ -78,10 +78,10 @@
             me._on(me.$container, 'mouseout', $.proxy(me.stopZoom, me));
             me._on(me.$lens, 'click', $.proxy(me.onLensClick, me));
 
-            $.subscribe('plugin/swImageSlider/onRightArrowClick', $.proxy(me.stopZoom, me));
-            $.subscribe('plugin/swImageSlider/onLeftArrowClick', $.proxy(me.stopZoom, me));
-            $.subscribe('plugin/swImageSlider/onClick', $.proxy(me.stopZoom, me));
-            $.subscribe('plugin/swImageSlider/onLightbox', $.proxy(me.stopZoom, me));
+            $.subscribe(me.getEventName('plugin/swImageSlider/onRightArrowClick'), $.proxy(me.stopZoom, me));
+            $.subscribe(me.getEventName('plugin/swImageSlider/onLeftArrowClick'), $.proxy(me.stopZoom, me));
+            $.subscribe(me.getEventName('plugin/swImageSlider/onClick'), $.proxy(me.stopZoom, me));
+            $.subscribe(me.getEventName('plugin/swImageSlider/onLightbox'), $.proxy(me.stopZoom, me));
 
             $.publish('plugin/swImageZoom/onRegisterEvents', [ me ]);
         },
@@ -448,10 +448,10 @@
         destroy: function () {
             var me = this;
 
-            $.unsubscribe('plugin/swImageSlider/onRightArrowClick');
-            $.unsubscribe('plugin/swImageSlider/onLeftArrowClick');
-            $.unsubscribe('plugin/swImageSlider/onClick');
-            $.unsubscribe('plugin/swImageSlider/onLightbox');
+            $.unsubscribe(me.getEventName('plugin/swImageSlider/onRightArrowClick'));
+            $.unsubscribe(me.getEventName('plugin/swImageSlider/onLeftArrowClick'));
+            $.unsubscribe(me.getEventName('plugin/swImageSlider/onClick'));
+            $.unsubscribe(me.getEventName('plugin/swImageSlider/onLightbox'));
 
             me.$lens.remove();
             me.$flyout.remove();

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.last-seen-products.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.last-seen-products.js
@@ -359,6 +359,14 @@
             });
 
             return queryParams;
-        }
+        },
+
+        destroy: function() {
+            var me = this;
+
+            $.unsubscribe(me.getEventName('plugin/swAjaxVariant/onRequestData'));
+
+            me._destroy();
+        },
     });
 }(jQuery));

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.lightbox.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.lightbox.js
@@ -48,7 +48,7 @@
                     me.setSize(me.image.width, me.image.height);
                 });
 
-                $.subscribe('plugin/swModal/onClose', function() {
+                $.subscribe(me.getEventName('plugin/swModal/onClose'), function() {
                     $(window).off('resize.lightbox');
                 });
             };
@@ -137,7 +137,7 @@
         destroy: function() {
             var me = this;
 
-            $.unsubscribe('plugin/swModal/onClose');
+            $.unsubscribe(me.getEventName('plugin/swModal/onClose'));
 
             me._destroy();
         },

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.lightbox.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.lightbox.js
@@ -132,6 +132,14 @@
             $.publish('plugin/swLightbox/onGetOptimizedSize', [ me, size ]);
 
             return size;
-        }
+        },
+
+        destroy: function() {
+            var me = this;
+
+            $.unsubscribe('plugin/swModal/onClose');
+
+            me._destroy();
+        },
     };
 })(jQuery, window, Math);

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.modal.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.modal.js
@@ -739,7 +739,7 @@
 
             me._on(me.$target, 'click', $.proxy(me.onClick, me));
 
-            $.subscribe('plugin/swModal/onClose', $.proxy(me.onClose, me));
+            $.subscribe(me.getEventName('plugin/swModal/onClose'), $.proxy(me.onClose, me));
 
             $.publish('plugin/swModalbox/onRegisterEvents', [ me ]);
         },
@@ -793,7 +793,7 @@
                 $.modal.close();
             }
 
-            $.unsubscribe('plugin/swModal/onClose', $.proxy(me.onClose, me));
+            $.unsubscribe(me.getEventName('plugin/swModal/onClose'));
 
             me._destroy();
         }

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.off-canvas-menu.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.off-canvas-menu.js
@@ -229,7 +229,7 @@
             // Allow the user to close the off canvas menu
             me.$offCanvas.on(me.getEventName('click'), opts.closeButtonSelector, $.proxy(me.onClickCloseButton, me));
 
-            $.subscribe('plugin/swOffcanvasMenu/onBeforeOpenMenu', $.proxy(me.onBeforeOpenMenu, me));
+            $.subscribe(me.getEventName('plugin/swOffcanvasMenu/onBeforeOpenMenu'), $.proxy(me.onBeforeOpenMenu, me));
 
             $.publish('plugin/swOffcanvasMenu/onRegisterEvents', [ me ]);
         },
@@ -391,7 +391,7 @@
 
             me.$el.off(me.getEventName('click'), opts.closeButtonSelector);
 
-            $.unsubscribe('plugin/swOffcanvasMenu/onBeforeOpenMenu', $.proxy(me.onBeforeOpenMenu, me));
+            $.unsubscribe(me.getEventName('plugin/swOffcanvasMenu/onBeforeOpenMenu'));
 
             me._destroy();
         }

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js
@@ -1081,6 +1081,13 @@
         destroy: function () {
             var me = this;
 
+            if (me.opts.initOnEvent !== null) {
+                $.unsubscribe(me.opts.initOnEvent);
+            }
+
+            $.unsubscribe('plugin/swTabMenu/onChangeTab');
+            $.unsubscribe('plugin/swCollapsePanel/onOpenPanel');
+
             if (me.$arrowPrev) me.$arrowPrev.remove();
             if (me.$arrowNext) me.$arrowNext.remove();
 

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js
@@ -320,7 +320,7 @@
             }
 
             if (me.opts.initOnEvent !== null) {
-                $.subscribe(me.opts.initOnEvent, function() {
+                $.subscribe(me.getEventName(me.opts.initOnEvent), function() {
                     if (!me.initialized) {
                         me.initSlider();
                         me.registerEvents();
@@ -435,8 +435,8 @@
 
             me._on($window, 'resize', $.proxy(me.buffer, me, me.update, 600));
 
-            $.subscribe('plugin/swTabMenu/onChangeTab', $.proxy(me.update, me));
-            $.subscribe('plugin/swCollapsePanel/onOpenPanel', $.proxy(me.update, me));
+            $.subscribe(me.getEventName('plugin/swTabMenu/onChangeTab'), $.proxy(me.update, me));
+            $.subscribe(me.getEventName('plugin/swCollapsePanel/onOpenPanel'), $.proxy(me.update, me));
 
             $.publish('plugin/swProductSlider/onRegisterEvents', [ me ]);
         },
@@ -1082,11 +1082,11 @@
             var me = this;
 
             if (me.opts.initOnEvent !== null) {
-                $.unsubscribe(me.opts.initOnEvent);
+                $.unsubscribe(me.getEventName(me.opts.initOnEvent));
             }
 
-            $.unsubscribe('plugin/swTabMenu/onChangeTab');
-            $.unsubscribe('plugin/swCollapsePanel/onOpenPanel');
+            $.unsubscribe(me.getEventName('plugin/swTabMenu/onChangeTab'));
+            $.unsubscribe(me.getEventName('plugin/swCollapsePanel/onOpenPanel'));
 
             if (me.$arrowPrev) me.$arrowPrev.remove();
             if (me.$arrowNext) me.$arrowNext.remove();


### PR DESCRIPTION
To prevent side effects, a jquery plugin should remove its event listeners when its being destroyed.

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Keeping its event listeners after a plugin is destroyed may cause unwanted side effects. |
| BC breaks?              | no |
| Tests exists & pass?    | no (do not exist) |
| Related tickets?        | - |
| How to test?            | Destroy an initialised plugin. If it has event listeners attached to other plugins, trigger these events. The plugin object has been destroyed, but the event listener is still active, most likely causing a JavaScript error.  |
| Requirements met?       | yes |