### PR TITLE
Fixed warnings in cli while using PHP 7.2

### DIFF
--- a/engine/Library/Enlight/Event/EventManager.php
+++ b/engine/Library/Enlight/Event/EventManager.php
@@ -99,6 +99,10 @@ class Enlight_Event_EventManager extends Enlight_Class
     {
         $eventName = strtolower($handler->getName());
 
+        if (!isset($this->listeners[$eventName])) {
+            $this->listeners[$eventName] = [];
+        }
+
         $list =& $this->listeners[$eventName];
 
         if ($handler->getPosition()) {

--- a/engine/Library/Zend/Cache/Backend.php
+++ b/engine/Library/Zend/Cache/Backend.php
@@ -63,7 +63,7 @@ class Zend_Cache_Backend
      */
     public function __construct(array $options = array())
     {
-        while (list($name, $value) = each($options)) {
+        foreach ($options as $name => $value) {
             $this->setOption($name, $value);
         }
     }
@@ -78,7 +78,7 @@ class Zend_Cache_Backend
     public function setDirectives($directives)
     {
         if (!is_array($directives)) Zend_Cache::throwException('Directives parameter must be an array');
-        while (list($name, $value) = each($directives)) {
+        foreach ($directives as $name => $value) {
             if (!is_string($name)) {
                 Zend_Cache::throwException("Incorrect option name : $name");
             }

--- a/engine/Library/Zend/Cache/Core.php
+++ b/engine/Library/Zend/Cache/Core.php
@@ -143,7 +143,7 @@ class Zend_Cache_Core
             Zend_Cache::throwException("Options passed were not an array"
             . " or Zend_Config instance.");
         }
-        while (list($name, $value) = each($options)) {
+        foreach ($options as $name => $value) {
             $this->setOption($name, $value);
         }
         $this->_loggerSanity();


### PR DESCRIPTION
### 1. Why is this change necessary?
While executing commands on cli there a many warnings like
"PHP Deprecated:  The each() function is deprecated. This message will be suppressed on further calls in /var/www/clients/client1/web10/web/engine/Library/Zend/Cache/Backend.php on line 66"
or
"PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /var/www/clients/client1/web10/web/engine/Library/Enlight/Event/EventManager.php on line 111" 20 times

### 2. What does this change do, exactly?
Replaced deprecated each method with a simple foreach and fixes the count issue in eventmanager

### 3. Describe each step to reproduce the issue or behaviour.
Install PHP7.2RC1 and simple run php bin/console    

### 4. Please link to the relevant issues (if any).
Nothing

### 5. Which documentation changes (if any) need to be made because of this PR?
Nothing

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.