### PR TITLE
Fixed: Null values are not stored correctly

### DIFF
--- a/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
@@ -769,9 +769,11 @@ class DqlHelper
             $value = null;
         }
 
-        $type = $info['type'];
-        if ($value && $type == 'decimal' || $type == 'integer' || $type == 'float') {
-            $value = str_replace(',', '.', $value);
+        if($value !== null) {
+            $type = $info['type'];
+            if ($value && $type == 'decimal' || $type == 'integer' || $type == 'float') {
+                $value = str_replace(',', '.', $value);
+            }
         }
 
         return $value;

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
@@ -769,9 +769,9 @@ class DqlHelper
             $value = null;
         }
 
-        if($value !== null) {
+        if ($value !== null) {
             $type = $info['type'];
-            if ($value && $type == 'decimal' || $type == 'integer' || $type == 'float') {
+            if ($type == 'decimal' || $type == 'integer' || $type == 'float') {
                 $value = str_replace(',', '.', $value);
             }
         }


### PR DESCRIPTION
Values with empty string are not stored as null in database which causes that MySQL falls back to default value.

### 1. Why is this change necessary?
It fixes the problem, that empty strings are written to database which cause that the database falls back to default value instead of writing NULL on corresponding table column.

### 2. What does this change do, exactly?
It corrects the wrong if statement which does not correctly check if value is changed to null in prior lines. The "||" ignores that value is null so value will be changed to an empty string in case of integer, float or decimal.

### 3. Describe each step to reproduce the issue or behaviour.
Add a custom attribute to an article as an integer which can be nullable. Change it inline in the backend in the article list(i.e.: activate or deactivate). Then in the database the value is not null. It has the value 0 because en empty string is send to database.

### 4. Please link to the relevant issues (if any).
Ticket: SW-20826

### 5. Which documentation changes (if any) need to be made because of this PR?
-


  