### PR TITLE
Amend Shopware/Models/Order/Detail::getTaxRate

### DIFF
--- a/engine/Shopware/Models/Order/Detail.php
+++ b/engine/Shopware/Models/Order/Detail.php
@@ -746,7 +746,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @param string $taxRate
+     * @param float $taxRate
      */
     public function setTaxRate($taxRate)
     {

--- a/engine/Shopware/Models/Order/Detail.php
+++ b/engine/Shopware/Models/Order/Detail.php
@@ -754,7 +754,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return float
      */
     public function getTaxRate()
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
Because it is a minor ~~upfuck~~ discomfort for IDEs and their users.

### 2. What does this change do, exactly?
It just fixes a type in phpDoc.

### 3. Describe each step to reproduce the issue or behaviour.
```php
/** @var $model \Shopware\Models\Order\Detail */
$model = /* --- */;
$taxRate = $model->getTaxRate(); // this gets hinted as string
var_dump($taxRate); // this will dump float
```

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
It is a documentation change.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.