### PR TITLE
Fix config select store value translation logic

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -72,6 +72,10 @@ This changelog references changes done in Shopware 5.5 patch versions.
     Please check your templates when you extend `cart_item.tpl`. You now have to extend one of the added subtemplates.
 * Changed `country_id` to `countryId` and `state_id` to `stateId` in `Shopware.apps.Customer.model.Address`
 * Changed xml files in `engine/Library/Zend/Locale/Data` to be more up-to-date
+* Changed the translation logic for config elements of types `combo` and
+  `select` to consider translations other than for the non-standard `en`
+  locale, but to instead try the user's locale, `en_GB` and `en` as fallbacks
+  before resorting to the first defined (by array index) translation.
 
 ### Removals
 

--- a/engine/Shopware/Controllers/Backend/Config.php
+++ b/engine/Shopware/Controllers/Backend/Config.php
@@ -175,6 +175,9 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
         $data = $this->translateValues($fallback, $data);
         $data = $this->translateValues($locale->getId(), $data);
 
+        // 'en' is supported as last fallback.
+        $storeFallbackLocales = ['en_GB', 'en'];
+
         foreach ($data['elements'] as &$values) {
             $values = $this->translateValues($fallback, $values);
             $values = $this->translateValues($locale->getId(), $values);
@@ -183,8 +186,10 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
                 continue;
             }
 
-            $values['options']['store'] = $this->translateStore('en', $values['options']['store']);
-            $values['options']['store'] = $this->translateStore($language, $values['options']['store']);
+            $store = $values['options']['store'];
+            // Replace the store, which may contain multiple translations, with
+            // a store with translated messages:
+            $values['options']['store'] = $this->translateStore($language, $store, $storeFallbackLocales);
             if (!isset($values['options']['queryMode'])) {
                 $values['options']['queryMode'] = 'remote';
             }
@@ -926,6 +931,8 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
     /**
      * Helper function to translate the store of select- and combo-fields
      * Store value will be replaced by the value in the correct language.
+     * If no match for $language is found in the $store array, the first found translation
+     * for the languages defined by $fallbackLocales will be used.
      * If there is no matching language in array defined, the first array element will be used.
      * If the store or a value is not an array, it will not be changed.
      *
@@ -934,34 +941,44 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
      * $store = array(
      *              array(1, array('de_DE' => 'Auto', 'en_GB' => 'car')),
      *              array(2, array('de_DE' => 'Hund', 'en_GB' => 'dog')),
-     *              array(3, array('de_DE' => 'Katze', 'en_GB' => 'cat'))
+     *              array(3, array('de_DE' => 'Katze', 'en_GB' => 'cat')),
+     *              array(4, 'A string without translation')
      *          );
      *
-     * @param string $language
+     * @param string $language        the preferred locale (e.g., the user's locale)
      * @param mixed  $store
+     * @param array  $fallbackLocales a list of locales (e.g., ['en_GB', 'en'])
      *
      * @return mixed
      */
