### PR TITLE
Fixed range slider values

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.range-slider.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.range-slider.js
@@ -440,7 +440,7 @@
                 me.$minInputEl.prop('disabled', 'disabled')
                     .trigger('change');
             } else {
-                me.$minInputEl.val(value.toFixed(me.opts.digits))
+                me.$minInputEl.val(me.formatValueFloat(value))
                     .removeAttr('disabled')
                     .trigger('change');
             }
@@ -459,7 +459,7 @@
                 me.$maxInputEl.prop('disabled', 'disabled')
                     .trigger('change');
             } else {
-                me.$maxInputEl.val(value.toFixed(me.opts.digits))
+                me.$maxInputEl.val(me.formatValueFloat(value))
                     .removeAttr('disabled')
                     .trigger('change');
             }
@@ -512,6 +512,24 @@
             } else {
                 value = me.roundTo(value, 5);
             }
+
+            return value;
+        },
+
+        formatValueFloat: function (value) {
+            var me = this;
+
+            if (value != me.minRange && value != me.maxRange) {
+                value = me.roundValue(value);
+            }
+
+            if (!me.opts.labelFormat.length) {
+                return value.toFixed(me.opts.digits) + ' ' + me.opts.suffix;
+            }
+
+            var division = Math.pow(10, me.opts.digits);
+            value = Math.round(value * division) / division;
+            value = value.toFixed(me.opts.digits);
 
             return value;
         },


### PR DESCRIPTION
### 1. Why is this change necessary?
When i filter the price from 415€ to unlimited the range slider value is 416.55. It makes no sense. The value of the label and the value of the input should be the same, otherwise the results are wrong.

### 2. What does this change do, exactly?
Uses the same rounding of label to the value in url, so it should be equal anytime.

### 3. Describe each step to reproduce the issue or behaviour.
Goto https://www.shopwaredemo.de/hoehenluft-abenteuer/ausruestung/ski/
Filter price from 415€ to unlimited and show the url it outputs ?p=1&o=1&n=12&min=416.55

should be ?p=1&o=1&n=12&min=415.00
😕 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.