### PR TITLE
Catch categoryId notice in seo url

### DIFF
--- a/engine/Shopware/Core/sRewriteTable.php
+++ b/engine/Shopware/Core/sRewriteTable.php
@@ -637,6 +637,9 @@ class sRewriteTable
         $translation = $translator->readWithFallback($shopId, $fallbackShopId, 'emotion', $campaign['id']);
 
         $campaign = array_merge($campaign, $translation);
+        if (!isset($campaign['categoryId'])) {
+            $campaign['categoryId'] = null;
+        }
 
         $this->data->assign('campaign', $campaign);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Catches the fancy notice in seo urls (http://shopware.local/Notice-Undefined-index-categoryId-in/var/www/html/sw53/var/cache/production-REVISION/templates/frontend-Responsive-en-GB-2/16/c6/27/16c62700d0a9aa95f0d43d859a21dd7d24c9e894.string.php-on-line-26/The-Deli-Garage)

### 2. What does this change do, exactly?
Fills the categoryId with null if not exists, to prevent the notice

### 3. Describe each step to reproduce the issue or behaviour.
Add the following to config.php
```php
'front' => [
    'showException' => true,
    'throwExceptions' => true,
    'noErrorHandler' => false,
],
'phpsettings' => [
    'display_errors' => 1,
],
```
and run ./bin/console sw:rebuild:seo:index and you get the fancy urls in campaign urls
![heidisql_2017-10-28_15-47-12](https://user-images.githubusercontent.com/6224096/32134957-51583f84-bbf7-11e7-839e-2006d6e9f7e0.png)


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.