### PR TITLE
Catch Throwable on cronjobs

### DIFF
--- a/engine/Library/Enlight/Components/Cron/Manager.php
+++ b/engine/Library/Enlight/Components/Cron/Manager.php
@@ -286,6 +286,21 @@ class Enlight_Components_Cron_Manager
             ]);
 
             throw $e;
+        } catch (\Throwable $e) {
+            $job->setData(['error' => $e->getMessage()]);
+
+            if ($job->getDisableOnError()) {
+                $this->disableJob($job);
+            } else {
+                $this->endJob($job);
+            }
+
+            $this->eventManager->notify('Shopware_CronJob_Error_' . $action, [
+                'subject' => $this,
+                'job'     => $job,
+            ]);
+
+            throw $e;
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently Throwables are not catched by cronjob manager. (http://php.net/manual/de/language.errors.php7.php)

### 2. What does this change do, exactly?
Catches also Throwable's on on php7.x systems

### 3. Describe each step to reproduce the issue or behaviour.
Create a cronjob which sends a mail and have a error in mailtemplate like {$orderTime.date} $orderTime is a DateTime so it throws a unhandled exception currently.

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.