### PR TITLE
Enable store autoload in the select element component

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/element/select.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/select.js
@@ -133,7 +133,8 @@ Ext.define('Shopware.apps.Base.view.element.Select', {
         try {
             store = Ext.create(storeId, {
                 storeId: configSelectStoreId,
-                pageSize: 1000
+                pageSize: 1000,
+                autoLoad: true
             });
             // Override the load() method so the store is only ever loaded once
             Ext.override(store, {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Given we have a plugin config.xml containing a combo element:

```
<element type="combo">
    <name>orderStates</name>
    <label>Order status</label>
    <store>Shopware.apps.Base.store.OrderStatus</store>
</element>
```
The appropiate option values for the dropdown list are not fetched from the backend and the list remains empty. Even when the select list is clicked, no options will be lazy loaded. On Chrome DevTools no ajax request is submitted to the backend that fetches any option values.

That behaviour differs to prior versions of Shopware, for example the latest Version for the 5.2 branch.

### 2. What does this change do, exactly?

It enables the `autoload` property for the store on the select element. When the plugin form is opened, the store will be loaded and the options will be fetched from the backend.

### 3. Describe each step to reproduce the issue or behaviour.

Create a plugin config with at least one (remote) combo element and choose a ExtJs store to select options from (e.g `Shopware.apps.Base.store.OrderStatus` or `Shopware.apps.Base.store.PaymentStatus`)

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.