### PR TITLE
Added applyDataAttributes() to swJumpToTab plugin

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.jump-to-tab.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.jump-to-tab.js
@@ -20,6 +20,8 @@
         init: function () {
             var me = this,
                 param = decodeURI((RegExp('(?:action|jumpTab)=(.+?)(&|$)').exec(location.search) || [null, null])[1]);
+            
+            me.applyDataAttributes();
 
             me.$htmlBody = $('body, html');
             me.tabMenuProduct = me.$el.find(me.opts.tabDetail).data('plugin_swTabMenu');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Right now it is not easy to change the defaults of the jquery plugin `swJumpToTab`. With this change it becomes as easy as adding some data-attributes to the body-tag.

### 2. What does this change do, exactly?
At the beginning of the init-function the options are merged from the defaults and the given data-attributes. The remaining plugin remains the same as before.

### 3. Describe each step to reproduce the issue or behaviour.
Try to change the defaults of the `swJumpToTab` plugin by markup.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.