### PR TITLE
Add s_user_attributes to pdf-documents

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -349,18 +349,22 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
     }
 
     
-     /**
+    /**
      * Get user_attributes (s_user_attributes)
+     *
+     * @param int $userID
+     *
+     * @return array
+     * @throws Exception
      */
-
-    public function getUserAttributes($id)
+    public function getUserAttributes($userID)
     {
-        if (empty($id)) {
+        if (empty($userID)) {
             return false;
         }
 
         $service = Shopware()->Container()->get('shopware_attribute.data_loader');
-        $sqlUserAttributes = $service->load('s_user_attributes', $id);
+        $sqlUserAttributes = $service->load('s_user_attributes', $userID);
 
         return $sqlUserAttributes;
     }

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -348,6 +348,24 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         return $getVoucher;
     }
 
+    
+     /**
+     * Get user_attributes (s_user_attributes)
+     */
+
+    public function getUserAttributes($id)
+    {
+        if (empty($id)) {
+            return false;
+        }
+
+        $service = Shopware()->Container()->get('shopware_attribute.data_loader');
+        $sqlUserAttributes = $service->load('s_user_attributes', $id);
+
+        return $sqlUserAttributes;
+    }
+    
+    
     /**
      * Assign configuration / data to template, new template base
      */
@@ -434,6 +452,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
                 'countryShipping' => $order->shipping->country,
                 'country' => $order->billing->country,
             ],
+            'attributes' => $this->getUserAttributes($order->userID),
         ];
         $this->_view->assign('User', $user);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently there are no s_user_attributes available on the pdf-documents

### 2. What does this change do, exactly?
adds the user_attributes to pdf-documents

### 3. Describe each step to reproduce the issue or behaviour.
Create a new document/index.tpl in your own theme and try to use the user_attributes:
`
    {$User.attributes.attributeName}
`

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/pull/1457
I edited my PR to use the data_loader.

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
  
  