### PR TITLE
bugfix - translation of attribute values in ProductAttributeFacetHandler

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ProductAttributeFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ProductAttributeFacetHandler.php
@@ -183,7 +183,7 @@ class ProductAttributeFacetHandler implements PartialFacetHandlerInterface
 
         $items = array_map(function ($row) use ($actives, $facet) {
             $viewName = $row[$facet->getField()];
-            $translation = $this->extractTranslations($row, $facet->getField());
+            $translation = $this->extractTranslations($row, '__attribute_'.$facet->getField());
             if ($translation !== null) {
                 $viewName = $translation;
             }


### PR DESCRIPTION
### 1. Why is this change necessary?
Translations do not work for values of product attributes in filter frontend display.

### 2. What does this change do, exactly?
Fetch correct translation


### 3. Describe each step to reproduce the issue or behaviour.
1. Setup an attribute filter with translations for a language shop
2. View filter in frontend - the values will not be translated

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ × ] I have written tests and verified that they fail without my change
- [ × ] I have squashed any insignificant commits
- [ × ] This change has comments for package types, values, functions, and non-obvious lines of code
- [×  ] I have read the contribution requirements and fulfil them.