### PR TITLE
Index added to s_media_used

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -30,6 +30,8 @@ This changelog references changes done in Shopware 5.3 patch versions.
 * Changed the `createValueListFacetResult` method of `ProductAttributeFacetHandler` to display translations of attribute values in facet list
 * Changed the snippet export to specify the fallback language
 * The tax id of the invoice address is now also used for deliveries to foreign countries if the invoice country and delivery country are marked to be tax free for companies and if the delivery address does not have a tax id
+* Changed command sw:media:cleanup  (GarbageCollector in MediaBundle) to find unused media in large media tables
+
 
 ### Removals
 

--- a/engine/Shopware/Bundle/MediaBundle/GarbageCollector.php
+++ b/engine/Shopware/Bundle/MediaBundle/GarbageCollector.php
@@ -111,7 +111,7 @@ class GarbageCollector
      */
     private function createTempTable()
     {
-        $this->connection->exec('CREATE TEMPORARY TABLE IF NOT EXISTS s_media_used (id int auto_increment, mediaId int NOT NULL, PRIMARY KEY pkid (id))');
+        $this->connection->exec('CREATE TEMPORARY TABLE IF NOT EXISTS s_media_used (id int auto_increment, mediaId int NOT NULL, PRIMARY KEY pkid (id), INDEX `index_media_id` (mediaId) )');
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Garbage collector couldn't collect unused media data on large media tables.


### 2. What does this change do, exactly?
Added an index to the temporaly created table s_media_used.


### 3. Describe each step to reproduce the issue or behaviour.
run sw:media:cleanup on installations 50000 entries in  s_media table

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20037

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