-    private function translateStore($language, $store)
+    private function translateStore($language, $store, array $fallbackLocales)
     {
         if (!is_array($store)) {
             return $store;
         }
 
+        // All locales ordered according to which translations shall be preferred:
+        $tryLocales = array_merge([$language], $fallbackLocales);
+
         foreach ($store as &$row) {
             $value = array_pop($row);
 
+            // If not an array, there are no translations and we directly choose the given value:
             if (!is_array($value)) {
                 $row[] = $value;
                 continue;
             }
 
-            if (!array_key_exists($language, $value)) {
-                $row[] = array_shift($value);
-                continue;
+            // Find the most preferable translation:
+            foreach ($tryLocales as $tryLocale) {
+                if (isset($value[$tryLocale])) {
+                    $row[] = $value[$tryLocale];
+                    continue 2;
+                }
             }
 
-            $row[] = $value[$language];
+            // If none of the available locales could be identified as preferable, fallback to the first defined translation:
+            $row[] = array_shift($value);
         }
 
         return $store;

--- a/tests/Functional/Controllers/Backend/ConfigGetFormTest.php
+++ b/tests/Functional/Controllers/Backend/ConfigGetFormTest.php
@@ -1,0 +1,357 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @category  Shopware
+ *
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class Shopware_Tests_Controllers_Backend_ConfigGetFormTest extends Enlight_Components_Test_Controller_TestCase
+{
+    const TEST_USER_USERNAME = 'testuser';
+    const TEST_ROLE_NAME = 'testadminrole';
+    const TEST_FORM_NAME = 'FormUnderTest';
+    const TEST_FORM_ELEMENT_NAME = 'formElementUnderTest';
+    const TEST_LOCALE_LOCALE = 'test_TEST';
+    const TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITH_FALLBACKS = [
+        'first_LANG' => 'first_LANG: Language fallback that should never happen if there is an en/en_GB locale',
+        'de_DE' => 'de_DE: Getestete Einstellung',
+        self::TEST_LOCALE_LOCALE => 'test_TEST: Tested Test Translation',
+        'en_GB' => 'en_GB: Tested Setting',
+        'en' => 'en: Tested Setting (fallback)',
+    ];
+    const TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITHOUT_FALLBACK = [
+        'first_LANG' => 'first_LANG: Language fallback that should never happen',
+        self::TEST_LOCALE_LOCALE => 'test_TEST: Tested Test Translation',
+    ];
+    const TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITH_EN_FALLBACK = [
+        'first_LANG' => 'first_LANG: Language fallback that should never happen if there is an en/en_GB locale',
+        'en' => 'en: Fallback locale translation',
+        self::TEST_LOCALE_LOCALE => 'test_TEST: Tested Test Translation',
+    ];
+
+    /**
+     * Locales that where created on the fly for the tests.
+     *
+     * @var array an array of locales (e.g. ['test_TEST', 'de_DE'])
+     *
+     * @see self::getLocaleIdOrCreate creates locales for the tests
+     * @see self::formLocaleTestCleanup removes these locales
+     */
+    protected $temporaryLocales = [];
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->formLocaleTestCleanup();
+    }
+
+    public function tearDown()
+    {
+        $this->formLocaleTestCleanup();
+        $this->reset();
+        parent::tearDown();
+    }
+
+    public function testFormElementSettingTranslationIsUserLocaleIfMatching()
+    {
+        $this->createAndLoginAdminUserWithLocaleId($this->getLocaleIdOrCreate(static::TEST_LOCALE_LOCALE));
+        $storeSettings = $this->getTranslatedFormElementStoreSettings(static::TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITH_FALLBACKS);
+        $this->assertEquals(
+            static::TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITH_FALLBACKS[static::TEST_LOCALE_LOCALE],
+            $storeSettings[0][1]
+        );
+    }
+
+    public function testFormElementSettingTranslationIsFallbackIfNonTranslatedUserLocale()
+    {
+        $this->createAndLoginAdminUserWithLocaleId($this->getLocaleIdOrCreate('fr_FR'));
+        $storeSettings = $this->getTranslatedFormElementStoreSettings(static::TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITH_FALLBACKS);
+        $this->assertEquals(
+            static::TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITH_FALLBACKS['en_GB'],
+            $storeSettings[0][1],
+            'Should be the en_GB translation, as that is the translation of the first, hard-coded fallback locale.'
+        );
+    }
+
+    public function testFormElementSettingTranslationIsFallbackIfNonTranslatedUserTerritory()
+    {
+        $this->createAndLoginAdminUserWithLocaleId($this->getLocaleIdOrCreate('de_CH'));
+        $storeSettings = $this->getTranslatedFormElementStoreSettings(static::TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITH_FALLBACKS);
+        $this->assertEquals(
+            static::TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITH_FALLBACKS['en_GB'],
+            $storeSettings[0][1],
+            'Should be the en_GB translation, as that is the translation of the first, hard-coded fallback locale.'
+            . ' Here, de_DE exists as well, but we define there is no logic to match potentially "similar" locales.'
+        );
+    }
+
+    public function testFormElementSettingTranslationIsFirstTranslationIfUnmatchedAndWithoutFallbacks()
+    {
+        $this->createAndLoginAdminUserWithLocaleId($this->getLocaleIdOrCreate('en_GB'));
+        $storeSettings = $this->getTranslatedFormElementStoreSettings(static::TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITHOUT_FALLBACK);
+        $this->assertEquals(
+            static::TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITHOUT_FALLBACK['first_LANG'],
+            $storeSettings[0][1],
+            'If no matching translation and no locale-based (en_GB, en) translation exists, should use '
+            . 'the first (index-based) translation from the store settings.'
+        );
+    }
+
+    public function testFormElementSettingTranslationIsEnglishFallbackIfBritishEnglishDoesNotExist()
+    {
+        $this->createAndLoginAdminUserWithLocaleId($this->getLocaleIdOrCreate('de_DE'));
+        $storeSettings = $this->getTranslatedFormElementStoreSettings(static::TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITH_EN_FALLBACK);
+        $this->assertEquals(
+            static::TEST_FORM_ELEMENT_STORE_TRANSLATIONS_WITH_EN_FALLBACK['en'],
+            $storeSettings[0][1],
+            'If neither a matching location, nor the preferred en_GB fallback exist, should fall back to '
+            . 'en translation'
+        );
+    }
+
+    public function testFormElementSettingTranslationCanBeFixedString()
+    {
+        $this->createAndLoginAdminUserWithLocaleId($this->getLocaleIdOrCreate(static::TEST_LOCALE_LOCALE));
+        $storeSettings = $this->getTranslatedFormElementStoreSettings('A fixed string');
+        $this->assertEquals(
+            'A fixed string',
+            $storeSettings[0][1]
+        );
+    }
+
+    /**
+     * Create and signs in new backend admin user with a specified locale.
+     *
+     * Logging in the user makes the user's identity available for later requests.
+     *
+     * @param mixed $localeId the id of the new user's locale (a {@link \Shopware\Models\Shop\Locale})
+     *
+     * @see self::formLocaleTestCleanup removes the user
+     */
+    protected function createAndLoginAdminUserWithLocaleId($localeId)
+    {
+        $entityManager = Shopware()->Models();
+
+        $user = new \Shopware\Models\User\User();
+        $user->setUsername(static::TEST_USER_USERNAME);
+        $user->setLocaleId($localeId);
+        // Set lockedUntil to the past, so the user can log in.
+        $user->setLockedUntil('1970-01-01 00:00:00 UTC');
+
+        // Set password analogously to \Shopware\Commands\AdminCreateCommand::setPassword:
+        /** @var \Shopware\Components\Password\Manager $passworEncoderRegistry */
+        $passworEncoderRegistry = Shopware()->Container()->get('PasswordEncoder');
+        $defaultEncoderName = $passworEncoderRegistry->getDefaultPasswordEncoderName();
+        $encoder = $passworEncoderRegistry->getEncoderByName($defaultEncoderName);
+        $user->setPassword($encoder->encodePassword('testpassword'));
+        $user->setEncoder($encoder->getName());
+
+        // The user must have a role and shall be an admin.
+        $userRole = new \Shopware\Models\User\Role();
+        $userRole->setName(static::TEST_ROLE_NAME);
+        $userRole->setDescription('test admin role description');
+        $userRole->setSource('custom');
+        $userRole->setAdmin(1);
+        $userRole->setEnabled(1);
+        $user->setRole($userRole);
+
+        $entityManager->persist($userRole);
+        $entityManager->persist($user);
+
+        // The user must be flushed to the database before we can log them in.
+        $entityManager->flush();
+
+        // Login user.
+        $this->Request()->setMethod('POST');
+        $this->Request()->setPost([
+            'username' => static::TEST_USER_USERNAME,
+            'password' => 'testpassword',
+        ]);
+        $loginResponse = $this->dispatch('backend/Login/login');
+        $this->assertGreaterThanOrEqual(200, $loginResponse->getHttpResponseCode(), 'Login failed.');
+        $this->assertLessThanOrEqual(299, $loginResponse->getHttpResponseCode(), 'Login failed.');
+        $this->resetRequest();
+        $this->resetResponse();
+    }
+
+    protected function formLocaleTestCleanup()
+    {
+        $entityManager = Shopware()->Models();
+
+        $oldEntities = array_merge(
+            $entityManager->getRepository('Shopware\Models\Shop\Locale')->findBy([
+                'locale' => array_merge(
+                    [static::TEST_LOCALE_LOCALE],
+                    $this->temporaryLocales
+                ),
+            ]),
+            $entityManager->getRepository('Shopware\Models\User\User')->findBy([
+                'username' => static::TEST_USER_USERNAME,
+            ]),
+            $entityManager->getRepository('Shopware\Models\User\Role')->findBy([
+                'name' => static::TEST_ROLE_NAME,
+            ]),
+            $entityManager->getRepository('Shopware\Models\Config\Form')->findBy([
+                'name' => static::TEST_FORM_NAME,
+            ])
+        );
+
+        foreach ($oldEntities as $oldEntity) {
+            $entityManager->remove($oldEntity);
+        }
+        $entityManager->flush();
+        // Assume temporaryLocales have been removed.
+        $this->temporaryLocales = [];
+    }
+
+    protected function getLocaleIdOrCreate($locale)
+    {
+        $entityManager = Shopware()->Models();
+
+        $foundLocale = $entityManager->getRepository('Shopware\Models\Shop\Locale')->findOneBy([
+            'locale' => $locale,
+        ]);
+
+        if ($foundLocale !== null) {
+            return $foundLocale->getId();
+        }
+
+        $newLocale = new \Shopware\Models\Shop\Locale();
+        $newLocale->setLocale($locale);
+        $newLocale->setLanguage('<' . $locale . ' language name as created for ' . get_class($this) . '>');
+        $newLocale->setTerritory('<' . $locale . ' territory name>');
+        $entityManager->persist($newLocale);
+        // Flush $newLocale to database,so we can retrieve its new id afterwards.
+        $entityManager->flush($newLocale);
+
+        $this->temporaryLocales[] = $newLocale;
+
+        return $newLocale->getId();
+    }
+
+    /**
+     * Creates a {@link \Shopware\Models\Config\Form} with a select {@link * \Shopware\Models\Config\Element} with a setting that has
+     * $settingsTranslations as its translations.
+     *
+     * A user must already be logged for a locale to be selectable and to prevent a redirect to /backend/.
+     *
+     * @param string|array $settingsTranslations
+     *
+     * @return array the element's store
+     */
+    protected function getTranslatedFormElementStoreSettings($settingsTranslations)
+    {
+        $entityManager = Shopware()->Models();
+
+        $form = new \Shopware\Models\Config\Form();
+        $form->setName(static::TEST_FORM_NAME);
+        $form->setElement(
+            'select',
+            static::TEST_FORM_ELEMENT_NAME,
+            [
+                'label' => 'The Form Element Under Test',
+                'store' => [
+                    [
+                        'settingUnderTest',
+                        $settingsTranslations,
+                    ],
+                ],
+            ]
+        );
+        $entityManager->persist($form);
+        $entityManager->flush($form);
+
+        $requestFilter = [
+            [
+                'property' => 'id',
+                'value' => $form->getId(),
+            ],
+        ];
+
+        $requestUrl = sprintf(
+            'backend/Config/getForm?filter=%s&page=1&_dc=' . time() . '&page=1&start=0&limit=25',
+            urlencode(json_encode($requestFilter))
+        );
+
+        // Disable ACLs for this request:
+        $this->Request()->setMethod('GET');
+        Shopware()->Plugins()->Backend()->Auth()->setNoAcl();
+        try {
+            $response = $this->dispatch($requestUrl);
+        } finally {
+            // Re-enable ACLs:
+            Shopware()->Plugins()->Backend()->Auth()->setNoAcl(false);
+        }
+
+        $this->assertRegExp(',^\s*application/json\s*(;.*)?$,u', $response->getHeader('Content-Type'));
+
+        // Only accept 2xx success codes. Here, redirects may be a sign
+        // that the login did not work.
+        $this->assertGreaterThanOrEqual(200, $response->getHttpResponseCode());
+        $this->assertLessThanOrEqual(299, $response->getHttpResponseCode());
+
+        $responseBody = $response->getBody();
+        $responseDataTransferObject = json_decode($responseBody);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Exception(
+                'JSON parse error: ' . json_last_error_msg()
+                . ' for request to ' . $requestUrl
+                . ' which returned ' . $responseBody
+            );
+        }
+        if (!is_object($responseDataTransferObject)) {
+            throw new \Exception(
+                'Response could not be parsed to an object'
+                . ' for request to ' . $requestUrl
+                . ' which returned ' . $responseBody
+            );
+        }
+
+        // Basic assertions about the response to catch non-test-related errors early:
+        $this->assertTrue($responseDataTransferObject->success);
+        $this->assertNotEmpty($responseDataTransferObject->data);
+
+        $formData = $responseDataTransferObject->data;
+        $formDataErrorMessageSuffix = ' Form data does not match expectation: '
+            . json_encode($formData);
+
+        $this->assertNotEmpty(
+            $formData->elements,
+            'Form elements are missing.' . $formDataErrorMessageSuffix
+        );
+        $this->assertNotEmpty(
+            $formData->elements[0]->options,
+            'Form element options are missing.' . $formDataErrorMessageSuffix
+        );
+        $this->assertNotEmpty(
+            $formData->elements[0]->options->store,
+            'Form element store options are missing.' . $formDataErrorMessageSuffix
+        );
+
+        $storeSettings = $formData->elements[0]->options->store;
+
+        return $storeSettings;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

[This line here](https://github.com/shopware/shopware/commit/db7b41e813b456e081576e222130d9482d384ae2#diff-82dab508fe5ae6234ffc4ea20d371fc8R187) tries to implement a language fallback logic for translated config select store values, but in doing so overwrites the loaded store array which contains the translations. This leads to the problem that the following call to `translateStore`, which should perform the real, non-fallback store translation, only finds the "fallback" and thus fails to translate the store values. This means that translation of config select store values is broken in Shopware 5.3.

This is the line in question:

```php
$values['options']['store'] = $this->translateStore('en', $values['options']['store']);
```
I'm also not really sure what the intended effect of this line is, since the documentation of `\Shopware_Controllers_Backend_Config::translateStore()` states that it expects a full locale as its first argument, but here, only an ISO 639-1 language code is given. Also, `translateStore()` already performs a fallback if no key matching the given locale exists by just using the first translation in this case. @OliverSkroblin, can you offer more insight on this?

### 2. What does this change do, exactly?

It makes a copy of the loaded config store with all translations intact before performing the fallback logic.

Please note that if my intuition is correct and the fallback line is not actually needed at all, the best approach is probably to just remove that fallback and reject this PR.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have a plugin with a translated config select store, e.g. like this config field from Pickware ERP:
    ```php
    $form->setElement(
        'select',
        'purchasePriceMode',
        [
            'label' => 'Eingabe von Einkaufspreisen',
            'description' => 'Wählen Sie den Modus, in dem Einkaufspreise eingegeben/angezeigt werden sollen.',
            'value' => 'net',
            'store' => [[
                'net',
                [
                    'de_DE' =>'Netto',
                    'en_GB' => 'Net'
                ],
            ], [
                'gross',
                [
                    'de_DE' => 'Brutto',
                    'en_GB' => 'Gross'
                ]
            ]]
        ]
    );
    ```
2. Log in with a locale of `en_GB`.
3. Open the plugin config and observe that the select value is shown in German instead of English.

### 4. Please link to the relevant issues (if any).

None.

### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.