### PR TITLE
Show Growl message when creating order document

### DIFF
--- a/themes/Backend/ExtJs/backend/order/controller/detail.js
+++ b/themes/Backend/ExtJs/backend/order/controller/detail.js
@@ -537,7 +537,8 @@ Ext.define('Shopware.apps.Order.controller.Detail', {
      * @param [Ext.container.Container] me
      */
     onCreateDocument: function(order, config, panel) {
-        var store = Ext.create('Shopware.apps.Order.store.Configuration');
+        var me = this,
+            store = Ext.create('Shopware.apps.Order.store.Configuration');
 
         panel.setLoading(true);
 
@@ -552,6 +553,8 @@ Ext.define('Shopware.apps.Order.controller.Detail', {
                 if ( rawData.success === true ) {
                     var data = rawData.data[0];
                     order.set(data);
+
+                    Shopware.Notification.createGrowlMessage(me.snippets.successTitle, me.snippets.documents.successMessage, me.snippets.growlMessage);
 
                     var documentStore = order['getReceiptStore'],
                         documents = order.get('documents');
@@ -570,6 +573,8 @@ Ext.define('Shopware.apps.Order.controller.Detail', {
                         model['getDocTypeStore'] = typeStore;
                         documentStore.add(model);
                     });
+                } else {
+                    Shopware.Notification.createGrowlMessage(me.snippets.failureTitle, me.snippets.documents.failureMessage + '<br> ' + rawData.message, me.snippets.growlMessage);
                 }
             }
         });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When creating a document for an order in the backend there is neither a success nor a failure message. The document just appears in the list, but especially when recreating/overwriting a document it is not distinguishable when the action is actually finished. This is even more annoying, when an error occurs while creating the document. The problem is not visible for users at all and painful debugging ensues...

### 2. What does this change do, exactly?
Show success and error growl messages when creating an order document. The respective snippets for this where already present in the code BTW but never used.
![document-message](https://user-images.githubusercontent.com/710188/29661736-3fd85902-88c5-11e7-8d56-46b90cb99b9f.png)

### 3. Describe each step to reproduce the issue or behaviour.
Create a document in the backend and a success message should be shown. For some mPDF errors (missing rights on `files/documents` or no disk space for example) there will still be no correct error message unfortunately. The currently shipped mPDF version responds with an error string instead of throwing an exception (leading to a `200 OK` HTTP code, which will not be interpreted as a failure). This was fixed with mPDF `v6.1.0` (see https://github.com/mpdf/mpdf/commit/2d02c208b8d7b15c4208517375b9a10b0ea7cefa), once mPDF gets updated these exceptions will be shown as well.

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.