### PR TITLE
Fixed emotion default value size to TEXT

### DIFF
--- a/_sql/migrations/955-fix-emotion-default-value.php
+++ b/_sql/migrations/955-fix-emotion-default-value.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration955 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('ALTER TABLE `s_library_component_field` CHANGE `default_value` `default_value` TEXT  CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL;');
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
The current column has a limitation to 256 Characters. A html example is currently not possible with this size.

### 2. What does this change do, exactly?
The migration makes the default value field of elements the same size like the value (s_emotion_element_value.value)

### 3. Describe each step to reproduce the issue or behaviour.
Create a emotion world field with a longer default value

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.