### PR TITLE
Emotion boxed width should comply with @desktopViewportWidth

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/emotions.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/emotions.less
@@ -154,7 +154,7 @@ body.emotion--preview {
 .emotion--wrapper {
     display: block;
     margin: 0 auto;
-    max-width: 1160px;
+    max-width: @desktopViewportWidth;
     overflow: hidden;
 
     &.is--fullscreen {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware!

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).

Take the time to edit the "Answers" rows with the necessary information.
Click the form's "Preview button" to make sure the table is functional in GitHub.
-->

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | Emotion elements should get same width in boxed mode as header and footer |
| BC breaks?              | no |
| Tests exists & pass?    | yes/no |
| Related tickets?        |  |
| How to test?            | Create a Shopping World with fullscreen mode disabled. The shopping world has a different size in desktop mode than the header and footer. Does not look good. |
| Requirements met?       | you tell me?|