### PR TITLE
Save state of expert modus in snippet module

### DIFF
--- a/themes/Backend/ExtJs/backend/snippet/controller/main.js
+++ b/themes/Backend/ExtJs/backend/snippet/controller/main.js
@@ -164,13 +164,31 @@ Ext.define('Shopware.apps.Snippet.controller.Main', {
                     var snippet = Ext.create('Shopware.apps.Snippet.model.Snippet', me.subApplication.snippet);
                     me.onTranslate(snippet);
                 } else {
-                    me.mainWindow = me.getView('main.Window').create({
-                        nSpaceStore:     me.getStore('NSpace'),
-                        snippetStore:    me.getStore('Snippet'),
-                        shoplocaleStore: localeStore
+                    Ext.Ajax.request({
+                        url: '{url controller=UserConfig action=get}',
+                        params: {
+                            name: 'snippet_module'
+                        },
+                        callback: function (request, success, response) {
+                            var config = Ext.JSON.decode(response.responseText);
+
+                            if (!config || config.length <= 0) {
+                                config = { extendedMode: false };
+                            }
+
+                            me.subApplication.userConfig = config;
+
+                            me.mainWindow = me.getView('main.Window').create({
+                                nSpaceStore:     me.getStore('NSpace'),
+                                snippetStore:    me.getStore('Snippet'),
+                                shoplocaleStore: localeStore
+                            });
+                            me.subApplication.setAppWindow(me.mainWindow);
+                            me.mainWindow.show();
+
+                            me.onToggleExpert(null, config.extendedMode);
+                        }
                     });
-                    me.subApplication.setAppWindow(me.mainWindow);
-                    me.mainWindow.show();
                 }
             }
         });
@@ -436,7 +454,17 @@ Ext.define('Shopware.apps.Snippet.controller.Main', {
      * @return void
      */
     onToggleExpert: function(btn, isPressed) {
-        var me = this;
+        var me = this, config = me.subApplication.userConfig;
+
+        config.extendedMode = isPressed;
+
+        Ext.Ajax.request({
+            url: '{url controller=UserConfig action=save}',
+            params: {
+                config: Ext.JSON.encode(config),
+                name: 'snippet_module'
+            }
+        });
 
         me.getSnippetPanel().enableExpertMode(isPressed);
    },


### PR DESCRIPTION
### 1. Why is this change necessary?
I guess everyone hate it, that the expert mode in snippet module does not save

### 2. What does this change do, exactly?
Saves the state of snippet module expert mode

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.