### PR TITLE
improved emotion template loading

### DIFF
--- a/themes/Frontend/Bare/widgets/emotion/index.tpl
+++ b/themes/Frontend/Bare/widgets/emotion/index.tpl
@@ -99,44 +99,8 @@
 
                                     {block name="widgets/emotion/index/inner-element"}
 
-                                        {$file = ''}
-
-                                        {if $template == 'component_article'}
-                                            {$file = 'widgets/emotion/components/component_article.tpl'}
-
-                                        {elseif $template == 'component_article_slider'}
-                                            {$file = 'widgets/emotion/components/component_article_slider.tpl'}
-
-                                        {elseif $template == 'component_banner'}
-                                            {$file = 'widgets/emotion/components/component_banner.tpl'}
-
-                                        {elseif $template == 'component_banner_slider'}
-                                            {$file = 'widgets/emotion/components/component_banner_slider.tpl'}
-
-                                        {elseif $template == 'component_blog'}
-                                            {$file = 'widgets/emotion/components/component_blog.tpl'}
-
-                                        {elseif $template == 'component_category_teaser'}
-                                            {$file = 'widgets/emotion/components/component_category_teaser.tpl'}
-
-                                        {elseif $template == 'component_html'}
-                                            {$file = 'widgets/emotion/components/component_html.tpl'}
-
-                                        {elseif $template == 'component_iframe'}
-                                            {$file = 'widgets/emotion/components/component_iframe.tpl'}
-
-                                        {elseif $template == 'component_manufacturer_slider'}
-                                            {$file = 'widgets/emotion/components/component_manufacturer_slider.tpl'}
-
-                                        {elseif $template == 'component_youtube'}
-                                            {$file = 'widgets/emotion/components/component_youtube.tpl'}
-
-                                        {elseif "widgets/emotion/components/{$template}.tpl"|template_exists}
-                                            {$file = "widgets/emotion/components/{$template}.tpl"}
-
-                                        {/if}
-
-                                        {if $file != ''}
+                                        {$file = "widgets/emotion/components/{$template}.tpl"}
+                                        {if $file|template_exists}
                                             {include file=$file}
                                         {/if}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
This change simplifies the loading of the emotion components template files

### 2. What does this change do, exactly?
There was a big if/elseif/else-block where every part loaded the template of a component in the same way, so I removed it and left only the last general part of the block

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.