### PR TITLE
simplified if-return-return statements

### DIFF
--- a/engine/Shopware/Components/Plugin/Bootstrap.php
+++ b/engine/Shopware/Components/Plugin/Bootstrap.php
@@ -145,11 +145,7 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
      */
     public function secureUninstall()
     {
-        if (empty($this->info->capabilities['secureUninstall']) || empty($this->info->capabilities['install'])) {
-            return false;
-        }
-
-        return true;
+        return !(empty($this->info->capabilities['secureUninstall']) || empty($this->info->capabilities['install']));
     }
 
     /**

--- a/engine/Shopware/Controllers/Backend/CanceledOrder.php
+++ b/engine/Shopware/Controllers/Backend/CanceledOrder.php
@@ -840,11 +840,7 @@ class Shopware_Controllers_Backend_CanceledOrder extends Shopware_Controllers_Ba
      */
     private function isValidStock(Shopware\Models\Article\Detail $variant, $newStock)
     {
-        if ($newStock < 0 && $variant->getArticle()->getLastStock()) {
-            return false;
-        }
-
-        return true;
+        return !($newStock < 0 && $variant->getArticle()->getLastStock());
     }
 
     /**

--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Steps/DownloadStep.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Steps/DownloadStep.php
@@ -68,11 +68,7 @@ class DownloadStep
         $download = new Download();
         $startTime = microtime(true);
         $download->setHaltCallback(function () use ($startTime) {
-            if (microtime(true) - $startTime > 10) {
-                return true;
-            }
-
-            return false;
+            return microtime(true) - $startTime > 10;
         });
         $offset = $download->downloadFile($this->version->uri, $this->destination, $this->version->size, $this->version->sha1);
 

--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Components/SepaPaymentMethod.php
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Components/SepaPaymentMethod.php
@@ -219,11 +219,7 @@ class SepaPaymentMethod extends GenericPaymentMethod
             $rest = intval($part) % 97;
         }
 
-        if ($rest != 1) {
-            return false;
-        }
-
-        return true;
+        return !($rest != 1);
     }
 
     private function sendSepaEmail($orderNumber, $userId, $data)


### PR DESCRIPTION
### 1. Why is this change necessary?
there are some
if ($foo == $bar) { return true } return false;
statements in the code which can be simplified by using only one return statement

### 2. What does this change do, exactly?
simplifies the statements to
return $foo == $bar

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.