### PR TITLE
[BUGFIX] Fixed error in note uniqueId is newly set and not available …

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Note.php
+++ b/engine/Shopware/Controllers/Frontend/Note.php
@@ -71,14 +71,20 @@ class Shopware_Controllers_Frontend_Note extends Enlight_Controller_Action
 
         $this->Front()->Plugins()->ViewRenderer()->setNoRender();
 
+        $notesCount = $this->addNote($this->Request()->getParam('ordernumber'));
+
         $this->Response()->setBody(json_encode(
             [
-                'success' => $this->addNote($this->Request()->getParam('ordernumber')),
-                'notesCount' => (int) Shopware()->Modules()->Basket()->sCountNotes(),
+                'success' => (bool) $notesCount,
+                'notesCount' => (int) $notesCount,
             ]
         ));
     }
 
+    /**
+     * @param string $orderNumber
+     * @return int
+     */
     private function addNote($orderNumber)
     {
         if (empty($orderNumber)) {
@@ -92,8 +98,8 @@ class Shopware_Controllers_Frontend_Note extends Enlight_Controller_Action
             return false;
         }
 
-        Shopware()->Modules()->Basket()->sAddNote($articleID, $articleName, $orderNumber);
+        $notesCount = Shopware()->Modules()->Basket()->sAddNote($articleID, $articleName, $orderNumber);
 
-        return true;
+        return $notesCount;
     }
 }

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1197,7 +1197,7 @@ class sBasket
      *
      * @throws Enlight_Exception If entry could not be added to database
      *
-     * @return bool If operation was successful
+     * @return int If operation was successful
      */
     public function sAddNote($articleID, $articleName, $articleOrderNumber)
     {
@@ -1233,7 +1233,9 @@ class sBasket
             }
         }
 
-        return true;
+        $notesCount = $this->sCountNotes($uniqueId);
+
+        return $notesCount;
     }
 
     /**
@@ -1279,16 +1281,19 @@ class sBasket
      * Returns the number of wishlist entries
      * Used in several locations
      *
+     * @param null|int $uniqueId
      * @return int
      */
-    public function sCountNotes()
+    public function sCountNotes($uniqueId = null)
     {
         $responseCookies = $this->front->Response()->getCookies();
 
-        if (isset($responseCookies['sUniqueID']['value']) && $responseCookies['sUniqueID']['value']) {
-            $uniqueId = $responseCookies['sUniqueID']['value'];
-        } else {
-            $uniqueId = $this->front->Request()->getCookie('sUniqueID');
+        if(!$uniqueId) {
+            if (isset($responseCookies['sUniqueID']['value']) && $responseCookies['sUniqueID']['value']) {
+                $uniqueId = $responseCookies['sUniqueID']['value'];
+            } else {
+                $uniqueId = $this->front->Request()->getCookie('sUniqueID');
+            }
         }
 
         $count = (int) $this->db->fetchOne('

--- a/tests/Functional/Core/sBasketTest.php
+++ b/tests/Functional/Core/sBasketTest.php
@@ -1917,7 +1917,7 @@ class sBasketTest extends PHPUnit\Framework\TestCase
             [$this->module->sSYSTEM->_COOKIE['sUniqueID'], $randomArticle['ordernumber']]
         ));
 
-        $this->assertTrue($this->module->sAddNote(
+        $this->assertEquals(1, $this->module->sAddNote(
             $randomArticle['articleID'],
             $randomArticle['name'],
             $randomArticle['ordernumber']
@@ -1928,7 +1928,7 @@ class sBasketTest extends PHPUnit\Framework\TestCase
             [$this->module->sSYSTEM->_COOKIE['sUniqueID'], $randomArticle['ordernumber']]
         ));
 
-        $this->assertTrue($this->module->sAddNote(
+        $this->assertEquals(1, $this->module->sAddNote(
             $randomArticle['articleID'],
             $randomArticle['name'],
             $randomArticle['ordernumber']
@@ -1979,7 +1979,7 @@ class sBasketTest extends PHPUnit\Framework\TestCase
             [$randomArticleOne['id']]
         );
 
-        $this->assertTrue($this->module->sAddNote(
+        $this->assertEquals(2, $this->module->sAddNote(
             $randomArticleTwo['articleID'],
             $randomArticleTwo['name'],
             $randomArticleTwo['ordernumber']


### PR DESCRIPTION
…in sCountNotes (returned 0)

### 1. Why is this change necessary?
When adding an article to the notes, the first time it will return 0 due to cookie with value sUniqueId is not available on initial call.

### 2. What does this change do, exactly?
Fixes the error that 0 will be returned.

### 3. Describe each step to reproduce the issue or behaviour.

1. Visit the shop
2. Add an article to the note list (on first try it will display 0 above the heart)
3. If not reproduceable clear all your application data of the site and retry