### PR TITLE
Add Order Attribute Join to List Query

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -422,6 +422,7 @@ class Repository extends ModelRepository
             'dispatch',
             'paymentStatus',
             'orderStatus',
+            'attribute'
         ]);
 
         $query->from('Shopware\Models\Order\Order', 'orders', 'orders.id');
@@ -439,6 +440,7 @@ class Repository extends ModelRepository
         $query->leftJoin('billing.state', 'billingState');
         $query->leftJoin('orders.shop', 'shop');
         $query->leftJoin('orders.dispatch', 'dispatch');
+        $query->leftJoin('orders.attribute', 'attribute');
         $query->where('orders.id IN (:ids)');
         $query->setParameter(':ids', $ids, Connection::PARAM_INT_ARRAY);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Extend Order List Grid with Attributes assigned to order

### 2. What does this change do, exactly?
add a left join to order attributes on getList Function

### 3. Describe each step to reproduce the issue or behaviour.
--

### 4. Please link to the relevant issues (if any).
--

### 5. Which documentation changes (if any) need to be made because of this PR?
--

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.