### PR TITLE
Fix topseller generation

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
@@ -424,7 +424,7 @@ class Shopware_Plugins_Core_MarketingAggregate_Bootstrap extends Shopware_Compon
             self::AGGREGATE_STRATEGY_LIVE
         );
 
-        if (!($this->isTopSellerActivated()) || $strategy !== self::AGGREGATE_STRATEGY_CRON_JOB) {
+        if ($strategy !== self::AGGREGATE_STRATEGY_CRON_JOB) {
             return true;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The setting for displaying topseller in the frontend prevents the cron job for generating latest topseller stats from doing his job. This leads to wrong "popular" sorting in listings and product streams because they are based on the generated topseller values.

### 2. What does this change do, exactly?
It removes the config check for `topSellerActive` inside the topseller cron job what allows the job to run even when the topseller frontend display is disabled.

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to `Performance > Einstellungen > Marketing > Topseller` and disable the setting `Topseller im Shop anzeigen`.
2. Enable the cron job `Topseller Refresh` and make sure that the cron job has run through.
3. Look into `s_articles_top_seller_ro` and you will see no updates here.

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.