### PR TITLE
fixed nonstatic call of static method

### DIFF
--- a/engine/Shopware/Controllers/Backend/Login.php
+++ b/engine/Shopware/Controllers/Backend/Login.php
@@ -142,8 +142,8 @@ class Shopware_Controllers_Backend_Login extends Shopware_Controllers_Backend_Ex
         $data = [];
         foreach ($locales as $id => $locale) {
             list($l, $t) = explode('_', $locale);
-            $l = $current->getTranslation($l, 'language', $current);
-            $t = $current->getTranslation($t, 'territory', $current);
+            $l = $current::getTranslation($l, 'language', $current);
+            $t = $current::getTranslation($t, 'territory', $current);
             $data[] = [
                 'id' => $id,
                 'name' => "$l ($t)",


### PR DESCRIPTION
### 1. Why is this change necessary?
the static method Zend_Locale::getTranslation was called like a nonstatic method

### 2. What does this change do, exactly?
this pr changes the call to a static call


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.