### PR TITLE
Added applyDataAttributes to ajax-product-navigation

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-product-navigation.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-product-navigation.js
@@ -120,6 +120,8 @@
             if (!(isListing || isDetail)) {
                 return;
             }
+            
+            me.applyDataAttributes();
 
             me.storage = StorageManager.getStorage('session');
 


### PR DESCRIPTION
The jquery plugin `jquery.ajax-product-navigation.js` is now configurable via data-attributes.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
To have the ability to configure the `ajax-product-navigation` via markup.

### 2. What does this change do, exactly?
It calls `me.applyDataAttributes()` in the plugins init-function, so that the elements data-attributes are merged into the options-array of the plugin instance.

### 3. Describe each step to reproduce the issue or behaviour.
Add some data-attributes to the element this plugin is called on and see that its options remain unchanged.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.