### PR TITLE
support functional test for plugins (services.xml)

### DIFF
--- a/engine/Shopware/Components/ContainerAwareEventManager.php
+++ b/engine/Shopware/Components/ContainerAwareEventManager.php
@@ -162,6 +162,16 @@ class ContainerAwareEventManager extends \Enlight_Event_EventManager
             }
         }
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->containerListeners = [];
+        
+        return parent::reset();
+    }
 
     /**
      * Lazily loads listeners for this event from the dependency injection


### PR DESCRIPTION
### 1. Why is this change necessary?
If you create a functional test in the new structure (custom/plugins) and use `Enlight_Components_Test_Plugin_TestCase` the subscriber registered in `services.xml` won’t get called after you used the reset-Method of `Enlight_Components_Test_Plugin_TestCase`.

### 2. What does this change do, exactly?
The issue was that the class `Enlight_Components_Test_Plugin_TestCase`. The reset-Method will get called from `Enlight_Event_EventManager` , which loads the services from services.xml but get cached in `Shopware\Components\ContainerAwareEventManager: $containerListeners` and not reseted on reset-Method. This runtime cache (`$containerListeners`) has to be cleared as well.

### 3. Describe each step to reproduce the issue or behaviour.

Just create a plugin with a PostDispatch-Function that fwrites the function name on call and one subscriber, which is loaded from the services.xml .
Plugin-Source: <https://github.com/wesolowski/PluginTest>

File: PluginTest/PluginTest.php
```
<?php

namespace PluginTest;

use Shopware\Components\Plugin;

class PluginTest extends Plugin
{
    public static function getSubscribedEvents()
    {
        return [
            'Enlight_Controller_Action_PreDispatch_Frontend_Detail' => 'onPreDispatch'
        ];
    }

    public function onPreDispatch()
    {
        fwrite(STDOUT, __FUNCTION__ . ' in ' . __FILE__ . PHP_EOL);
    }

}
```

File: PluginTest/ Subscriber/Detail.php
```
<?php
	
namespace PluginTest\Subscriber;

use Enlight\Event\SubscriberInterface;


class Detail implements SubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [
            'Enlight_Controller_Action_PreDispatch_Frontend_Detail' => 'onPreDispatchSubscriber'
        ];
    }

    public function onPreDispatchSubscriber()
    {
        fwrite(STDOUT, __FUNCTION__ . ' in ' . __FILE__ . PHP_EOL);
    }
}
```

Those subscribers do the same thing an different ways, one plugin subscriber and one subscriber loaded the services.xml. Each subscriber fwrites the function name on PreDispatch. If you write a Test dispatching a detail page multiple times, you get the following result.

File: PluginTest/Test/DetailTest.php

```
<?php

namespace PluginTest\Test;

class DetailTest extends \Enlight_Components_Test_Controller_TestCase
{
    public function testNoRedirectProductNotLoggedUser()
    {
        $this->dispatch('/sommerwelten/accessoires/170/sonnenbrille-red?number=SW10170');
        $this->reset();
        $this->dispatch('/sommerwelten/accessoires/170/sonnenbrille-red?number=SW10170');
        $this->reset();
        $this->dispatch('/sommerwelten/accessoires/170/sonnenbrille-red?number=SW10170');
    }
}
```

![screen-unit](https://user-images.githubusercontent.com/1388643/32807156-3db90896-c98f-11e7-871b-67fd5303f0a0.png)




I found this issue while creating a screen record. I documented the debugging and solution process in an Youtube-Tutorial:
https://www.youtube.com/watch?v=rkry7PVpRwk&t=14m55s

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.