### PR TITLE
Make Unitize behave like CSS properties

### DIFF
--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/unitize.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/unitize.less
@@ -21,8 +21,8 @@ In addition to the general `.unitize()` mixin, Shopware contains specific mixins
 `.unitize-max-height(@value)`<br/>
 `.unitize-max-width(@value)`<br/>
 `.unitize-min-width(@value)`<br/>
-`.unitize-padding(@topValue, @rightValue, @bottomValue: @topValue, @leftValue: @rightValue)`<br/>
-`.unitize-margin(@topValue, @rightValue, @bottomValue: @topValue, @leftValue: @rightValue)`<br/>
+`.unitize-padding(@topValue, @rightValue: @topValue, @bottomValue: @topValue, @leftValue: @rightValue)`<br/>
+`.unitize-margin(@topValue, @rightValue: @topValue, @bottomValue: @topValue, @leftValue: @rightValue)`<br/>
 `.unitize-variable(@value)`<br/>
 */
 
@@ -41,7 +41,7 @@ In addition to the general `.unitize()` mixin, Shopware contains specific mixins
 	@{property}: ~"@{remValue}rem";
 }
 
-.unitize-multiple(@topValue, @rightValue, @bottomValue: @topValue, @leftValue: @rightValue, @baseValue: @remScaleFactor, @property: padding) {
+.unitize-multiple(@topValue, @rightValue: @topValue, @bottomValue: @topValue, @leftValue: @rightValue, @baseValue: @remScaleFactor, @property: padding) {
 	@pxTopValue: @topValue;
 	@emTopValue: (@topValue / @baseValue);
 
@@ -82,11 +82,11 @@ In addition to the general `.unitize()` mixin, Shopware contains specific mixins
     .unitize(min-width, @value, @baseValue);
 }
 
-.unitize-margin(@topValue, @rightValue, @bottomValue: @topValue, @leftValue: @rightValue, @baseValue: @remScaleFactor) {
+.unitize-margin(@topValue, @rightValue: @topValue, @bottomValue: @topValue, @leftValue: @rightValue, @baseValue: @remScaleFactor) {
 	.unitize-multiple(@topValue, @rightValue, @bottomValue, @leftValue, @baseValue, margin);
 }
 
-.unitize-padding(@topValue, @rightValue, @bottomValue: @topValue, @leftValue: @rightValue, @baseValue: @remScaleFactor) {
+.unitize-padding(@topValue, @rightValue: @topValue, @bottomValue: @topValue, @leftValue: @rightValue, @baseValue: @remScaleFactor) {
 	.unitize-multiple(@topValue, @rightValue, @bottomValue, @leftValue, @baseValue, padding);
 }
 


### PR DESCRIPTION
Adjust .unitize-padding, .unitize-margin, .unitize-multiple to behave like standard CSS properties. I.E. you can just supply a single value like this:
.unitize-padding(10);

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Better usability for FE devs

### 2. What does this change do, exactly?
Change signature of .unitize-multiple, .unitize-margin, .unitize-padding mixins to conform to standard CSS properties

### 3. Describe each step to reproduce the issue or behaviour.
Use .unitize-padding, .unitize-margin, .unitize-multiple with only one argument and try to compile themes

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
Inline documentation included in PR

### 6. Checklist

- [ n ] I have written tests and verified that they fail without my change
- [ y ] I have squashed any insignificant commits
- [ y ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ y ] I have read the contribution requirements and fulfil them.