### PR TITLE
bugfix - do not continue in the beforeUpdate() function when the necessary data is missing

### DIFF
--- a/engine/Shopware/Models/Order/Detail.php
+++ b/engine/Shopware/Models/Order/Detail.php
@@ -633,6 +633,10 @@ class Detail extends ModelEntity
         //returns a change set for the model, which contains all changed properties with the old and new value.
         $changeSet = Shopware()->Models()->getUnitOfWork()->getEntityChangeSet($this);
 
+        if (!array_key_exists('articleNumber', $changeSet) && !array_key_exists('quantity', $changeSet)) {
+            return;
+        }
+
         $articleChange = $changeSet['articleNumber'];
         $quantityChange = $changeSet['quantity'];
 


### PR DESCRIPTION
### 1. Why is this change necessary?
To prevent the code from being executed without the right data available. An exception is not thrown, since this part should only be executed when changes in the quantity or article number occur.

### 2. What does this change do, exactly?
When an order detail entry is updated in one specific part (for example, in my case, a status), the code fails because the required data in the beforeUpdate() function is not set.

### 3. Describe each step to reproduce the issue or behaviour.
Write a piece of code that updates an order with order details. Just update the status on an order detail entry and the errors will be visible.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.