### PR TITLE
fixed typehint sAddArticle and getArticleForAddArticle

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1541,8 +1541,8 @@ class sBasket
      * Add product to cart
      * Used in multiple locations
      *
-     * @param int $id       Order number (s_articles_details.ordernumber)
-     * @param int $quantity Amount
+     * @param string $id       Order number (s_articles_details.ordernumber)
+     * @param int    $quantity Amount
      *
      * @throws \Exception
      * @throws \Enlight_Exception         If no price could be determined, or a database error occurs
@@ -2855,7 +2855,7 @@ class sBasket
     /**
      * Get article data for sAddArticle
      *
-     * @param int $id Article ordernumber
+     * @param string $id Article ordernumber
      *
      * @throws \Exception
      *


### PR DESCRIPTION
### 1. Why is this change necessary?
Both methods have the misnamed parameter $id which is typehinted as int althought $id is the ordernumber of a product.

### 2. What does this change do, exactly?
changes the typehint to string


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.