### PR TITLE
Fix SW-19032

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Resource.php
+++ b/engine/Shopware/Components/Api/Resource/Resource.php
@@ -424,7 +424,7 @@ abstract class Resource
                 );
                 continue;
             }
-            if ($entity->$method() == $value) {
+            if ($entity->$method() === $value) {
                 return $entity;
             }
         }


### PR DESCRIPTION
This commit fixes the issue outlined in https://issues.shopware.com/issues/SW-19032

I personally encountered the very same issue in Shopware 5.2.27 the exact same way and came to the same conclusion as the ticket creator.

Either way this is a very, very, insanely easy fix that doesn't break tests (coverage says this condition is covered in 49 tests) and it also allows third-party plugin creators to create entities with circular dependencies that can be used via the API without problems.