### PR TITLE
Fix for nesting level too deep

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Resource.php
+++ b/engine/Shopware/Components/Api/Resource/Resource.php
@@ -424,7 +424,7 @@ abstract class Resource
                 );
                 continue;
             }
-            if ($entity->$method() == $value) {
+            if ($entity->$method() === $value) {
                 return $entity;
             }
         }


### PR DESCRIPTION

### 1. Why is this change necessary?
Uploading child articles with more than one image causes a
"Fatal error: nesting too deep - recursive dependency"
error in
"/engine/Shopware/Components/Api/Resource/Resource.php line 427"
and stops the upload.


This ensures a correct and more clean way to check for the value
and avoids returning wrong entity instead of NULL.


### 2. What does this change do, exactly?
This is fixed by changing the return value check of
$entity->$method() == $value to
$entity->$method() === $value
in
"/engine/Shopware/Components/Api/Resource/Resource.php line 427"

### 3. Describe each step to reproduce the issue or behaviour.
Uploading child articles with more than one image causes a
"Fatal error: nesting too deep - recursive dependency"
error in
"/engine/Shopware/Components/Api/Resource/Resource.php line 427"
and stops the upload.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.