### PR TITLE
[Labs] Fix XSS vulnerability on search result page

### DIFF
--- a/src/Storefront/Resources/views/frontend/search/index.html.twig
+++ b/src/Storefront/Resources/views/frontend/search/index.html.twig
@@ -15,7 +15,7 @@
     <div class="content search--content">
         <h1 class="search--headline">
             {# @var listing \Shopware\Storefront\Page\Search\SearchPageStruct #}
-            {{ 'SearchHeadline'|trans({'%searchTerm%': searchTerm, '%searchResultProductsCount%': listing.products.total}, 'frontend/search/fuzzy')|raw}}
+            {{ 'SearchHeadline'|trans({'%searchTerm%': searchTerm|escape, '%searchResultProductsCount%': listing.products.total}, 'frontend/search/fuzzy')|raw}}
         </h1>
 
         {# Listing #}


### PR DESCRIPTION
### 1. Why is this change necessary?

Userinput is injected into the DOM without escaping resulting in a non-persistent Cross-site scripting vulnerability.

## before patch

![image](https://user-images.githubusercontent.com/55820/34153945-1c6821aa-e4b4-11e7-94e7-caa6994dd603.png)

## after patch

![image](https://user-images.githubusercontent.com/55820/34153964-2f78810e-e4b4-11e7-98f9-33029f8da483.png)

### 2. What does this change do, exactly?

Escapes the variable before passing into the twig function

### 3. Describe each step to reproduce the issue or behaviour.

Attack can be triggered via the `search` query parameter of the search:

http://172.18.0.3/search?search=%3Cscript%3Ealert(%22XSS%22)%3B%3C%2Fscript%3E

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


