### PR TITLE
Changed realpath() to dirname()

### DIFF
--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -374,7 +374,7 @@ class Kernel implements HttpKernelInterface
      */
     public function getRootDir()
     {
-        return realpath(__DIR__ . '/../../');
+        return dirname(__DIR__, 2) . '/';
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
https://github.com/kalessil/phpinspectionsea/blob/master/docs/probable-bugs.md#phar-incompatible-realpath-usage

### 2. What does this change do, exactly?
'dirname(dirname(__DIR__)) . '/'' should be used instead (due to how realpath handles streams).

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.