### PR TITLE
Updated currency cookie after context is created

### DIFF
--- a/src/Storefront/Context/StorefrontContextService.php
+++ b/src/Storefront/Context/StorefrontContextService.php
@@ -122,6 +122,7 @@ class StorefrontContextService implements StorefrontContextServiceInterface
         }
 
         $context = $this->factory->create($shopScope, $customerScope, $checkoutScope);
+        $this->requestStack->getMasterRequest()->attributes->set('_currency_uuid', $context->getCurrency()->getUuid());
 
         $outputKey = $this->getCacheKey(
             ShopScope::createFromContext($context),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The ContextFactory finds the currency based on the currency uuid in the given currency cookie. If there is none, a fallback will be used. This fallback is never persisted to the cookies.

### 2. What does this change do, exactly?
This change writes the currency uuid to the request attributes where it will later be read from and sent back to the browser as a cookie.

### 3. Describe each step to reproduce the issue or behaviour.
Open the Storefront without a currency cookie.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.