### PR TITLE
Improved autocomplete of synthetic services

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -12,9 +12,9 @@
     </parameters>
 
     <services>
-        <service id="application"     synthetic="true" />
-        <service id="PasswordEncoder" synthetic="true" />
-        <service id="db_connection"   synthetic="true" />
+        <service id="application" class="Shopware" synthetic="true" />
+        <service id="PasswordEncoder" class="Shopware\Components\Password\Manager" synthetic="true" />
+        <service id="db_connection" class="PDO" synthetic="true" />
 
         <service id="bootstrap" class="Shopware_Bootstrap">
             <argument type="service" id="service_container"/>
@@ -696,6 +696,5 @@
         <service id="shopware.model.search_builder" class="Shopware\Components\Model\SearchBuilder">
             <argument id="shopware_searchdbal.search_term_helper" type="service"/>
         </service>
-
     </services>
 </container>


### PR DESCRIPTION
### 1. Why is this change necessary?
Class definition is required to see the service in PhpStorm Symfony Plugin

### 2. What does this change do, exactly?
Adds class definitions to synthetic services

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.