### PR TITLE
Remove the relative css class when the overlay is closed.

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.overlay.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.overlay.js
@@ -148,9 +148,7 @@
             me.isOpen = false;
 
             me.$overlay.removeClass(me.options.openClass + ' ' + me.options.closableClass);
-            if (!$renderElement.hasClass(me.options.relativeClass)) {
-                $renderElement.removeClass(me.options.relativeClass);
-            }
+            $renderElement.removeClass(me.options.relativeClass);
 
             me.$overlay.one('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function() {
                 me.$overlay.off(me.options.events).removeAttr('style').remove();


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently there is a simple logic error that prevents the removal of a class from the overlay's render element. To resolve this it was necessary to simply remove one if-condition.

### 2. What does this change do, exactly?

The change simplifies the code _if render element **not** has relative class, then remove relative class_ to _remove relative class from render element_. Please note that the logic was wrong and above is not a mistake on my side.

If jQuery's `removeClass` doesn't encounter the supplied class, no error is generated, so wrapping the line with an if-statement is not necessary.

### 3. Describe each step to reproduce the issue or behaviour.

To reproduce this problem:

1. Navigate to the Shopware demo and pick a product detail page.
2. Add the product to the cart.
3. The overlay is rendered. Open the Inspector and look at the classes added to the body tag. Notice the class `js--overlay-relative`.
4. Close the overlay (e.g. by pressing _Weiter einkaufen_) and notice that the class is still there.

### 4. Please link to the relevant issues (if any).

I could not find a relevant issue in the issue tracker.

### 5. Which documentation changes (if any) need to be made because of this PR?

I'm not aware of any changes that need to be made due to this PR.

### 6. Checklist

- I believe there are no unit tests for the frontend. Even so, the change is very small and I believe there are no side effects to be feared.