### PR TITLE
Removed obsolete statement from sAdmin::sCheckUser

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -853,11 +853,6 @@ class sAdmin
             );
             $this->sSYSTEM->sUSERGROUPDATA = $this->sSYSTEM->sUSERGROUPDATA ?: [];
 
-            if ($this->sSYSTEM->sUSERGROUPDATA['mode']) {
-                $this->sSYSTEM->sUSERGROUP = 'EK';
-            } else {
-                $this->sSYSTEM->sUSERGROUP = $getUser['customergroup'];
-            }
             $this->sSYSTEM->sUSERGROUP = $getUser['customergroup'];
 
             $this->session->offsetSet('sUserGroup', $this->sSYSTEM->sUSERGROUP);


### PR DESCRIPTION
These lines were obsolete because in the following line the value of `$this->sSYSTEM->sUSERGROUP` is always overwritten.

### 1. Why is this change necessary?
Although core classes will be obsolete soon, this one was really unpleasant while debugging so I just wanted to fix this.

### 2. What does this change do, exactly?
Nothing, but reducing the lines of code and increasing the scrutinizer score by removing the usage of 3 variables that are marked as deprecated. There are no magic getters or setters involved.

### 3. Describe each step to reproduce the issue or behaviour.
None.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.