### PR TITLE
[FEATURE] Added payment api to get all payments

### DIFF
--- a/engine/Shopware/Components/Api/Resource/PaymentMethods.php
+++ b/engine/Shopware/Components/Api/Resource/PaymentMethods.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Api\Resource;
+
+use Shopware\Components\Api\Exception as ApiException;
+use Shopware\Models\Payment\Payment as PaymentModel;
+use Shopware\Models\Country\Country as CountryModel;
+use Shopware\Models\Plugin\Plugin;
+
+/**
+ * Payment API Resource
+ *
+ * @category  Shopware
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class PaymentMethods extends Resource
+{
+    /**
+     * @return \Shopware\Models\Media\Repository
+     */
+    public function getRepository()
+    {
+        return $this->getManager()->getRepository(PaymentModel::class);
+    }
+
+    /**
+     * @param int $id
+     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
+     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     * @return array|MediaModel
+     */
+    public function getOne($id)
+    {
+        $this->checkPrivilege('read');
+
+        if (empty($id)) {
+            throw new ApiException\ParameterMissingException('id');
+        }
+
+        $filters = [['property' => 'p.id', 'expression' => '=', 'value' => $id]];
+        $query = $this->getRepository()->getAllPaymentsQuery($filters, [], 1);
+
+        /** @var $media MediaModel */
+        $payment = $query->getOneOrNullResult($this->getResultMode());
+
+        if (!$payment) {
+            throw new ApiException\NotFoundException("Payment by id $id not found");
+        }
+
+        return $payment;
+    }
+
+    /**
+     * @param int $offset
+     * @param int $limit
+     * @param array $filter
+     * @param array $orderBy
+     * @return array
+     */
+    public function getList($offset = 0, $limit = 25, array $filter = [], array $orderBy = [])
+    {
+        $this->checkPrivilege('read');
+
+        $query = $this->getRepository()->getAllPaymentsQuery($filter, $orderBy, $offset, $limit);
+        $query->setHydrationMode($this->resultMode);
+
+        $paginator = $this->getManager()->createPaginator($query);
+
+        //returns the total count of the query
+        $totalResult = $paginator->count();
+
+        //returns the category data
+        $payments = $paginator->getIterator()->getArrayCopy();
+
+        return ['data' => $payments, 'total' => $totalResult];
+    }
+
+    /**
+     * @param array $params
+     * @throws \Shopware\Components\Api\Exception\ValidationException
+     * @throws \Exception
+     * @return PaymentModel
+     */
+    public function create(array $params)
+    {
+        $this->checkPrivilege('create');
+
+        $payment = new PaymentModel();
+
+        $payment->setAdditionalDescription('');
+
+        $params = $this->preparePaymentData($params);
+
+        $payment->fromArray($params);
+
+        $violations = $this->getManager()->validate($payment);
+
+        if ($violations->count() > 0) {
+            throw new ApiException\ValidationException($violations);
+        }
+
+        $this->getManager()->persist($payment);
+        $this->flush();
+
+        return $payment;
+    }
+
+    /**
+     * @param int $id
+     * @param array $params
+     * @throws \Shopware\Components\Api\Exception\ValidationException
+     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
+     * @throws \Shopware\Components\Api\Exception\CustomValidationException
+     * @return PaymentModel
+     */
+    public function update($id, array $params)
+    {
+        $this->checkPrivilege('update');
+
+        if (empty($id)) {
+            throw new ApiException\ParameterMissingException('id');
+        }
+
+        /** @var $payment PaymentModel */
+        $payment = $this->getRepository()->find($id);
+
+        if (!$payment) {
+            throw new ApiException\NotFoundException(sprintf('Payment by id "%d" not found', $id));
+        }
+
+        $params = $this->preparePaymentData($params);
+
+        $payment->fromArray($params);
+
+        $violations = $this->getManager()->validate($payment);
+        if ($violations->count() > 0) {
+            throw new ApiException\ValidationException($violations);
+        }
+
+        $this->flush();
+
+        return $payment;
+    }
+
+    /**
+     * @param int $id
+     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
+     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     * @return PaymentModel
+     */
+    public function delete($id)
+    {
+        $this->checkPrivilege('delete');
+
+        if (empty($id)) {
+            throw new ApiException\ParameterMissingException('id');
+        }
+
+        /** @var $payment PaymentModel */
+        $payment = $this->getRepository()->find($id);
+
+        if (!$payment) {
+            throw new ApiException\NotFoundException("Payment by id $id not found");
+        }
+
+        $this->getManager()->remove($payment);
+        $this->flush();
+
+        return $payment;
+    }
+
+    /**
+     * @param array $params
+     * @return array
+     * @throws ApiException\NotFoundException
+     */
+    protected function preparePaymentData($params)
+    {
+        $paymentWhiteList = [
+            'name',
+            'description',
+            'template',
+            'hide',
+            'additionalDescription',
+            'debitPercent',
+            'surcharge',
+            'surchargeString',
+            'position',
+            'active',
+            'esdActive',
+            'mobileInactive',
+            'hideProspect',
+            'action',
+            'pluginId',
+            'countries',
+            'attribute',
+        ];
+
+        $params = array_intersect_key($params, array_flip($paymentWhiteList));
+
+        if (isset($params['countries'])) {
+            foreach ($params['countries'] as &$country) {
+                $countryModel = $this->getContainer()->get('models')->find(CountryModel::class, $country['countryId']);
+                if (!$countryModel) {
+                    throw new ApiException\NotFoundException(sprintf(
+                        'Country by id %s not found',
+                        $country['countryId']
+                    ));
+                }
+
+                $country = $countryModel;
+            }
+        }
+
+        if (isset($params['pluginId'])) {
+            $params['plugin'] = $this->getContainer()->get('models')->find(Plugin::class, $params['pluginId']);
+            if (empty($params['plugin'])) {
+                throw new ApiException\NotFoundException(sprintf(
+                    'plugin by id %s not found',
+                    $params['pluginId']
+                ));
+            }
+        }
+
+        return $params;
+    }
+}

