### PR TITLE
Hide document boxes field set when creating new document type

### DIFF
--- a/themes/Backend/ExtJs/backend/config/controller/document.js
+++ b/themes/Backend/ExtJs/backend/config/controller/document.js
@@ -82,6 +82,9 @@ Ext.define('Shopware.apps.Config.controller.Document', {
             },
             'config-base-detail combo[name=elements]': {
                 change: me.onSelectElement
+            },
+            'config-form-document config-base-detail': {
+                recordchange: me.onRecordChange
             }
         });
 
@@ -122,6 +125,20 @@ Ext.define('Shopware.apps.Config.controller.Document', {
         newStyleField.show();
         newContentField.setValue(newRecord.get('value'));
         newStyleField.setValue(newRecord.get('style'));
+    },
+
+    /**
+     * Hide the document boxes field set when creating a new document
+     *
+     * @param { Ext.form.Panel } formPanel
+     * @param { Shopware.apps.Config.model.form.Document } record
+     */
+    onRecordChange: function (formPanel, record) {
+        if (!record) {
+            return;
+        }
+        var showDocumentBoxesFieldSet = record.get('id') !== 0;
+        formPanel.down('[name=elementFieldSet]').setVisible(showDocumentBoxesFieldSet);
     }
 
 });

--- a/themes/Backend/ExtJs/backend/config/view/base/detail.js
+++ b/themes/Backend/ExtJs/backend/config/view/base/detail.js
@@ -70,7 +70,7 @@ Ext.define('Shopware.apps.Config.view.base.Detail', {
             form._record = undefined;
             form.reset();
         }
-        form.fireEvent('recordchange', form, record);
+        this.fireEvent('recordchange', this, record);
     },
 
     updateRecord: function(record) {


### PR DESCRIPTION
### 1. Why is this change necessary?
When creating a new document type via the configuration, the drop down fox the document boxes is empty:

![image](https://user-images.githubusercontent.com/6232639/32323247-aefc5368-bfc7-11e7-8711-a52018e1ef88.png)

Also, if you accidently click 'Use the element-config for all forms' the document boxes of all documents get deleted permanently.

### 2. What does this change do, exactly?
It hides the field set with the dropdown when creating a new document type.

![image](https://user-images.githubusercontent.com/6232639/32323527-93f3f4da-bfc8-11e7-8f45-e12a4c29f83f.png)


### 3. Describe each step to reproduce the issue or behaviour.

Go to 'basic settings' and select 'Shop settings' -> 'PDF document creation'. Click 'Add' and then click 'Use the element-config for all forms'. Now the document boxes for all document disappeared.


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.