### PR TITLE
[next] Use tag to fetch view line item transformer collection.

### DIFF
--- a/src/CartBridge/DependencyInjection/services.xml
+++ b/src/CartBridge/DependencyInjection/services.xml
@@ -62,15 +62,14 @@
         </service>
 
         <service id="shopware.cart.view.product_transformer" class="Shopware\CartBridge\View\ViewProductTransformer">
+            <tag name="view.line_item_transformer"/>
             <argument type="service" id="shopware.product.repository" />
             <argument type="service" id="shopware.product_detail.repository" />
             <argument type="service" id="shopware.product_media.repository" />
         </service>
 
         <service id="shopware.cart.view.cart_transformer" class="Shopware\CartBridge\View\ViewCartTransformer">
-            <argument type="collection">
-                <argument type="service" id="shopware.cart.view.product_transformer" />
-            </argument>
+            <argument type="tagged" tag="view.line_item_transformer" />
         </service>
 
         <service id="shopware.cart.voucher.gateway" class="Shopware\CartBridge\Voucher\VoucherGateway" >

--- a/src/CartBridge/View/ViewCartTransformer.php
+++ b/src/CartBridge/View/ViewCartTransformer.php
@@ -36,7 +36,7 @@ class ViewCartTransformer
      */
     private $transformers;
 
-    public function __construct(array $transformers)
+    public function __construct(iterable $transformers)
     {
         $this->transformers = $transformers;
     }


### PR DESCRIPTION
Adds a tag to collect all view cart transformers to allow for different types of line items to be shown.

I can change the PR if #1320 should be merged before this. Just let me know :-)