### PR TITLE
Normalise attribute name, if no data was found

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
@@ -46,6 +46,16 @@
     }
 
     /**
+     * Replaces uppercase characters with a dash and its lowercase character.
+     *
+     * @param {String} key
+     * @returns {String}
+     */
+    function normaliseKey(key) {
+        return key.replace(/([A-Z])/g, '-$1').toLowerCase();
+    }
+
+    /**
      * Constructor method of the PluginBase class. This method will try to
      * call the ```init```-method, where you can place your custom initialization of the plugin.
      *
@@ -305,7 +315,12 @@
                 attr = me.$el.attr('data-' + key);
 
                 if (typeof attr === 'undefined') {
-                    return true;
+                    var normalisedKey = normaliseKey(key);
+                    attr = me.$el.attr('data-' + normalisedKey);
+
+                    if (typeof attr === 'undefined') {
+                        return true;
+                    }
                 }
 
                 me.opts[key] = shouldDeserialize !== false ? deserializeValue(attr) : attr;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
So that data attributes can have a consistent style, if they are used to change plugin settings.

### 2. What does this change do, exactly?
It adds a check for a 'normalised' data attribute, when a camel case attributes wasn't found. The attribute "data-tabName" could now be called "data-tab-name", for example.

### 3. Describe each step to reproduce the issue or behaviour.
Change an existing data attribute, which uses camel case, to the described format and verify that the setting still gets applied to the javascript plugin.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.