### PR TITLE
Fixed theme smarty loading on finish page

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -211,7 +211,9 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action
             return $this->forward('cart');
         }
 
-        $this->session['sOrderVariables'] = new ArrayObject($this->View()->getAssign(), ArrayObject::ARRAY_AS_PROPS);
+        $viewVariables = $this->View()->getAssign();
+        unset($viewVariables['theme']);
+        $this->session['sOrderVariables'] = new ArrayObject($viewVariables, ArrayObject::ARRAY_AS_PROPS);
 
         $agbChecked = $this->Request()->getParam('sAGB');
         if (!empty($agbChecked)) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently on the finish page the smarty plugins are not added because, we save the theme settings in the Session Variables and restore it and the ConfigLoader checks for theme variable. If it is empty it fills the variable and adds the smarty folders
See: https://github.com/shopware/shopware/blob/9a116f29f78c0005e031e34ffcce919b6a50e3a9/engine/Shopware/Components/Theme/EventListener/ConfigLoader.php#L79

### 2. What does this change do, exactly?
Removes theme from session variables

### 3. Describe each step to reproduce the issue or behaviour.
Register a custom smarty function and use these in template and open the finish page.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.