### PR TITLE
Add interface for LegacyStructConverter

### DIFF
--- a/engine/Shopware/Bundle/EmotionBundle/Service/StructConverter.php
+++ b/engine/Shopware/Bundle/EmotionBundle/Service/StructConverter.php
@@ -36,13 +36,13 @@ use Shopware\Bundle\EmotionBundle\Struct\Emotion;
 use Shopware\Bundle\EmotionBundle\Struct\Library\Component;
 use Shopware\Bundle\MediaBundle\MediaServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\Product\Manufacturer;
-use Shopware\Components\Compatibility\LegacyStructConverter;
+use Shopware\Components\Compatibility\LegacyStructConverterInterface;
 use Shopware\Components\DependencyInjection\Container;
 
 class StructConverter
 {
     /**
-     * @var LegacyStructConverter
+     * @var LegacyStructConverterInterface
      */
     private $converter;
 
@@ -62,12 +62,12 @@ class StructConverter
     private $container;
 
     /**
-     * @param LegacyStructConverter       $converter
-     * @param MediaServiceInterface       $mediaService
-     * @param \Enlight_Event_EventManager $eventManager
-     * @param Container                   $container
+     * @param LegacyStructConverterInterface $converter
+     * @param MediaServiceInterface          $mediaService
+     * @param \Enlight_Event_EventManager    $eventManager
+     * @param Container                      $container
      */
-    public function __construct(LegacyStructConverter $converter, MediaServiceInterface $mediaService, \Enlight_Event_EventManager $eventManager, Container $container)
+    public function __construct(LegacyStructConverterInterface $converter, MediaServiceInterface $mediaService, \Enlight_Event_EventManager $eventManager, Container $container)
     {
         $this->converter = $converter;
         $this->mediaService = $mediaService;

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -40,7 +40,7 @@ use Shopware\Models\Emotion\Emotion;
  *
  * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
-class LegacyStructConverter
+class LegacyStructConverter implements LegacyStructConverterInterface
 {
     /**
      * @var \Shopware_Components_Config

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverterInterface.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverterInterface.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Compatibility;
+
+use Shopware\Bundle\StoreFrontBundle;
+
+interface LegacyStructConverterInterface
+{
+    /**
+     * @param StoreFrontBundle\Struct\Country[] $countries
+     *
+     * @return array
+     */
+    public function convertCountryStructList($countries);
+
+    /**
+     * @param StoreFrontBundle\Struct\Country $country
+     *
+     * @return array
+     */
+    public function convertCountryStruct(StoreFrontBundle\Struct\Country $country);
+
+    /**
+     * @param StoreFrontBundle\Struct\Country\State[] $states
+     *
+     * @return array
+     */
+    public function convertStateStructList($states);
+
+    /**
+     * @param StoreFrontBundle\Struct\Country\State $state
+     *
+     * @return array
+     */
+    public function convertStateStruct(StoreFrontBundle\Struct\Country\State $state);
+
+    /**
+     * Converts a configurator group struct which used for default or selection configurators.
+     *
+     * @param StoreFrontBundle\Struct\Configurator\Group $group
+     *
+     * @return array
+     */
+    public function convertConfiguratorGroupStruct(StoreFrontBundle\Struct\Configurator\Group $group);
+
+    /**
+     * @param StoreFrontBundle\Struct\Category $category
+     *
+     * @throws \Exception
+     *
+     * @return array
+     */
+    public function convertCategoryStruct(StoreFrontBundle\Struct\Category $category);
+
+    /**
+     * @param StoreFrontBundle\Struct\ListProduct[] $products
+     *
+     * @return array
+     */
+    public function convertListProductStructList(array $products);
+
+    /**
+     * Converts the passed ListProduct struct to a shopware 3-4 array structure.
+     *
+     * @param StoreFrontBundle\Struct\ListProduct $product
+     *
+     * @return array
+     */
+    public function convertListProductStruct(StoreFrontBundle\Struct\ListProduct $product);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\Price $price
+     *
+     * @return array
+     */
+    public function convertProductPriceStruct(StoreFrontBundle\Struct\Product\Price $price);
+
+    /**
+     * Converts the passed ProductStream struct to an array structure.
+     *
+     * @param StoreFrontBundle\Struct\ProductStream $productStream
+     *
+     * @return array
+     */
+    public function convertRelatedProductStreamStruct(StoreFrontBundle\Struct\ProductStream $productStream);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product $product
+     *
+     * @return array
+     */
+    public function convertProductStruct(StoreFrontBundle\Struct\Product $product);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\VoteAverage $average
+     *
+     * @return array
+     */
+    public function convertVoteAverageStruct(StoreFrontBundle\Struct\Product\VoteAverage $average);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\Vote $vote
+     *
+     * @return array
+     */
+    public function convertVoteStruct(StoreFrontBundle\Struct\Product\Vote $vote);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\Price $price
+     *
+     * @return array
+     */
+    public function convertPriceStruct(StoreFrontBundle\Struct\Product\Price $price);
+
+    /**
+     * @param StoreFrontBundle\Struct\Media $media
+     *
+     * @return array
+     */
+    public function convertMediaStruct(StoreFrontBundle\Struct\Media $media = null);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\Unit $unit
+     *
+     * @return array
+     */
+    public function convertUnitStruct(StoreFrontBundle\Struct\Product\Unit $unit);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\Manufacturer $manufacturer
+     *
+     * @return string
+     */
+    public function getSupplierListingLink(StoreFrontBundle\Struct\Product\Manufacturer $manufacturer);
+
+    /**
+     * Example:
+     *
+     * return [
+     *     9 => [
+     *         'id' => 9,
+     *         'optionID' => 9,
+     *         'name' => 'Farbe',
+     *         'groupID' => 1,
+     *         'groupName' => 'Edelbrände',
+     *         'value' => 'goldig',
+     *         'values' => [
+     *             53 => 'goldig',
+     *         ],
+     *     ],
+     *     2 => [
+     *         'id' => 2,
+     *         'optionID' => 2,
+     *         'name' => 'Flaschengröße',
+     *         'groupID' => 1,
+     *         'groupName' => 'Edelbrände',
+     *         'value' => '0,5 Liter, 0,7 Liter, 1,0 Liter',
+     *         'values' => [
+     *             23 => '0,5 Liter',
+     *             24 => '0,7 Liter',
+     *             25 => '1,0 Liter',
+     *         ],
+     *     ],
+     * ];
+     *
+     * @param StoreFrontBundle\Struct\Property\Set $set
+     *
+     * @return array
+     */
+    public function convertPropertySetStruct(StoreFrontBundle\Struct\Property\Set $set);
+
+    /**
+     * @param StoreFrontBundle\Struct\Property\Group $group
+     *
+     * @return array
+     */
+    public function convertPropertyGroupStruct(StoreFrontBundle\Struct\Property\Group $group);
+
+    /**
+     * @param StoreFrontBundle\Struct\Property\Option $option
+     *
+     * @return array
+     */
+    public function convertPropertyOptionStruct(StoreFrontBundle\Struct\Property\Option $option);
+
+    /**
+     * @param StoreFrontBundle\Struct\Product\Manufacturer $manufacturer
+     *
+     * @return array
+     */
+    public function convertManufacturerStruct(StoreFrontBundle\Struct\Product\Manufacturer $manufacturer);
+
+    /**
+     * @param StoreFrontBundle\Struct\ListProduct      $product
+     * @param StoreFrontBundle\Struct\Configurator\Set $set
+     *
+     * @return array
+     */
+    public function convertConfiguratorStruct(
+        StoreFrontBundle\Struct\ListProduct $product,
+        StoreFrontBundle\Struct\Configurator\Set $set
+    );
+
+    /**
+     * @param StoreFrontBundle\Struct\ListProduct      $product
+     * @param StoreFrontBundle\Struct\Configurator\Set $set
+     *
+     * @return array
+     */
+    public function convertConfiguratorPrice(
+        StoreFrontBundle\Struct\ListProduct $product,
+        StoreFrontBundle\Struct\Configurator\Set $set
+    );
+
+    /**
+     * Creates the settings array for the passed configurator set
+     *
+     * @param StoreFrontBundle\Struct\Configurator\Set $set
+     * @param StoreFrontBundle\Struct\ListProduct      $product
+     *
+     * @return array
+     */
+    public function getConfiguratorSettings(
+        StoreFrontBundle\Struct\Configurator\Set $set,
+        StoreFrontBundle\Struct\ListProduct $product
+    );
+
+    /**
+     * Converts a configurator option struct which used for default or selection configurators.
+     *
+     * @param StoreFrontBundle\Struct\Configurator\Group  $group
+     * @param StoreFrontBundle\Struct\Configurator\Option $option
+     *
+     * @return array
+     */
+    public function convertConfiguratorOptionStruct(
+        StoreFrontBundle\Struct\Configurator\Group $group,
+        StoreFrontBundle\Struct\Configurator\Option $option
+    );
+
+    /**
+     * @param StoreFrontBundle\Struct\Blog\Blog $blog
+     *
+     * @return array
+     */
+    public function convertBlogStruct(StoreFrontBundle\Struct\Blog\Blog $blog);
+}

--- a/engine/Shopware/Controllers/Widgets/Listing.php
+++ b/engine/Shopware/Controllers/Widgets/Listing.php
@@ -26,7 +26,7 @@ use Shopware\Bundle\SearchBundle\ProductSearchInterface;
 use Shopware\Bundle\SearchBundle\ProductSearchResult;
 use Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\Search\CustomFacet;
-use Shopware\Components\Compatibility\LegacyStructConverter;
+use Shopware\Components\Compatibility\LegacyStructConverterInterface;
 use Shopware\Components\Routing\RouterInterface;
 
 /**
@@ -568,7 +568,7 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
      */
     private function convertArticlesResult(ProductSearchResult $result, $categoryId)
     {
-        /** @var LegacyStructConverter $converter */
+        /** @var LegacyStructConverterInterface $converter */
         $converter = $this->get('legacy_struct_converter');
         /** @var RouterInterface $router */
         $router = $this->get('router');

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -129,7 +129,7 @@ class sArticles
     private $db;
 
     /**
-     * @var \Shopware\Components\Compatibility\LegacyStructConverter
+     * @var \Shopware\Components\Compatibility\LegacyStructConverterInterface
      */
     private $legacyStructConverter;
 

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2134,7 +2134,7 @@ class sBasket
         $propertyService = $container->get('shopware_storefront.property_service');
         /** @var \Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface $context */
         $context = $container->get('shopware_storefront.context_service');
-        /** @var \Shopware\Components\Compatibility\LegacyStructConverter $legacyStructConverter */
+        /** @var \Shopware\Components\Compatibility\LegacyStructConverterInterface $legacyStructConverter */
         $legacyStructConverter = $container->get('legacy_struct_converter');
 
         $products = $listProduct->getList($numbers, $context->getShopContext());


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Any plugin decorating the `legacy_struct_converter` service will currently cause a fatal error in the EmotionBundle, because `Shopware\Bundle\EmotionBundle\Service\StructConverter` depends on the actual base implementation.

### 2. What does this change do, exactly?
It introduces an interface for the LegacyStructConverter and uses it in place of the actual implementation.

### 3. Describe each step to reproduce the issue or behaviour.
Decorate the service `legacy_struct_converter` and try to open any page with an emotion/shopping world.

You can use the attached example plugin `MyPlugin` for this:

<details><summary>MyPlugin.php</summary>

```php
<?php

namespace MyPlugin;

use Shopware\Components\Plugin;
use Shopware\Components\Compatibility\LegacyStructConverter as BaseService;

class MyPlugin extends Plugin
{
    public static function getSubscribedEvents()
    {
        return [
            'Enlight_Bootstrap_AfterInitResource_legacy_struct_converter' => 'decorateLegacyStructConverter',
        ];
    }

    public function decorateLegacyStructConverter()
    {
        $this->container->set(
            'legacy_struct_converter',
            new LegacyStructConverter($this->container->get('legacy_struct_converter'))
        );
    }
}

class LegacyStructConverter
{
    /** @var BaseService */
    private $baseService;

    /**
     * LegacyStructConverter constructor.
     *
     * @param BaseService $baseService
     */
    public function __construct(BaseService $baseService)
    {
        $this->baseService = $baseService;
    }

    /**
     * @param string $name
     * @param mixed  $arguments
     *
     * @return mixed
     */
    public function __call($name, $arguments)
    {
        return call_user_func_array([$this->baseService, $name], $arguments);
    }
}
```
</details>

You will then see this error instead of an emotion/shopping world:

```Uncaught TypeError: Argument 1 passed to Shopware\Bundle\EmotionBundle\Service\StructConverter::__construct() must be an instance of Shopware\Components\Compatibility\LegacyStructConverter, instance of MyPlugin\LegacyStructConverter given```

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
Probably none.

### 6. Checklist

- [X] I have written tests and verified that they fail without my change (see example plugin)
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

