### PR TITLE
Expose eventemitter as global

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
@@ -286,6 +286,8 @@
         }
     };
 
+    window.EventEmitter = EventEmitter;
+
     /**
      * @public
      * @static

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
@@ -286,8 +286,6 @@
         }
     };
 
-    window.EventEmitter = EventEmitter;
-
     /**
      * @public
      * @static
@@ -296,7 +294,16 @@
      * @type {Object}
      */
     window.StateManager = $.extend(Object.create(EventEmitter.prototype), {
-
+        
+        /**
+         * Constructor for Shopware EventEmitter
+         *
+         * @public
+         * @class EventEmitter
+         * @constructor
+         */
+        EventEmitter: EventEmitter,
+        
         /**
          * Collection of all registered breakpoints
          *


### PR DESCRIPTION
### 1. Why is this change necessary?
The EventEmitter is a useful pattern already included in shopware. Expose it as a global to open it for reusability for other developers.

### 2. What does this change do, exactly?
Create `window.EventEmitter`

### 3. Describe each step to reproduce the issue or behaviour.
`console.log(EventEmitter)`

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
Possibly add it to the DevDocs

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.