### PR TITLE
Added missing date expression to firstLogin

### DIFF
--- a/themes/Backend/ExtJs/backend/customer/view/main/customer_list_filter.js
+++ b/themes/Backend/ExtJs/backend/customer/view/main/customer_list_filter.js
@@ -123,7 +123,8 @@ Ext.define('Shopware.apps.Customer.view.main.CustomerListFilter', {
                     store: shopStore
                 },
                 firstLogin: {
-                    fieldLabel: '{s name="first_login"}{/s}'
+                    fieldLabel: '{s name="first_login"}{/s}',
+                    expression: '>='
                 },
                 lastLogin: {
                     fieldLabel: '{s name="lastLogin"}{/s}'


### PR DESCRIPTION
### 1. Why is this change necessary?
The filter custom since currently uses "=" expression which is wrong.

### 2. What does this change do, exactly?
Uses ">=" expression

### 3. Describe each step to reproduce the issue or behaviour.
see https://issues.shopware.com/issues/SW-20393

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20393

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.