### PR TITLE
Duplicate catch block is redundant and bloats the exception/catch stack

### DIFF
--- a/engine/Library/Enlight/Controller/Front.php
+++ b/engine/Library/Enlight/Controller/Front.php
@@ -219,14 +219,7 @@ class Enlight_Controller_Front extends Enlight_Class implements Enlight_Hook
                 /**
                  * Dispatch request
                  */
-                try {
-                    $this->dispatcher->dispatch($this->request, $this->response);
-                } catch (Exception $e) {
-                    if ($this->throwExceptions()) {
-                        throw $e;
-                    }
-                    $this->response->setException($e);
-                }
+                $this->dispatcher->dispatch($this->request, $this->response);
             } catch (Exception $e) {
                 if ($this->throwExceptions()) {
                     throw $e;


### PR DESCRIPTION
### 1. Why is this change necessary?
Small code quality improvement.

### 2. What does this change do, exactly?
Removes a redundant catch.

### 3. Describe each step to reproduce the issue or behaviour.
Debug through a request and get caught twice due to an uncaught exception.

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.