### PR TITLE
Add possibility to set log email address

### DIFF
--- a/_sql/migrations/965-add-log-mail-address.php
+++ b/_sql/migrations/965-add-log-mail-address.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+use Shopware\Components\Migrations\AbstractMigration;
+class Migrations_Migration965 extends AbstractMigration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function up($modus)
+    {
+        $this->addSql("SET @parent = (SELECT id FROM s_core_config_forms WHERE name = 'Log' LIMIT 1);");
+        $sql = "INSERT INTO s_core_config_elements (form_id, name, value, label, description, type, required, position, scope, options)
+                    VALUES (@parent, 'log_mail_address', NULL, 'Email-Adresse für Fehlermeldungen', 'Hier kannst einstellen, an welche Email-Adresse die Logeinträge geschickt werden sollen', 'text', '0', '0', '0', NULL);";
+        $this->addSql($sql);
+        $this->addSql("SET @elementID = (SELECT id FROM s_core_config_elements WHERE name = 'log_mail_address' LIMIT 1);");
+        $this->addSql("INSERT IGNORE INTO s_core_config_element_translations (element_id, locale_id, label, description) VALUES(@elementID, 2, 'email address for log entries', 'define an email address for logs ');");
+    }
+}

--- a/_sql/migrations/965-add-log-mail-address.php
+++ b/_sql/migrations/965-add-log-mail-address.php
@@ -34,6 +34,6 @@ class Migrations_Migration965 extends AbstractMigration
                     VALUES (@parent, 'log_mail_address', NULL, 'Email-Adresse für Fehlermeldungen', 'Hier kannst einstellen, an welche Email-Adresse die Logeinträge geschickt werden sollen', 'text', '0', '0', '0', NULL);";
         $this->addSql($sql);
         $this->addSql("SET @elementID = (SELECT id FROM s_core_config_elements WHERE name = 'log_mail_address' LIMIT 1);");
-        $this->addSql("INSERT IGNORE INTO s_core_config_element_translations (element_id, locale_id, label, description) VALUES(@elementID, 2, 'email address for log entries', 'define an email address for logs ');");
+        $this->addSql("INSERT IGNORE INTO s_core_config_element_translations (element_id, locale_id, label, description) VALUES(@elementID, 2, 'Email address for log entries', 'Define an email address for logs');");
     }
 }

--- a/engine/Shopware/Plugins/Default/Core/ErrorHandler/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/ErrorHandler/Bootstrap.php
@@ -292,7 +292,13 @@ class Shopware_Plugins_Core_ErrorHandler_Bootstrap extends Shopware_Components_P
         }
 
         $mailer = new \Enlight_Components_Mail();
-        $mailer->addTo($mail);
+
+        if(!Shopware()->Config()->log_mail_address){
+            $mailer->addTo(Shopware()->Config()->Mail);
+        } else {
+            $mailer->addTo(Shopware()->Config()->log_mail_address);
+        }
+        
         $mailer->setSubject('Error in shop "'.Shopware()->Config()->Shopname.'".');
         $mailHandler = new EnlightMailHandler($mailer, \Monolog\Logger::WARNING);
         $mailHandler->pushProcessor(new ShopwareEnvironmentProcessor());


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
A lot of customers are complaining about the log mails sent to the address of the shopowner

### 2. What does this change do, exactly?
This pull-request adds a new field to the log-settings in the basic settings, where you can define an email-address for logs. It also adds a fallback to the shopowner-address in case this function is already in use.

### 3. Describe each step to reproduce the issue or behaviour.
Activate the log function and create an error in the shop

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-17733

### 5. Which documentation changes (if any) need to be made because of this PR?
the wiki entry for the basic settings->system->log needs to be changed.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
  