### PR TITLE
Bugfix: select-values not always showing in plugin config

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/element/select.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/select.js
@@ -133,7 +133,8 @@ Ext.define('Shopware.apps.Base.view.element.Select', {
         try {
             store = Ext.create(storeId, {
                 storeId: configSelectStoreId,
-                pageSize: 1000
+                pageSize: 1000,
+                autoLoad: true
             });
             // Override the load() method so the store is only ever loaded once
             Ext.override(store, {


### PR DESCRIPTION
### 1. Why is this change necessary?
When not autoloading, the loading mechanism isn't always triggered. 

### 2. What does this change do, exactly?
This fix makes sure the loading happens on time, in order to show
the options to the user. (By setting `autoLoad` to true.) This fixes some
issues that arose when `autoLoad` was removed two months ago. 

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a plugin with config file like:

```xml
<element type="select">
            <name>standardCurrency</name>
            <label lang="en">Default Currency</label>
            <label lang="de">Standard Währung</label>
            <store>Shopware.apps.Base.store.Currency</store>
</element>
```

2. Install it
3. Attempt to configure this field (using the plugin manager). No options will be shown/visible/selectable. 
![screenshot-2017-11-23_14 40 58](https://user-images.githubusercontent.com/3962174/33175338-c0683938-d05b-11e7-917f-b829fd06c355.jpg)


### 4. Please link to the relevant issues (if any).
N/A

### 5. Which documentation changes (if any) need to be made because of this PR?
N/A

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.