### PR TITLE
add text snippets for subshops and remove the static definition of ma…

### DIFF
--- a/engine/Shopware/Components/Snippet/DatabaseHandler.php
+++ b/engine/Shopware/Components/Snippet/DatabaseHandler.php
@@ -113,6 +113,8 @@ class DatabaseHandler
         $snippetCount = $this->em->getConnection()->fetchArray('SELECT * FROM s_core_snippets LIMIT 1');
         $databaseWriter->setUpdate((bool) $snippetCount);
 
+        $shops = $this->em->getRepository('Shopware\Models\Shop\Shop')->getShopIds();
+
         foreach ($finder as $file) {
             $filePath = $file->getRelativePathname();
             if (strpos($filePath, '.ini') == strlen($filePath) - 4) {
@@ -135,7 +137,10 @@ class DatabaseHandler
                     $locale = $localeRepository->findOneBy(['locale' => $index]);
                 }
 
-                $databaseWriter->write($values, $namespacePrefix . $namespace, $locale->getId(), 1);
+                foreach ($shops as $shop)
+                {
+                    $databaseWriter->write($values, $namespacePrefix . $namespace, $locale->getId(), $shop['id']);
+                }
 
                 $this->printNotice('<info>Imported ' . count($values) . ' snippets into ' . $locale->getLocale() . '</info>');
             }

--- a/engine/Shopware/Models/Shop/Repository.php
+++ b/engine/Shopware/Models/Shop/Repository.php
@@ -431,6 +431,19 @@ class Repository extends ModelRepository
     }
 
     /**
+     * @return array
+     */
+    public function getShopIds()
+    {
+        $builder = $this->createQueryBuilder('shop');
+        $builder->select('shop.id');
+
+        $shopIds = $builder->getQuery()->getArrayResult();
+
+        return $shopIds;
+    }
+
+    /**
      * @param Shop $shop
      *
      * @return DetachedShop


### PR DESCRIPTION
### 1. Why is this change necessary?
Text snippets are only changed for main shop by using the CLI.

### 2. What does this change do, exactly?
Saves the snippets by locale from the ini files to all of the shops.

### 3. Describe each step to reproduce the issue or behaviour.
Use the CLI "php console sw:snippets:to:db --include-plugins" and check if the snippets are changed by locale of all the subshops.

### 4. Please link to the relevant issues (if any).
- For Shopware 5.2: https://github.com/shopware/shopware/pull/1446

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.