### PR TITLE
Fix regex in removeSpecialCharacters to filter all symbols

### DIFF
--- a/engine/Shopware/Controllers/Backend/MediaManager.php
+++ b/engine/Shopware/Controllers/Backend/MediaManager.php
@@ -846,7 +846,7 @@ class Shopware_Controllers_Backend_MediaManager extends Shopware_Controllers_Bac
     private function removeSpecialCharacters($name)
     {
         $name = iconv('utf-8', 'ascii//translit', $name);
-        $name = preg_replace('#[^A-z0-9\-_]#', '-', $name);
+        $name = preg_replace('#[^A-Za-z0-9\-_]#', '-', $name);
         $name = preg_replace('#-{2,}#', '-', $name);
         $name = trim($name, '-');
 

--- a/engine/Shopware/Models/Media/Media.php
+++ b/engine/Shopware/Models/Media/Media.php
@@ -1249,7 +1249,7 @@ class Media extends ModelEntity
     private function removeSpecialCharacters($name)
     {
         $name = iconv('utf-8', 'ascii//translit', $name);
-        $name = preg_replace('#[^A-z0-9\-_]#', '-', $name);
+        $name = preg_replace('#[^A-Za-z0-9\-_]#', '-', $name);
         $name = preg_replace('#-{2,}#', '-', $name);
         $name = trim($name, '-');
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The Regex `[A-z]` is unfit to remove all special characters as its contained-in function intends to do.

### 2. What does this change do, exactly?

Matches the upper- and lowercase alphabets separately and thus filters the symbols `[]\^` (see the ascii table in `man ascii`).

### 3. Describe each step to reproduce the issue or behaviour.

Upload a filename with one or several of the unfiltered special chars.

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

### 7. BC Breaks?

The backend media manager will stop showing preview images for media names containing `[]\^`. Frontend pages will continue to work and use existing media paths.
