### PR TITLE
[BUGFIX] Fixed ordering of blog entries in shopping world element

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/BlogService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/BlogService.php
@@ -61,11 +61,16 @@ class BlogService implements Service\BlogServiceInterface
      */
     public function getList(array $ids, Struct\ShopContextInterface $context)
     {
+        $result = [];
         $blogs = $this->blogGateway->getList($ids, $context);
 
         $this->resolveMedias($blogs, $context);
 
-        return $blogs;
+        foreach($ids as $id) {
+            $result[$id] = $blogs[$id];
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Right now the blog entries are ordered by ID ASCENDING. So the last one will be shown in first position.

### 2. What does this change do, exactly?
Reorders the elements by display_date.

### 3. Describe each step to reproduce the issue or behaviour.
Add the blog emotion element to the shopping world, set it to display two or three. Add more blog entries to the blog category than displayed in the emotion element.