### PR TITLE
[Bugfix] Consider also currency factors smaller than 1

### DIFF
--- a/themes/Frontend/Bare/documents/index.tpl
+++ b/themes/Frontend/Bare/documents/index.tpl
@@ -331,7 +331,7 @@ td.head  {
 
                 {$Containers.Content_Info.value}
             {block name="document_index_info_currency"}
-                {if $Order._currency.factor > 1}{s name="DocumentIndexCurrency"}
+                {if $Order._currency.factor != 1}{s name="DocumentIndexCurrency"}
                     <br>Euro Umrechnungsfaktor: {$Order._currency.factor|replace:".":","}
                     {/s}
                 {/if}


### PR DESCRIPTION
### 1. Why is this change necessary?
The condition should consider all currency factors not equal 1.

### 2. What does this change do, exactly?
Replacing the condition inside the document template.

### 3. Describe each step to reproduce the issue or behaviour.
Create a currency in the backend with a factor larger than 1. There will be no currency factor notice in invoice documents.

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.