### PR TITLE
Ensure router module is as first in url

### DIFF
--- a/engine/Shopware/Components/Routing/Matchers/DefaultMatcher.php
+++ b/engine/Shopware/Components/Routing/Matchers/DefaultMatcher.php
@@ -68,9 +68,9 @@ class DefaultMatcher implements MatcherInterface
         $query = [];
         $params = [];
 
-        foreach (explode($this->separator, $path) as $routePart) {
+        foreach (explode($this->separator, $path) as $i => $routePart) {
             $routePart = urldecode($routePart);
-            if (empty($query[$context->getModuleKey()]) && $this->dispatcher->isValidModule($routePart)) {
+            if (empty($query[$context->getModuleKey()]) && $this->dispatcher->isValidModule($routePart) && $i === 0) {
                 $query[$context->getModuleKey()] = $routePart;
             } elseif (empty($query[$context->getControllerKey()])) {
                 $query[$context->getControllerKey()] = $routePart;
@@ -91,6 +91,7 @@ class DefaultMatcher implements MatcherInterface
                 }
             }
         }
+
 
         $query = $this->fillDefaults($context, $query);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If i create a frontend controller action and name it "widgets" or "backend". Shopware thinks yea there stands "widgets" lets drive to the widgets.

Example URLs:
https://www.shopwaredemo.de/account/login/widgets => 404, because he search for a account controller in widgets scope

https://www.shopwaredemo.de/account/login/backend => redirects to the shopware backend xD

### 2. What does this change do, exactly?
Ensure module definition in url is as first key

### 3. Describe each step to reproduce the issue or behaviour.
See section 1

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20484

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.