### PR TITLE
Fix getShopArrayByHostAlias when s_core_shops.hosts has only one line

### DIFF
--- a/engine/Shopware/Models/Shop/Repository.php
+++ b/engine/Shopware/Models/Shop/Repository.php
@@ -575,11 +575,12 @@ class Repository extends ModelRepository
     private function getShopArrayByHostAlias($host)
     {
         $query = $this->getDbalShopsQuery();
-        $query->where('(shop.hosts LIKE :host1 OR shop.hosts LIKE :host2 OR shop.hosts LIKE :host3)');
+        $query->where('(shop.hosts LIKE :host1 OR shop.hosts LIKE :host2 OR shop.hosts LIKE :host3 OR shop.hosts LIKE :host4)');
         $query->andWhere('shop.active = 1');
         $query->setParameter('host1', "%\n" . $host . "\n%");
         $query->setParameter('host2', $host . "\n%");
         $query->setParameter('host3', "%\n" . $host);
+        $query->setParameter('host4', $host);
         $query->orderBy('shop.main_id');
         $query->addOrderBy('shop.position');
         $query->setMaxResults(1);


### PR DESCRIPTION
Fix \Shopware\Models\Shop\Repository::getShopArrayByHostAlias when s_core_shops.hosts has only one line.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Invalid redirect to default shop when the hosts alias field have only one line.

### 2. What does this change do, exactly?
It fixes the query which tries to search for a shop by host aliases.

### 3. Describe each step to reproduce the issue or behaviour.
Create a new subshop with a custom domain and put in hostalias just an alternative host (e.g. example.com without www) without any new line. Just "example.com" - not "example.com\n" or similar.

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.