### PR TITLE
Fix voucher tax model fields

### DIFF
--- a/themes/Backend/ExtJs/backend/voucher/model/tax.js
+++ b/themes/Backend/ExtJs/backend/voucher/model/tax.js
@@ -47,7 +47,9 @@ Ext.define('Shopware.apps.Voucher.model.Tax', {
     */
     fields: [
         //{block name="backend/voucher/model/tax/fields"}{/block}
-        'id', 'name' ],
+        { name: 'id', type: 'string' },
+        { name: 'name', type: 'string' },
+    ],
     /**
     * Configure the data communication
     * @object


### PR DESCRIPTION
### 1. Why is this change necessary?
When a voucher is configured with a fix tax group instead of the special choises 'automatic, 'default' or 'none', the tax rate is not preselected in the tax configuration combo box of the voucher configuration. Instead there is just the id in the combobox. 




### 2. What does this change do, exactly?
In the ExtJS model, declare the id explicit as string and not as automatic. This fixes the problem and autoselects the correct entry when opening 

### 3. Describe each step to reproduce the issue or behaviour.
Creating a new vouche with (for example) 19 % tax:
![image](https://user-images.githubusercontent.com/6232639/33024548-ade7c96a-ce0b-11e7-81a4-260ebf3ab6cc.png)

Reopen the voucher:
![image](https://user-images.githubusercontent.com/6232639/33024552-aff14c0e-ce0b-11e7-8ec7-ac59fadd5c5d.png)

The tax configuration is '1' instead of '19 %'
![image](https://user-images.githubusercontent.com/6232639/33024557-b2e97bb6-ce0b-11e7-970e-9ecdad2fa2fb.png)

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.