### PR TITLE
change searchcolumn for article numbers to search for variants

### DIFF
--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -474,7 +474,7 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
             if ($filter['property'] === 'free') {
                 $builder->andWhere(
                     $builder->expr()->orX(
-                        'detail.number LIKE :free',
+                        'details.number LIKE :free',
                         'articles.name LIKE :free'
                     )
                 );


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If you want to add articles in cross selling tab or stream you have to use always the number of the main detail, if you enter the number from a variant there are no results

### 2. What does this change do, exactly?
allows to search for variants on cross selling tab, filtered streams tab or all filter forms wich use /base/getArticles as data source

### 3. Describe each step to reproduce the issue or behaviour.
open cross selling tab and enter a article number wich is no main detail -> no results
with this PR you will get the article

### 4. Please link to the relevant issues (if any).
--

### 5. Which documentation changes (if any) need to be made because of this PR?
--

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.