### PR TITLE
Fix sorting of the tax rates

### DIFF
--- a/engine/Shopware/Models/Article/Repository.php
+++ b/engine/Shopware/Models/Article/Repository.php
@@ -1406,7 +1406,7 @@ class Repository extends ModelRepository
 
         return $builder->select(['taxes'])
                 ->from('Shopware\Models\Tax\Tax', 'taxes')
-                ->orderBy('taxes.name', 'ASC');
+                ->orderBy('taxes.tax', 'DESC');
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The sorting of the tax rates in the article windows is unexpected. Currenty the tax rates are sorted by their NAME and not by their actual RATE.  It is only a coincidence that the default tax list is sorted correctly. But if you add other taxrates, the sorting results in a wrong sorting order. Example, if you add 0 % and 9 % taxes, it leads to the following sorting.
 - 0 %
 - 19 %
 - 7 %
 - 9 %

Also when creating a new article now the "0 %" is selected by default.


### 2. What does this change do, exactly?
Now the tax rates are sorted by their RATE (DESC) instead of their NAME (ASC).


### 3. Describe each step to reproduce the issue or behaviour.
Create a tax rate with a zero tax rate, name it "0 %". Now the list in the article windows looks like this:
 - 0 %
 - 19 %
 - 7 %

This is not expected and should be:
 - 19 %
 - 7 %
 - 0 %

### 4. Please link to the relevant issues (if any).
No issue

### 5. Which documentation changes (if any) need to be made because of this PR?
No

### 6. Checklist

- [ No test needed ] I have written tests and verified that they fail without my change
- [ X ] I have squashed any insignificant commits
- [ X ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ X ] I have read the contribution requirements and fulfil them.