--- a/engine/Shopware/Controllers/Api/PaymentMethods.php
+++ b/engine/Shopware/Controllers/Api/PaymentMethods.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Shopware_Controllers_Api_PaymentMethods extends Shopware_Controllers_Api_Rest
+{
+    /**
+     * @var Shopware\Components\Api\Resource\Payment
+     */
+    protected $resource = null;
+
+    public function init()
+    {
+        $this->resource = \Shopware\Components\Api\Manager::getResource('PaymentMethods');
+    }
+
+    /**
+     * Returns the current version
+     */
+    public function indexAction()
+    {
+        $limit = $this->Request()->getParam('limit', 1000);
+        $offset = $this->Request()->getParam('start', 0);
+        $sort = $this->Request()->getParam('sort', []);
+        $filter = $this->Request()->getParam('filter', []);
+
+        $result = $this->resource->getList($offset, $limit, $filter, $sort);
+
+        $this->View()->assign($result);
+        $this->View()->assign('success', true);
+    }
+
+    /**
+     * Get one payment
+     *
+     * GET /api/payment/{id}
+     */
+    public function getAction()
+    {
+        $id = $this->Request()->getParam('id');
+
+        $media = $this->resource->getOne($id);
+
+        $this->View()->assign('data', $media);
+        $this->View()->assign('success', true);
+    }
+
+    /**
+     * Create new payment
+     *
+     * POST /api/payment
+     */
+    public function postAction()
+    {
+        $params = $this->Request()->getPost();
+
+        $payment = $this->resource->create($params);
+
+        $location = $this->apiBaseUrl . 'paymentMethods/' . $payment->getId();
+        $data = [
+            'id' => $payment->getId(),
+            'location' => $location,
+        ];
+
+        $this->View()->assign(['success' => true, 'data' => $data]);
+        $this->Response()->setHeader('Location', $location);
+    }
+
+    /**
+     * Update payment
+     *
+     * PUT /api/payment/{id}
+     */
+    public function putAction()
+    {
+        $id = $this->Request()->getParam('id');
+        $params = $this->Request()->getPost();
+
+        $payment = $this->resource->update($id, $params);
+
+        $location = $this->apiBaseUrl . 'paymentMethods/' . $payment->getId();
+        $data = [
+            'id' => $payment->getId(),
+            'location' => $location,
+        ];
+
+        $this->View()->assign(['success' => true, 'data' => $data]);
+    }
+
+    /**
+     * Delete payment
+     *
+     * DELETE /api/payment/{id}
+     */
+    public function deleteAction()
+    {
+        $id = $this->Request()->getParam('id');
+
+        $this->resource->delete($id);
+
+        $this->View()->assign(['success' => true]);
+    }
+}

