### PR TITLE
Added support for less parser caching

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/theme.xml
+++ b/engine/Shopware/Components/DependencyInjection/theme.xml
@@ -10,7 +10,11 @@
         <service id="oyejorge_compiler" class="Shopware\Components\Theme\LessCompiler\Oyejorge">
             <argument type="service" id="oyejorge_compiler_lib" />
         </service>
-        <service id="oyejorge_compiler_lib" class="Less_Parser" />
+        <service id="oyejorge_compiler_lib" class="Less_Parser">
+            <argument type="collection">
+                <argument key="cache_dir">%kernel.cache_dir%/less_parser/</argument>
+            </argument>
+        </service>
 
         <service id="js_compressor" class="Shopware\Components\Theme\Compressor\Js" />
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
It speeds up the theme compiler by creating a cache file for every individual less file it has to parse.

### 2. What does this change do, exactly?
This modifies the dependency-injection container by adding an argument to the service `oyejorge_compiler_lib`. This argument is an array of options for the less parser. By now it holds just one item that is the `cache_dir`. The location is `<Shopware-Root>/var/cache/<Environment>/less_parser/`.

### 3. Describe each step to reproduce the issue or behaviour.
Compile the theme via backend or command line and see the performance improvement. A noticable performance improvement will be present **after the first** compilation with this PR.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.