### PR TITLE
Added notifyUntil event before invalidating cache

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -659,6 +659,16 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
         } else {
             $entityName = get_class($entity);
         }
+        
+        if (Shopware()->Events()->notifyUntil(
+            'Shopware_Plugins_HttpCache_ShouldNotInvalidateCache',
+            [
+                'entity' => $entity,
+                'entityName' => $entityName
+            ]
+        )) {
+            return;
+        }
 
         $cacheIds = [];
 


### PR DESCRIPTION
In huge shop systems (10,000 products, 50 subshops) you should not always clear the cache for every entity. In this setup clearing the cache for a category with a lof of articles will take minutes.

<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Please describe *why* your change is necessary. |
| BC breaks?              | yes/no |
| Tests exists & pass?    | yes/no |
| Related tickets?        | If this PR fixes an existing issue ticket, please add there url here. |
| How to test?            | Please describe how to best verify that this PR is correct. |
| Requirements met?       | Does your PR fulfil our [contribution requirements](https://developers.shopware.com/contributing/contribution-guideline/#requirements-for-a-successful-pull-request)? |