### PR TITLE
Fix document type models

### DIFF
--- a/engine/Shopware/Models/Document/Document.php
+++ b/engine/Shopware/Models/Document/Document.php
@@ -24,6 +24,7 @@
 
 namespace   Shopware\Models\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
 
@@ -114,11 +115,19 @@ class Document extends ModelEntity
     /**
      * INVERSED SIDE
      *
-     * @var \Shopware\Models\Document\Element
+     * @var ArrayCollection
      * @ORM\OneToMany(targetEntity="\Shopware\Models\Document\Element", mappedBy="document", orphanRemoval=true, cascade={"persist"})
      * @ORM\JoinColumn(name="id", referencedColumnName="documentID")
      */
     private $elements;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->elements = new ArrayCollection();
+    }
 
     /**
      * Getter function for the unique id identifier property
@@ -135,7 +144,7 @@ class Document extends ModelEntity
      *
      * @param string $name
      *
-     * @return \Shopware\Models\Document\Document
+     * @return Document
      */
     public function setName($name)
     {
@@ -159,7 +168,7 @@ class Document extends ModelEntity
      *
      * @param string $template
      *
-     * @return \Shopware\Models\Document\Document
+     * @return Document
      */
     public function setTemplate($template)
     {
@@ -183,7 +192,7 @@ class Document extends ModelEntity
      *
      * @param string $numbers
      *
-     * @return \Shopware\Models\Document\Document
+     * @return Document
      */
     public function setNumbers($numbers)
     {
@@ -207,7 +216,7 @@ class Document extends ModelEntity
      *
      * @param int $bottom
      *
-     * @return \Shopware\Models\Document\Document
+     * @return Document
      */
     public function setBottom($bottom)
     {
@@ -231,7 +240,7 @@ class Document extends ModelEntity
      *
      * @param int $left
      *
-     * @return \Shopware\Models\Document\Document
+     * @return Document
      */
     public function setLeft($left)
     {
@@ -255,7 +264,7 @@ class Document extends ModelEntity
      *
      * @param int $pageBreak
      *
-     * @return \Shopware\Models\Document\Document
+     * @return Document
      */
     public function setPageBreak($pageBreak)
     {
@@ -279,7 +288,7 @@ class Document extends ModelEntity
      *
      * @param int $right
      *
-     * @return \Shopware\Models\Document\Document
+     * @return Document
      */
     public function setRight($right)
     {
@@ -303,7 +312,7 @@ class Document extends ModelEntity
      *
      * @param int $top
      *
-     * @return \Shopware\Models\Document\Document
+     * @return Document
      */
     public function setTop($top)
     {
@@ -315,8 +324,6 @@ class Document extends ModelEntity
     /**
      * Gets the top-value of the document.
      *
-     * Gets the top-value of the document.
-     *
      * @return int
      */
     public function getTop()
@@ -325,11 +332,11 @@ class Document extends ModelEntity
     }
 
     /**
-     * Sets the form-elements.
+     * Sets the document elements (document boxes)
      *
-     * @param \Shopware\Models\Document\Element $elements
+     * @param ArrayCollection $elements
      *
-     * @return \Shopware\Models\Document\Document
+     * @return Document
      */
     public function setElements($elements)
     {
@@ -339,9 +346,9 @@ class Document extends ModelEntity
     }
 
     /**
-     * Gets the form-elements.
+     * Gets the document elements (document boxes)
      *
-     * @return \Doctrine\Common\Collections\ArrayCollection
+     * @return ArrayCollection
      */
     public function getElements()
     {

--- a/engine/Shopware/Models/Document/Element.php
+++ b/engine/Shopware/Models/Document/Element.php
@@ -48,7 +48,7 @@ class Element extends ModelEntity
     private $id;
 
     /**
-     * Contains the name of the document.
+     * ID of the owning Document.
      *
      * @var int
      * @ORM\Column(name="documentID", type="integer", nullable=false)
@@ -56,7 +56,7 @@ class Element extends ModelEntity
     private $documentId = '';
 
     /**
-     * Contains the name of the document.
+     * Name of the Element
      *
      * @var string
      * @ORM\Column(name="name", type="string", nullable=false)
@@ -64,7 +64,7 @@ class Element extends ModelEntity
     private $name = '';
 
     /**
-     * Contains the name of the document.
+     * CSS style of the Element
      *
      * @var string
      * @ORM\Column(name="style", type="string", nullable=false)
@@ -72,7 +72,7 @@ class Element extends ModelEntity
     private $style = '';
 
     /**
-     * Contains the name of the document.
+     * Value of the Element
      *
      * @var string
      * @ORM\Column(name="value", type="string", nullable=false)
@@ -80,12 +80,14 @@ class Element extends ModelEntity
     private $value = '';
 
     /**
-     * Owning Side
+     * OWNING SIDE
      *
-     * @ORM\ManyToOne(targetEntity="Shopware\Models\Document\Document", inversedBy="elements")
+     * The owning document
+     *
+     * @ORM\ManyToOne(targetEntity="Shopware\Models\Document\Document", inversedBy="Elements")
      * @ORM\JoinColumn(name="documentID", referencedColumnName="id")
      *
-     * @var \Shopware\Models\Document\Document
+     * @var Document
      */
     private $document;
 
@@ -100,11 +102,11 @@ class Element extends ModelEntity
     }
 
     /**
-     * Gets the name of the document.
+     * Gets the name of the Element
      *
      * @param string $name
      *
-     * @return \Shopware\Models\Document\Element
+     * @return Element
      */
     public function setName($name)
     {
@@ -114,7 +116,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * Sets the documents name.
+     * Sets the Element name.
      *
      * @return string
      */
@@ -124,11 +126,11 @@ class Element extends ModelEntity
     }
 
     /**
-     * Sets the value for an element.
+     * Sets the value for the Element.
      *
      * @param string $value
      *
-     * @return \Shopware\Models\Document\Element
+     * @return Element
      */
     public function setValue($value)
     {
@@ -138,7 +140,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * Gets the value for an element.
+     * Gets the value for an Element.
      *
      * @return string
      */
@@ -148,11 +150,11 @@ class Element extends ModelEntity
     }
 
     /**
-     * Sets the style for
+     * Sets the CSS style for the Element
      *
      * @param string $style
      *
-     * @return \Shopware\Models\Document\Element
+     * @return Element
      */
     public function setStyle($style)
     {
@@ -162,6 +164,8 @@ class Element extends ModelEntity
     }
 
     /**
+     * Gets the CSS style for the Element
+     *
      * @return string
      */
     public function getStyle()
@@ -170,9 +174,11 @@ class Element extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Document\Document $document
+     * Sets the Document for this Element
      *
-     * @return \Shopware\Models\Document\Element
+     * @param Document $document
+     *
+     * @return Element
      */
     public function setDocument($document)
     {
@@ -182,7 +188,9 @@ class Element extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Document\Document
+     * Gets the Document for this Element
+     *
+     * @return Document
      */
     public function getDocument()
     {

--- a/engine/Shopware/Models/Order/Document/Type.php
+++ b/engine/Shopware/Models/Order/Document/Type.php
@@ -22,27 +22,26 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Models\Order\Document;
+namespace   Shopware\Models\Order\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
 
 /**
- * Shopware order document type model represents a single order document.
- * <br>
- * The Shopware order document type model represents a row of the core_documents table.
- * The core_documents table has the follows indices:
- * <code>
- * </code>
+ * Shopware document model represents a document.
  *
  * @ORM\Entity
  * @ORM\Table(name="s_core_documents")
+ * @ORM\HasLifecycleCallbacks
  */
 class Type extends ModelEntity
 {
     /**
-     * @var int
+     * The id property is an identifier property which means
+     * doctrine associations can be defined over this field
      *
+     * @var int
      * @ORM\Column(name="id", type="integer", nullable=false)
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
@@ -50,63 +49,88 @@ class Type extends ModelEntity
     private $id;
 
     /**
+     * Contains the name of the document.
+     *
      * @var string
-     *
-     * @ORM\Column(name="name", type="string", length=255, nullable=false)
+     * @ORM\Column(name="name", type="string", nullable=false)
      */
-    private $name;
+    private $name = '';
 
     /**
+     * Contains the template-file of the document.
+     *
      * @var string
-     *
-     * @ORM\Column(name="template", type="string", length=255, nullable=false)
+     * @ORM\Column(name="template", type="string", nullable=false)
      */
-    private $template;
+    private $template = '';
 
     /**
+     * Contains the numbers of the document.
+     *
      * @var string
-     *
-     * @ORM\Column(name="numbers", type="string", length=25, nullable=false)
+     * @ORM\Column(name="numbers", type="string", nullable=false)
      */
-    private $numbers;
+    private $numbers = '';
 
     /**
-     * @var int
+     * Contains the left-value of the document.
      *
-     * @ORM\Column(name="left", type="integer", nullable=false)
+     * @var int
+     * @ORM\Column(name="`left`", type="integer", nullable=false)
      */
-    private $left;
+    private $left = 0;
 
     /**
-     * @var int
+     * Contains the right-value of the document.
      *
-     * @ORM\Column(name="right", type="integer", nullable=false)
+     * @var int
+     * @ORM\Column(name="`right`", type="integer", nullable=false)
      */
-    private $right;
+    private $right = 0;
 
     /**
-     * @var int
+     * Contains the top-value of the document.
      *
+     * @var int
      * @ORM\Column(name="top", type="integer", nullable=false)
      */
-    private $top;
+    private $top = 0;
 
     /**
-     * @var int
+     * Contains the bottom-value of the document.
      *
+     * @var int
      * @ORM\Column(name="bottom", type="integer", nullable=false)
      */
-    private $bottom;
+    private $bottom = 0;
 
     /**
-     * @var int
+     * Contains the pageBreak-value of the document.
      *
+     * @var int
      * @ORM\Column(name="pagebreak", type="integer", nullable=false)
      */
-    private $pageBreak;
+    private $pageBreak = 0;
 
     /**
-     * Get id
+     * INVERSED SIDE
+     *
+     * @var ArrayCollection
+     * @ORM\OneToMany(targetEntity="\Shopware\Models\Document\Element", mappedBy="document", orphanRemoval=true, cascade={"persist"})
+     * @ORM\JoinColumn(name="id", referencedColumnName="documentID")
+     */
+    private $elements;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->elements = new ArrayCollection();
+    }
+
+    /**
+     * Getter function for the unique id identifier property
      *
      * @return int
      */
@@ -116,7 +140,7 @@ class Type extends ModelEntity
     }
 
     /**
-     * Set name
+     * Gets the name of the document.
      *
      * @param string $name
      *
@@ -130,7 +154,7 @@ class Type extends ModelEntity
     }
 
     /**
-     * Get name
+     * Sets the documents name.
      *
      * @return string
      */
@@ -140,7 +164,7 @@ class Type extends ModelEntity
     }
 
     /**
-     * Set template
+     * Sets the documents template-file.
      *
      * @param string $template
      *
@@ -154,7 +178,7 @@ class Type extends ModelEntity
     }
 
     /**
-     * Get template
+     * Gets the name of the template-file.
      *
      * @return string
      */
@@ -164,7 +188,7 @@ class Type extends ModelEntity
     }
 
     /**
-     * Set numbers
+     * Sets the documents numbers.
      *
      * @param string $numbers
      *
@@ -178,7 +202,7 @@ class Type extends ModelEntity
     }
 
     /**
-     * Get numbers
+     * Gets the numbers of the document.
      *
      * @return string
      */
@@ -188,79 +212,7 @@ class Type extends ModelEntity
     }
 
     /**
-     * Set left
-     *
-     * @param int $left
-     *
-     * @return Type
-     */
-    public function setLeft($left)
-    {
-        $this->left = $left;
-
-        return $this;
-    }
-
-    /**
-     * Get left
-     *
-     * @return int
-     */
-    public function getLeft()
-    {
-        return $this->left;
-    }
-
-    /**
-     * Set right
-     *
-     * @param int $right
-     *
-     * @return Type
-     */
-    public function setRight($right)
-    {
-        $this->right = $right;
-
-        return $this;
-    }
-
-    /**
-     * Get right
-     *
-     * @return int
-     */
-    public function getRight()
-    {
-        return $this->right;
-    }
-
-    /**
-     * Set top
-     *
-     * @param int $top
-     *
-     * @return Type
-     */
-    public function setTop($top)
-    {
-        $this->top = $top;
-
-        return $this;
-    }
-
-    /**
-     * Get top
-     *
-     * @return int
-     */
-    public function getTop()
-    {
-        return $this->top;
-    }
-
-    /**
-     * Set bottom
+     * Sets the bottom-value for the document.
      *
      * @param int $bottom
      *
@@ -274,7 +226,7 @@ class Type extends ModelEntity
     }
 
     /**
-     * Get bottom
+     * Gets the bottom-value of the document.
      *
      * @return int
      */
@@ -284,7 +236,31 @@ class Type extends ModelEntity
     }
 
     /**
-     * Set pageBreak
+     * Sets the left-value for the document.
+     *
+     * @param int $left
+     *
+     * @return Type
+     */
+    public function setLeft($left)
+    {
+        $this->left = $left;
+
+        return $this;
+    }
+
+    /**
+     * Gets the left-value of the document.
+     *
+     * @return int
+     */
+    public function getLeft()
+    {
+        return $this->left;
+    }
+
+    /**
+     * Sets the pageBreak-value for the document.
      *
      * @param int $pageBreak
      *
@@ -298,12 +274,84 @@ class Type extends ModelEntity
     }
 
     /**
-     * Get pageBreak
+     * Gets the pageBreak-value of the document.
      *
      * @return int
      */
     public function getPageBreak()
     {
         return $this->pageBreak;
+    }
+
+    /**
+     * Sets the right-value for the document.
+     *
+     * @param int $right
+     *
+     * @return Type
+     */
+    public function setRight($right)
+    {
+        $this->right = $right;
+
+        return $this;
+    }
+
+    /**
+     * Gets the right-value of the document.
+     *
+     * @return int
+     */
+    public function getRight()
+    {
+        return $this->right;
+    }
+
+    /**
+     * Sets the top-value for the document.
+     *
+     * @param int $top
+     *
+     * @return Type
+     */
+    public function setTop($top)
+    {
+        $this->top = $top;
+
+        return $this;
+    }
+
+    /**
+     * Gets the top-value of the document.
+     *
+     * @return int
+     */
+    public function getTop()
+    {
+        return $this->top;
+    }
+
+    /**
+     * Sets the document elements (document boxes)
+     *
+     * @param ArrayCollection $elements
+     *
+     * @return Type
+     */
+    public function setElements($elements)
+    {
+        $this->elements = $elements;
+
+        return $this;
+    }
+
+    /**
+     * Gets the document elements (document boxes)
+     *
+     * @return ArrayCollection
+     */
+    public function getElements()
+    {
+        return $this->elements;
     }
 }

--- a/tests/Functional/Models/Order/OrderDocumentDocumentTest.php
+++ b/tests/Functional/Models/Order/OrderDocumentDocumentTest.php
@@ -1,4 +1,6 @@
 <?php
+use Shopware\Components\Model\ModelManager;
+
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -71,5 +73,24 @@ class Shopware_Tests_Models_Order_Document_DocumentTest extends Enlight_Componen
             // Check that document was actually created
             $this->assertNotNull($document);
         }
+    }
+
+    /**
+     * Test whether new instances of Document and Type can be persisted
+     */
+    public function testCreateNewDocumentDocument()
+    {
+        /** @var ModelManager $modelManager */
+        $modelManager = Shopware()->Container()->get('models');
+
+        $documentDocument = new Shopware\Models\Document\Document();
+        $modelManager->persist($documentDocument);
+        $modelManager->flush($documentDocument);
+        self::assertGreaterThan(0, $documentDocument->getId());
+
+        $orderDocumentType = new Shopware\Models\Order\Document\Type();
+        $modelManager->persist($orderDocumentType);
+        $modelManager->flush($orderDocumentType);
+        self::assertGreaterThan(0, $orderDocumentType->getId());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The models `Shopware\Models\Document\Document` and `Shopware\Models\Order\Document\Type` are referencing the same database table. So their definition should match.

Also: The model  `Shopware\Models\Order\Document\Type` cannot be persistet because of missing backticks in the ORM annotation

### 2. What does this change do, exactly?

- Equalizes the definitions of the models `Shopware\Models\Document\Document` and `Shopware\Models\Order\Document\Type` 
- Fixes missing backticks in `Shopware\Models\Order\Document\Type` in the ORM annotation for fields 'left' and 'right' so they can be persisted without a MySQL error.
- Fixes several copy paste errors in the doc blocks for the models `Shopware\Models\Order\Document\Type`, `Shopware\Models\Document\Document` and `Shopware\Models\Document\Element` 

### 3. Describe each step to reproduce the issue or behaviour.

```
<?php
use Shopware\Models\Order\Document\Type;

/** @var ModelManager $modelManager */
$modelManager = Shopware()->Container()->get('models');

$newDocumentType = new Type();
$modelManager->persist($newDocumentType);
$modelManager->flush($newDocumentType);
```

### 4. Please link to the relevant issues (if any).
No issue.

### 5. Which documentation changes (if any) need to be made because of this PR?
No changes required.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.