### PR TITLE
add event 'Shopware_Modules_Order_SaveOrder_FilterAttributes'

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -646,7 +646,15 @@ class sOrder
 
         $attributeData = array_merge($attributeData, $this->orderAttributes);
 
-        $attributeData = $this->eventManager->filter('Shopware_Modules_Order_SaveOrder_FilterAttributes', $attributeData, ['subject' => $this]);
+        $attributeData = $this->eventManager->filter(
+            'Shopware_Modules_Order_SaveOrder_FilterAttributes',
+            $attributeData,
+            [
+                'subject' => $this,
+                'orderID' => $orderID,
+                'orderParams' => $orderParams,
+            ]
+        );
         
         $this->attributePersister->persist($attributeData, 's_order_attributes', $orderID);
         $attributes = $this->attributeLoader->load('s_order_attributes', $orderID);

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -646,6 +646,8 @@ class sOrder
 
         $attributeData = array_merge($attributeData, $this->orderAttributes);
 
+        $attributeData = $this->eventManager->filter('Shopware_Modules_Order_SaveOrder_FilterAttributes', $attributeData, ['subject' => $this]);
+        
         $this->attributePersister->persist($attributeData, 's_order_attributes', $orderID);
         $attributes = $this->attributeLoader->load('s_order_attributes', $orderID);
         unset($attributes['id']);


### PR DESCRIPTION
add a filter event to easily add/modify the order attributes on saving
an order, similar to SW-17847 which added the event for the attributes
of the order detail(s).

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Allow easy modification or addition of the order attributes by a plugin on saving an order.

### 2. What does this change do, exactly?
Adds a new filter event.

### 3. Describe each step to reproduce the issue or behaviour.
Subscribe to the event and you're ready to add/read/modify the order attributes.

### 4. Please link to the relevant issues (if any).
Similar to SW-17847 which added the event for the order DETAIL attributes (but not for the attributes at the order level).

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.