### PR TITLE
s_core_states id is not autoincrement but the ORM thinks so

### DIFF
--- a/engine/Shopware/Models/Order/Status.php
+++ b/engine/Shopware/Models/Order/Status.php
@@ -100,7 +100,6 @@ class Status extends ModelEntity
      *
      * @ORM\Column(name="id", type="integer", nullable=false)
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
     private $id;
 
@@ -151,6 +150,14 @@ class Status extends ModelEntity
         return $this->id;
     }
 
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+    
     /**
      * @return string
      */

--- a/tests/Functional/Models/Order/StatusTest.php
+++ b/tests/Functional/Models/Order/StatusTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @category  Shopware
+ *
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class Shopware_Tests_Models_Order_StatusTest extends Enlight_Components_Test_TestCase
+{
+    public function testStatusIsPersistableViaOrm()
+    {
+        $order = new \Shopware\Models\Order\Status();
+        $order->setId(123456789);
+        $order->setPosition(123456789);
+        $order->setSendMail(0);
+        $order->setName('prettyIgnorableNameForThisTest');
+        $order->setGroup(\Shopware\Models\Order\Status::GROUP_PAYMENT);
+
+        Shopware()->Models()->persist($order);
+        Shopware()->Models()->flush($order);
+
+        // cleanup
+        Shopware()->Models()->remove($order);
+        Shopware()->Models()->flush($order);
+        Shopware()->Models()->clear();
+    }
+}

--- a/tests/Functional/Models/Order/StatusTest.php
+++ b/tests/Functional/Models/Order/StatusTest.php
@@ -36,6 +36,7 @@ class Shopware_Tests_Models_Order_StatusTest extends Enlight_Components_Test_Tes
         $order->setPosition(123456789);
         $order->setSendMail(0);
         $order->setName('prettyIgnorableNameForThisTest');
+        $order->setDescription('prettyIgnorableNameForThisTest');
         $order->setGroup(\Shopware\Models\Order\Status::GROUP_PAYMENT);
 
         Shopware()->Models()->persist($order);


### PR DESCRIPTION
### 1. Why is this change necessary?
The column `id` of `table s_core_states` is not set to autoincrement although the ORM annotations in the model hints that. The most obvious solution to just alter the column does not work as the following command:
```sql
ALTER TABLE s_core_states MODIFY COLUMN id INT auto_increment;
```
cannot be executed due to a conflict with a foreign key constraint `s_core_config_mails_ibfk_1` of table `s_core_config_mails`. In addition: a new attribute to the column may conflict with already used solutions to fill this table by community plugins.

### 2. What does this change do, exactly?
It removes the annotation that the `id` column is automagically generated so the ORM will generate a set clause in the SQL when updating/inserting this column.
It adds a setter so you can set the `id`. Current work-around for setting the `id`:
```php
\Closure::bind(function($instance) { $instance->id = /* insert value here */; }, null, $order)($order);
```

### 3. Describe each step to reproduce the issue or behaviour.
```php
$order = new \Shopware\Models\Order\Status();
$order->setPosition(123456789);
$order->setSendMail(0);
$order->setName('prettyIgnorableNameForThisTest');
$order->setDescription('prettyIgnorableNameForThisTest');
$order->setGroup(\Shopware\Models\Order\Status::GROUP_PAYMENT);
Shopware()->Models()->persist($order);
// all right, BOOM!
Shopware()->Models()->flush($order);
```

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
None as there are no breaking changes.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.