### PR TITLE
added precision and service and copyright header

### DIFF
--- a/engine/Shopware/Models/Shop/Currency.php
+++ b/engine/Shopware/Models/Shop/Currency.php
@@ -2,7 +2,7 @@
 /**
  * Shopware 5
  * Copyright (c) shopware AG
- *
+ * Copyright (c) 2017 @Zwilla (precision and service)
  * According to our dual licensing model, this program can be used either
  * under the terms of the GNU Affero General Public License, version 3,
  * or under a proprietary license.
@@ -92,6 +92,40 @@ class Currency extends ModelEntity
      * @ORM\Column(name="position", type="integer", nullable=false)
      */
     private $position = 0;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="precision", type="integer", nullable=false)
+     */
+    private $precision;
+
+    /**
+     * Get precision
+     *
+     * @return int
+     */
+    public function getPrecision()
+    {
+        return $this->precision;
+    }
+
+    /**
+     * @var text
+     *
+     * @ORM\Column(name="service", type="text", nullable=false)
+     */
+    private $service;
+
+    /**
+     * Get service
+     *
+     * @return text
+     */
+    public function getService()
+    {
+        return $this->service;
+    }
 
     /**
      * Get id
@@ -289,6 +323,8 @@ class Currency extends ModelEntity
             'name' => $this->getName(),
             'currency' => $this->getCurrency(),
             'factor' => $this->getFactor(),
+            'precision' => $this->getPrecision(),
+            'service' => $this->getService(),
         ];
         if ($this->getSymbol()) {
             $options['symbol'] = $this->getSymbol();


### PR DESCRIPTION
### 1. Why is this change necessary?
At moment the currency precision is static, but by default Zend_Currency it could be also dynamic
Let us make a start and accept my pr, to open the way for currencies with more than 2 decimals.

Many lines inside of shopware code for the currency has a static precision

### 2. What does this change do, exactly?
By this PR we do not break any existing function, I just extend it.
If you accept my pr, then it will follow some more PR.
* adding field: precision and 
* adding field: service (for future use to grab the right factor
* depends also by a pr to the database.sql https://github.com/shopware/shopware/pull/1327

### 3. Describe each step to reproduce the issue or behaviour.
Check our shop at https://shop.zwilla.de to see it in action.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20289

### 5. Which documentation changes (if any) need to be made because of this PR?
New Doc for Currencies: 
By default there is no need to change anything, just if you add a currency with more than 2 decimals (precision) it is necessary to set them on settings menu -> ShopSettings ->currency 

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements