### PR TITLE
change baseurl to prevent wrong links

### DIFF
--- a/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/BannerSliderComponentHandler.php
+++ b/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/BannerSliderComponentHandler.php
@@ -73,7 +73,7 @@ class BannerSliderComponentHandler implements ComponentHandlerInterface
 
         foreach ($sliderList as &$slider) {
             if (!empty($slider['link']) && !preg_match('/^(http|https):\/\//', $slider['link'])) {
-                $slider['link'] = $context->getBaseUrl() . $slider['link'];
+                $slider['link'] = $context->getShop()->getUrl() . $slider['link'];
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Banner-Slider-Links are invalid

### 2. What does this change do, exactly?
Change the Banner-Slider Mapping Link to the right structure

### 3. Describe each step to reproduce the issue or behaviour.
- create new emotion world
- add banner slider element and add a link like "shopware.php?sViewport=cat&sCategory=47826"
- save element and emotion world
- view emotion world in frontend and look at the banner slider link. It looks like www.domain.deshopware.php?sViewport=cat&sCategory=47826

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.