### PR TITLE
Show minimum amount for surcharge free order in basket 

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -903,9 +903,9 @@ class sBasket
         }
 
         $surcharge = $minimumOrderSurcharge * $factor;
-        $surchargeName = $this->snippetManager
+        $surchargeName = str_replace('{sMinimumOrder}', $minimumOrder, $this->snippetManager
             ->getNamespace('backend/static/discounts_surcharges')
-            ->get('surcharge_name');
+            ->get('surcharge_name'));
 
         $params = [
             'sessionID' => $this->session->get('sessionId'),


### PR DESCRIPTION
### 1. Why is this change necessary?

Customers should easily see the minimum order amount needed to get the order free of minimum order surcharge. This should be visible directly in the surcharge in the basket, so the customers needn't look into the terms and conditions to find out.

### 2. What does this change do, exactly?

With this change the place holder {sMinimumOrder} in the snippet for the minimum order surcharge will be replaced with the minimum order amount configured for the customer group.

### 3. Describe each step to reproduce the issue or behaviour.

Add a product to the basket which costs less then the minimum order amount configured for the customer group. The added surcharge doesn't tell the needed amount to be free of surcharge. With multiple customer groups having different surcharges this can't be simply solved with the snippet text. However this small change enables viewing the needed amount to the customer directly in the surcharge item in the basket.

### 4. Please link to the relevant issues (if any).

None open. Had a support call some time ago, support told us we need to program it ourselfs or contract an agency therefore.

### 5. Which documentation changes (if any) need to be made because of this PR?

It should be mentioned in the documentation that it is possible to show the minium amount by changing the snippet and adding the placeholder {sMinimumOrder} in the snippet. The change doesn't do changes to the snippet itself to avoid breaking anything.

### 6. Checklist

- [ x ] I have written tests and verified that they fail without my change => testsInsertSurchargeWithMinimumOrderAmountInfo() in tests/Functional/Core/sBasketTest.php
- [ x ] I have squashed any insignificant commits
- [ x ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.