### PR TITLE
Add new cronjob event

### DIFF
--- a/engine/Library/Enlight/Components/Cron/Manager.php
+++ b/engine/Library/Enlight/Components/Cron/Manager.php
@@ -265,6 +265,10 @@ class Enlight_Components_Cron_Manager
             }
 
             $this->endJob($job);
+            $this->eventManager->notify('Shopware_CronJob_Finished_' . $job->getAction(), [
+                'subject' => $this,
+                'job'     => $job,
+            ]); 
 
             return $jobArgs;
         } catch (Exception $e) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently there is no way to get a notification about a finished CronJob. 

Such an event would allow plugins to implement an event based cronjob tracking / logging over selected or all jobs. Cronjobs can be a very crucial part that can use that kind of control.

### 2. What does this change do, exactly?
Introducing a new 'notify' event in the cron manager class after a job has finished. 

### 3. Describe each step to reproduce the issue or behaviour.
### 4. Please link to the relevant issues (if any).
### 5. Which documentation changes (if any) need to be made because of this PR?
Inform developers about the new event

### 6. Checklist
- [x ] I have squashed any insignificant commits
- [x ] I have read the contribution requirements and fulfil them.