### PR TITLE
fix emotion banner component

### DIFF
--- a/themes/Frontend/Bare/widgets/emotion/components/component_banner.tpl
+++ b/themes/Frontend/Bare/widgets/emotion/components/component_banner.tpl
@@ -47,7 +47,7 @@
                         <source sizes="{$itemSize}" srcset="{$srcSet}">
 
                         {* Fallback *}
-                        <img src="{$baseSource}" srcset="{$retinaBaseSource} 2x" class="banner--image-src"{if $Data.title} alt="{$Data.title|escape}"{/if} />
+                        <img src="{$baseSource}" {if $retinaBaseSource}srcset="{$retinaBaseSource} 2x"{/if} class="banner--image-src"{if $Data.title} alt="{$Data.title|escape}"{/if} />
                     </picture>
                 {/block}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If a emotion banner has no retina source image, the image will not display on the site actually.

### 2. What does this change do, exactly?
This change fix this issue.

### 3. Describe each step to reproduce the issue or behaviour.
Delete all retina images for a banner image.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.