### PR TITLE
Improves performance of product listing

### DIFF
--- a/themes/Frontend/Bare/frontend/listing/box_article.tpl
+++ b/themes/Frontend/Bare/frontend/listing/box_article.tpl
@@ -1,22 +1,26 @@
 {block name="frontend_listing_box_article_includes"}
 
     {if $productBoxLayout == 'minimal'}
-        {include file="frontend/listing/product-box/box-minimal.tpl"}
+        {$path = "frontend/listing/product-box/box-minimal.tpl"}
 
     {elseif $productBoxLayout == 'image'}
-        {include file="frontend/listing/product-box/box-big-image.tpl"}
+        {$path = "frontend/listing/product-box/box-big-image.tpl"}
 
     {elseif $productBoxLayout == 'slider'}
-        {include file="frontend/listing/product-box/box-product-slider.tpl"}
+        {$path = "frontend/listing/product-box/box-product-slider.tpl"}
 
     {elseif $productBoxLayout == 'emotion'}
-        {include file="frontend/listing/product-box/box-emotion.tpl"}
-    {elseif $productBoxLayout == 'list'}
-        {include file="frontend/listing/product-box/box-list.tpl"}
+        {$path = "frontend/listing/product-box/box-emotion.tpl"}
 
     {else}
+        {$path = "frontend/listing/product-box/box-emotion.tpl"}
+    {/if}
+    
+    {if $path == ''}
         {block name="frontend_listing_box_article_includes_additional"}
             {include file="frontend/listing/product-box/box-basic.tpl" productBoxLayout="basic"}
         {/block}
+    {else}
+        {include file=$path}
     {/if}
 {/block}

--- a/themes/Frontend/Bare/frontend/listing/box_article.tpl
+++ b/themes/Frontend/Bare/frontend/listing/box_article.tpl
@@ -1,5 +1,6 @@
 {block name="frontend_listing_box_article_includes"}
-
+    {$path = ''}
+    
     {if $productBoxLayout == 'minimal'}
         {$path = "frontend/listing/product-box/box-minimal.tpl"}
 
@@ -12,8 +13,8 @@
     {elseif $productBoxLayout == 'emotion'}
         {$path = "frontend/listing/product-box/box-emotion.tpl"}
 
-    {else}
-        {$path = "frontend/listing/product-box/box-emotion.tpl"}
+    {elseif $productBoxLayout == 'list'}
+        {$path = "frontend/listing/product-box/box-list.tpl"}
     {/if}
     
     {if $path == ''}


### PR DESCRIPTION
### 1. Why is this change necessary?
Each {include} causes that the page load time increases. Instead of using {include} in every if/else condition it's better to set the template file path in a variable and load the file afterwards. By testing it in a project we got a massive improvement. While (even if force compile === false) the listing did last about 8 seconds, loading the same listing now lasts about 300 milliseconds.

### 2. What does this change do, exactly?
Removing multiple usage of {include} in the box_article.tpl and instead set the file path of the different box templates into a variable to load the dynamically determined template afterwards.

### 3. Describe each step to reproduce the issue or behaviour.
Create a big list of articles in a category and navigate to the category's listing view in your browser. Loading the page is pretty slow. Now replace the original code in themes/Frontend/Bare/frontend/listing/box_article.tpl by the one I committed and you will see how this change improves the page load time.

### 4. Please link to the relevant issues (if any).
---

### 5. Which documentation changes (if any) need to be made because of this PR?
---

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.