### PR TITLE
bug fix - sort order of property options within a set (e.g. on article detail page)

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/PropertyGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/PropertyGateway.php
@@ -126,6 +126,7 @@ class PropertyGateway implements Gateway\PropertyGatewayInterface
             ->where('propertyOption.id IN (:ids)')
             ->groupBy('propertyOption.id')
             ->orderBy('propertySet.position')
+            ->orderBy('relations.position')
             ->setParameter(':ids', $valueIds, Connection::PARAM_INT_ARRAY);
 
         $this->fieldHelper->addMediaTranslation($query, $context);


### PR DESCRIPTION
## Clean Version of https://github.com/shopware/shopware/pull/1251

### 1. Why is this change necessary?
Property options are not displayed in the order provided in the backend on article's detail page

### 2. What does this change do, exactly?
Add the missing order-by to the related db query

### 3. Describe each step to reproduce the issue or behaviour.
Set up a couple of properties in the backend and try to sort them in a different order

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ x ] I have written tests and verified that they fail without my change
- [ x ] I have squashed any insignificant commits
- [ not needed ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.