### PR TITLE
[BUGFIX] Fixed error tab not changing on mobile devices when click on…

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.jump-to-tab.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.jump-to-tab.js
@@ -20,7 +20,7 @@
         init: function () {
             var me = this,
                 param = decodeURI((RegExp('(?:action|jumpTab)=(.+?)(&|$)').exec(location.search) || [null, null])[1]);
-            
+
             me.applyDataAttributes();
 
             me.$htmlBody = $('body, html');
@@ -56,7 +56,7 @@
         registerEvents: function () {
             var me = this;
 
-            me.$el.on(me.getEventName('click'), '.product--rating-link, .link--publish-comment', $.proxy(me.onJumpToTab, me));
+            me.$el.on(me.getEventName('touchstart click'), '.product--rating-link, .link--publish-comment', $.proxy(me.onJumpToTab, me));
 
             $.publish('plugin/swJumpToTab/onRegisterEvents', [ me ]);
         },


### PR DESCRIPTION
… rating link

### 1. Why is this change necessary?
Tab is not changing from product description to rating on tablet/mobile devices. Sometimes it works on first click, but not on following clicks.

### 2. What does this change do, exactly?
Fixes the error.

### 3. Describe each step to reproduce the issue or behaviour.
1. Visit the detail page with mobile device or mobile emulator in chrome (https://www.shopwaredemo.de/balance-c4.0-47?c=35)
2. Click on "Bewerten" below the button "In den Warenkorb"
3. The page scrolls down, but the tab won't change.
