### PR TITLE
Do not show 'open article action button' for vouchers

### DIFF
--- a/themes/Backend/ExtJs/backend/order/view/detail/position.js
+++ b/themes/Backend/ExtJs/backend/order/view/detail/position.js
@@ -421,7 +421,7 @@ Ext.define('Shopware.apps.Order.view.detail.Position', {
                             grid.fireEvent('openArticle', record);
                         },
                         getClass: function(value, metadata, record) {
-                             if (!record.get('articleId'))  {
+                             if (!record.get('articleId') || record.get('mode') !== 0)  {
                                  return 'x-hidden';
                              }
                         }

--- a/themes/Backend/ExtJs/backend/order/view/list/position.js
+++ b/themes/Backend/ExtJs/backend/order/view/list/position.js
@@ -230,7 +230,7 @@ Ext.define('Shopware.apps.Order.view.list.Position', {
                             me.fireEvent('openArticle', record);
                         },
                         getClass: function(value, metadata, record) {
-                             if (!record.get('articleId'))  {
+                             if (!record.get('articleId') || record.get('mode') !== 0)  {
                                  return 'x-hidden';
                              }
                          }


### PR DESCRIPTION
### 1. Why is this change necessary?
The button 'open article' in the order positions list (in the backend) leads to random articles when the position is a redeemed voucher.

This is because the field 'articleId' of the underlying record is actually the id of the redeemed voucher (code) when the position is a voucher. Then the click on the button opens the article that accidentally shares the same id with the redeemed voucher (code).

### 2. What does this change do, exactly?
Hide the 'open article' button for redeemed vouchers.

### 3. Describe each step to reproduce the issue or behaviour.
Create an order that has a redeemed voucher code. Open the order in the backend. Click 'open article' button in the order positions list.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.