### PR TITLE
fix config cache clearance via backend

### DIFF
--- a/engine/Shopware/Controllers/Backend/Cache.php
+++ b/engine/Shopware/Controllers/Backend/Cache.php
@@ -127,7 +127,7 @@ class Shopware_Controllers_Backend_Cache extends Shopware_Controllers_Backend_Ex
         }
 
         if ($cache['config'] == 'on' || $cache['backend'] == 'on' || $cache['frontend'] == 'on') {
-            $this->cacheManager->clearTemplateCache();
+            $this->cacheManager->clearConfigCache();
         }
         if ($cache['search'] == 'on') {
             $this->cacheManager->clearSearchCache();


### PR DESCRIPTION
### 1. Why is this change necessary?
I can't clear the config cache with this gui:
![image](https://user-images.githubusercontent.com/4624237/32859705-8d17afc6-ca4f-11e7-9b82-339d11255bde.png)

I think this issue was introduced with this commit: 0d7484fc5c74532e022218a36e50c0e0264f3861 was fixed with this 32dc0e3ec0657c6963386397b8774a3b0ac046de and was broken again with this merge commit: 384545c797deaea65209c1f1c4e776265fcfbad2

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.