### PR TITLE
SW-20344 - Improve PluginInitializer by defining namespace prefixes b…

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
@@ -57,7 +57,8 @@ class PluginInitializer
      */
     public function initializePlugins()
     {
-        $plugins = [];
+        $plugins          = [];
+        $pluginsAvailable = [];
 
         $classLoader = new Psr4ClassLoader();
         $classLoader->register(true);
@@ -80,11 +81,21 @@ class PluginInitializer
             $className = '\\' . $namespace . '\\' . $pluginName;
             $classLoader->addPrefix($namespace, $pluginDir->getPathname());
 
+            $isActive                      = in_array($pluginName, $activePlugins, true);
+            $pluginsAvailable[$pluginName] = compact('pluginFile', 'className', 'isActive');
+        }
+
+        foreach ($pluginsAvailable as $pluginName => $config) {
+            /**
+             * @var string $className
+             * @var string $pluginFile
+             * @var bool   $isActive
+             */
+            extract($config);
+
             if (!class_exists($className)) {
                 throw new \RuntimeException(sprintf('Unable to load class %s for plugin %s in file %s', $className, $pluginName, $pluginFile));
             }
-
-            $isActive = in_array($pluginName, $activePlugins, true);
 
             /** @var Plugin $plugin */
             $plugin = new $className($isActive);


### PR DESCRIPTION
Change plugin initialization to a 'two tier' loop. The first registers PSR4 prefixes and the second initializes the plugins.

This is necessary for plugins built with inheritance (ClassA extends ClassB). The \DirectoryIterator gives a faulty result: child directories are returned in random order causing prefixes to NOT be defined on plugin construction.
This fix isn't as pretty as can be, but it works flawlessly. Please review/update the code as you see fit.