### PR TITLE
change order of the customer overview

### DIFF
--- a/engine/Shopware/Controllers/Backend/CustomerQuickView.php
+++ b/engine/Shopware/Controllers/Backend/CustomerQuickView.php
@@ -126,6 +126,7 @@ class Shopware_Controllers_Backend_CustomerQuickView extends Shopware_Controller
         $query->leftJoin('customer.defaultBillingAddress', 'billing');
         $query->leftJoin('customer.attribute', 'attribute');
         $query->leftJoin('customer.group', 'groups');
+        $query->orderBy('customer.id','DESC');
 
         $filters = $this->Request()->getParam('filter', []);
         $search = null;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Since the new customer module of 5.3, new customers won't be listed as first ones, if there were higher customer-numbers used in the past.


### 2. What does this change do, exactly?
Add an orderBy for the id

### 3. Describe each step to reproduce the issue or behaviour.
Change the customernumber and open the order module, the newest customer might not be the first one in the list (depending on the customernumber)

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-19907

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.