### PR TITLE
Fix undefined index changelog when refreshing the plugin list

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
@@ -300,7 +300,7 @@ class PluginInstaller
                 'capability_secure_uninstall' => true,
                 'refresh_date' => $refreshDate,
                 'translations' => $translations ? json_encode($translations) : null,
-                'changes' => $info['changelog'] ? json_encode($info['changelog']) : null,
+                'changes' => isset($info['changelog']) ? json_encode($info['changelog']) : null,
             ];
 
             if ($currentPluginInfo) {

--- a/tests/Unit/Bundle/PluginInstallerBundle/Fixtures/TestPlugin/TestPlugin.php
+++ b/tests/Unit/Bundle/PluginInstallerBundle/Fixtures/TestPlugin/TestPlugin.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TestPlugin;
+
+use Shopware\Components\Plugin;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Shopware-Plugin TestPlugin.
+ */
+class TestPlugin extends Plugin
+{
+
+    /**
+    * @param ContainerBuilder $container
+    */
+    public function build(ContainerBuilder $container)
+    {
+        $container->setParameter('test_plugin.plugin_dir', $this->getPath());
+        parent::build($container);
+    }
+
+}

--- a/tests/Unit/Bundle/PluginInstallerBundle/Fixtures/TestPlugin/plugin.xml
+++ b/tests/Unit/Bundle/PluginInstallerBundle/Fixtures/TestPlugin/plugin.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="./../../../../../../engine/Shopware/Components/Plugin/schema/plugin.xsd">
+    <label>TestPlugin</label>
+
+    <version>1.0.0</version>
+</plugin>

--- a/tests/Unit/Bundle/PluginInstallerBundle/PluginInstallerTest.php
+++ b/tests/Unit/Bundle/PluginInstallerBundle/PluginInstallerTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Service;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Statement;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Components\Plugin\RequirementValidator;
+use Shopware\Components\Snippet\DatabaseHandler;
+
+/**
+ * Class PluginInstallerTest
+ */
+class PluginInstallerTest extends TestCase
+{
+    public function testRefreshPluginList()
+    {
+        $dateTime = new DateTimeImmutable();
+
+        $expectedData = [
+            'namespace' => 'ShopwarePlugins',
+            'version' => '1.0.0',
+            'author' => null,
+            'name' => 'TestPlugin',
+            'link' => null,
+            'label' => 'TestPlugin',
+            'description' => null,
+            'capability_update' => true,
+            'capability_install' => true,
+            'capability_enable' => true,
+            'capability_secure_uninstall' => true,
+            'refresh_date' => $dateTime,
+            'translations' => '{"en":{"label":"TestPlugin"}}',
+            'changes' => null,
+            'added' => $dateTime
+        ];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('fetchAssoc')->willReturn(null);
+        $connection->expects($this->once())->method('insert')->with('s_core_plugins', $expectedData, [
+            'added' => 'datetime',
+            'refresh_date' => 'datetime',
+        ]);
+
+        $entityManager = $this->createMock(ModelManager::class);
+        $entityManager->expects($this->any())->method('getConnection')->willReturn($connection);
+
+        $databaseHandler = $this->createMock(DatabaseHandler::class);
+        $requirementValidator = $this->createMock(RequirementValidator::class);
+
+        $statement = $this->createMock(Statement::class);
+        $statement->expects($this->once())->method('fetchAll')->willReturn([]);
+
+        $pdo = $this->createMock(PDO::class);
+        $pdo->expects($this->once())->method('query')->willReturn($statement);
+
+        $pluginInstaller = new PluginInstaller(
+            $entityManager,
+            $databaseHandler,
+            $requirementValidator,
+            $pdo,
+            __DIR__ . '/Fixtures'
+        );
+
+        $pluginInstaller->refreshPluginList($dateTime);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?
undefined index changelog when refreshing the plugin list and a plugin with only the minimum plugin.xml is present

### 3. Describe each step to reproduce the issue or behaviour.
install TestPlugin (from tests/Unit/Bundle/PluginInstallerBundle/Fixtures/) or run test without the isset change inside the PluginInstaller

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.