### PR TITLE
Always use the HttpHost and BasePath from ShopwareBackend

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/MediaService.php
+++ b/engine/Shopware/Bundle/MediaBundle/MediaService.php
@@ -291,6 +291,11 @@ class MediaService implements MediaServiceInterface
     {
         $request = $this->container->get('front')->Request();
 
+        $proto = 'http';
+        if ($request && $request->isSecure()) {
+            $proto = 'https';
+        }
+        
         if ($this->container->has('Shop')) {
             /** @var Shop $shop */
             $shop = $this->container->get('Shop');
@@ -307,7 +312,7 @@ class MediaService implements MediaServiceInterface
             return 'https://' . $shop->getSecureHost() . $shop->getSecureBasePath() . '/';
         }
 
-        return ($request->isSecure() ? 'https' : 'http') . $shop->getHost() . $shop->getBasePath() . '/';
+        return $proto . $shop->getHost() . $shop->getBasePath() . '/';
     }
 
     /**

--- a/engine/Shopware/Bundle/MediaBundle/MediaService.php
+++ b/engine/Shopware/Bundle/MediaBundle/MediaService.php
@@ -291,10 +291,6 @@ class MediaService implements MediaServiceInterface
     {
         $request = $this->container->get('front')->Request();
 
-        if ($request && $request->getHttpHost()) {
-            return ($request->isSecure() ? 'https' : 'http') . '://' . $request->getHttpHost() . $request->getBasePath() . '/';
-        }
-
         if ($this->container->has('Shop')) {
             /** @var Shop $shop */
             $shop = $this->container->get('Shop');
@@ -311,7 +307,7 @@ class MediaService implements MediaServiceInterface
             return 'https://' . $shop->getSecureHost() . $shop->getSecureBasePath() . '/';
         }
 
-        return 'http://' . $shop->getHost() . $shop->getBasePath() . '/';
+        return ($request->isSecure() ? 'https' : 'http') . $shop->getHost() . $shop->getBasePath() . '/';
     }
 
     /**

--- a/engine/Shopware/Bundle/MediaBundle/MediaService.php
+++ b/engine/Shopware/Bundle/MediaBundle/MediaService.php
@@ -312,7 +312,7 @@ class MediaService implements MediaServiceInterface
             return 'https://' . $shop->getSecureHost() . $shop->getSecureBasePath() . '/';
         }
 
-        return $proto . $shop->getHost() . $shop->getBasePath() . '/';
+        return $proto. '://' . $shop->getHost() . $shop->getBasePath() . '/';
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
When the Request does not have a BasePath because of Rewrites but you have a BasePath in the Backend it will not provide the correct Paths

### 2. What does this change do, exactly?
Removes the fetching of the URL over the Request

### 3. Describe each step to reproduce the issue or behaviour.
Have a Shop with a Basepath and try to display an Image in the Backend

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.