### PR TITLE
Add groupBy in getFilterQueryBuilder of multi_edit.product.filter

### DIFF
--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Filter.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Filter.php
@@ -137,8 +137,31 @@ class Filter
         } else {
             $builder->orderBy('detail.id', 'DESC');
         }
+        
+        if (!$this->displayVariants($tokens)) {
+            $builder->addGroupBy('article.id');
+        }
 
         return $builder;
+    }
+    
+    /**
+     * @param array[] $tokens
+     *
+     * @return bool
+     */
+    public function displayVariants($tokens)
+    {
+        foreach ($tokens as $filter) {
+            if (!isset($filter['token'])) {
+                continue;
+            }
+            if ($filter['token'] === 'ISMAIN') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/engine/Shopware/Controllers/Backend/ArticleList.php
+++ b/engine/Shopware/Controllers/Backend/ArticleList.php
@@ -358,7 +358,7 @@ class Shopware_Controllers_Backend_ArticleList extends Shopware_Controllers_Back
         $resource = $this->container->get('multi_edit.' . $resource);
         $result = $resource->filter($ast, $offset, $limit, $sort);
 
-        if ($this->displayVariants($ast)) {
+        if ($this->container->get('multi_edit.product.filter')->displayVariants($ast)) {
             $result = $this->addAdditionalText($result);
         }
 
@@ -599,25 +599,6 @@ class Shopware_Controllers_Backend_ArticleList extends Shopware_Controllers_Back
         }
 
         return $products;
-    }
-
-    /**
-     * @param array[] $ast
-     *
-     * @return bool
-     */
-    private function displayVariants($ast)
-    {
-        foreach ($ast as $filter) {
-            if (!isset($filter['token'])) {
-                continue;
-            }
-            if ($filter['token'] === 'ISMAIN') {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

Articles won't be grouped if there are variants lacking options for all groups of a configurator set.

### 2. What does this change do, exactly?

Migrated the method displayVariants into the multi_edit.product.filter service to be called from there. If variants are not to be shown, group the query by article.id.

### 3. Describe each step to reproduce the issue or behaviour.

Say we have three groups: a, b, c
All of them are part of a configurator set that is related to the article. For our project we had to make some changes to the configurator logic so we could have variants that only have associations to options of group a and c. Another variant only has associations to group b and c. And so on.
This resulted in variants of articles not being grouped correctly in the backend article listing and showing up as separate entities instead.

### 4. Please link to the relevant issues (if any).

-

### 5. Which documentation changes (if any) need to be made because of this PR?

-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.