### PR TITLE
Added esd article support to rest-api

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -32,6 +32,8 @@ use Shopware\Models\Article\Article as ArticleModel;
 use Shopware\Models\Article\Configurator\Group;
 use Shopware\Models\Article\Configurator\Option;
 use Shopware\Models\Article\Detail;
+use Shopware\Models\Article\Esd;
+use Shopware\Models\Article\EsdSerial;
 use Shopware\Models\Article\Image;
 use Shopware\Models\Article\Price;
 use Shopware\Models\Article\Unit;
@@ -533,6 +535,9 @@ class Variant extends Resource implements BatchInterface
         }
         if (isset($data['images'])) {
             $data = $this->prepareImageAssociation($data, $article, $variant);
+        }
+        if (isset($data['esd'])) {
+            $data = $this->prepareEsdAssociation($data, $variant);
         }
 
         if (!empty($data['number']) && $data['number'] !== $variant->getNumber()) {
@@ -1039,5 +1044,110 @@ class Variant extends Resource implements BatchInterface
         }
 
         throw new ApiException\CustomValidationException(sprintf('To create a unit you need to pass `name` and `unit`'));
+    }
+
+    /**
+     * @param $data
+     * @param Detail $variant
+     * @return array
+     */
+    private function prepareEsdAssociation($data, Detail $variant)
+    {
+        if (is_array($data['esd'])) {
+            $esd = $variant->getEsd();
+
+            // Use already uploaded download file
+            if (!isset($data['esd']['reuse'])) {
+                $data['esd']['reuse'] = false;
+            }
+
+            if (!$esd) {
+                $esd = new Esd();
+                $esd->setArticleDetail($variant);
+            }
+
+            if (isset($data['esd']['link'])) {
+                $file = $this->getMediaResource()->load($data['esd']['link']);
+                $fileName = pathinfo($data['esd']['link'], PATHINFO_FILENAME);
+                $fileExt = pathinfo($data['esd']['link'], PATHINFO_EXTENSION);
+
+                $esdDir = Shopware()->DocPath('files_' . Shopware()->Config()->get('sESDKEY'));
+
+                // File already exists?
+                if (file_exists($esdDir . '/' . $fileName . '.' . $fileExt) && !$data['esd']['reuse']) {
+                    $saveFileName = uniqid($fileName) . '.' . $fileExt;
+                } else {
+                    $saveFileName = $fileName . '.' . $fileExt;
+                }
+                $saveFile = $esdDir . '/' . $saveFileName;
+
+                copy($file, $saveFile);
+                @unlink($file);
+                $data['esd']['file'] = $saveFileName;
+            }
+
+            if (isset($data['esd']['serials'])) {
+                $data = $this->prepareEsdSerialsAssociation($data, $esd);
+            }
+
+            $esd->fromArray($data['esd']);
+            $variant->setEsd($esd);
+        } elseif (is_null($data['esd'])) {
+            $variant->setEsd(null);
+        }
+
+        unset($data['esd']);
+
+        return $data;
+    }
+
+    /**
+     * @param array $data
+     * @param Esd $esd
+     * @return array
+     */
+    private function prepareEsdSerialsAssociation($data, Esd $esd)
+    {
+        // remove old serials
+        /** @var EsdSerial $serial */
+        foreach ($esd->getSerials() as $serial) {
+            $found = false;
+            foreach ($data['esd']['serials'] as $newSerial) {
+                if ($newSerial['serialnumber'] === $serial->getSerialnumber()) {
+                    $serial->fromArray($newSerial);
+                    $found = true;
+                    break;
+                }
+            }
+
+            if ($found === false) {
+                $this->manager->remove($serial);
+                $esd->getSerials()->removeElement($serial);
+            }
+        }
+
+        // add new items
+        foreach ($data['esd']['serials'] as $newSerial) {
+            $found = false;
+
+            /** @var EsdSerial $serial */
+            foreach ($esd->getSerials() as $serial) {
+                if ($newSerial['serialnumber'] === $serial->getSerialnumber()) {
+                    $found = true;
+                }
+            }
+
+            if ($found === false) {
+                $newSerialModel = new EsdSerial();
+                $newSerialModel->fromArray($newSerial);
+                $newSerialModel->setEsd($esd);
+                $this->getManager()->persist($newSerialModel);
+                $esd->getSerials()->add($newSerialModel);
+            }
+        }
+
+        unset($data['esd']['serials']);
+
+        return $data;
     }
 }

--- a/tests/Functional/Components/Api/VariantTest.php
+++ b/tests/Functional/Components/Api/VariantTest.php
@@ -28,6 +28,7 @@ use Shopware\Components\Api\Resource\Article;
 use Shopware\Components\Api\Resource\Resource;
 use Shopware\Components\Api\Resource\Variant;
 use Shopware\Models\Article\Configurator\Group;
