### PR TITLE
Fix: og:.. & twitter:description now displaying the same text as the default description

### DIFF
--- a/themes/Frontend/Bare/frontend/index/header.tpl
+++ b/themes/Frontend/Bare/frontend/index/header.tpl
@@ -18,13 +18,13 @@
         <meta property="og:type" content="website" />
         <meta property="og:site_name" content="{{config name=sShopname}|escapeHtml}" />
         <meta property="og:title" content="{{config name=sShopname}|escapeHtml}" />
-        <meta property="og:description" content="{s name='IndexMetaDescriptionStandard'}{/s}" />
+        <meta property="og:description" content="{block name='frontend_index_header_meta_description'}{s name='IndexMetaDescriptionStandard'}{/s}{/block}" />
         <meta property="og:image" content="{link file=$theme.desktopLogo fullPath}" />
 
         <meta name="twitter:card" content="website" />
         <meta name="twitter:site" content="{{config name=sShopname}|escapeHtml}" />
         <meta name="twitter:title" content="{{config name=sShopname}|escapeHtml}" />
-        <meta name="twitter:description" content="{s name='IndexMetaDescriptionStandard'}{/s}" />
+        <meta name="twitter:description" content="{block name='frontend_index_header_meta_description'}{s name='IndexMetaDescriptionStandard'}{/s}{/block}" />
         <meta name="twitter:image" content="{link file=$theme.desktopLogo fullPath}" />
     {/block}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If you change the Page Meta Description of the Root Kategory, the og:description & twitter:description didnt get it

### 2. What does this change do, exactly?
Change the Header.tpl and extend the og:description and twitter:discripton tag

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.