### PR TITLE
Running a CronJob with --force should not postpone the next occurrence.

### DIFF
--- a/engine/Library/Enlight/Components/Cron/Manager.php
+++ b/engine/Library/Enlight/Components/Cron/Manager.php
@@ -297,9 +297,9 @@ class Enlight_Components_Cron_Manager
         $now = $now->getTimestamp();
         $interval =  $job->getInterval();
         $next = $job->getNext()->getTimestamp();
-        do {
+        while ($now >= $next) {
             $next += $interval;
-        } while ($now >= $next);
+        }
         $job->setNext($next);
         $job->setEnd($now);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When running a cronjob manually (bin/console sw:cron:run <jobname> --force), the "next" column in s_crontab will be increased despite already being set to a future date. When running a cron job multiple times, this causes later normal runs to be skipped.

### 2. What does this change do, exactly?

Prevent the next occurrence from being postponed further.

### 3. Describe each step to reproduce the issue or behaviour.
run
$ bin/console sw:cron:list   
choose any cron action, note the date set for "Next run"
run the action multiple times using the --force flag
$ bin/console sw:cron:run RefreshSearchIndex --force
$ bin/console sw:cron:run RefreshSearchIndex --force
$ bin/console sw:cron:run RefreshSearchIndex --force
finally run
$ bin/console sw:cron:list   
The "Next run" for the chosen job will be postponed for each forced run

### 4. Please link to the relevant issues (if any).

None.

### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.