### PR TITLE
Use UploadedFile instead of File

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Media.php
+++ b/engine/Shopware/Components/Api/Resource/Media.php
@@ -244,7 +244,7 @@ class Media extends Resource
         $name = $name . '.' . $ext;
         $path = $this->load($link, $name);
         $name = pathinfo($path, PATHINFO_FILENAME);
-        $file = new File($path);
+        $file = new UploadedFile($path, $link);
 
         $media = new MediaModel();
 


### PR DESCRIPTION
*Why*
To keep the file-ending and treat every file as an uploaded file.
If you are using `File` for files added via API, Shopware tries to guess the file-extension. This is sometimes wrong.
It's better to treat the files as `UploadedFile` instead of `File` so Shopware will use the given file-extension.

*What*
Use `UploadedFile` instead of `File`

## Description

| Questions               | Answers |
|-------------------------|-------------------------------------------------------|
| Why?                    | To keep the file-ending and treat every file as an uploaded file.
If you are using File for files added via API, Shopware tries to guess the file-extension. This is sometimes wrong.
It's better to treat the files as UploadedFile instead of File so Shopware will use the given file-extension. |
| BC breaks?              | no |
| Tests exists & pass?    | no |
| Related tickets?        | If this PR fixes an existing issue ticket, please add there url here. |
| How to test?            | Upload a file via API.
Before: If you upload a `.stp` file, it will be saved as `.txt`
After: If you upload a `.stp` file, it will be saved as `.stp` |
| Requirements met?       | Yes |