### PR TITLE
Correctly create QueryBuilder with $indexBy parameter

### DIFF
--- a/engine/Shopware/Components/Model/ModelRepository.php
+++ b/engine/Shopware/Components/Model/ModelRepository.php
@@ -55,7 +55,7 @@ class ModelRepository extends EntityRepository
     public function createQueryBuilder($alias, $indexBy = null)
     {
         /** @var QueryBuilder $builder */
-        $builder = parent::createQueryBuilder($alias, $indexBy = null);
+        $builder = parent::createQueryBuilder($alias, $indexBy);
         $builder->setAlias($alias);
 
         return $builder;


### PR DESCRIPTION
### 1. Why is this change necessary?
It provides ability to created indexed queries with Shopware'e ModelRespoitory

### 2. What does this change do, exactly?
Minor fix which allows to use $indeBy in QueryBuilder in case of repositories based on Shopware's ModelRepository.


### 3. Describe each step to reproduce the issue or behaviour.
Create query builder in shopware's repository using second parameter - it will be disregarded.

### 4. Please link to the relevant issues (if any).
-


### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.