### PR TITLE
Added block to article model for adding associations

### DIFF
--- a/themes/Backend/ExtJs/backend/article/model/article.js
+++ b/themes/Backend/ExtJs/backend/article/model/article.js
@@ -101,6 +101,7 @@ Ext.define('Shopware.apps.Article.model.Article', {
         }
     ],
     associations: [
+        //{block name="backend/article/model/article/associations"}{/block}
         { type: 'hasMany', model: 'Shopware.apps.Article.model.Detail', name: 'getMainDetail', associationKey: 'mainDetail' },
         { type: 'hasMany', model: 'Shopware.apps.Article.model.Category', name: 'getCategory', associationKey: 'categories' },
         { type: 'hasMany', model: 'Shopware.apps.Article.model.SeoCategory', name: 'getSeoCategories', associationKey: 'seoCategories' },


### PR DESCRIPTION
### 1. Why is this change necessary?

If you extend the backend views of the article backend app, e.g. adding a new tab, you might want to use associations to handle relations between articles and custom models.

### 2. What does this change do, exactly?

Adds an empty smarty block prior to the default associations.  

### 3. Describe each step to reproduce the issue or behaviour.

-

### 4. Please link to the relevant issues (if any).

-

### 5. Which documentation changes (if any) need to be made because of this PR?

none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.