### PR TITLE
fix product layout in manufacturer action

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -130,8 +130,9 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
         /** @var \Shopware\Bundle\StoreFrontBundle\Service\CustomSortingServiceInterface $service */
         $sortingService = $this->get('shopware_storefront.custom_sorting_service');
 
+        $mainCategory = $context->getShop()->getCategory();
+        $categoryId = $mainCategory->getId();
         if (!$this->Request()->getParam('sCategory')) {
-            $categoryId = $context->getShop()->getCategory()->getId();
 
             $this->Request()->setParam('sCategory', $categoryId);
 
@@ -154,7 +155,7 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
         }
 
         $categoryArticles = Shopware()->Modules()->Articles()->sGetArticlesByCategory(
-            $context->getShop()->getCategory()->getId(),
+            $categoryId,
             $criteria
         );
 
@@ -186,10 +187,13 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
         $this->View()->assign('manufacturer', $manufacturer);
         $this->View()->assign('ajaxCountUrlParams', [
             'sSupplier' => $manufacturerId,
-            'sCategory' => $context->getShop()->getCategory()->getId(),
+            'sCategory' => $categoryId,
         ]);
 
-        $this->View()->assign('sCategoryContent', $this->getSeoDataOfManufacturer($manufacturer));
+        $categoryContent = $this->getSeoDataOfManufacturer($manufacturer);
+        $categoryContent['productBoxLayout'] = $mainCategory->getProductBoxLayout();
+
+        $this->View()->assign('sCategoryContent', $categoryContent);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
the manufacturer listing shows the wrong productbox layout
example: main category has layout "minimal" but the manufacturer listing shows the "basic" layout. If infinite scrolling is activated, the reloaded templates are the correct "minimal" ones

### 2. What does this change do, exactly?
sets the productBoxLayout field in the $sCategoryContent array according to the selected layout of the main category

### 3. Describe each step to reproduce the issue or behaviour.
see 1.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20234
I already did a pr for this but I accidentally deleted the old commit... (was https://github.com/shopware/shopware/pull/1306)

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.