### PR TITLE
Keep array keys in array_slice

### DIFF
--- a/engine/Shopware/Bundle/SearchBundle/BatchProductNumberSearch.php
+++ b/engine/Shopware/Bundle/SearchBundle/BatchProductNumberSearch.php
@@ -100,7 +100,7 @@ class BatchProductNumberSearch
         }
 
         // use internal pointer to return different products to each request with the same criteria/context
-        $items = array_slice($baseProducts, $this->pointer[$key], $numberOfProducts);
+        $items = array_slice($baseProducts, $this->pointer[$key], $numberOfProducts, true);
         $missingItems = $numberOfProducts - count($items);
         $this->pointer[$key] += count($items);
 


### PR DESCRIPTION
Another bug that prevented working product streams for a slightly different scenario then the one before this

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Product streams weren't working because the array keys for the products kept vanishing

### 2. What does this change do, exactly?
Preserve array keys for further usage

### 3. Describe each step to reproduce the issue or behaviour.
1. Install Shopware 5.2.25
2. Create some articles (more then 25 with article numbers counting up from 1)
3. Create a product stream to filter the products
4. Add an article slider to an "Erlebnisswelt" with the newly created product stream
5. Watch as the only articles with IDs from 0 - 24 get selected for display.

(could not reproduce this on shopwaredemo.com... dont know why)

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
No changes needed

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.