### PR TITLE
Use AdditionalTextServiceInterface instead of actual implementation

### DIFF
--- a/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleComponentHandler.php
+++ b/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleComponentHandler.php
@@ -32,7 +32,7 @@ use Shopware\Bundle\SearchBundle\Sorting\RandomSorting;
 use Shopware\Bundle\SearchBundle\Sorting\ReleaseDateSorting;
 use Shopware\Bundle\SearchBundle\SortingInterface;
 use Shopware\Bundle\SearchBundle\StoreFrontCriteriaFactoryInterface;
-use Shopware\Bundle\StoreFrontBundle\Service\Core\AdditionalTextService;
+use Shopware\Bundle\StoreFrontBundle\Service\AdditionalTextServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware_Components_Config as ShopwareConfig;
@@ -59,19 +59,19 @@ class ArticleComponentHandler implements ComponentHandlerInterface
     private $shopwareConfig;
 
     /**
-     * @var AdditionalTextService
+     * @var AdditionalTextServiceInterface
      */
     private $additionalTextService;
 
     /**
      * @param StoreFrontCriteriaFactoryInterface $criteriaFactory
      * @param ShopwareConfig                     $shopwareConfig
-     * @param AdditionalTextService              $additionalTextService
+     * @param AdditionalTextServiceInterface     $additionalTextService
      */
     public function __construct(
         StoreFrontCriteriaFactoryInterface $criteriaFactory,
         ShopwareConfig $shopwareConfig,
-        AdditionalTextService $additionalTextService
+        AdditionalTextServiceInterface $additionalTextService
     ) {
         $this->criteriaFactory = $criteriaFactory;
 

--- a/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php
+++ b/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php
@@ -32,7 +32,7 @@ use Shopware\Bundle\SearchBundle\Sorting\PriceSorting;
 use Shopware\Bundle\SearchBundle\Sorting\ReleaseDateSorting;
 use Shopware\Bundle\SearchBundle\SortingInterface;
 use Shopware\Bundle\SearchBundle\StoreFrontCriteriaFactoryInterface;
-use Shopware\Bundle\StoreFrontBundle\Service\Core\AdditionalTextService;
+use Shopware\Bundle\StoreFrontBundle\Service\AdditionalTextServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Components\ProductStream\RepositoryInterface;
@@ -67,7 +67,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
     private $shopwareConfig;
 
     /**
-     * @var AdditionalTextService
+     * @var AdditionalTextServiceInterface
      */
     private $additionalTextService;
 
@@ -75,13 +75,13 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
      * @param StoreFrontCriteriaFactoryInterface $criteriaFactory
      * @param RepositoryInterface                $productStreamRepository
      * @param ShopwareConfig                     $shopwareConfig
-     * @param AdditionalTextService              $additionalTextService
+     * @param AdditionalTextServiceInterface     $additionalTextService
      */
     public function __construct(
         StoreFrontCriteriaFactoryInterface $criteriaFactory,
         RepositoryInterface $productStreamRepository,
         ShopwareConfig $shopwareConfig,
-        AdditionalTextService $additionalTextService
+        AdditionalTextServiceInterface $additionalTextService
     ) {
         $this->criteriaFactory = $criteriaFactory;
         $this->productStreamRepository = $productStreamRepository;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
At the moment it is not possible to decorate the AdditionalTextService because of wrong typehints.

### 2. What does this change do, exactly?
Changes the typehints to the interface

### 3. Describe each step to reproduce the issue or behaviour.
Register a decorater for AdditionalTextService

### 4. Please link to the relevant issues (if any).
/

### 5. Which documentation changes (if any) need to be made because of this PR?
/

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.