### PR TITLE
Document Creation - Remove wrong UstID table relation

### DIFF
--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -571,7 +571,7 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
     public function getBilling()
     {
         $this->_billing = new ArrayObject(Shopware()->Db()->fetchRow('
-        SELECT sob.*,sub.ustid,u.customernumber FROM s_order_billingaddress AS sob
+        SELECT sob.*,u.customernumber FROM s_order_billingaddress AS sob
         LEFT JOIN s_user_addresses AS sub ON sub.id = ?
         LEFT JOIN s_user u ON u.id = sub.user_id
         WHERE sob.userID = ? AND

--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -572,11 +572,10 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
     {
         $this->_billing = new ArrayObject(Shopware()->Db()->fetchRow('
         SELECT sob.*,u.customernumber FROM s_order_billingaddress AS sob
-        LEFT JOIN s_user_addresses AS sub ON sub.id = ?
-        LEFT JOIN s_user u ON u.id = sub.user_id
+        LEFT JOIN s_user u ON u.id = sob.userID
         WHERE sob.userID = ? AND
         sob.orderID = ?
-        ', [$this->_user['default_billing_address_id'], $this->_userID, $this->_id]), ArrayObject::ARRAY_AS_PROPS);
+        ', [$this->_userID, $this->_id]), ArrayObject::ARRAY_AS_PROPS);
 
         $this->_billing['country'] = new ArrayObject(Shopware()->Db()->fetchRow('
         SELECT * FROM s_core_countries


### PR DESCRIPTION
### 1. Why is this change necessary?
The change improves the ability to edit data for only one particular order.

### 2. What does this change do, exactly?
Changes dependency of UstID setting from "default Billing Adress" to "order billing adress"

### 3. Describe each step to reproduce the issue or behaviour.
When changing UstID settings of an order in the detail settings, Shopware still uses the UstID setting of the default billing address. So the change in the first steps doesn't take any effect on the document creation unless the default billing address is changed..

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.