### PR TITLE
Set \Shopware\Models\Order\Status::$description initially to empty string

### DIFF
--- a/engine/Shopware/Models/Order/Status.php
+++ b/engine/Shopware/Models/Order/Status.php
@@ -118,7 +118,7 @@ class Status extends ModelEntity
      *
      * @ORM\Column(name="description", type="string", length=255, nullable=false)
      */
-    private $description;
+    private $description = '';
 
     /**
      * @var int


### PR DESCRIPTION
### 1. Why is this change necessary?
This is pure developer experience. The annotations hints that one is discouraged to use `\Shopware\Models\Order\Status::setDescription` but one is forced to do so as the default value is not compatible with database constraints. Making the database column nullable is considered as a break change as everyone currently expects it to be non-nullable.

One can write a test for this, but the ORM is not usable for this model, yet. See #1355. This PR is not part of #1355 as this is not part of the core problem in #1355 but a nice-to-have.

### 2. What does this change do, exactly?
It sets the default value of description to empty string. Therefore you do not have to use the setter to use this model properly.

### 3. Describe each step to reproduce the issue or behaviour.
Do not use `\Shopware\Models\Order\Status::setDescription` on a new model instance and then insert it.

### 4. Please link to the relevant issues (if any).
#1355 as this ships the fix to use the ORM to work with this model on insertion.

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.