### PR TITLE
read countries via post instead of get method

### DIFF
--- a/themes/Backend/ExtJs/backend/shipping/store/country.js
+++ b/themes/Backend/ExtJs/backend/shipping/store/country.js
@@ -82,6 +82,9 @@ Ext.define('Shopware.apps.Shipping.store.Country', {
             type: 'json',
             root: 'data',
             totalProperty: 'total'
+        },
+        actionMethods: {
+            read: 'POST'
         }
     }
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
If you have a lot of countries in your shop - like all the countries in the world - the request to load the store will fail because shopware sends every available country as parameter and the url will be too long to handle.

### 2. What does this change do, exactly?
Send the request as post instead of get.

### 3. Describe each step to reproduce the issue or behaviour.
Install / create a lot of countries and try to load any dispatch windows.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.