### PR TITLE
redirect to shopdomain with request uri

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -144,6 +144,10 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
             if ($preferBasePath && strpos($request->getPathInfo(), '/shopware.php/') === 0) {
                 $removePath = $request->getBasePath() . '/shopware.php';
                 $newPath = str_replace($removePath, $request->getBasePath(), $request->getRequestUri());
+            } else {
+                if (isset($newPath)) {
+                    $newPath .= $request->getRequestUri();
+                }
             }
 
             if (isset($newPath)) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
redirect user to the right url if he request your shop with an url that is not default

### 2. What does this change do, exactly?
if you request http://shopwaredemo.de/beach-relax/fashion/women/ you would be redirected to start page. Some Tools e.g. sistrix call your shop with an invalid url to check the 404 status for non existing pages. In this case you got 301 for the redirect.


### 3. Describe each step to reproduce the issue or behaviour.
call http://shopwaredemo.de/beach-relax/fashion/women/ and you should be redirected to http://www.shopwaredemo.de/beach-relax/fashion/women/

### 4. Please link to the relevant issues (if any).
---

### 5. Which documentation changes (if any) need to be made because of this PR?
---

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.