### PR TITLE
Improved message for local plugin update

### DIFF
--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Snippets/backend/plugin_manager/translation.ini
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Snippets/backend/plugin_manager/translation.ini
@@ -1,7 +1,7 @@
 [en_GB]
 title = "Plugin Manager"
 binary_version = "Binary version"
-local_update = "Update"
+local_update = "Local update"
 installation_manual = "Installation manual"
 sbp_not_available = "Shopware store not available, store features disabled."
 execute_update = "Plugin is being updated"
@@ -215,7 +215,7 @@ content/safe_mode_off = "Safe Mode has been turned off"
 [de_DE]
 title = "Plugin Manager"
 shop = "Shop"
-local_update = "Update"
+local_update = "Lokales Update"
 initial_download = "Initialisiere Plugin Download"
 execute_plugin_download = "Plugin wird heruntergeladen"
 installation_manual = "Installationsanleitung"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently the update buttons are ambiguous if there is an update available via the store and also already locally uploaded:
![local update](https://user-images.githubusercontent.com/710188/30283074-6385903a-9717-11e7-94e0-6f0cece464c1.png)
The left button tries to download and install the update via the store, the right one just applies the local update.

### 2. What does this change do, exactly?
Clearer wording for the right, local update button.

### 3. Describe each step to reproduce the issue or behaviour.
Manually download an a newer version from the store and upload it via the plugin manager in the backend. Now both buttons will appear and it's unclear which means which.

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
n/a

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.