### PR TITLE
Added notifyUntil event before invalidating cache

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -659,6 +659,16 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
         } else {
             $entityName = get_class($entity);
         }
+        
+        if (Shopware()->Events()->notifyUntil(
+            'Shopware_Plugins_HttpCache_ShouldNotInvalidateCache',
+            [
+                'entity' => $entity,
+                'entityName' => $entityName
+            ]
+        )) {
+            return;
+        }
 
         $cacheIds = [];
 


### PR DESCRIPTION
### 1. Why is this change necessary?
In huge shop systems (10,000 products, 50 subshops) you should not always clear the cache for every entity. In this setup clearing the cache for a category with a lof of articles will take minutes.

### 2. What does this change do, exactly?
It adds a notifyUntil before invalidating caches to stop further processing.

### 3. Describe each step to reproduce the issue or behaviour.
Create a shop with thousands of articles and categories, multiple subshops and create a category with lots of articles in it. Save the category and invalidating the cache will take a lot of time.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.