### PR TITLE
Avoid requesting abstract controllers

### DIFF
--- a/engine/Library/Enlight/Controller/Dispatcher/Default.php
+++ b/engine/Library/Enlight/Controller/Dispatcher/Default.php
@@ -504,6 +504,13 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
         } catch (Exception $e) {
             throw new Enlight_Exception('Controller "' . $class . '" can\'t load failure');
         }
+        $reflectionController = new ReflectionClass($class);
+        if ($reflectionController->isAbstract()) {
+            throw new Enlight_Controller_Exception(
+                'Controller "' . $request->getControllerName() . '" is abstract',
+                Enlight_Controller_Exception::Controller_Dispatcher_Controller_Not_Found
+            );
+        }
 
         $proxy = Shopware()->Hooks()->getProxy($class);
 

--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -59,7 +59,7 @@ use Shopware\Components\Model\QueryBuilder;
  *
  * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
-class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Backend_ExtJs
+abstract class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Backend_ExtJs
 {
     /**
      * Contains the repository class of the configured


### PR DESCRIPTION
### 1. Why is this change necessary?
Avoid requesting /backend/application which fires a Fatal Error (see: https://shopwaredemo.de/backend/application). It can spam customers with error mails or other usages.

### 2. What does this change do, exactly?
Makes Application Controller in backend abstract and handles abstract Controller as 404.

### 3. Describe each step to reproduce the issue or behaviour.
Request /backend/application

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
Shopware_Controllers_Backend_Application is now abstract

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.