### PR TITLE
Update jquery.jump-to-tab.js

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.jump-to-tab.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.jump-to-tab.js
@@ -14,7 +14,11 @@
         defaults: {
             contentCls: 'has--content',
             tabDetail: '.tab-menu--product',
-            tabCrossSelling: '.tab-menu--cross-selling'
+            tabCrossSelling: '.tab-menu--cross-selling',
+            btnJumpSelectors: [
+                '.product--rating-link',
+                '.link--publish-comment'
+            ]
         },
 
         init: function () {
@@ -35,7 +39,19 @@
                 me.jumpToTab(index, $tab);
             }
         },
-
+        
+        /**
+         * Destroys the plugin by removing all events of the plugin.
+         *
+         * @public
+         * @method destroy
+         */        
+        destroy: function() {
+            var me = this;
+            me.$el.off(this.getEventName('click'), me.opts.btnJumpSelectors.join(', '));
+            me._destroy();
+        },
+        
         resizeCrossSelling: function () {
             var me = this,
                 $container;
@@ -54,7 +70,7 @@
         registerEvents: function () {
             var me = this;
 
-            me.$el.on(me.getEventName('click'), '.product--rating-link, .link--publish-comment', $.proxy(me.onJumpToTab, me));
+            me.$el.on(me.getEventName('click'), me.opts.btnJumpSelectors.join(', '), $.proxy(me.onJumpToTab, me));
 
             $.publish('plugin/swJumpToTab/onRegisterEvents', [ me ]);
         },


### PR DESCRIPTION
Made invoking elements configurable by exposing the selectors.
Unbind the click event on destroy.

### 1. Why is this change necessary?
If you remove the plugin from the StateManager and still use the rating link below the 'add to cart' button on a detail page, it is still working. An additional warning is displayed that this plugin has no customized destroy method.
> :warning: Plugin swJumpToTab should have a custom destroy method!

### 2. What does this change do, exactly?
It adds the hinted destroy method to unregister the registered events in `registerEvents`. As this duplicates the used selectors, these were extracted into a plugin option. So you can benefit from customizability.

### 3. Describe each step to reproduce the issue or behaviour.
1. Load a product detail page
2. Open browser console
3. Execute `window.StateManager.removePlugin('.is--ctl-detail', 'swJumpToTab');`
4. Click the rating link under the 'add to cart' button
5. Still works :unamused: 

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.