### PR TITLE
[BUGFIX] Added join on attribute to getBannerMainQuery function

### DIFF
--- a/engine/Shopware/Models/Banner/Repository.php
+++ b/engine/Shopware/Models/Banner/Repository.php
@@ -97,7 +97,8 @@ class Repository extends ModelRepository
     public function getBannerMainQuery($filter = null)
     {
         $builder = $this->createQueryBuilder('banner');
-        $builder->select(['banner']);
+        $builder->select(['banner', 'attribute'])
+            ->leftJoin('banner.attribute', 'attribute');
         if (null !== $filter || !empty($filter)) {
             //filter the displayed columns with the passed filter
             $builder->andWhere('banner.categoryId = ?1')


### PR DESCRIPTION
### 1. Why is this change necessary?
No attributes of the banner (marketing) in frontend available.

### 2. What does this change do, exactly?
Adds a join to the query builder function in the banner repository

### 3. Describe each step to reproduce the issue or behaviour.
Generate freetextfield of banner in backend. add var_dump to $sBanner in frontend /frontend/listing/index.tpl) -> NO attributes of banner (only media).