### PR TITLE
Bugfix for ProductAttributeFacetHandler

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ProductAttributeFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ProductAttributeFacetHandler.php
@@ -99,7 +99,7 @@ class ProductAttributeFacetHandler implements PartialFacetHandlerInterface
 
         $sqlField = 'productAttribute.' . $facet->getField();
         $query->andWhere($sqlField . ' IS NOT NULL')
-            ->andWhere($sqlField . " NOT IN ('', 0, '0000-00-00')");
+            ->andWhere($sqlField . " NOT IN ('', '0', '0000-00-00')");
 
         /** @var ConfigurationStruct $attribute */
         $attribute = $this->crudService->get('s_articles_attributes', $facet->getField());


### PR DESCRIPTION
### 1. Why is this change necessary?
Bug in the facet handler of free text facets


### 2. What does this change do, exactly?
0 will be equal to any string because of automatic typecasting - therefore it has to be removed or replaced by a string zero 

### 3. Describe each step to reproduce the issue or behaviour.
Try to setup a free text facet with random strings


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.