### PR TITLE
SW-20450 - Flush category cache tags when saving an article

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -681,6 +681,9 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
                 break;
             case Shopware\Models\Article\Article::class:
                 $cacheIds[] = 'a' . $entity->getId();
+                foreach ($entity->getCategories() as $category) {
+                    $cacheIds[] = 'c' . $category->getId();
+                }
                 break;
             case Shopware\Models\Article\Detail::class:
                 $cacheIds[] = 'a' . $entity->getArticleId();


### PR DESCRIPTION
When you assign a new category to an article the category page does not get flushed.
### 1. Why is this change necessary?
The article does not appear on the category page after the editor assign it.

### 2. What does this change do, exactly?
Adding the assigned categories as additional cache ids 

### 3. Describe each step to reproduce the issue or behaviour.
https://issues.shopware.com/issues/SW-20450

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20450

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.