### PR TITLE
Added is_object to secure smarty functions

### DIFF
--- a/engine/Shopware/Configs/smarty_functions.php
+++ b/engine/Shopware/Configs/smarty_functions.php
@@ -216,6 +216,7 @@ return [
     'is_nan',
     'is_null',
     'is_numeric',
+    'is_object',
     'is_string',
     'iterator_apply',
     'iterator_count',


### PR DESCRIPTION
Added is_object to secure smarty functions

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | This function is missing in the allowed smarty function list. We use it in our template to check if a custom article attribute is set: if ( is_object( $sArticle.attributes.my_plugin ) ) |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | None. |
| How to test?            | Use is_object() in any template. |
| Requirements met?       | Yes |