### PR TITLE
Fix document generation when template security is disabled

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -510,7 +510,9 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
 
         $path = basename($this->_subshop['doc_template']);
 
-        $this->_template->security_policy->secure_dir[] = $frontendThemeDirectory . DIRECTORY_SEPARATOR . $path;
+        if ($this->_template->security_policy) {
+            $this->_template->security_policy->secure_dir[] = $frontendThemeDirectory . DIRECTORY_SEPARATOR . $path;
+        }
         $this->_template->setTemplateDir(['custom' => $path]);
         $this->_template->setCompileId(str_replace('/', '_', $path) . '_' . $this->_subshop['id']);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

[This change](https://github.com/shopware/shopware/commit/589fe76f4c7a827030bb38a0caf7f60d09716f6e#diff-b1518c1fa8fe33a028c3e75e5cb49df6R513) made for SW 5.3 causes `$smarty->security_policy` to be an invalid value of `stdClass` when template security is disabled (i.e. `security_policy` is `null` when that line is executed), which causes document generation to break [further down the line](https://github.com/shopware/shopware/blob/d4c4f2e731d94c9a385791fc5898e9c3c4a18479/engine/Library/Smarty/sysplugins/smarty_internal_templatecompilerbase.php#L471). 

### 2. What does this change do, exactly?

This change adds a `null` guard that prevents the `security_policy` from being assigned an invalid value when template security is disabled (which is deprecated, but still allowed in 5.3).

### 3. Describe each step to reproduce the issue or behaviour.

Disable template security and try to generate a document from the backend.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.