### PR TITLE
MediaBundle GarbageCollector: Add mediaId index to the helper table

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/GarbageCollector.php
+++ b/engine/Shopware/Bundle/MediaBundle/GarbageCollector.php
@@ -111,7 +111,14 @@ class GarbageCollector
      */
     private function createTempTable()
     {
-        $this->connection->exec('CREATE TEMPORARY TABLE IF NOT EXISTS s_media_used (id int auto_increment, mediaId int NOT NULL, PRIMARY KEY pkid (id))');
+        $this->connection->exec('
+            CREATE TEMPORARY TABLE IF NOT EXISTS s_media_used (
+                id int auto_increment,
+                mediaId int NOT NULL,
+                PRIMARY KEY pkid (id),
+                INDEX (mediaId)
+            ) ENGINE=InnoDB
+        ');
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
The media bundle's garbage collector suffers from significant performance issues when dealing with large data sets. Especially the query in the final `moveToTrash` method can take a lot of time to process.

### 2. What does this change do, exactly?
Creating an index for the `mediaId` column of the temporary `s_media_used` table greatly increases the GC's performance, without requiring any changes to its logic.

### 3. Describe each step to reproduce the issue or behaviour.
```php bin/console sw:media:cleanup```

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.