### PR TITLE
Allow session namespaces

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
@@ -87,8 +87,10 @@ class Session
         /** @var $shop \Shopware\Models\Shop\Shop */
         $shop = $container->get('Shop');
 
-        $name = 'session-' . $shop->getId();
+        $name = $sessionOptions['namespace'] . $shop->getId();
         $sessionOptions['name'] = $name;
+
+        unset($sessionOptions['namespace']);
 
         $mainShop = $shop->getMain() ?: $shop;
         if ($mainShop->getAlwaysSecure()) {

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -159,6 +159,7 @@ return array_replace_recursive([
         'save_handler' => 'db',
         'use_trans_sid' => 0,
         'locking' => true,
+        'namespace' => 'session-',
     ],
     'phpsettings' => [
         'error_reporting' => E_ALL & ~E_USER_DEPRECATED,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
It allows to store the sessions of multiple Shopware-instances in one redis or memcache-Server by providing them with different namespaces.

### 2. What does this change do, exactly?
It changes how the session-key is being generated by moving the default name to Defaults, allowing it to be overwritten in the config.php.

### 3. Describe each step to reproduce the issue or behaviour.
Install two shopware-instances and point them to one memcache-server.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
The documentation regarding how to define memcache or redis as a session backend should be extended to include the namespace-parameter.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.