### PR TITLE
Fix _includes/messages.html.twig docs

### DIFF
--- a/src/Storefront/Resources/views/frontend/_includes/messages.html.twig
+++ b/src/Storefront/Resources/views/frontend/_includes/messages.html.twig
@@ -28,7 +28,6 @@
  *
  * ```
  *    {% sw_include '@Storefront/frontend/_includes/messages.html.twig' with { 'type': 'error', 'list': errorMessages } %}
- *    {include file="frontend/_includes/messages.tpl" type="error" list=$error_messages}
  * ```
  *
  * The template also supportes bold texts for the content or list entires, which could be modified using the parameter

--- a/src/Storefront/Resources/views/frontend/_includes/messages.html.twig
+++ b/src/Storefront/Resources/views/frontend/_includes/messages.html.twig
@@ -9,24 +9,25 @@
  *  The component requires at least the parameters ```content``` and ```type``` to display the message correctly.
  *
  *  ```
- *     {include file="frontend/_includes/messages.tpl" type="error" content="Your content"}
+ *    {% sw_include '@Storefront/frontend/_includes/messages.html.twig' with { 'type': 'error', 'content': 'Your content' } %}
  *  ```
  *
  *  Customized icons can be passed using the icon font to the component using the parameter ```icon```:
  *  ```
- *     {include file="frontend/_includes/messages.tpl" type="error" content="Your content" icon="icon--shopware"}
+ *    {% sw_include '@Storefront/frontend/_includes/messages.html.twig' with { 'type': 'error', 'content': 'Your content', 'icon': 'icon--shopware' } %}
  *  ```
  *
  *  The border-radius can be modified using the parameter ```borderRadius```. The default behavior contains a
  *  border radius for the message:
  *  ```
- *     {include file="frontend/_includes/messages.tpl" type="error" content="Your content" borderRadius=true}
+ *    {% sw_include '@Storefront/frontend/_includes/messages.html.twig' with { 'type': 'error', 'content': 'Your content', 'borderRadius': true } %}
  *  ```
  *
  * If you need to display a bunch of messages (for example error messages in the registration), you can pass an array
  * of messages to the template using the parameter ```list```:
  *
  * ```
+ *    {% sw_include '@Storefront/frontend/_includes/messages.html.twig' with { 'type': 'error', 'list': errorMessages } %}
  *    {include file="frontend/_includes/messages.tpl" type="error" list=$error_messages}
  * ```
  *
@@ -34,14 +35,14 @@
  * ```bold```. By default the parameter is set to ```true```.
  *
  * ```
- *    {include file="frontend/_includes/messages.tpl" type="error" content="Your content" bold=false}
+ *    {% sw_include '@Storefront/frontend/_includes/messages.html.twig' with { 'type': 'error', 'content': 'Your content', 'bold': false } %}
  * ```
  *
  * If you need to insert the message into the DOM but don't want to display it, you can use the parameter ```visible```
  * to hide the message on startup. By default the parameter is set to ```true```.
  *
  * ```
- *    {include file="frontend/_includes/messages.tpl" type="error" content="Your content" visible=false}
+ *    {% sw_include '@Storefront/frontend/_includes/messages.html.twig' with { 'type': 'error', 'content': 'Your content', 'visible': false } %}
  * ```
  #}
 


### PR DESCRIPTION
Shopware labs Change

### 1. Why is this change necessary?
Correct docs

### 2. What does this change do, exactly?
Change smarty-syntax to twig-syntax

### 3. Describe each step to reproduce the issue or behaviour.
x

### 4. Please link to the relevant issues (if any).
x

### 5. Which documentation changes (if any) need to be made because of this PR?
x

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.