### PR TITLE
Argee88/sw 19720

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Components/SepaPaymentMethod.php
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Components/SepaPaymentMethod.php
@@ -89,6 +89,7 @@ class SepaPaymentMethod extends GenericPaymentMethod
             'bankname' => $request->getParam('sSepaBankName'),
             'iban' => preg_replace('/\s+|\./', '', $request->getParam('sSepaIban')),
             'bic' => $request->getParam('sSepaBic'),
+            'account_holder' => $request->getParam('sSepaAccountHolder'),
         ];
 
         $data = Shopware()->Container()->get('events')->filter('Sepa_Payment_Method_Save_Payment_Data', $data, [
@@ -126,6 +127,7 @@ class SepaPaymentMethod extends GenericPaymentMethod
                 'sSepaBankName' => $paymentData['bankName'],
                 'sSepaIban' => $paymentData['iban'],
                 'sSepaBic' => $paymentData['bic'],
+                'sSepaAccountHolder' => $paymentData['accountHolder'],
             ];
 
             $arrayData = Shopware()->Container()->get('events')->filter('Sepa_Payment_Method_Current_Payment_Data_Array', $arrayData, [
@@ -169,7 +171,7 @@ class SepaPaymentMethod extends GenericPaymentMethod
             'city' => $paymentData['sSepaUseBillingData'] ? $addressData->getCity() : null,
 
             'bank_name' => $paymentData['sSepaBankName'],
-            'account_holder' => $paymentData['sSepaUseBillingData'] ? ($addressData->getFirstname() . ' ' . $addressData->getLastname()) : null,
+            'account_holder' => !empty($paymentData['sSepaAccountHolder']) ? $paymentData['sSepaAccountHolder'] : ($paymentData['sSepaUseBillingData'] ? ($addressData->getFirstname() . ' ' . $addressData->getLastname()) : null),
             'bic' => $paymentData['sSepaBic'],
             'iban' => $paymentData['sSepaIban'],
 

--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/emotion/backend/customer/payment_methods/controller/detail.js
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/emotion/backend/customer/payment_methods/controller/detail.js
@@ -62,7 +62,7 @@ Ext.define('Shopware.apps.Customer.PaymentMethods.controller.Detail', {
                     });
                 }
                 paymentFieldSet.accountNumberField.hide().allowBlank = true;
-                paymentFieldSet.accountHolderField.hide().allowBlank = true;
+                paymentFieldSet.accountHolderField.show().allowBlank = true;
                 paymentFieldSet.bankCodeField.hide().allowBlank = true;
                 paymentFieldSet.bankNameField.allowBlank = true;
                 paymentFieldSet.useBillingDataField.show();

--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/emotion/backend/customer/payment_methods/controller/detail.js
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/emotion/backend/customer/payment_methods/controller/detail.js
@@ -105,8 +105,7 @@ Ext.define('Shopware.apps.Customer.PaymentMethods.controller.Detail', {
         if (form.getForm().isValid() && paymentData) {
             switch (paymentMean.get('name')) {
                 case 'sepa':
-                    values['paymentData[accountHolder]'] = "";
-                    values['paymentData[accountHolder]'] = "";
+                    values['paymentData[accountNumber]'] = "";
                     values['paymentData[bankCode]'] = "";
                     break;
                 case 'debit':

--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/emotion/backend/customer/payment_methods/view/detail/payment_methods.js
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/emotion/backend/customer/payment_methods/view/detail/payment_methods.js
@@ -17,7 +17,7 @@ Ext.define('Shopware.apps.Customer.view.detail.PaymentMethods', {
         }
         if (me.record.getPaymentData().first().get('name') === 'sepa') {
             me.fieldContainer.show();
-            me.accountHolderField.hide();
+            me.accountHolderField.show();
             me.accountNumberField.hide();
             me.bankCodeField.hide();
             me.ibanField.show();

--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/responsive/frontend/plugins/payment/sepa.tpl
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/responsive/frontend/plugins/payment/sepa.tpl
@@ -3,6 +3,14 @@
 <div class="debit">
     {block name="frontend_checkout_shipping_payment_core_payment_fields_sepa"}
         <p class="none">
+            <input name="sSepaAccountHolder"
+                   type="text"
+                   id="accountHolder"
+                   placeholder="{s name='PaymentDebitPlaceholderName'}{/s}"
+                   value="{$form_data.sSepaAccountHolder|escape}"
+                   class="{if $error_flags.sSepaAccountHolder} has--error{/if}" />
+        </p>
+        <p class="none">
             <input name="sSepaIban"
                    type="text"
                    id="iban"

--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/responsive/frontend/plugins/payment/sepa.tpl
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/responsive/frontend/plugins/payment/sepa.tpl
@@ -6,7 +6,7 @@
             <input name="sSepaAccountHolder"
                    type="text"
                    id="accountHolder"
-                   placeholder="{s name='PaymentDebitPlaceholderName'}{/s}"
+                   placeholder="{s name='PaymentSepaPlaceholderName'}{/s}"
                    value="{$form_data.sSepaAccountHolder|escape}"
                    class="{if $error_flags.sSepaAccountHolder} has--error{/if}" />
         </p>

--- a/snippets/frontend/plugins/payment/sepa.ini
+++ b/snippets/frontend/plugins/payment/sepa.ini
@@ -5,6 +5,7 @@ PaymentSepaLabelBankName = "Name of bank"
 PaymentSepaLabelBic = "BIC"
 PaymentSepaLabelIban = "IBAN"
 PaymentSepaLabelUseBillingData = "Use billing information for SEPA debit mandate?"
+PaymentSepaPlaceholderName = "Account holder"
 
 [de_DE]
 ErrorIBAN = "Ungültige IBAN"
@@ -13,3 +14,4 @@ PaymentSepaLabelBankName = "Ihre Bank"
 PaymentSepaLabelBic = "BIC"
 PaymentSepaLabelIban = "IBAN"
 PaymentSepaLabelUseBillingData = "Rechnungs-Adresse in Mandat übernehmen?"
+PaymentSepaPlaceholderName = "Konto-Inhaber"


### PR DESCRIPTION
### 1. Why is this change necessary?
It was not possible to add an account holder to SEPA payment method.

### 2. What does this change do, exactly?
1. It adds a field for the customer to enter an account holder himself.
2. It provides the logic to save and retrieve the data to and from the database. Also, it generates a payment-instance according to the provided data.
3. It displays the account holder field in the backend for the SEPA payment method.
4. It fixes a bug, where account number was not reseted when changing payment to SEPA.

### 3. Describe each step to reproduce the issue or behaviour.
Use version 5.3.1 and check for mentioned fields when using SEPA payment method.

### 4. Please link to the relevant issues (if any).
[SW-19720](https://issues.shopware.com/issues/SW-19720)

### 5. Which documentation changes (if any) need to be made because of this PR?
[German: Beispiel-Ansicht Storefront](http://community.shopware.com/SEPA-Lastschrift_detail_1449.html) and [English: Example from the storefront](http://en.community.shopware.com/_detail_1505.html) in SEPA documentation: Image needs to be updated.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.