### PR TITLE
Exclude hidden categories from sidebar menu

### DIFF
--- a/themes/Frontend/Bare/frontend/index/sidebar-categories.tpl
+++ b/themes/Frontend/Bare/frontend/index/sidebar-categories.tpl
@@ -6,29 +6,31 @@
 
         {block name="frontend_index_categories_left_before"}{/block}
         {foreach $categories as $category}
-            {block name="frontend_index_categories_left_entry"}
-                <li class="navigation--entry{if $category.flag} is--active{/if}{if $category.subcategories} has--sub-categories{/if}{if $category.childrenCount} has--sub-children{/if}" role="menuitem">
-                    <a class="navigation--link{if $category.flag} is--active{/if}{if $category.subcategories} has--sub-categories{/if}{if $category.childrenCount} link--go-forward{/if}"
-                        href="{$category.link}"
-                        data-categoryId="{$category.id}"
-                        data-fetchUrl="{url module=widgets controller=listing action=getCategory categoryId={$category.id}}"
-                        title="{$category.description|escape}"
-                        {if $category.external && $category.externalTarget}target="{$category.externalTarget}"{/if}>
-                        {$category.description}
+            {if !$sCategory.hideTop}
+                {block name="frontend_index_categories_left_entry"}
+                    <li class="navigation--entry{if $category.flag} is--active{/if}{if $category.subcategories} has--sub-categories{/if}{if $category.childrenCount} has--sub-children{/if}" role="menuitem">
+                        <a class="navigation--link{if $category.flag} is--active{/if}{if $category.subcategories} has--sub-categories{/if}{if $category.childrenCount} link--go-forward{/if}"
+                            href="{$category.link}"
+                            data-categoryId="{$category.id}"
+                            data-fetchUrl="{url module=widgets controller=listing action=getCategory categoryId={$category.id}}"
+                            title="{$category.description|escape}"
+                            {if $category.external && $category.externalTarget}target="{$category.externalTarget}"{/if}>
+                            {$category.description}
 
-                        {if $category.childrenCount}
-                            <span class="is--icon-right">
-                                <i class="icon--arrow-right"></i>
-                            </span>
-                        {/if}
-                    </a>
-                    {block name="frontend_index_categories_left_entry_subcategories"}
-                        {if $category.subcategories}
-                            {call name=categories categories=$category.subcategories level=$level+1}
-                        {/if}
-                    {/block}
-                </li>
-            {/block}
+                            {if $category.childrenCount}
+                                <span class="is--icon-right">
+                                    <i class="icon--arrow-right"></i>
+                                </span>
+                            {/if}
+                        </a>
+                        {block name="frontend_index_categories_left_entry_subcategories"}
+                            {if $category.subcategories}
+                                {call name=categories categories=$category.subcategories level=$level+1}
+                            {/if}
+                        {/block}
+                    </li>
+                {/block}
+            {/if}
         {/foreach}
         {block name="frontend_index_categories_left_after"}{/block}
     </ul>


### PR DESCRIPTION
### 1. Why is this change necessary?
Issue SW-16689
Categories marked as "hidden" for the main navigation will still be displayed in the offcanvas menu.

### 2. What does this change do, exactly?
It adds the same if-clause as in /themes/frontend/Bare/frontend/index/main-navigation.tpl line 20

### 3. Describe each step to reproduce the issue or behaviour.
Look at any offcanvas menu and compare it to the corresponding main navigation when a category is set as "hidden"

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-16689

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.