### PR TITLE
[Bugfix] add missing database field changetime to ListProduct struct

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -25,6 +25,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 * Added numeric amounts for order details in the account orders action
 * Added pagination to backend order filter shipping country and billing country
 * Added numeric amounts for cart items in cart array structure
+* Added article database field `changetime` to `ListProduct` struct
 
 ### Changes
 

--- a/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductMapping.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductMapping.php
@@ -154,6 +154,7 @@ class ProductMapping implements MappingInterface
 
                 // Dates
                 'formattedCreatedAt' => ['type' => 'date', 'format' => 'yyyy-MM-dd'],
+                'formattedUpdatedAt' => ['type' => 'date', 'format' => 'yyyy-MM-dd'],
                 'formattedReleaseDate' => ['type' => 'date', 'format' => 'yyyy-MM-dd'],
 
                 // Nested structs

--- a/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductProvider.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductProvider.php
@@ -241,11 +241,15 @@ class ProductProvider implements ProductProviderInterface
             $product->setFormattedCreatedAt(
                 $this->formatDate($product->getCreatedAt())
             );
+            $product->setFormattedUpdatedAt(
+                $this->formatDate($product->getUpdatedAt())
+            );
             $product->setFormattedReleaseDate(
                 $this->formatDate($product->getReleaseDate())
             );
 
             $product->setCreatedAt(null);
+            $product->setUpdatedAt(null);
             $product->setReleaseDate(null);
             $product->setPrices(null);
             $product->setPriceRules(null);

--- a/engine/Shopware/Bundle/ESIndexingBundle/Struct/Product.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Struct/Product.php
@@ -42,6 +42,11 @@ class Product extends ListProduct
     /**
      * @var string
      */
+    protected $formattedUpdatedAt;
+
+    /**
+     * @var string
+     */
     protected $formattedReleaseDate;
 
     /**
@@ -159,6 +164,22 @@ class Product extends ListProduct
     public function setFormattedCreatedAt($formattedCreatedAt)
     {
         $this->formattedCreatedAt = $formattedCreatedAt;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFormattedUpdatedAt()
+    {
+        return $this->formattedUpdatedAt;
+    }
+
+    /**
+     * @param int $formattedUpdatedAt
+     */
+    public function setFormattedUpdatedAt($formattedUpdatedAt)
+    {
+        $this->formattedUpdatedAt = $formattedUpdatedAt;
     }
 
     /**

--- a/engine/Shopware/Bundle/StoreFrontBundle/Common/StructHelper.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Common/StructHelper.php
@@ -61,6 +61,7 @@ class StructHelper
         $product->setWidth($listProduct->getWidth());
         $product->setPriceGroup($listProduct->getPriceGroup());
         $product->setCreatedAt($listProduct->getCreatedAt());
+        $product->setUpdatedAt($listProduct->getUpdatedAt());
         $product->setPriceRules($listProduct->getPriceRules());
         $product->setCheapestPriceRule($listProduct->getCheapestPriceRule());
         $product->setManufacturerNumber($listProduct->getManufacturerNumber());

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/ProductHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/ProductHydrator.php
@@ -226,6 +226,11 @@ class ProductHydrator extends Hydrator
                 new \DateTime($data['__product_datum'])
             );
         }
+        if ($data['__product_changetime']) {
+            $product->setUpdatedAt(
+                new \DateTime($data['__product_changetime'])
+            );
+        }
 
         $product->setAdditional($data['__variant_additionaltext']);
         $product->setEan($data['__variant_ean']);

--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/ListProduct.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/ListProduct.php
@@ -120,6 +120,14 @@ class ListProduct extends BaseProduct
     protected $createdAt;
 
     /**
+     * Defines the date which the product was last updated in
+     * the database.
+     *
+     * @var \DateTime
+     */
+    protected $updatedAt;
+
+    /**
      * Defines a list of keywords for this product.
      *
      * @var array
@@ -841,6 +849,22 @@ class ListProduct extends BaseProduct
     public function setCreatedAt($createdAt)
     {
         $this->createdAt = $createdAt;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param \DateTime $updatedAt
+     */
+    public function setUpdatedAt($updatedAt)
+    {
+        $this->updatedAt = $updatedAt;
     }
 
     /**

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -1146,6 +1146,10 @@ class LegacyStructConverter
         if ($product->getCreatedAt()) {
             $createDate = $product->getCreatedAt()->format('Y-m-d');
         }
+        $updateDate = null;
+        if ($product->getUpdatedAt()) {
+            $updateDate = $product->getUpdatedAt()->format('Y-m-d');
+        }
 
         $data = [
             'articleID' => $product->getId(),
@@ -1171,6 +1175,7 @@ class LegacyStructConverter
             'laststock' => $product->isCloseouts(),
             'additionaltext' => $product->getAdditional(),
             'datum' => $createDate,
+            'update' => $updateDate,
             'sales' => $product->getSales(),
             'filtergroupID' => null,
             'priceStartingFrom' => null,


### PR DESCRIPTION
### 1. Why is this change necessary?
Because the field is missing in the frontend and is needed for structured data markup (https://developers.google.com/search/docs/data-types/article#non-amp)

### 2. What does this change do, exactly?
Add the missing article field `changetime` to the `ListProduct` struct and make the field available as `$sArticle.update` at the frontend.

### 3. Describe each step to reproduce the issue or behaviour.
.

### 4. Please link to the relevant issues (if any).
.

### 5. Which documentation changes (if any) need to be made because of this PR?
.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.