### PR TITLE
Fix clones of template manager with actived smarty security

### DIFF
--- a/engine/Library/Enlight/Template/Manager.php
+++ b/engine/Library/Enlight/Template/Manager.php
@@ -297,6 +297,8 @@ class Enlight_Template_Manager extends Smarty
      * SmartyException with message 'directory [...] not allowed by security setting'. This is because
      * the security_policy still holds a reference to the old Smarty instance that does not know this new directories
      * as template sources.
+     *
+     * The security_policy is also cloned so other instances of the Enlight_Template_Manager do not get affected.
      */
     public function __clone()
     {

--- a/engine/Library/Enlight/Template/Manager.php
+++ b/engine/Library/Enlight/Template/Manager.php
@@ -287,4 +287,24 @@ class Enlight_Template_Manager extends Smarty
         }
         return array_merge($after, $pluginDirs, $before);
     }
+
+    /**
+     * Technically smarty security is enabled, if a security policy is set for the template manager instance. The
+     * security policy holds a reference to the template manager instance. When cloning the template manager, the
+     * reference of the security_policy to the Smarty instance has be updated to the new cloned Smarty instance.
+     *
+     * Without doing this, every self::fetch() after a directory was added with self::addTemplateDir(), would lead to a
+     * SmartyException with message 'directory [...] not allowed by security setting'. This is because
+     * the security_policy still holds a reference to the old Smarty instance that does not know this new directories
+     * as template sources.
+     */
+    public function __clone()
+    {
+        parent::__clone();
+
+        if ($this->security_policy !== null) {
+            $this->security_policy = clone $this->security_policy;
+            $this->security_policy->smarty = $this;
+        }
+    }
 }

--- a/tests/Functional/Components/Template/TemplateManagerTest.php
+++ b/tests/Functional/Components/Template/TemplateManagerTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\tests\Unit\Components\Template;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the template manager
+ */
+class TemplateManagerTest extends TestCase
+{
+    /**
+     * Tests whether the directories added to a cloned TemplateManager are recognized as secure dirs by SmartySecurity
+     */
+    public function testCloningTemplateManagerWithEnabledSmartySecurity()
+    {
+        // Create a dummy file
+        $tempDir = Shopware()->Container()->getParameter('kernel.root_dir') . '/media/temp';
+        $tempFile = $tempDir . '/template.tpl';
+        file_put_contents($tempFile, 'test');
+
+        /** @var \Enlight_Template_Manager $templateManager */
+        $templateManager = clone Shopware()->Container()->get('template');
+        $templateManager->addTemplateDir($tempDir);
+        $renderingResult = $templateManager->fetch('template.tpl');
+
+        // The actual thing to test here is that there is no SmartyException thrown here
+        self::assertEquals($renderingResult, 'test');
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
This PR will fix many SmartySecurity problem with messages like 'directory [...] not allowed by security setting'

The problem is cloning instances of `Enlight_Template_Manager`. This is done at several places in the Shopware code. 

The security policy of the `Enlight_Template_Manager` instance holds a reference to the template manager instance. When cloning the template manager, the reference of the security_policy to the Smarty instance has to be updated to the new cloned Smarty instance.

Without doing this, every self::fetch() after a directory was added with self::addTemplateDir(), would lead to a SmartyException with message 'directory [...] not allowed by security setting'. This is because
the security_policy still holds a reference to the old Smarty instance that does not know this new directories as template sources.

### 2. What does this change do, exactly?
After cloning instances of `Enlight_Template_Manager`, it clones the security_police object and updates the reference of the security_police to point to the correct, new, cloned instance of `Enlight_Template_Manager`.

### 3. Describe each step to reproduce the issue or behaviour.
The added UnitTest failes without the fix and is successfull with the fix.

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.