### PR TITLE
Whitelist array() built-in in smarty security

### DIFF
--- a/engine/Shopware/Configs/smarty_functions.php
+++ b/engine/Shopware/Configs/smarty_functions.php
@@ -28,6 +28,7 @@ return [
     'acosh',
     'addcslashes',
     'addslashes',
+    'array',
     'array_change_key_case',
     'array_chunk',
     'array_column',


### PR DESCRIPTION
### 1. Why is this change necessary?

Smarty erroneously treats the PHP `array()` built-in as a function and applies its PHP function security policy to it (https://github.com/shopware/shopware/blob/9a116f29f78c0005e031e34ffcce919b6a50e3a9/engine/Library/Smarty/sysplugins/smarty_internal_templateparser.php#L2871). This causes template security to prevent `array()` from being used from templates.

Right now, we work around this for Shopware 5.3 by using `array_fill(0, 0, null)` within our templates instead of `array()`.

### 2. What does this change do, exactly?

It adds the `array()` built-in to Shopware's whitelist of functions that are allowed within smarty templates.

### 3. Describe each step to reproduce the issue or behaviour.

Call `array()` from a template (e.g. by doing `{assign var=a value=array()}`) and try to compile that on Shopware 5.3. Smarty security will throw an Exception.

After applying the patch, remember to clear the cache before testing the fix.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.