--- a/tests/Api/PaymentMethodsTest.php
+++ b/tests/Api/PaymentMethodsTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Shopware_Tests_Api_PaymentMethodsTest extends PHPUnit\Framework\TestCase
+{
+
+    const API_PATH = '/PaymentMethods/';
+    public $apiBaseUrl = '';
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $helper = Shopware();
+
+        $hostname = $helper->Shop()->getHost();
+        if (empty($hostname)) {
+            $this->markTestSkipped(
+                'Hostname is not available.'
+            );
+        }
+
+        $this->apiBaseUrl = 'http://' . $hostname . $helper->Shop()->getBasePath() . '/api';
+
+        Shopware()->Db()->query('UPDATE s_core_auth SET apiKey = ? WHERE username LIKE "demo"', [sha1('demo')]);
+    }
+
+    /**
+     * @return Zend_Http_Client
+     */
+    public function getHttpClient()
+    {
+        $username = 'demo';
+        $password = sha1('demo');
+
+        $adapter = new Zend_Http_Client_Adapter_Curl();
+        $adapter->setConfig([
+            'curloptions' => [
+                CURLOPT_HTTPAUTH => CURLAUTH_DIGEST,
+                CURLOPT_USERPWD  => "$username:$password",
+            ],
+        ]);
+
+        $client = new Zend_Http_Client();
+        $client->setAdapter($adapter);
+
+        return $client;
+    }
+
+    public function testRequestWithoutAuthenticationShouldReturnError()
+    {
+        $client = new Zend_Http_Client($this->apiBaseUrl . self::API_PATH);
+        $response = $client->request('GET');
+
+        $this->assertEquals('application/json', $response->getHeader('Content-Type'));
+        $this->assertEquals(null, $response->getHeader('Set-Cookie'));
+        $this->assertEquals(401, $response->getStatus());
+
+        $result = $response->getBody();
+
+        $result = Zend_Json::decode($result);
+
+        $this->assertArrayHasKey('success', $result);
+        $this->assertFalse($result['success']);
+
+        $this->assertArrayHasKey('message', $result);
+    }
+
+    public function testGetPaymentWithInvalidIdShouldReturnMessage()
+    {
+        $id = 99999999;
+        $response = $this->getHttpClient()
+            ->setUri($this->apiBaseUrl . self::API_PATH . $id)
+            ->request('GET');
+
+        $this->assertEquals('application/json', $response->getHeader('Content-Type'));
+        $this->assertEquals(null, $response->getHeader('Set-Cookie'));
+        $this->assertEquals(404, $response->getStatus());
+
+        $result = $response->getBody();
+
+        $result = Zend_Json::decode($result);
+
+        $this->assertArrayHasKey('success', $result);
+        $this->assertFalse($result['success']);
+
+        $this->assertArrayHasKey('message', $result);
+    }
+
+    public function testGetPaymentShouldBeSuccessful()
+    {
+        $client = $this->getHttpClient()->setUri($this->apiBaseUrl . self::API_PATH);
+        $result = $client->request('GET');
+
+        $this->assertEquals('application/json', $result->getHeader('Content-Type'));
+        $this->assertEquals(null, $result->getHeader('Set-Cookie'));
+        $this->assertEquals(200, $result->getStatus());
+
+        $result = $result->getBody();
+        $result = Zend_Json::decode($result);
+
+        $this->assertArrayHasKey('success', $result);
+        $this->assertTrue($result['success']);
+
+        $this->assertArrayHasKey('data', $result);
+
+        $this->assertArrayHasKey('total', $result);
+        $this->assertInternalType('int', $result['total']);
+
+        $data = $result['data'];
+        $this->assertInternalType('array', $data);
+    }
+
+    public function testPostPaymentShouldBeSuccessful()
+    {
+        $client = $this->getHttpClient()->setUri($this->apiBaseUrl . self::API_PATH);
+
+        $requestData = [
+            'name'        => 'debit2',
+            'description' => 'Lastschrift2',
+            'position'    => '6',
+        ];
+        $requestData = Zend_Json::encode($requestData);
+
+        $client->setRawData($requestData, 'application/json; charset=UTF-8');
+        $response = $client->request('POST');
+
+        $this->assertEquals(201, $response->getStatus());
+        $this->assertEquals('application/json', $response->getHeader('Content-Type'));
+        $this->assertNull(
+            $response->getHeader('Set-Cookie'),
+            'There should be no set-cookie header set.'
+        );
+
+        $result = $response->getBody();
+        $result = Zend_Json::decode($result);
+
+        $this->assertArrayHasKey('success', $result);
+        $this->assertTrue($result['success']);
+
+        $location = $response->getHeader('Location');
+        $identifier = (int)array_pop(explode('/', $location));
+
+        $this->assertGreaterThan(0, $identifier);
+
+        // Check ID
+        $Payment = Shopware()->Models()->find('Shopware\Models\Payment\Payment', $identifier);
+        $this->assertGreaterThan(0, $Payment->getId());
+
+        return $identifier;
+    }
+
+    /**
+     * @depends testPostPaymentShouldBeSuccessful
+     * @param $identifier
+     */
+    public function testGetPaymentWithIdShouldBeSuccessful($identifier)
+    {
+        $client = $this->getHttpClient()->setUri($this->apiBaseUrl . self::API_PATH . $identifier);
+        $result = $client->request('GET');
+
+        $this->assertEquals('application/json', $result->getHeader('Content-Type'));
+        $this->assertEquals(null, $result->getHeader('Set-Cookie'));
+        $this->assertEquals(200, $result->getStatus());
+
+        $result = $result->getBody();
+        $result = Zend_Json::decode($result);
+
+        $this->assertArrayHasKey('success', $result);
+        $this->assertTrue($result['success']);
+
+        $this->assertArrayHasKey('data', $result);
+
+        $data = $result['data'];
+        $this->assertInternalType('array', $data);
+    }
+
+    /**
+     * @depends testPostPaymentShouldBeSuccessful
+     * @param $id
+     */
+    public function testDeletePaymentWithIdShouldBeSuccessful($id)
+    {
+        $client = $this->getHttpClient()->setUri($this->apiBaseUrl . self::API_PATH . $id);
+
+        $response = $client->request('DELETE');
+
+        $this->assertEquals('application/json', $response->getHeader('Content-Type'));
+        $this->assertEquals(null, $response->getHeader('Set-Cookie'));
+        $this->assertEquals(200, $response->getStatus());
+
+        $result = $response->getBody();
+        $result = Zend_Json::decode($result);
+
+        $this->assertArrayHasKey('success', $result);
+        $this->assertTrue($result['success']);
+    }
+
+    public function testDeletePaymentWithInvalidIdShouldFailWithMessage()
+    {
+        $id = 9999999;
+        $client = $this->getHttpClient()->setUri($this->apiBaseUrl . self::API_PATH . $id);
+
+        $response = $client->request('DELETE');
+
+        $this->assertEquals('application/json', $response->getHeader('Content-Type'));
+        $this->assertEquals(null, $response->getHeader('Set-Cookie'));
+        $this->assertEquals(404, $response->getStatus());
+
+        $result = $response->getBody();
+        $result = Zend_Json::decode($result);
+
+        $this->assertArrayHasKey('success', $result);
+        $this->assertFalse($result['success']);
+
+        $this->assertArrayHasKey('message', $result);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Get a list of all available payments (makes it easier for WaWi apis to get information out of shop)

### 2. What does this change do, exactly?
Adds api endpoint for payments

### 3. Describe each step to reproduce the issue or behaviour.
http://example-shop.de/api/payment

### 5. Which documentation changes (if any) need to be made because of this PR?
https://developers.shopware.com/developers-guide/rest/
New endpoint

Return of API will look like this:
`data: [
{
id: 2,
name: "debit",
description: "Lastschrift",
position: 4,
active: false
},
{
id: 3,
name: "cash",
description: "Nachnahme",
position: 2,
active: true
},
{
id: 4,
name: "invoice",
description: "Rechnung",
position: 3,
active: true
},
{
id: 5,
name: "prepayment",
description: "Vorkasse",
position: 1,
active: true
},
{
id: 6,
name: "sepa",
description: "SEPA",
position: 5,
active: true
}
],
total: 5,
success: true
}`