### PR TITLE
HTML rendering for documents

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1540,7 +1540,10 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
      */
     private function createDocument($orderId, $documentType)
     {
-        $renderer = 'pdf'; // html / pdf
+        $renderer = strtolower($this->Request()->getParam('renderer', 'pdf')); // html / pdf
+        if (!in_array($renderer, ['html', 'pdf']) {
+            $renderer = 'pdf';
+        }
 
         $deliveryDate = $this->Request()->getParam('deliveryDate');
         if (!empty($deliveryDate)) {

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1541,7 +1541,7 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
     private function createDocument($orderId, $documentType)
     {
         $renderer = strtolower($this->Request()->getParam('renderer', 'pdf')); // html / pdf
-        if (!in_array($renderer, ['html', 'pdf']) {
+        if (!in_array($renderer, ['html', 'pdf'])) {
             $renderer = 'pdf';
         }
 

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1573,7 +1573,7 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
                 'forceTaxCheck' => $this->Request()->getParam('forceTaxCheck', false),
             ]
         );
-        $document->render();
+        $document->render($renderer);
 
         if ($renderer === 'html') {
             exit;


### PR DESCRIPTION
### 1. Why is this change necessary?
The code assumed the default value of the first argument of the `render` function. Do not assume a default value. :exclamation::cool: 
In addition I added a small core hack (maybe it won't be a hack any more). It adds support for a request parameter to change the `$renderer` variable. This makes debugging document templates so much easier :+1:.

### 2. What does this change do, exactly?
Uses the variable `$renderer` with the assumed content as function parameter for `render`.
Checks the requests for a suitable renderer and always falls back to original value `pdf`.

### 3. Describe each step to reproduce the issue or behaviour.
Change the `$renderer` variable to `html` and the `render` function does not behave like expected. It generates a pdf and just exists.

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
You can append `&renderer=html` to urls when generating documents and see the original html source. Suits best to @shyim [shopware-profiler](https://github.com/shyim/shopware-profiler).

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.