### PR TITLE
Fix wrong data hydration in AddressHydrator

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/AddressHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/AddressHydrator.php
@@ -71,7 +71,7 @@ class AddressHydrator extends Hydrator
         $address->setVatId($data['__address_ustid']);
         $address->setPhone($data['__address_phone']);
         $address->setAdditionalAddressLine1($data['__address_additional_address_line1']);
-        $address->setAdditionalAddressLine1($data['__address_additional_address_line2']);
+        $address->setAdditionalAddressLine2($data['__address_additional_address_line2']);
 
         if ($address->getCountryId()) {
             $address->setCountry(


### PR DESCRIPTION
### 1. Why is this change necessary?
Because $address->setAdditionalAddressLine1 will be used twice, once with the data from address_line1 and once with data from address_line2, the AddressGateway will retrieve invalid data. To put it in a nutshell the address_line1 data will be overridden by address_line2 so we need to use $address->setAdditionalAddressLine2

### 2. What does this change do, exactly?
Just replace the second usage of $address->setAdditionalAddressLine1() by $address->setAdditionalAddressLine2() in the AddressHydrator's hydrate method.

### 3. Describe each step to reproduce the issue or behaviour.
When trying to retrieve a customers address by the AddressGateway it will return wrong data in additionalAddressLine1. Instead of the correct value there mistakenly appears the value of additionalAddressLine2.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.