### PR TITLE
Add unique placeholders in condition parser trait

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/ConditionHandler/DynamicConditionParserTrait.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/ConditionHandler/DynamicConditionParserTrait.php
@@ -102,8 +102,8 @@ trait DynamicConditionParserTrait
             );
         }
 
-        //Identify each field placeholder value with the table alias and the field name
-        $boundParamName = sprintf(':%s_%s', $tableAlias, $field);
+        //Identify each field placeholder value with table alias and a hash of condition properties
+        $boundParamName = sprintf(':%s_%s', $tableAlias, md5($field . $operator . json_encode($value)));
         $field = sprintf('%s.%s', $tableAlias, $field);
 
         switch (true) {


### PR DESCRIPTION
The condition is not unique if the same attribute is used for multiple
conditions.

### 1. Why is this change necessary?
The introduced DynamicConditionParserTrait has a bug in it's current implementation regarding placeholder name generation if multiple conditions on the same attribute are applied.

### 2. What does this change do, exactly?
It generates a hash placeholder based on the `field`,  `operator` and `value` of the condition.

### 3. Describe each step to reproduce the issue or behaviour.
Add a new `ProductAttributeCondition ` with an "attribute" `OPERATOR_LT` and a second `ProductAttributeCondition` with the same "attribute" and `OPERATOR_GT operator`.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.