### PR TITLE
Don't display warnings related to session in CLI applications

### DIFF
--- a/engine/Shopware/Components/Log/Processor/ShopwareEnvironmentProcessor.php
+++ b/engine/Shopware/Components/Log/Processor/ShopwareEnvironmentProcessor.php
@@ -50,7 +50,7 @@ class ShopwareEnvironmentProcessor
                 'query' => $this->filterRequestUserData($request->getQuery()),
                 'post' => $this->filterRequestUserData($request->getPost()),
             ];
-        } elseif ($_SERVER['REQUEST_URI']) {
+        } elseif (!empty($_SERVER['REQUEST_URI'])) {
             $record['extra']['request'] = [
                 'uri' => $_SERVER['REQUEST_URI'],
                 'method' => $_SERVER['REQUEST_METHOD'],
@@ -73,7 +73,7 @@ class ShopwareEnvironmentProcessor
             $record['extra']['shop'] = 'No shop data available';
         }
 
-        if (is_object($_SESSION['Shopware']['Auth'])) {
+        if (!empty($_SESSION) && is_object($_SESSION['Shopware']['Auth'])) {
             $record['extra']['session'] = [
                 'userId' => $_SESSION['Shopware']['Auth']->id,
                 'roleId' => $_SESSION['Shopware']['Auth']->roleID,


### PR DESCRIPTION
When using logger in CLI scripts warnings are displayed because of the fact that env processor is accessing session and server variables available only in case of HTTP interface.