### PR TITLE
Changed api variant resource to check for existing configurator group…

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -838,7 +838,7 @@ class Variant extends Resource implements BatchInterface
                 throw new ApiException\CustomValidationException(sprintf('Unit by id %s not found', $data['unitId']));
             }
 
-        //new unit data send? create new unit for this variant
+            //new unit data send? create new unit for this variant
         } elseif (!empty($data['unit'])) {
             $data['unit'] = $this->updateUnitReference($data['unit']);
         }
@@ -981,9 +981,13 @@ class Variant extends Resource implements BatchInterface
      */
     private function getAvailableGroup($availableGroups, array $groupData)
     {
-        /** @var $availableGroup Option */
+        //Convert string to lower case to avoid problems with case insensitivity in database
+        //vs case sensitivity in PHP
+        $groupName = mb_strtolower($groupData['name']);
+
+        /** @var $availableGroup Group */
         foreach ($availableGroups as $availableGroup) {
-            if (($availableGroup->getName() == $groupData['name'] && $groupData['name'] !== null)
+            if ((mb_strtolower($availableGroup->getName()) == $groupName && $groupData['name'] !== null)
                 || ($availableGroup->getId() == $groupData['id']) && $groupData['id'] !== null) {
                 return $availableGroup;
             }
@@ -999,13 +1003,17 @@ class Variant extends Resource implements BatchInterface
      * @param Collection|array $availableOptions
      * @param array            $optionData
      *
-     * @return bool
+     * @return bool|Option
      */
     private function getAvailableOption($availableOptions, array $optionData)
     {
+        //Convert string to lower case to avoid problems with case insensitivity in database
+        //vs case sensitivity in PHP
+        $optionName = mb_strtolower($optionData['name']);
+
         /** @var $availableOption Option */
         foreach ($availableOptions as $availableOption) {
-            if (($availableOption->getName() == $optionData['name'] && $optionData['name'] !== null)
+            if ((mb_strtolower($availableOption->getName()) == $optionName && $optionData['name'] !== null)
                 || ($availableOption->getId() == $optionData['id'] && $optionData['id'] !== null)) {
                 return $availableOption;
             }

--- a/tests/Functional/Components/Api/VariantTest.php
+++ b/tests/Functional/Components/Api/VariantTest.php
@@ -385,6 +385,14 @@ class VariantTest extends TestCase
                 'inStock' => 2000,
                 'number' => $variantData['number'] . '-Updated',
                 'unitId' => $this->getRandomId('s_core_units'),
+                // Make sure conf. options and groups work in a case insensitive way, just like in the DB
+                'configuratorOptions' => [[
+                    'group' => 'farbe',
+                    'option' => 'Grün',
+                ], [
+                    'group' => 'Gräße',
+                    'option' => 'xl',
+                ]],
             ];
             $variant = $this->resource->update($variantData['id'], $updateData);
 


### PR DESCRIPTION
…s and options only via the database

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
These changes are necessary to guarantee that existing configurator options and groups are found according in the case insensitive database tables, which ultimately is the authority on what exists and what doesn't.

This is mostly evident when the api's variant resource checks if a configurator option for any given group already exists via the options name. Because the comparison is done via sting comparison in PHP, any option names that are the same except for capitalization are not recognized as equal.

This means that the PHP code will try to create a new option for a given group with a name that is only different in capitalization and will violate the unique index set on group_id and name name for the s_article_configurator_options database table.

This change converts these strings to lower case for comparison to mimic the database's case insensitivity.

### 2. What does this change do, exactly?
Change the getAvailableGroup and getAvailableOption methods in Shopware\Components\Api\Resource\Variant to convert the names of the respective entities to lower case before performing their checks.

### 3. Describe each step to reproduce the issue or behaviour.
The test method testVariantUpdate in Shopware\Tests\Functional\Components\Api\VariantTest
was altered to include changed configurator options that will not only fail but cause an exception without this fix.

This should serve as a demonstration on how to reproduce.

### 4. Please link to the relevant issues (if any).

None I am aware of.

### 5. Which documentation changes (if any) need to be made because of this PR?

None as far as I can tell. This is all internal implementation detail.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
Updated some incorrect/missing PhpDoc hints as well.
- [x] I have read the contribution requirements and fulfil them.