### PR TITLE
Adjusted schema.org markup on blog detail page

### DIFF
--- a/themes/Frontend/Bare/frontend/blog/detail.tpl
+++ b/themes/Frontend/Bare/frontend/blog/detail.tpl
@@ -14,10 +14,12 @@
 
                 {* Rich snippets *}
                 {block name='frontend_blog_detail_rich_snippets'}
-                    {if $sArticle.author.name}
-                        <meta itemprop="author" content="{$sArticle.author.name}">
-                    {/if}
-
+                    <div itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+                        <meta itemprop="name" content="{{config name=sShopname}|escapeHtml}">
+                        <div itemprop="logo" itemscope itemtype="http://schema.org/ImageObject">
+                            <meta itemprop="url" content="{link file=$theme.desktopLogo fullPath}">
+                        </div>
+                    </div>
                     <meta itemprop="wordCount" content="{$sArticle.description|strip_tags|count_words}">
                 {/block}
 
@@ -27,7 +29,7 @@
 
                         {* Article name *}
                         {block name='frontend_blog_detail_title'}
-                            <h1 class="blog--detail-headline" itemprop="name">{$sArticle.title}</h1>
+                            <h1 class="blog--detail-headline" itemprop="headline">{$sArticle.title}</h1>
                         {/block}
 
                         {* Metadata *}
@@ -37,13 +39,13 @@
                                 {* Author *}
                                 {block name='frontend_blog_detail_author'}
                                     {if $sArticle.author.name}
-                                        <span class="blog--metadata-author blog--metadata is--first">{s name="BlogInfoFrom"}{/s}: {$sArticle.author.name}</span>
+                                        <span class="blog--metadata-author blog--metadata is--first" itemprop="author" itemscope itemtype="https://schema.org/Person">{s name="BlogInfoFrom"}{/s}: <span itemprop="name">{$sArticle.author.name}</span></span>
                                     {/if}
                                 {/block}
 
                                 {* Date *}
                                 {block name='frontend_blog_detail_date'}
-                                    <span class="blog--metadata-date blog--metadata{if !$sArticle.author.name} is--first{/if}" itemprop="dateCreated">{$sArticle.displayDate|date:"DATETIME_SHORT"}</span>
+                                    <span class="blog--metadata-date blog--metadata{if !$sArticle.author.name} is--first{/if}" itemprop="datePublished" content="{$sArticle.displayDate->format(DateTime::ATOM)|escapeHtml}">{$sArticle.displayDate|date:"DATETIME_SHORT"}</span>
                                 {/block}
 
                                 {* Category *}


### PR DESCRIPTION
Added
- publisher property

Changed
- name to headline
- dateCreated to datePublished

Replaced
- standalone author with inline definition

### 1. Why is this change necessary?
Because the Google Structured Data testing tool had 4 errors and 2 warnings on the blog article page. After the change the errors are gone.

### 2. What does this change do, exactly?
It adds, changes and replaces some schema.org markup on the blog detail template

### 3. Describe each step to reproduce the issue or behaviour.
See results (errors / warnings) here: https://search.google.com/structured-data/testing-tool?hl=de#url=https%3A%2F%2Fwww.shopwaredemo.de%2Fblog%2Fnews-sit-amet


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.