### PR TITLE
Check bundle view folder exists in dump administration plugins command

### DIFF
--- a/src/Administration/Command/AdministrationDumpPluginsCommand.php
+++ b/src/Administration/Command/AdministrationDumpPluginsCommand.php
@@ -27,6 +27,7 @@ namespace Shopware\Administration\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
 
 class AdministrationDumpPluginsCommand extends ContainerAwareCommand
@@ -62,6 +63,9 @@ class AdministrationDumpPluginsCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->searchPluginDirectories();
+
+        $style = new SymfonyStyle($input, $output);
+        $style->success('Successfully dumped administration modules confiugration');
     }
 
     protected function searchPluginDirectories()
@@ -71,6 +75,10 @@ class AdministrationDumpPluginsCommand extends ContainerAwareCommand
 
         foreach ($this->plugins as $pluginName => $plugin) {
             $directory = $plugin->getPath() . '/Resources/views/src';
+            if (!file_exists($directory)) {
+                continue;
+            }
+
             $manifestFiles = $finder->in($directory)->files()->name('manifest.js')->getIterator();
 
             if (count($manifestFiles) === 0) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Dumping currently not work when a Bundle has not a view folder

### 2. What does this change do, exactly?
Checks that the bundle has a view folder

### 3. Describe each step to reproduce the issue or behaviour.
Create a empty bundle and try dumping

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.