### PR TITLE
[BUGFIX] JS error caused by empty sidebar filter

### DIFF
--- a/themes/Frontend/Bare/frontend/listing/sidebar.tpl
+++ b/themes/Frontend/Bare/frontend/listing/sidebar.tpl
@@ -8,9 +8,7 @@
 
                 <div class="sidebar-filter">
                     <div class="sidebar-filter--content">
-                        {if $criteria && $facets}
-                            {include file="frontend/listing/actions/action-filter-panel.tpl"}
-                        {/if}
+                        {include file="frontend/listing/actions/action-filter-panel.tpl"}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently if you have the filter placed in the sidebar and no facets are set up for the current view, the essential information for themes/Frontend/Responsive/frontend/_public/src/js/jquery.listing-actions.js especially the data attributes of the HTML filter form are missing – thus resulting in a JS error.

### 2. What does this change do, exactly?
It takes care of the invisible filter form to be rendered even if there are no facets set up for the current view, as it is if you do not have placed it in the sidebar. Basically it just adapts the (correct) behaviour of the non-sidebar-filter.

### 3. Describe each step to reproduce the issue or behaviour.
1. Place the filter in the sidebar
2. Disable all facets
3. Open a product category in the shop's frontend

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.