### PR TITLE
[BUGFIX] SW-20344 - PluginInitializer: Register PSR4 prefixes before plugin autoload

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
@@ -64,6 +64,7 @@ class PluginInitializer
     {
         $plugins = [];
         $shopwarePlugins = [];
+        $pluginsAvailable = [];
 
         $classLoader = new Psr4ClassLoader();
         $classLoader->register(true);
@@ -94,11 +95,21 @@ class PluginInitializer
             $className = '\\' . $namespace . '\\' . $pluginName;
             $classLoader->addPrefix($namespace, $pluginDir->getPathname());
 
+            $isActive                      = in_array($pluginName, $shopwarePlugins, true);
+            $pluginsAvailable[$pluginName] = compact('pluginFile', 'className', 'isActive');
+        }
+
+        foreach ($pluginsAvailable as $name => $config) {
+            /**
+             * @var string $className
+             * @var string $pluginFile
+             * @var bool   $isActive
+             */
+            extract($config);
+
             if (!class_exists($className)) {
                 throw new \RuntimeException(sprintf('Unable to load class %s for plugin %s in file %s', $className, $pluginName, $pluginFile));
             }
-
-            $isActive = in_array($pluginName, $shopwarePlugins, true);
 
             /** @var Plugin $plugin */
             $plugin = new $className($isActive);

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
@@ -99,7 +99,7 @@ class PluginInitializer
             $pluginsAvailable[$pluginName] = compact('pluginFile', 'className', 'isActive');
         }
 
-        foreach ($pluginsAvailable as $name => $config) {
+        foreach ($pluginsAvailable as $pluginName => $config) {
             /**
              * @var string $className
              * @var string $pluginFile


### PR DESCRIPTION
### 1. Why is this change necessary?
Plugins built with inheritance (ClassA extends ClassB) or requirements from other plugins (traits, libs etc.) fail to load, because PSR4 prefixes aren't defined before plugin initialization. 

### 2. What does this change do, exactly?
Change plugin initialization to a 'two tier' loop. The first registers PSR4 prefixes and the second initializes the plugins.
NB: This issue may relate multiple versions of SW

### 3. Describe each step to reproduce the issue or behaviour.

1. Create various plugins in /custom/plugins/
2. Inherit / require components from one library to another (see code block)
3. Results in "Failed to load class B in A on line X"

Example pseudo-code:
```php
// /custom/plugins/MyPlugin/MyPlugin.php
namespace MyPlugin;

class MyPlugin extends Shopware\Components\Plugin\Plugin
{
 // code
}

// /custom/plugins/MyPlugin/Lib/MyTrait.php
namespace MyPlugin\Lib;

trait MyTrait
{
 // code
}

// /custom/plugins/MyOtherPlugin/MyOtherPlugin.php
namespace MyOtherPlugin;

class MyOtherPlugin extends MyPlugin
{ 
   use \MyPlugin\Lib\MyTrait;
   // code
}
```

**Internals**
In PluginIntitializer, \DirectoryIterator gives a faulty result: child directories are returned in random order causing prefixes to NOT be defined on plugin construction. E.g.:
```
 new \DirectoryIterator('/custom/plugins/') 
 // => [
   /custom/plugins/.
   /custom/plugins/MyOtherPlugin
   /custom/plugins/..
   /custom/plugins/MyPlugin
 ]
```
In the old code *MyOtherPlugin* is autoloaded directly (with class_exists), before *MyPlugin* has been defined in *Psr4ClassLoader*. This fix resolves this by first indexing all plugins, then initializing plugins.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20344

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.