### PR TITLE
Added filter event in sOrder::sSaveOrder for mail context

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -903,6 +903,12 @@ class sOrder
         if ($variables['sBookingID']) {
             $context['sBookingID'] = $variables['sBookingID'];
         }
+        
+        $context = $this->eventManager->filter(
+            'Shopware_Modules_Order_SendMail_FilterContext',
+            $context,
+            ['subject' => $this]
+        );
 
         $mail = null;
         if ($event = $this->eventManager->notifyUntil(


### PR DESCRIPTION
A new filter event to allow third party plugins to manipulate the mail context for order mails without creating a custom object of \Zend_Mail

### 1. Why is this change necessary?
Prior to this change, when a plugin wanted to modify the context of available variables for the mail template of order confirmation mails, they had to create a custom object of `\Zend_Mail` and fill it with their modified context. This prevents other plugins from doing the same thing as the notify-until event `Shopware_Modules_Order_SendMail_Create` stops at the first result it gets from a listener and used that result as the new `$mail` variable. The filter event `Shopware_Modules_Order_SendMail_Filter` cannot be used either because once a mail object is created, it is rendered and the context effectively cannot be changed anymore.

### 2. What does this change do, exactly?
It adds a new filter event that lets plugins manipulate the mail context in an easy way that does not block other plugins.

### 3. Describe each step to reproduce the issue or behaviour.
Subscribe a listener to the new event `Shopware_Modules_Order_SendMail_FilterContext` and change the context. See if it makes a difference to the variables available in the mail template of the order mail.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.