### PR TITLE
Show menu and shop sites when a error is occurred

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/ControllerBase/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/ControllerBase/Bootstrap.php
@@ -53,11 +53,9 @@ class Shopware_Plugins_Core_ControllerBase_Bootstrap extends Shopware_Components
     public function onPostDispatch(Enlight_Event_EventArgs $args)
     {
         $request = $args->getSubject()->Request();
-        $response = $args->getSubject()->Response();
         $view = $args->getSubject()->View();
 
-        if (!$request->isDispatched() || $response->isException()
-            || $request->getModuleName() != 'frontend'
+        if (!$request->isDispatched() || $request->getModuleName() != 'frontend'
             || !$view->hasTemplate()
         ) {
             return;


### PR DESCRIPTION
### 1. Why is this change necessary?
The user should have also on error page the categories and shop sites to go to a another page

### 2. What does this change do, exactly?
Adds categories informations to error page

Before:
![Before](https://i.imgur.com/B6fAjUS.png)
After:
![After](https://i.imgur.com/gpyrex0.png)

### 3. Describe each step to reproduce the issue or behaviour.
Throw a exception in a controller

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.