### PR TITLE
Added pagination to emotion template select

### DIFF
--- a/themes/Backend/ExtJs/backend/emotion/view/detail/layout.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/detail/layout.js
@@ -114,7 +114,7 @@ Ext.define('Shopware.apps.Emotion.view.detail.Layout', {
 
         me.tplStore = Ext.create('Shopware.apps.Emotion.store.Templates').load();
 
-        me.tplComboBox = Ext.create('Ext.form.field.ComboBox', {
+        me.tplComboBox = Ext.create('Shopware.form.field.PagingComboBox', {
             fieldLabel: me.snippets.fields.templateLabel,
             name: 'templateId',
             valueField: 'id',
@@ -122,8 +122,7 @@ Ext.define('Shopware.apps.Emotion.view.detail.Layout', {
             queryMode: 'remote',
             store: me.tplStore,
             emptyText: me.snippets.fields.templateEmptyText,
-            labelWidth: layoutLabelWidth,
-            pageSize: 20
+            labelWidth: layoutLabelWidth
         });
 
         me.modeSelectionTpl = new Ext.XTemplate(

--- a/themes/Backend/ExtJs/backend/emotion/view/detail/layout.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/detail/layout.js
@@ -122,7 +122,8 @@ Ext.define('Shopware.apps.Emotion.view.detail.Layout', {
             queryMode: 'remote',
             store: me.tplStore,
             emptyText: me.snippets.fields.templateEmptyText,
-            labelWidth: layoutLabelWidth
+            labelWidth: layoutLabelWidth,
+            pageSize: 20
         });
 
         me.modeSelectionTpl = new Ext.XTemplate(


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently only shows first 20 records

### 2. What does this change do, exactly?
Adds a pagination

### 3. Describe each step to reproduce the issue or behaviour.
Create many templates :laughing: 

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20695

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.