### PR TITLE
Support a shared symlink directory with smarty link function

### DIFF
--- a/engine/Library/Enlight/Template/Plugins/function.flink.php
+++ b/engine/Library/Enlight/Template/Plugins/function.flink.php
@@ -67,6 +67,15 @@ function smarty_function_flink($params, $template)
             $file = substr($file, strlen($docPath));
         }
 
+        // remove shared directory from file
+        $config = Shopware()->Container()->get('kernel')->getConfig();
+        $sharedPath = $config['custom']['sharedPath'];
+        if (!empty($sharedPath)) {
+            if (strpos($file, $sharedPath) === 0) {
+                $file = substr($file, strlen($sharedPath));
+            }
+        }
+
         // make sure we have the right separator for the web context
         if (DIRECTORY_SEPARATOR !== '/') {
             $file = str_replace(DIRECTORY_SEPARATOR, '/', $file);

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -35,7 +35,9 @@ if (!is_array($customConfig)) {
 }
 
 return array_replace_recursive([
-    'custom' => [],
+    'custom' => [
+        'sharedPath' => ''
+    ],
     'trustedproxies' => [],
     'cdn' => [
         'backend' => 'local',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When someone uses automatic deployment with e.g. Capistrano, a shared directory outside the DocumentRoot will be used for some files. It creates the following directory structure:

- current (DocumentRoot and symlink to the latest release in releases directory)
- releases (holds the latest releases)
- shared (directory for all files and directories that should not be overwritten between the releases, like config.php or the community plugins)

When the directory "engine/Shopware/Plugins/Community" is a symlink to the shared directory and someone uses the smarty function "link", a wrong path will be built. 

So instead of outputting this correct path
`/engine/Shopware/Plugins/Community/Frontend/SwagPaymentPaypal/Views/responsive/frontend/_public/src/img/paypal-button-express-de.png`

It outputs this path (or whatever your web directory is)
`/home/vagrant/www/shopware/shared/engine/Shopware/Plugins/Community/Frontend/SwagPaymentPaypal/Views/responsive/frontend/_public/src/img/paypal-button-express-de.png`

### 2. What does this change do, exactly?
The smarty function flink checks also for the new config paramter `['custom']['sharedPath']` and removes it from the whole path.

### 3. Describe each step to reproduce the issue or behaviour.
Replace the Community Plugin directory with a symlink to another directory than DocumentRoot. Files loaded via the smarty "link" function will not be loaded properly, because the path ignores the symlink.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
Add new `['custom']['sharedPath']` configuration for a directory that is symlinked inside DocumentRoot

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.