### PR TITLE
Fixed sitemap.xml with multiple tiers in content-sites

### DIFF
--- a/_sql/demo/latest.sql
+++ b/_sql/demo/latest.sql
@@ -6001,7 +6001,8 @@ INSERT INTO `s_core_shop_currencies` (`shop_id`, `currency_id`) VALUES
 
 TRUNCATE TABLE `s_core_shop_pages`;
 INSERT INTO `s_core_shop_pages` (`shop_id`, `group_id`) VALUES
-(2, 7),
+(1, 1),
+(1, 2),
 (2, 9),
 (2, 10);
 

--- a/engine/Shopware/Components/SitemapXMLRepository.php
+++ b/engine/Shopware/Components/SitemapXMLRepository.php
@@ -239,7 +239,7 @@ class SitemapXMLRepository
         foreach ($sites as &$site) {
             $site['urlParams'] = [
                 'sViewport' => 'custom',
-                'sCustom' => $site['id']
+                'sCustom' => $site['id'],
             ];
             $site['changed'] = new \DateTime($site['changed']);
             $site['show'] = $this->filterLink($site['link'], $site['urlParams']);
@@ -251,25 +251,27 @@ class SitemapXMLRepository
     /**
      * Helper function to read all static pages of a shop from the database
      *
-     * @param integer $shopId
-     * @return array
+     * @param int $shopId
+     *
      * @throws \Doctrine\DBAL\DBALException
+     *
+     * @return array
      */
     private function getSitesByShopId($shopId)
     {
-        $sql = "
+        $sql = '
             SELECT groups.key
             FROM s_core_shop_pages shopPages
               INNER JOIN s_cms_static_groups groups
                 ON groups.id = shopPages.group_id
             WHERE shopPages.shop_id = ?
-        ";
+        ';
 
-        $statement = $this->connection->executeQuery($sql, array($shopId));
+        $statement = $this->connection->executeQuery($sql, [$shopId]);
 
         $keys = $statement->fetchAll(\PDO::FETCH_COLUMN);
 
-        $sites = array();
+        $sites = [];
         foreach ($keys as $key) {
             $builder = $this->connection->createQueryBuilder();
             $current = $builder->from('s_cms_static', 'sites')

--- a/tests/Functional/Controllers/Frontend/SitemapXmlTest.php
+++ b/tests/Functional/Controllers/Frontend/SitemapXmlTest.php
@@ -29,6 +29,8 @@
  */
 class Shopware_Tests_Controllers_Frontend_SitemapXmlTest extends Enlight_Components_Test_Controller_TestCase
 {
+    const SITEMENU_ITEM_NAME = 'THIRD LEVEL ITEM';
+
     /**
      * Test case method
      */
@@ -53,5 +55,35 @@ class Shopware_Tests_Controllers_Frontend_SitemapXmlTest extends Enlight_Compone
         $crawler = $crawler->filter('url');
 
         $this->assertGreaterThanOrEqual(40, count($crawler));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testMultipleChildrenCms()
+    {
+        $this->createThirdLevelStaticPage();
+
+        $response = $this->dispatch('/SitemapXml');
+        $content = $response->getBody();
+        $this->assertContains(strtolower(Shopware()->Container()->get('shopware.slug')->slugify(self::SITEMENU_ITEM_NAME)), $content);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createThirdLevelStaticPage()
+    {
+        $duplicatePage = Shopware()->Container()->get('dbal_connection')->fetchAssoc('SELECT * FROM s_cms_static WHERE id = ?', [
+            52
+        ]);
+        $duplicatePage['id'] = null;
+        $duplicatePage['parentID'] = 52;
+        $duplicatePage['description'] = self::SITEMENU_ITEM_NAME;
+
+        Shopware()->Container()->get('dbal_connection')->insert('s_cms_static', $duplicatePage);
+
+        Shopware()->Modules()->RewriteTable()->baseSetup();
+        Shopware()->Modules()->RewriteTable()->sCreateRewriteTableContent();
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently only 2 tiers available in sitemap.xml

### 2. What does this change do, exactly?
Uses simple faster dbal instead of ORM and fetches all children

### 3. Describe each step to reproduce the issue or behaviour.
Creates multiple tiers content pages

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.