### PR TITLE
fix ide typehint in phpdoc

### DIFF
--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -606,7 +606,7 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
     /**
      * Helper function to get the repository of the configured model.
      *
-     * @return \Shopware\Models\Partner\Repository
+     * @return \Shopware\Components\Model\ModelRepository
      */
     protected function getRepository()
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
wrong typehint in IDEs like phpstorm

### 2. What does this change do, exactly?
fixing the typehint

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.