### PR TITLE
Allow creation of documents for inactive subshops

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -15,6 +15,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 * Changed `engine/Library/Smarty/sysplugins/smarty_internal_write_file.php` in order to prevent race condition when creating directories concurrently
 * Support namespaces for controllers. The event `Enlight_Controller_Dispatcher_ControllerPath_{module}_{controller}` now accepts a class name as return value to allow namespaces for controllers in plugins.
 * Changed representation of empty `conditions` in `s_customer_streams` to NULL instead of `{}`
+* Add Shopware\Models\Shop\Repository::getById() to retrieve shops regardless of active state
 
 
 ## 5.3.0

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -532,7 +532,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
 
         $repository = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop');
         // "language" actually refers to a language-shop and not to a locale
-        $shop = $repository->getActiveById($this->_order->order->language);
+        $shop = $repository->getById($this->_order->order->language);
         if (!empty($this->_order->order->currencyID)) {
             $repository = Shopware()->Models()->getRepository('Shopware\Models\Shop\Currency');
             $shop->setCurrency($repository->find($this->_order->order->currencyID));

--- a/engine/Shopware/Models/Shop/Repository.php
+++ b/engine/Shopware/Models/Shop/Repository.php
@@ -276,6 +276,25 @@ class Repository extends ModelRepository
     }
 
     /**
+     * @param int $id
+     *
+     * @return DetachedShop
+     */
+    public function getById($id)
+    {
+        $builder = $this->getQueryBuilder();
+        $builder->andWhere('shop.id=:shopId');
+        $builder->setParameter('shopId', $id);
+        $shop = $builder->getQuery()->getOneOrNullResult();
+
+        if ($shop !== null) {
+            $shop = $this->fixActive($shop);
+        }
+
+        return $shop;
+    }
+
+    /**
      * Returns the default shop with additional data
      *
      * @return DetachedShop
@@ -368,7 +387,7 @@ class Repository extends ModelRepository
     /**
      * @return \Doctrine\ORM\QueryBuilder
      */
-    public function getActiveQueryBuilder()
+    public function getQueryBuilder()
     {
         /* @var $builder QueryBuilder */
         return $this->createQueryBuilder('shop')
@@ -399,9 +418,18 @@ class Repository extends ModelRepository
             ->leftJoin('main.template', 'mainTemplate')
             ->leftJoin('main.currencies', 'mainCurrencies')
 
-            ->where('shop.active = 1')
             ->orderBy('shop.main')
             ->addOrderBy('shop.position');
+    }
+
+    /**
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    public function getActiveQueryBuilder()
+    {
+        /* @var $builder QueryBuilder */
+        return $this->getQueryBuilder()
+            ->where('shop.active = 1');
     }
 
     /**

--- a/tests/Functional/Models/Shop/ShopRepositoryTest.php
+++ b/tests/Functional/Models/Shop/ShopRepositoryTest.php
@@ -273,4 +273,45 @@ class Shopware_Tests_Models_ShopRepositoryTest extends Enlight_Components_Test_C
         $order->setComment('');
         Shopware()->Models()->flush($order);
     }
+
+    /**
+     * Test Shopware\Models\Shop\Repository::getById() and getActiveById()
+     */
+    public function testRetrieveInactiveSubshop()
+    {
+        // Create test shops
+        $sql = "
+            INSERT IGNORE INTO `s_core_shops` (
+              `id`, `main_id`, `name`, `title`, `position`,
+              `host`, `base_path`, `base_url`, `hosts`,
+              `secure`, `secure_host`, `secure_base_path`,
+              `template_id`, `document_template_id`, `category_id`,
+              `locale_id`, `currency_id`, `customer_group_id`,
+              `fallback_id`, `customer_scope`, `default`, `active`
+            ) VALUES (
+              12, NULL, 'Testshop Active', 'Testshop Active', 0,
+              'activetest.in', NULL, NULL, '',
+              0, NULL, NULL,
+              11, 11, 11, 2, 1, 1, 2, 0, 0, 1
+            ), (
+              13, NULL, 'Testshop Inactive', 'Testshop Inactive', 0,
+              'inactivetest.in', NULL, NULL, '',
+              0, NULL, NULL,
+              11, 11, 11, 2, 1, 1, 2, 0, 0, 0
+            );
+        ";
+        Shopware()->Db()->exec($sql);
+
+        // Only active shops
+        $this->assertNotNull($this->shopRepository->getActiveById(12));
+        $this->assertNull($this->shopRepository->getActiveById(13));
+
+        // Also inactive shops
+        $this->assertNotNull($this->shopRepository->getById(12));
+        $this->assertNotNull($this->shopRepository->getById(13));
+
+        // Delete test shops
+        $sql = 'DELETE FROM s_core_shops WHERE id IN (12, 13);';
+        Shopware()->Db()->exec($sql);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Shopware crashes with `Call to a member function setCurrency() on null` [here](https://github.com/shopware/shopware/blob/v5.3.2/engine/Shopware/Components/Document.php#L538) when one tries to create an order document (e.g. invoice) for an order with an inactive language subshop. It's a real world issue, as even when the subshop is deactivated and nothing is sold anymore, one might have to create cancelation invoices some time later for older orders.
The problem is also super annoying, as the exception (if visible) is does not really tell you about where the problem might be coming from, which leads to painful and long debugging for an actually easy problem. Especially a regular shop owner will not be able to figure it out by himself.

### 2. What does this change do, exactly?
It fixes the exception which occurred before when creating an order document for an inactive subshop and therefore allows to create documents for inactive subshops as well. Before this was only possible for active subshops.

### 3. Describe each step to reproduce the issue or behaviour.
Create a document for an order of which the language subshop is inactive. It will crash and not create the PDF. Then try again after the fix is applied.

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.