+use Shopware\Models\Article\Esd;
 
 /**
  * @category  Shopware
@@ -748,6 +749,154 @@ class VariantTest extends TestCase
                 }
             }
         }
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateEsdVariant()
+    {
+        $params = array(
+            'name' => 'My awesome liquor',
+            'description' => 'hmmmmm',
+            'active' => true,
+            'taxId'      => 1,
+            'mainDetail' => array(
+                'number' => 'brand1' . uniqid(rand()),
+                'inStock' => 15,
+                'active' => true,
+
+                'prices' => array(
+                    array(
+                        'customerGroupKey' => 'EK',
+                        'from'  => 1,
+                        'price' => 50
+                    )
+                ),
+                'esd' => [
+                    'link' => 'file://' . __DIR__ . '/fixtures/shopware_logo.png',
+                    'reuse' => true,
+                ],
+
+            )
+        );
+
+        $article = $this->resourceArticle->create($params);
+
+        $this->assertInstanceOf(Esd::class, $article->getMainDetail()->getEsd());
+        $this->assertEquals('shopware_logo.png', $article->getMainDetail()->getEsd()->getFile());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateEsdWithSerialsVariant()
+    {
+        $params = array(
+            'name' => 'My awesome liquor',
+            'description' => 'hmmmmm',
+            'active' => true,
+            'taxId'      => 1,
+            'mainDetail' => array(
+                'number' => 'brand2' . uniqid(rand()),
+                'inStock' => 15,
+                'active' => true,
+
+                'prices' => array(
+                    array(
+                        'customerGroupKey' => 'EK',
+                        'from'  => 1,
+                        'price' => 50
+                    )
+                ),
+                'esd' => [
+                    'link' => 'file://' . __DIR__ . '/fixtures/shopware_logo.png',
+                    'reuse' => true,
+                    'hasSerials' => true,
+                    'serials' => [
+                        [
+                            'serialnumber' => '1000'
+                        ],
+                        [
+                            'serialnumber' => '1001'
+                        ],
+                        [
+                            'serialnumber' => '1002'
+                        ],
+                        [
+                            'serialnumber' => '1003'
+                        ],
+                        [
+                            'serialnumber' => '1004'
+                        ],
+                    ]
+                ],
+
+            )
+        );
+
+        $article = $this->resourceArticle->create($params);
+
+        $this->assertInstanceOf(Esd::class, $article->getMainDetail()->getEsd());
+        $this->assertEquals(5, $article->getMainDetail()->getEsd()->getSerials()->count());
+        $this->assertTrue($article->getMainDetail()->getEsd()->getHasSerials());
+        $this->assertEquals('shopware_logo.png', $article->getMainDetail()->getEsd()->getFile());
+    }
+
+    /**
+     * @depends testCreateEsdVariant
+     * @return void
+     */
+    public function testCreateEsdReuseVariant()
+    {
+        $params = array(
+            'name' => 'My awesome liquor',
+            'description' => 'hmmmmm',
+            'active' => true,
+            'taxId'      => 1,
+            'mainDetail' => array(
+                'number' => 'brand2' . uniqid(rand()),
+                'inStock' => 15,
+                'active' => true,
+
+                'prices' => array(
+                    array(
+                        'customerGroupKey' => 'EK',
+                        'from'  => 1,
+                        'price' => 50
+                    )
+                ),
+                'esd' => [
+                    'link' => 'file://' . __DIR__ . '/fixtures/shopware_logo.png',
+                    'hasSerials' => true,
+                    'serials' => [
+                        [
+                            'serialnumber' => '1000'
+                        ],
+                        [
+                            'serialnumber' => '1001'
+                        ],
+                        [
+                            'serialnumber' => '1002'
+                        ],
+                        [
+                            'serialnumber' => '1003'
+                        ],
+                        [
+                            'serialnumber' => '1004'
+                        ],
+                    ]
+                ],
+
+            )
+        );
+
+        $article = $this->resourceArticle->create($params);
+
+        $this->assertInstanceOf(Esd::class, $article->getMainDetail()->getEsd());
+        $this->assertEquals(5, $article->getMainDetail()->getEsd()->getSerials()->count());
+        $this->assertTrue($article->getMainDetail()->getEsd()->getHasSerials());
+        $this->assertNotEquals('shopware_logo.png', $article->getMainDetail()->getEsd()->getFile());
     }
 
     private function getVariantOptionsOfSet($configuratorSet)


### PR DESCRIPTION
### 1. Why is this change necessary?
Its currently impossible to create esd articles throught the api without passing Doctrine models

### 2. What does this change do, exactly?
Adds a transformer from array to doctrine models :)

### 3. Describe each step to reproduce the issue or behaviour.
Just check the tests

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
Document how the array looks like :D

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.