### PR TITLE
Added service "modules" to di-container via services.xml

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -21,9 +21,7 @@
             <deprecated>The "%service_id%" service is deprecated since 5.2 and will be removed in 6.0.</deprecated>
         </service>
         
-        <service id="modules" class="Shopware_Components_Modules">
-            <factory service="Shopware_Plugins_Core_System_Bootstrap" method="onInitResourceModules" />
-        </service>
+        <service id="modules" class="Shopware_Components_Modules" synthetic="true" />
         <service id="modules.articles" class="sArticles">
             <factory service="modules" method="Articles" />
         </service>

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -20,6 +20,10 @@
             <argument type="service" id="service_container"/>
             <deprecated>The "%service_id%" service is deprecated since 5.2 and will be removed in 6.0.</deprecated>
         </service>
+        
+        <service id="modules" class="Shopware_Components_Modules">
+            <factory service="Shopware_Plugins_Core_System_Bootstrap" method="onInitResourceModules" />
+        </service>
 
         <service id="locale_factory" class="Shopware\Components\DependencyInjection\Bridge\Locale" />
         <service id="shopware.locale" alias="locale" />

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -24,6 +24,39 @@
         <service id="modules" class="Shopware_Components_Modules">
             <factory service="Shopware_Plugins_Core_System_Bootstrap" method="onInitResourceModules" />
         </service>
+        <service id="modules.articles" class="sArticles">
+            <factory service="modules" method="Articles" />
+        </service>
+        <service id="modules.categories" class="sCategories">
+            <factory service="modules" method="Categories" />
+        </service>
+        <service id="modules.basket" class="sBasket">
+            <factory service="modules" method="Basket" />
+        </service>
+        <service id="modules.marketing" class="sMarketing">
+            <factory service="modules" method="Marketing" />
+        </service>
+        <service id="modules.system" class="sSystem">
+            <factory service="modules" method="System" />
+        </service>
+        <service id="modules.admin" class="sAdmin">
+            <factory service="modules" method="Admin" />
+        </service>
+        <service id="modules.order" class="sOrder">
+            <factory service="modules" method="Order" />
+        </service>
+        <service id="modules.cms" class="sCms">
+            <factory service="modules" method="Cms" />
+        </service>
+        <service id="modules.core" class="sCore">
+            <factory service="modules" method="Core" />
+        </service>
+        <service id="modules.rewrite_table" class="sRewriteTable">
+            <factory service="modules" method="RewriteTable" />
+        </service>
+        <service id="modules.export" class="sExport">
+            <factory service="modules" method="Export" />
+        </service>
 
         <service id="locale_factory" class="Shopware\Components\DependencyInjection\Bridge\Locale" />
         <service id="shopware.locale" alias="locale" />


### PR DESCRIPTION
Added a section for an instance of Shopware_Components_Modules to services.xml to make it possible to depend on it. Also added every core class as a service using the new "modules"-service as a factory.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Without this change it is impossible to have a service with a dependency on "modules". Let's say I need to have some information of sAdmin in my service. Until now the only way to achieve this was to use `Shopware()->Modules()->Admin()`. But since the monolith should not be used, this is bad practice. The reason for this behavior is located in `Shopware_Plugins_Core_System_Bootstrap::onInitResourceModules`. This is called once the service "modules" is instantiated. But here's the catch: This only works after plugin events are registered, which happens after the di-container's logic.

### 2. What does this change do, exactly?
This change adds the service "modules" one step earlier than before. This is achieved through an entry in the services.xml file instead of a registration on an event.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a plugin (in the 5.2-system).
- Create a service and enter it in the services.xml file.
- Give the service an argument that is a service with the id "modules".
- See that your entire system dies because at the time the service "modules" is required it neither exists not is the event `Shopware_Plugins_Core_System_Bootstrap::onInitResourceModules` registered yet.

### 4. Please link to the relevant issues (if any).
None (yet).

### 5. Which documentation changes (if any) need to be made because of this PR?
None (I think).

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.