### PR TITLE
Fixed captcha validation with double optin

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Newsletter.php
+++ b/engine/Shopware/Controllers/Frontend/Newsletter.php
@@ -47,6 +47,7 @@ class Shopware_Controllers_Frontend_Newsletter extends Enlight_Controller_Action
     public function indexAction()
     {
         $this->View()->voteConfirmed = $this->isConfirmed();
+        $this->Request()->setParam('voteConfirmed', $this->View()->voteConfirmed);
         $this->View()->assign('sUserLoggedIn', Shopware()->Modules()->Admin()->sCheckUser());
 
         if (isset($this->Request()->sUnsubscribe)) {

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2250,7 +2250,7 @@ class sAdmin
             $errorFlag = [];
             $config = Shopware()->Container()->get('config');
 
-            if ($this->shouldVerifyCaptcha($config)) {
+            if ($this->shouldVerifyCaptcha($config) && $this->front->Request()->getParam('voteConfirmed') == false) {
                 /** @var \Shopware\Components\Captcha\CaptchaValidator $captchaValidator */
                 $captchaValidator = Shopware()->Container()->get('shopware.captcha.validator');
 

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2250,7 +2250,7 @@ class sAdmin
             $errorFlag = [];
             $config = Shopware()->Container()->get('config');
 
-            if ($this->shouldVerifyCaptcha($config) && $this->front->Request()->getParam('voteConfirmed') == false) {
+            if ($this->shouldVerifyCaptcha($config) && $this->front->Request()->getParam('voteConfirmed', false) == false) {
                 /** @var \Shopware\Components\Captcha\CaptchaValidator $captchaValidator */
                 $captchaValidator = Shopware()->Container()->get('shopware.captcha.validator');
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The captcha is also in double optin checked and we can't register to newsletter anymore.
![bildschirmfoto 2017-11-06 um 12 27 28](https://user-images.githubusercontent.com/6224096/32440150-33e50f98-c2f2-11e7-896f-f0b13549d859.png)


### 2. What does this change do, exactly?
Ignores captcha check if newsletter validation is confirmed.

I tested also newsletter registration in account. It works also after this patch 😄 

### 3. Describe each step to reproduce the issue or behaviour.
Enable Double-Optin Newsletter and change captcha to numbers and characters.
Try to register to the newsletter

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.