### PR TITLE
prevent scrolling on accept cookie permission

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-permission.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-permission.js
@@ -171,7 +171,8 @@
          * @public
          * @method onAcceptButtonClick
          */
-        onAcceptButtonClick: function() {
+        onAcceptButtonClick: function(event) {
+            event.preventDefault();
             var me = this;
 
             me.storage.setItem(me.storageKey, 'true');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
when someone is scrolled down on a page and clicks on the accept button, the page scrolls to the top

### 2. What does this change do, exactly?
prevent scrolling to the top by adding `preventDefault()` to the click handler

### 3. Describe each step to reproduce the issue or behaviour.
scroll down on the page
click accept button of the cookie notice

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.