### PR TITLE
Prevent missing locale from crashing snippet import

### DIFF
--- a/engine/Shopware/Components/Snippet/DatabaseHandler.php
+++ b/engine/Shopware/Components/Snippet/DatabaseHandler.php
@@ -135,9 +135,12 @@ class DatabaseHandler
                     $locale = $localeRepository->findOneBy(['locale' => $index]);
                 }
 
-                $databaseWriter->write($values, $namespacePrefix . $namespace, $locale->getId(), 1);
+                // Only write entry if locale was found
+                if ($locale) {
+                    $databaseWriter->write($values, $namespacePrefix . $namespace, $locale->getId(), 1);
 
-                $this->printNotice('<info>Imported ' . count($values) . ' snippets into ' . $locale->getLocale() . '</info>');
+                    $this->printNotice('<info>Imported ' . count($values) . ' snippets into ' . $locale->getLocale() . '</info>');
+                }
             }
 
             $this->printNotice('<info></info>');

--- a/tests/Functional/Components/Snippet/DatabaseHandlerTest.php
+++ b/tests/Functional/Components/Snippet/DatabaseHandlerTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @category  Shopware
+ *
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+class Shopware_Tests_Components_Snippet_DatabaseHandlerTest extends Enlight_Components_Test_TestCase
+{
+    /**
+     * Tests the import of snippets with missing locale.
+     * Asserts that all remaining snippets of a plugin are imported correctly even if some
+     * of the snippets are skipped because the respective locale is missing.
+     */
+    public function testLoadToDatabaseWithMissingLocale()
+    {
+        $em = Shopware()->Container()->get('models');
+
+        // Delete necessary locale
+        $germanLocale = $em->getRepository(\Shopware\Models\Shop\Locale::class)->findOneBy([
+            'locale' => 'de_DE',
+        ]);
+        $em->remove($germanLocale);
+        // Delete snippets of the AdvancedMenu plugin
+        $advancedMenuSnippets = $em->getRepository(\Shopware\Models\Snippet\Snippet::class)->findBy([
+            'namespace' => 'frontend/plugins/advanced_menu/advanced_menu',
+        ]);
+        foreach ($advancedMenuSnippets as $advancedMenuSnippet) {
+            $em->remove($advancedMenuSnippet);
+        }
+        $em->flush();
+
+        // No snippets are remaining
+        $advancedMenuSnippets = $em->getRepository(\Shopware\Models\Snippet\Snippet::class)->findBy([
+            'namespace' => 'frontend/plugins/advanced_menu/advanced_menu',
+        ]);
+        $this->assertCount(0, $advancedMenuSnippets);
+
+        // (partial) import snippets of the AdvancedMenu plugin
+        $namespace = Shopware()->Plugins()->Frontend();
+        $pluginBootstrap = $namespace->get('AdvancedMenu');
+        Shopware()->Container()->get('shopware.snippet_database_handler')
+            ->loadToDatabase($pluginBootstrap->Path() . 'Snippets/');
+
+        // Check that all snippets of the remaining locale are installed
+        $advancedMenuSnippets = $em->getRepository(\Shopware\Models\Snippet\Snippet::class)->findBy([
+            'namespace' => 'frontend/plugins/advanced_menu/advanced_menu',
+        ]);
+        $this->assertCount(3, $advancedMenuSnippets);
+
+        // Restore locale
+        $sql = "INSERT INTO s_core_locales values (1, 'de_DE', 'Deutsch', 'Deutschland');";
+        Shopware()->Db()->exec($sql);
+
+        // Import all remaining snippets
+        Shopware()->Container()->get('shopware.snippet_database_handler')
+            ->loadToDatabase($pluginBootstrap->Path() . 'Snippets/');
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Right now if you import snippets to the db while installing a plugin and if a specific entry in `s_core_locales` is missing, the whole import will crash with the following exception `Call to a member function getId() on null` in [this line](https://github.com/shopware/shopware/blob/d4c4f2e731d94c9a385791fc5898e9c3c4a18479/engine/Shopware/Components/Snippet/DatabaseHandler.php#L138) and the plugin installation will fail.
We encountered multiple customers who _cleaned up their database_ by removing some locales. Which is bad practise by itself, but it also causes all of our plugin installations to fail.

### 2. What does this change do, exactly?

This PR adds a safeguard that checks if the requested locale does in fact exist before importing a snippet for it. If no locale was found the specific snippets will be skipped. This way all remaining (and working) snippets can still be imported normally, which is better than throwing an exception (which also prevents the plugin from being installed) and probably what mentioned customers want to happen.

### 3. Describe each step to reproduce the issue or behaviour.

If you delete a locale that is needed in the snippets of a plugin from the db and try to import snippets of said plugin, it will fail for all remaining snippets of this plugin.

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.