### PR TITLE
Add config flag to allow multiple documents of the same type in an order

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -21,6 +21,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
     * `cart_item_rebate.tpl`
     * `cart_item_surcharge_discount.tpl`
     * `cart_item_voucher.tpl`
+* Added option to allow multiple documents of the same type for orders in `engine/Shopware/Components/Document.php`.
 
 ### Changes
 

--- a/tests/Functional/Models/Order/OrderDocumentDocumentTest.php
+++ b/tests/Functional/Models/Order/OrderDocumentDocumentTest.php
@@ -72,4 +72,88 @@ class Shopware_Tests_Models_Order_Document_DocumentTest extends Enlight_Componen
             $this->assertNotNull($document);
         }
     }
+
+    /**
+     * Test the creation of multiple documents of the same order and the same type.
+     * Asserts the number of created documents is 2 if the _allowMultipleDocuments flag is set.
+     */
+    public function testMultipleDocumentsOfTheSameType()
+    {
+        $document1 = Shopware_Components_Document::initDocument(
+            15,
+            1,
+            [
+                '_renderer' => 'pdf',
+                '_preview' => false,
+                '_allowMultipleDocuments' => true,
+            ]
+        );
+        $document1->render();
+
+        $document2 = Shopware_Components_Document::initDocument(
+            15,
+            1,
+            [
+                '_renderer' => 'pdf',
+                '_preview' => false,
+                '_allowMultipleDocuments' => true,
+            ]
+        );
+        $document2->render();
+
+        $documents = Shopware()->Container()->get('models')->getRepository(\Shopware\Models\Order\Document\Document::class)
+            ->findBy([
+                'typeId' => 1,
+                'orderId' => 15,
+            ]);
+        $this->assertCount(2, $documents);
+
+        // Revert changes of this test
+        foreach ($documents as $document) {
+            Shopware()->Container()->get('models')->remove($document);
+        }
+        Shopware()->Container()->get('models')->flush();
+    }
+
+    /**
+     * Test the creation of multiple documents of the same order and the same type.
+     * Asserts the number of created documents stays 1 if the _allowMultipleDocuments flag is not set.
+     */
+    public function testMultipleDocumentsOfTheSameTypeNegative()
+    {
+        $document1 = Shopware_Components_Document::initDocument(
+            15,
+            1,
+            [
+                '_renderer' => 'pdf',
+                '_preview' => false,
+                '_allowMultipleDocuments' => false,
+            ]
+        );
+        $document1->render();
+
+        $document2 = Shopware_Components_Document::initDocument(
+            15,
+            1,
+            [
+                '_renderer' => 'pdf',
+                '_preview' => false,
+                '_allowMultipleDocuments' => false,
+            ]
+        );
+        $document2->render();
+
+        $documents = Shopware()->Container()->get('models')->getRepository(\Shopware\Models\Order\Document\Document::class)
+            ->findBy([
+                'typeId' => 1,
+                'orderId' => 15,
+            ]);
+        $this->assertCount(1, $documents);
+
+        // Revert changes of this test
+        foreach ($documents as $document) {
+            Shopware()->Container()->get('models')->remove($document);
+        }
+        Shopware()->Container()->get('models')->flush();
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Currently it is not possibly to create multiple documents of the same type for an order. If another document of type X is created, the the first document is simply overwritten, instead of creating an additional one. For example this prevents the creation of partial invoices or partial delivery notes where you need multiple documents of the same type.

### 2. What does this change do, exactly?

This PR adds an optional config field to the Document component that allows the creation of multiple documents for the same type. This is a purely programmatic change and does not have any immediate effect when just using "plain" Shopware via the frontend or backend. It does have a lot of use cases for plugins though, especially together with the pretty new possibility to filter positions on documents (see https://github.com/shopware/shopware/pull/1031).
Currently super ugly hacks are required to achieve multiple documents of the same type for an order, but there is clearly a need for this, as can be seen with this plugin for example: http://store.shopware.com/mbdus41476730029/teildokumente-erstellen.html

### 3. Describe each step to reproduce the issue or behaviour.

Create a document for a certain type for an order. Create another one. The first document will be overwritten, no additional document will be created.

### 4. Please link to the relevant issues (if any).

n/a

### 5. Which documentation changes (if any) need to be made because of this PR?

None, since it just adds an additional option in the PHP code.

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.