### PR TITLE
Add price precision config for article prices in the backend

### DIFF
--- a/_sql/migrations/962-add-price-precision.php
+++ b/_sql/migrations/962-add-price-precision.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+use Shopware\Components\Migrations\AbstractMigration;
+class Migrations_Migration962 extends AbstractMigration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function up($modus)
+    {
+        $this->addSql("SET @parent = (SELECT id FROM s_core_config_forms WHERE name = 'Auth' LIMIT 1);");
+
+        $sql = "INSERT INTO s_core_config_elements (form_id, name, value, label, description, type, required, position, scope, options)
+                    VALUES (@parent, 'price_precision', 's:1:\"2\";', 'Pflegbare Nachkommastellen in der Preismaske', 'Hier kannst du einstellen, wie viele Nachkommastellen du in der Artikelpreis-Make pflegen möchtest', 'text', '0', '0', '0', NULL);";
+
+        $this->addSql($sql);
+        $this->addSql("SET @elementID = (SELECT id FROM s_core_config_elements WHERE name = 'price_precision' LIMIT 1);");
+        $this->addSql("INSERT IGNORE INTO s_core_config_element_translations (element_id, locale_id, label, description) VALUES(@elementID, 2, 'Decimal precision of article prices in the backend', 'define a decimal precision for article prices in the backend');");
+    }
+}

--- a/themes/Backend/ExtJs/backend/article/view/detail/prices.js
+++ b/themes/Backend/ExtJs/backend/article/view/detail/prices.js
@@ -254,9 +254,13 @@ Ext.define('Shopware.apps.Article.view.detail.Prices', {
                 xtype: 'numbercolumn',
                 header: me.snippets.grid.columns.price,
                 dataIndex: 'price',
+                renderer: function(val) {
+                    val = window.parseFloat(val);
+                    return Ext.Number.toFixed(val, window.parseInt('{config name="price_precision"}'));
+                },
                 editor: {
                     xtype: 'numberfield',
-                    decimalPrecision: 2,
+                    decimalPrecision: '{config name="price_precision"}',
                     minValue: 0
                 }
             }, {

--- a/themes/Backend/ExtJs/backend/article/view/variant/list.js
+++ b/themes/Backend/ExtJs/backend/article/view/variant/list.js
@@ -334,10 +334,14 @@ Ext.define('Shopware.apps.Article.view.variant.List', {
                 sortable: false,
                 flex: 1,
                 renderer: me.priceColumnRenderer,
+                renderer: function(val) {
+                    val = window.parseFloat(val);
+                    return Ext.Number.toFixed(val, window.parseInt('{config name="price_precision"}'));
+                },
                 editor: {
                     xtype: 'numberfield',
                     allowBlank: false,
-                    decimalPrecision: 2
+                    decimalPrecision: '{config name="price_precision"}'
                 }
             } ,{
                 header: me.snippets.columns.pseudoPrice.header,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Please see: https://github.com/shopware/shopware/pull/1390
I added a config-element for the price precision.

### 2. What does this change do, exactly?
It adds the possibility to change the decimal precision of the article prices in the backend

### 3. Describe each step to reproduce the issue or behaviour.
Please see the closed pull-request

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ x] I have written tests and verified that they fail without my change
- [x ] I have squashed any insignificant commits
- [ x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.