### PR TITLE
Translate breadcrumb on campaign page

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Campaign.php
+++ b/engine/Shopware/Controllers/Frontend/Campaign.php
@@ -51,6 +51,10 @@ class Shopware_Controllers_Frontend_Campaign extends Enlight_Controller_Action
         $translator = new Shopware_Components_Translation();
         $translation = $translator->readWithFallback($shopId, $fallbackId, 'emotion', $emotionId);
 
+        if (!empty($translation['name'])) {
+            $landingPage['name'] = $translation['name'];
+        }
+
         if (!empty($translation['seoTitle'])) {
             $landingPage['seo_title'] = $translation['seoTitle'];
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
The breadcrumb is not translated on campaign pages.

### 2. What does this change do, exactly?
It translates the breadcrumb on campaign pages.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-19825

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.