### PR TITLE
Change PSD File Type to unknown

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/MediaExtensionMappingService.php
+++ b/engine/Shopware/Bundle/MediaBundle/MediaExtensionMappingService.php
@@ -52,7 +52,7 @@ class MediaExtensionMappingService implements MediaExtensionMappingServiceInterf
         'tiff' => Media::TYPE_IMAGE,
         'eps' => Media::TYPE_VECTOR,
         'pbm' => Media::TYPE_IMAGE,
-        'psd' => Media::TYPE_IMAGE,
+        'psd' => Media::TYPE_UNKNOWN,
         'wbm' => Media::TYPE_IMAGE,
         '264' => Media::TYPE_VIDEO,
         '3g2' => Media::TYPE_VIDEO,


### PR DESCRIPTION
Changing PSD File Type to unknown, because media manager tries to generate an thumbnail and fails.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.