### PR TITLE
Move jQuery header block back

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -30,6 +30,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 * Changed the `createValueListFacetResult` method of `ProductAttributeFacetHandler` to display translations of attribute values in facet list
 * Changed the snippet export to specify the fallback language
 * The tax id of the invoice address is now also used for deliveries to foreign countries if the invoice country and delivery country are marked to be tax free for companies and if the delivery address does not have a tax id
+* Moved the block `frontend_index_header_javascript_jquery` back below `frontend_index_header_javascript_jquery_lib` (as it was before Shopware 5.3)
 
 ### Removals
 

--- a/themes/Frontend/Bare/frontend/index/index.tpl
+++ b/themes/Frontend/Bare/frontend/index/index.tpl
@@ -238,19 +238,19 @@
     {/if}
 {/block}
 
-{block name="frontend_index_header_javascript_jquery"}
-    {* Add the partner statistics widget, if configured *}
-    {if !{config name=disableShopwareStatistics} }
-        {include file='widgets/index/statistic_include.tpl'}
-    {/if}
-{/block}
-
 {*Include jQuery and all other javascript files at the bottom of the page*}
 {block name="frontend_index_header_javascript_jquery_lib"}
     {compileJavascript timestamp={themeTimestamp} output="javascriptFiles"}
     {foreach $javascriptFiles as $file}
         <script{if $theme.asyncJavascriptLoading} async{/if} src="{$file}" id="main-script"></script>
     {/foreach}
+{/block}
+
+{block name="frontend_index_header_javascript_jquery"}
+    {* Add the partner statistics widget, if configured *}
+    {if !{config name=disableShopwareStatistics} }
+        {include file='widgets/index/statistic_include.tpl'}
+    {/if}
 {/block}
 
 {block name="frontend_index_javascript_async_ready"}


### PR DESCRIPTION
### 1. Why is this change necessary?
At some point in the development of SW5.3 (specifically [this](https://github.com/shopware/shopware/commit/892860a071f5a5e9d68fdd9bae07607e68f224e4) commit) the block
"frontend_index_header_javascript_jquery" was moved below
"frontend_index_header_javascript_jquery_lib". This went undocumented
and breaks any script that relies on jQuery being present in that block
if asynchronous Javascript is disabled.

The block name suggests that jQuery should be available here, and it does not seem like moving it up was done intentionally.

### 2. What does this change do, exactly?
The block positions are changed back to how they were before the commit linked above.

### 3. Describe each step to reproduce the issue or behaviour.
Put jQuery code in and disable asynchronous Javascript loading.

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
n/a

### 6. Checklist

- [ /] I have written tests and verified that they fail without my change
- [ x] I have squashed any insignificant commits
- [ /] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x] I have read the contribution requirements and fulfil them.