### PR TITLE
Added default sorting to new vote module

### DIFF
--- a/themes/Backend/ExtJs/backend/vote/store/vote.js
+++ b/themes/Backend/ExtJs/backend/vote/store/vote.js
@@ -33,6 +33,10 @@ Ext.define('Shopware.apps.Vote.store.Vote', {
     model: 'Shopware.apps.Vote.model.Vote',
     configure: function() {
         return { controller: 'Vote' };
-    }
+    },
+    sorters: [{
+        property: 'datum',
+        direction: 'DESC'
+    }]
 });
 //{/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
Shows the latest votes after opening like in 5.2

### 2. What does this change do, exactly?
Adds default sorters

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-19793

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.