### PR TITLE
Added event dispatcher for command line

### DIFF
--- a/engine/Shopware/Components/Console/Application.php
+++ b/engine/Shopware/Components/Console/Application.php
@@ -102,6 +102,7 @@ class Application extends BaseApplication
             $output->writeln($formatter->formatBlock('WARNING! ' . $e->getMessage() . ' in ' . $e->getFile(), 'error'));
             $this->skipDatabase = true;
         }
+        $this->setDispatcher($this->kernel->getContainer()->get('event_dispatcher'));
 
         if (!$this->commandsRegistered) {
             $this->registerCommands($output);

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -697,5 +697,6 @@
             <argument id="shopware_searchdbal.search_term_helper" type="service"/>
         </service>
 
+        <service id="event_dispatcher" class="Symfony\Component\EventDispatcher\EventDispatcher"/>
     </services>
 </container>

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -59,6 +59,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -645,6 +646,7 @@ class Kernel implements HttpKernelInterface
         $container->addCompilerPass(new HandlerRegistryCompilerPass());
         $container->addCompilerPass(new SearchHandlerCompilerPass());
         $container->addCompilerPass(new EmotionPresetCompilerPass());
+        $container->addCompilerPass(new RegisterListenersPass());
 
         $container->setParameter('active_plugins', $this->activePlugins);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It is currently impossible to catch command line exceptions. Symfony Console renders the Exception in the try catch when no dispatcher is used.

### 2. What does this change do, exactly?
Makes use of Symfony default EventDispatcher and adds also the default CompilerPass to register custom Subscriber.

### 3. Describe each step to reproduce the issue or behaviour.
Throw a Exception in console and try to catch it..

### 4. Please link to the relevant issues (if any).
https://github.com/1drop/shopware-sentry/issues/4

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.