### PR TITLE
fixed generating emotion landingpage seo urls

### DIFF
--- a/engine/Shopware/Core/sRewriteTable.php
+++ b/engine/Shopware/Core/sRewriteTable.php
@@ -619,6 +619,9 @@ class sRewriteTable
             $fallbackId = $fallbackShop->getId();
         }
 
+        $queryBuilder->join( "emotions.shops", "shop", "WITH", "shop.id = :shopId" )
+            ->setParameter( "shopId", $languageId );
+
         $queryBuilder
             ->andWhere('emotions.isLandingPage = 1')
             ->andWhere('emotions.parentId IS NULL')


### PR DESCRIPTION
### 1. Why is this change necessary?

Generating emotion landingpages for every shop available is
1.) unnecessary because the emotion isnt available for every shop
2.) bad because we can overwrite existing, actually valid seo urls for selected shops

The emotion backend controller generates only seo urls for selected shops when saving an emotion. This should be the default behaviour.

### 2. What does this change do, exactly?

Only generate seo urls for those shops which are selected in the emotion.

### 3. Describe each step to reproduce the issue or behaviour.

Create two emotion landingpages with the same name (for example: "Supplier XY")
Emotion A for shop A
Emotion B for shop B
and run the seo refresh cronjob. The emotion B will generate seo urls for both shop A and B and will overwrite the correct seo url from emotion A.

### 4. Please link to the relevant issues (if any).

None.

### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.