### PR TITLE
added two filter events to allow the sql to be amended when additiona…

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2510,7 +2510,7 @@ class sAdmin
         $sql = $this->eventManager->filter(
             'Shopware_Modules_Admin_GetDispatchBasket_FilterSql',
             $sql,
-            ['subject' => $this, 'id' => $userId]
+            ['subject' => $this, 'user_id' => $userId]
         );
 
         $sessionId = $this->session->offsetGet('sessionId');
@@ -2737,7 +2737,7 @@ class sAdmin
         $sql = $this->eventManager->filter(
             'Shopware_Modules_Admin_GetPremiumDispatches_FilterSql',
             $sql,
-            ['subject' => $this, 'id' => $userId]
+            ['subject' => $this, 'user_id' => $userId]
         );
 
         $dispatches = $this->db->fetchAssoc(

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2508,7 +2508,7 @@ class sAdmin
         $userId = $this->session->offsetGet('sUserId');
 
         $sql = $this->eventManager->filter(
-            'Shopware_Modules_Admin_GetDispatchBasket_FilterResult',
+            'Shopware_Modules_Admin_GetDispatchBasket_FilterSql',
             $sql,
             ['subject' => $this, 'id' => $userId]
         );
@@ -2735,7 +2735,7 @@ class sAdmin
         $userId = $this->session->offsetGet('sUserId');
 
         $sql = $this->eventManager->filter(
-            'Shopware_Modules_Admin_GetPremiumDispatches_FilterResult',
+            'Shopware_Modules_Admin_GetPremiumDispatches_FilterSql',
             $sql,
             ['subject' => $this, 'id' => $userId]
         );

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2506,6 +2506,13 @@ class sAdmin
         ";
 
         $userId = $this->session->offsetGet('sUserId');
+
+        $sql = $this->eventManager->filter(
+            'Shopware_Modules_Admin_GetDispatchBasket_FilterResult',
+            $sql,
+            ['subject' => $this, 'id' => $userId]
+        );
+
         $sessionId = $this->session->offsetGet('sessionId');
         $basket = $this->db->fetchRow(
             $sql,
@@ -2726,6 +2733,13 @@ class sAdmin
         ";
 
         $userId = $this->session->offsetGet('sUserId');
+
+        $sql = $this->eventManager->filter(
+            'Shopware_Modules_Admin_GetPremiumDispatches_FilterResult',
+            $sql,
+            ['subject' => $this, 'id' => $userId]
+        );
+
         $dispatches = $this->db->fetchAssoc(
             $sql,
             [


### PR DESCRIPTION
…l joins are required in shipping cost terms or calculations

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The provided sql is not always enough to allow complex shipping calculations. A common scenario might be for countries to have additional attributes relating to shipping, but the countries attributes table can't be joined without adding these filter events.

### 2. What does this change do, exactly?
Adds two new events to allow the sql to be updated if needed.

### 3. Describe each step to reproduce the issue or behaviour.
If you wish to use data from a table not included in the query you currently have to write a complex list of sub select statements to get the data you require. A simple additional join is much more efficient.

### 4. Please link to the relevant issues (if any).
N/A

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.