### PR TITLE
support functional test for new structure plugins

### DIFF
--- a/engine/Library/Enlight/Components/Test/Controller/TestCase.php
+++ b/engine/Library/Enlight/Components/Test/Controller/TestCase.php
@@ -151,6 +151,13 @@ abstract class Enlight_Components_Test_Controller_TestCase extends Enlight_Compo
 
         $container->load('Front');
         $container->load('Plugins');
+
+        foreach ($container->get('kernel')->getPlugins() as $plugin) {
+            if (!$plugin->isActive()) {
+                continue;
+            }
+            $container->get('events')->addSubscriber($plugin);
+        }
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
If you create a functional test in the new structure (custom/plugins) and use `Enlight_Components_Test_Plugin_TestCase`  the subscriber won’t get called or just once. 

### 2. What does this change do, exactly?
The issue was that the class `Enlight_Components_Test_Plugin_TestCase`  just calls `$container->load('Plugins');` what does not initialize the plugins. I added the code from the kernel, which initializes the plugins and all their subscribers. 

### 3. Describe each step to reproduce the issue or behaviour.
Just create a plugin with a PostDispatch-Function that dies on call.

File: /customer/plugins/FirstPlugin/FirstPlugin.php
```
<?php
namespace FirstPlugin;

use Shopware\Components\Plugin;

class FirstPlugin extends Plugin
{
    /**
     * @return array
     */
    public static function getSubscribedEvents(): array
    {
        return [
            'Enlight_Controller_Action_PreDispatch_Frontend_Detail' => 'dieInPreDispecth',
        ];
    }
    /**
     * @param \Enlight_Controller_ActionEventArgs $args
     */
    public function dieInPreDispecth(\Enlight_Controller_ActionEventArgs $args)
    {
        die(__FILE__);
    }
}
```
If you visit a detail page in the browser, you can see the die-Message. So the method get calls.

The test written for the case “fails”. When I dispatch on the detail page I get a full response and don’t die on load.

File: /customer/plugins/FirstPlugin/Test/Functional/FirstPluginTest.php

```
<?php
namespace FirstPlugin\Test\Functional;

class FirstPluginTest extends \Enlight_Components_Test_Controller_TestCase
{
    public function testDieInPreDispecth()
    {
        $response = $this->dispatch('/detail/index/sArticle/8');
        var_dump($response);
    }
}
```

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.