### PR TITLE
Fix SW-19523

### DIFF
--- a/engine/Shopware/Components/Plugin/CronjobSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/CronjobSynchronizer.php
@@ -86,6 +86,7 @@ class CronjobSynchronizer
             $this->connection->update('s_crontab', $cronjob, ['id' => $id]);
         } else {
             $cronjob['next'] = new DateTime();
+            $cronjob['end'] = new DateTime();
             $this->connection->insert('s_crontab', $cronjob, ['next' => 'datetime']);
         }
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
New cronjobs are never 'active', because the 'end' date is never set. 

### 2. What does this change do, exactly?
Setting the 'end' date of *new* cronjobs, so the 'active' flag will actually be useful. As a result, plugins which are set `active` in the `cronjob.xml` file, will actually be executed / activated. (Which is the expected behavior)

### 3. Describe each step to reproduce the issue or behaviour.
Install any plugin with `cronjob.xml`, and look at the configuration of the cronjobs. It will show as 'not active' in configuration, even though you may have included `<active>true</active>` within the XML. 

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-19523

### 5. Which documentation changes (if any) need to be made because of this PR?
None, this fixes a bug. 

### 6. Checklist

- [x] [N/A] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
