### PR TITLE
Replaced ProductContextInterface type hints with ShopContextInterface

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/ContextServiceInterface.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/ContextServiceInterface.php
@@ -51,7 +51,7 @@ interface ContextServiceInterface
      * - Use the `shop` service of the di container for the language and current category
      * - Use the `session` service of the di container for the current user data.
      *
-     * @return Struct\ProductContextInterface
+     * @return Struct\ShopContextInterface
      */
     public function getContext();
 
@@ -62,7 +62,7 @@ interface ContextServiceInterface
      * - Fallback customer group of the current shop
      * - The currency of the shop
      *
-     * @return Struct\ProductContextInterface
+     * @return Struct\ShopContextInterface
      */
     public function getShopContext();
 
@@ -76,7 +76,7 @@ interface ContextServiceInterface
      * - Tax rules of the current customer group
      * - Price group discounts of the current customer group
      *
-     * @return Struct\ProductContextInterface
+     * @return Struct\ShopContextInterface
      */
     public function getProductContext();
 
@@ -85,7 +85,7 @@ interface ContextServiceInterface
      * Requires the following data:
      * - Location data of the current state. (area, country, state)
      *
-     * @return Struct\ProductContextInterface
+     * @return Struct\ShopContextInterface
      */
     public function getLocationContext();
 
@@ -123,7 +123,7 @@ interface ContextServiceInterface
      * @param null|int    $currencyId
      * @param string|null $customerGroupKey
      *
-     * @return Struct\ProductContextInterface
+     * @return Struct\ShopContextInterface
      */
     public function createProductContext($shopId, $currencyId = null, $customerGroupKey = null);
 
@@ -132,7 +132,7 @@ interface ContextServiceInterface
      * @param null|int    $currencyId
      * @param string|null $customerGroupKey
      *
-     * @return Struct\ProductContextInterface
+     * @return Struct\ShopContextInterface
      */
     public function createShopContext($shopId, $currencyId = null, $customerGroupKey = null);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
To make the life of developers easier.

### 2. What does this change do, exactly?
In the `ContextServiceInterface`, correct type-hints are now shown. 

`ProductContextInterface` is both deprecated and more restrictive than `ShopContextInterface` - using it with `declare(strict_types=1)` enabled leads to an error, even though IDEs show none.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.