### PR TITLE
Add Auto registered JS path

### DIFF
--- a/themes/grunt-tasks/config/chokidar.js
+++ b/themes/grunt-tasks/config/chokidar.js
@@ -18,7 +18,8 @@ module.exports = {
         files: [
             '../themes/Frontend/**/_public/src/js/*.js',
             '../engine/Shopware/Plugins/**/frontend/**/src/js/**/*.js',
-            '../custom/plugins/**/frontend/**/src/js/**/*.js'
+            '../custom/plugins/**/frontend/**/src/js/**/*.js',
+            '../custom/plugins/**/Resources/frontend/js/**/*.js'
         ],
         tasks: ['uglify:development'],
         options: {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Frontend resources auto-registration does not work with Grunt

### 2. What does this change do, exactly?

Adds the appropriate path to the files

### 3. Describe each step to reproduce the issue or behaviour.

Follow the instructions: (https://developers.shopware.com/developers-guide/plugin-quick-start/#frontend-resources-auto-registration) add a JS file, run the Ground and edit our JS file

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.