### PR TITLE
remove unnecessary method getBlogCategoryListIds

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Blog.php
+++ b/engine/Shopware/Controllers/Frontend/Blog.php
@@ -171,8 +171,7 @@ class Shopware_Controllers_Frontend_Blog extends Enlight_Controller_Action
 
         //get all blog articles
         $query = $this->getCategoryRepository()->getBlogCategoriesByParentQuery($categoryId);
-        $blogCategories = $query->getArrayResult();
-        $blogCategoryIds = $this->getBlogCategoryListIds($blogCategories);
+        $blogCategoryIds = array_column($query->getArrayResult(), 'id');
         $blogCategoryIds[] = $categoryId;
         $blogArticlesQuery = $this->getRepository()->getListQuery($blogCategoryIds, $limitStart, $limitEnd, $filter);
         $blogArticlesQuery->setHydrationMode(\Doctrine\ORM\AbstractQuery::HYDRATE_ARRAY);
@@ -669,22 +668,5 @@ class Shopware_Controllers_Frontend_Blog extends Enlight_Controller_Action
         }
 
         return $filter;
-    }
-
-    /**
-     * Helper method returns the blog category ids for the list query.
-     *
-     * @param array $blogCategories
-     *
-     * @return array
-     */
-    private function getBlogCategoryListIds(array $blogCategories)
-    {
-        $ids = [];
-        foreach ($blogCategories as $blogCategory) {
-            $ids[] = $blogCategory['id'];
-        }
-
-        return $ids;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
the method getBlogCategoryListIds() in the frontend blog controller is not necessary, it could be replace with array_column()

### 2. What does this change do, exactly?
removes getBlogCategoryListIds() and uses array_column()

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.