### PR TITLE
Remove DirectoryIndex for index.html and index.php

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -42,8 +42,6 @@ RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]
 #SetEnvIf Host "dev.shopware.in" SHOPWARE_ENV=dev
 #SetEnv SHOPWARE_ENV dev
 
-DirectoryIndex index.html
-DirectoryIndex index.php
 DirectoryIndex shopware.php
 
 # Disables download of configuration


### PR DESCRIPTION
### 1. Why is this change necessary?

It's the domain of the webserver to define `index.html` or `index.php` as `DirectoryIndex` and as Shopware doesn't even provide an `index.html` or `index.php` the `DirectoryIndex` on these both files is useless.

### 2. What does this change do, exactly?

It removes the following lines from the `.htaccess`:

```
DirectoryIndex index.html
DirectoryIndex index.php
```

### 3. Describe each step to reproduce the issue or behaviour.

:heavy_minus_sign: 

### 4. Please link to the relevant issues (if any).

:heavy_minus_sign: 

### 5. Which documentation changes (if any) need to be made because of this PR?

:heavy_minus_sign: 

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.