### PR TITLE
Fix action columns not being extendable dynamically

### DIFF
--- a/engine/Library/ExtJs/overrides/Ext.grid.column.Action.js
+++ b/engine/Library/ExtJs/overrides/Ext.grid.column.Action.js
@@ -35,7 +35,6 @@ Ext.override(Ext.grid.column.Action, {
         var me = this,
             cfg = Ext.apply({}, config),
             items = cfg.items || [me],
-            l = items.length,
             i,
             item;
 
@@ -52,8 +51,8 @@ Ext.override(Ext.grid.column.Action, {
             v = Ext.isFunction(cfg.renderer) ? cfg.renderer.apply(this, arguments)||'' : '';
 
             meta.tdCls += ' ' + Ext.baseCSSPrefix + 'action-col-cell';
-            for (i = 0; i < l; i++) {
-                item = items[i];
+            for (i = 0; i < me.items.length; i++) {
+                item = me.items[i];
                 item.disable = Ext.Function.bind(me.disableAction, me, [i]);
                 item.enable = Ext.Function.bind(me.enableAction, me, [i]);
 


### PR DESCRIPTION
Hello, I am a employee of VIISON GmbH / Pickware. This is my first pull request.

### 1. Why is this change necessary?
Actions column items cannot be added or removed after the action column has been instanciated.

### 2. What does this change do, exactly?
Change the renderer closure of the action columns to items can now be removed and added dynamically again.

The problem is because the variable `var l = items.length` is defined outside the `me.renderer` closure ...
https://github.com/shopware/shopware/blob/301699adba5f423cb0b0a11795e912fe21478118/engine/Library/ExtJs/overrides/Ext.grid.column.Action.js#L38
and used inside the closure:
https://github.com/shopware/shopware/blob/301699adba5f423cb0b0a11795e912fe21478118/engine/Library/ExtJs/overrides/Ext.grid.column.Action.js#L55
When now the items get modified after the action column object has been initialized, the value for `l` is not updated.
Solution: Get the length of `me.items` dynamically. (See commit of pull request)

### 3. Describe each step to reproduce the issue or behaviour.
The problem is for example reproducable with the order document table. The action column of this table is instanciated in the createActionColumn method (which is called directly by the initComponent() method)

```
    /**
     * Creates the action columns
     *
     * @returns { Ext.grid.column.Action }
     */
    createActionColumn: function() {
        var me = this;

        return Ext.create('Ext.grid.column.Action', {
            width: 60,
            items: [
                me.createDeleteColumn(),
                me.createSendColumn()
            ]
        });
    },
```
If you try to extend the action column now by doing the following:
```
Ext.define('Shopware.apps.Example.view.list.Document', {

    override: 'Shopware.apps.Order.view.list.Document',

    createActionColumn: function() {
        var actionColums = this.callParent(arguments);
        actionColums.items.push({
            iconCls: 'sprite-mail-send',
            action: 'example'
        });
        return actionColums;
    }
}
```
... the action column is not changed as expected.
