### PR TITLE
[BUGFIX] Prevent Fatal error when links or download is null

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -1963,17 +1963,21 @@ class Article extends Resource implements BatchInterface
             $shop
         );
 
-        $data['links'] = $this->translateAssociation(
-            $data['links'],
-            $shop,
-            'link'
-        );
+        if (isset($data['links'])) {
+            $data['links'] = $this->translateAssociation(
+                $data['links'],
+                $shop,
+                'link'
+            );
+        }
 
-        $data['downloads'] = $this->translateAssociation(
-            $data['downloads'],
-            $shop,
-            'download'
-        );
+        if (isset($data['downloads'])) {
+            $data['downloads'] = $this->translateAssociation(
+                $data['downloads'],
+                $shop,
+                'download'
+            );
+        }
 
         $data['supplier'] = $this->translateSupplier($data['supplier'], $shop);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
To prevent the following exception:
Fatal error: Uncaught TypeError: Argument 1 passed to Shopware\Components\Api\Resource\Article::translateAssociation() must be of the type array, null given

### 2. What does this change do, exactly?
Add a condition around the translations

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.