### PR TITLE
Changed visibility of createEntitySearchQuery

### DIFF
--- a/engine/Shopware/Controllers/Backend/Search.php
+++ b/engine/Shopware/Controllers/Backend/Search.php
@@ -302,7 +302,7 @@ class Shopware_Controllers_Backend_Search extends Shopware_Controllers_Backend_E
      *
      * @return \Doctrine\ORM\QueryBuilder
      */
-    private function createEntitySearchQuery($entity)
+    public function createEntitySearchQuery($entity)
     {
         /** @var \Doctrine\ORM\QueryBuilder $query */
         $query = $this->get('models')->createQueryBuilder();


### PR DESCRIPTION


### 1. Why is this change necessary?

The method createEntitySearchQuery should technically be part of a repository. While this might be too big of a change at the very least the method should be public. That's because I need to be able to alter the returned query builder when the method is called by searchAction for enhancing various entity searches on the backend side.

### 2. What does this change do, exactly?

Change visibility of method createEntitySearchQuery from private to public

### 3. Describe each step to reproduce the issue or behaviour.

-

### 4. Please link to the relevant issues (if any).

-

### 5. Which documentation changes (if any) need to be made because of this PR?

none

### 6. Checklist

- [x ] I have written tests and verified that they fail without my change
- [x ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x] I have read the contribution requirements and fulfil them.