### PR TITLE
add department to documents sender block

### DIFF
--- a/themes/Frontend/Bare/documents/index.tpl
+++ b/themes/Frontend/Bare/documents/index.tpl
@@ -94,7 +94,8 @@ td.head  {
                         <p class="sender">{$Containers.Header_Sender.value}</p>
                     {/block}
                     {block name="document_index_address_base"}
-                        {$User.$address.company}<br />
+                        {if $User.$address.company}{$User.$address.company}<br />{/if}
+                        {if $User.$address.department}{$User.$address.department}<br />{/if}
                         {$User.$address.salutation|salutation}
                         {if {config name="displayprofiletitle"}}
                             {$User.$address.title}<br/>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Department is not displayed on documents sender block.

### 2. What does this change do, exactly?

Adds the department, if given. Removes empty line, if company is not given.

### 3. Describe each step to reproduce the issue or behaviour.

Make order as company and give a department. Create invoice for order in backend.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.