### PR TITLE
Implemented fallback into getCurrency in ContextFactory

### DIFF
--- a/src/Context/Service/ContextFactory.php
+++ b/src/Context/Service/ContextFactory.php
@@ -231,7 +231,7 @@ class ContextFactory implements ContextFactoryInterface
         $currency = $this->currencyRepository->read([$currencyUuid], $context);
 
         if (!$currency->has($currencyUuid)) {
-            throw new \RuntimeException(sprintf('Currency by id %s not found', $currencyUuid));
+            return $shop->getCurrency();
         }
 
         return $currency->get($currencyUuid);


### PR DESCRIPTION
Replaced a generic RuntimeException that is never caught with the only logical fallback. This makes it impossible for the currency-cookie to break the storefront if it is invalid.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Without this change an invalid value in the currency-cookie will break the entire storefront because the RuntimeException for this was never caught.

### 2. What does this change do, exactly?
It replaces the thrown RuntimeException with a fallback. When a currency is being loaded based on a cookie and it is not found in the database, now the result falls back to the default shop currency.

### 3. Describe each step to reproduce the issue or behaviour.
Open the storefront and replace the value of the currency-cookie with a different one that is invalid. This could easily happen when a currency is removed after a shop already had customers that used the currency switch.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.