### PR TITLE
Fixed exception message in TableMapping::getDependingTables

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Service/TableMapping.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/TableMapping.php
@@ -166,7 +166,7 @@ class TableMapping
     public function getDependingTables($table)
     {
         if (!$this->isAttributeTable($table)) {
-            throw new \Exception(sprintf('Table %s is no supported attribute table'));
+            throw new \Exception(sprintf('Table %s is no supported attribute table', $table));
         }
 
         return $this->tables[$table]['dependingTables'];


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
To get a more useful error message when having a typo in an attribute table

### 2. What does this change do, exactly?
Currently, the `sprintf` function call has too few arguments, resulting in an E_WARNING and returning `false` instead of a useful exception message. This change adds the table name as argument.

### 3. Describe each step to reproduce the issue or behaviour.
```php
$container->get('shopware_attribute.crud_service')->update(
    'this_is_not_an_attribute_table',
    'column',
    'string'
);
```

Expected: Uncaught \Exception with the message "Table this_is_not_an_attribute_table is no supported attribute table"

Currently this yields an E_WARNING: "sprintf(): Too few arguments in [...]". If the interpreter is set not to halt on warnings, you'll additionally get an Exception without any message.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.