### PR TITLE
Use service interface in component handlers

### DIFF
--- a/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleComponentHandler.php
+++ b/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleComponentHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Shopware 5
- * Copyright (c) shopware AG
+ * Copyright (c) shopware AG.
  *
  * According to our dual licensing model, this program can be used either
  * under the terms of the GNU Affero General Public License, version 3,
@@ -21,7 +21,6 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
-
 namespace Shopware\Bundle\EmotionBundle\ComponentHandler;
 
 use Shopware\Bundle\EmotionBundle\Struct\Collection\PrepareDataCollection;
@@ -32,7 +31,7 @@ use Shopware\Bundle\SearchBundle\Sorting\RandomSorting;
 use Shopware\Bundle\SearchBundle\Sorting\ReleaseDateSorting;
 use Shopware\Bundle\SearchBundle\SortingInterface;
 use Shopware\Bundle\SearchBundle\StoreFrontCriteriaFactoryInterface;
-use Shopware\Bundle\StoreFrontBundle\Service\Core\AdditionalTextService;
+use Shopware\Bundle\StoreFrontBundle\Service\AdditionalTextServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware_Components_Config as ShopwareConfig;
@@ -59,19 +58,19 @@ class ArticleComponentHandler implements ComponentHandlerInterface
     private $shopwareConfig;
 
     /**
-     * @var AdditionalTextService
+     * @var AdditionalTextServiceInterface
      */
     private $additionalTextService;
 
     /**
      * @param StoreFrontCriteriaFactoryInterface $criteriaFactory
      * @param ShopwareConfig                     $shopwareConfig
-     * @param AdditionalTextService              $additionalTextService
+     * @param AdditionalTextServiceInterface     $additionalTextService
      */
     public function __construct(
         StoreFrontCriteriaFactoryInterface $criteriaFactory,
         ShopwareConfig $shopwareConfig,
-        AdditionalTextService $additionalTextService
+        AdditionalTextServiceInterface $additionalTextService
     ) {
         $this->criteriaFactory = $criteriaFactory;
 
@@ -94,7 +93,7 @@ class ArticleComponentHandler implements ComponentHandlerInterface
     public function prepare(PrepareDataCollection $collection, Element $element, ShopContextInterface $context)
     {
         $type = $element->getConfig()->get('article_type');
-        $key = 'emotion-element--' . $element->getId();
+        $key = 'emotion-element--'.$element->getId();
 
         if ($type === self::TYPE_STATIC_PRODUCT) {
             $collection->getBatchRequest()->setProductNumbers($key, [$element->getConfig()->get('article')]);
@@ -117,7 +116,7 @@ class ArticleComponentHandler implements ComponentHandlerInterface
      */
     public function handle(ResolvedDataCollection $collection, Element $element, ShopContextInterface $context)
     {
-        $key = 'emotion-element--' . $element->getId();
+        $key = 'emotion-element--'.$element->getId();
         $type = $element->getConfig()->get('article_type');
 
         /** @var ListProduct $product */

--- a/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php
+++ b/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Shopware 5
- * Copyright (c) shopware AG
+ * Copyright (c) shopware AG.
  *
  * According to our dual licensing model, this program can be used either
  * under the terms of the GNU Affero General Public License, version 3,
@@ -21,7 +21,6 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
-
 namespace Shopware\Bundle\EmotionBundle\ComponentHandler;
 
 use Shopware\Bundle\EmotionBundle\Struct\Collection\PrepareDataCollection;
@@ -32,7 +31,7 @@ use Shopware\Bundle\SearchBundle\Sorting\PriceSorting;
 use Shopware\Bundle\SearchBundle\Sorting\ReleaseDateSorting;
 use Shopware\Bundle\SearchBundle\SortingInterface;
 use Shopware\Bundle\SearchBundle\StoreFrontCriteriaFactoryInterface;
-use Shopware\Bundle\StoreFrontBundle\Service\Core\AdditionalTextService;
+use Shopware\Bundle\StoreFrontBundle\Service\AdditionalTextServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Components\ProductStream\RepositoryInterface;
@@ -67,7 +66,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
     private $shopwareConfig;
 
     /**
-     * @var AdditionalTextService
+     * @var AdditionalTextServiceInterface
      */
     private $additionalTextService;
 
@@ -75,13 +74,13 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
      * @param StoreFrontCriteriaFactoryInterface $criteriaFactory
      * @param RepositoryInterface                $productStreamRepository
      * @param ShopwareConfig                     $shopwareConfig
-     * @param AdditionalTextService              $additionalTextService
+     * @param AdditionalTextServiceInterface     $additionalTextService
      */
     public function __construct(
         StoreFrontCriteriaFactoryInterface $criteriaFactory,
         RepositoryInterface $productStreamRepository,
         ShopwareConfig $shopwareConfig,
-        AdditionalTextService $additionalTextService
+        AdditionalTextServiceInterface $additionalTextService
     ) {
         $this->criteriaFactory = $criteriaFactory;
         $this->productStreamRepository = $productStreamRepository;
@@ -104,7 +103,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
     public function prepare(PrepareDataCollection $collection, Element $element, ShopContextInterface $context)
     {
         $type = $element->getConfig()->get('article_slider_type', self::TYPE_STATIC_PRODUCT);
-        $key = 'emotion-element--' . $element->getId();
+        $key = 'emotion-element--'.$element->getId();
 
         switch ($type) {
             case self::TYPE_PRODUCT_STREAM:
@@ -154,7 +153,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
     public function handle(ResolvedDataCollection $collection, Element $element, ShopContextInterface $context)
     {
         $type = $element->getConfig()->get('article_slider_type', self::TYPE_STATIC_PRODUCT);
-        $key = 'emotion-element--' . $element->getId();
+        $key = 'emotion-element--'.$element->getId();
 
         switch ($type) {
             case self::TYPE_PRODUCT_STREAM:


### PR DESCRIPTION
Since the service in question has an Interface, it should be used to allow for decoration of the service

### 1. Why is this change necessary?
Decorating the `Shopware\Bundle\StoreFrontBundle\Service\AdditionalTextService` currently leads to a TypeError in shopware 5.3

### 2. What does this change do, exactly?
Change the Typehint in the constructors of `\Shopware\Bundle\EmotionBundle\ComponentHandler\ArticleComponentHandler` and `\Shopware\Bundle\EmotionBundle\ComponentHandler\ArticleSliderComponentHandler` to `AdditionalTextServiceInterface` instead of `AdditionalTextService`

### 3. Describe each step to reproduce the issue or behaviour.
1. Decorate `Shopware\Bundle\StoreFrontBundle\Service\AdditionalTextService`
2. Create a shopping world with an Article or ArticleSlider component
3. Load the page with the shopping world

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
n/a

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.