### PR TITLE
Add filter event to listing widget controller

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -2,6 +2,14 @@
 
 This changelog references changes done in Shopware 5.3 patch versions.
 
+## 5.3.6
+
+[View all changes from v5.3.5...v5.3.6](https://github.com/shopware/shopware/compare/v5.3.5...v5.3.6)
+
+### Additions
+
+* Added new event `Shopware_Controllers_Widgets_Listing_fetchListing_filterViewParams` to `Shopware_Controller_Widgets_Listing::fetchListing()` in order to allow for filtering of template variables before the template is fetched by the function.
+
 ## 5.3.5
 
 [View all changes from v5.3.4...v5.3.5](https://github.com/shopware/shopware/compare/v5.3.4...v5.3.5)

--- a/engine/Shopware/Controllers/Widgets/Listing.php
+++ b/engine/Shopware/Controllers/Widgets/Listing.php
@@ -30,12 +30,12 @@ use Shopware\Components\Compatibility\LegacyStructConverter;
 use Shopware\Components\Routing\RouterInterface;
 
 /**
- * Shopware Listing Widgets
+ * Shopware Listing Widgets.
  */
 class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
 {
     /**
-     * product navigation as json string
+     * product navigation as json string.
      */
     public function productNavigationAction()
     {
@@ -102,7 +102,7 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
 
     /**
      * topseller action for getting topsellers
-     * by category with perPage filtering
+     * by category with perPage filtering.
      */
     public function topSellerAction()
     {
@@ -177,7 +177,7 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
     }
 
     /**
-     * tag cloud by category
+     * tag cloud by category.
      */
     public function tagCloudAction()
     {
@@ -268,7 +268,7 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
     }
 
     /**
-     * Gets a Callback-Function (callback) and the Id of an category (categoryID) from Request and read its first child-level
+     * Gets a Callback-Function (callback) and the Id of an category (categoryID) from Request and read its first child-level.
      */
     public function getCategoryAction()
     {
@@ -281,7 +281,7 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
     }
 
     /**
-     * Gets a Callback-Function (callback) and the Id of an category (categoryID) from Request and read its first child-level
+     * Gets a Callback-Function (callback) and the Id of an category (categoryID) from Request and read its first child-level.
      */
     public function getCustomPageAction()
     {
@@ -294,7 +294,7 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
     }
 
     /**
-     * Helper function to return the category information by category id
+     * Helper function to return the category information by category id.
      *
      * @param int $categoryId
      *
@@ -530,12 +530,20 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
 
         $this->loadThemeConfig();
 
-        $this->View()->assign([
-            'sArticles' => $articles,
-            'pageIndex' => $this->Request()->getParam('sPage'),
-            'productBoxLayout' => $boxLayout,
-            'sCategoryCurrent' => $categoryId,
-        ]);
+        $viewParams = $this->get('events')->filter(
+            'Shopware_Controllers_Widgets_Listing_fetchListing_filterViewParams',
+            [
+                'sArticles' => $articles,
+                'pageIndex' => $this->Request()->getParam('sPage'),
+                'productBoxLayout' => $boxLayout,
+                'sCategoryCurrent' => $categoryId,
+            ],
+            [
+                'searchResult' => $result,
+            ]
+        );
+
+        $this->View()->assign($viewParams);
 
         return $this->View()->fetch('frontend/listing/listing_ajax.tpl');
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, it is impossible to manipulate the view parameters defined in `Shopware_Controllers_Widgets_Listing::fetchListing()` because the view is immediately fetched after assignment. 

### 2. What does this change do, exactly?
Add a new event `Shopware_Controllers_Widgets_Listing_fetchListing_filterViewParams` to allow developers to manipulate the variables before they are assigned to the template. 

### 3. Describe each step to reproduce the issue or behaviour.
-/-

### 4. Please link to the relevant issues (if any).
-/-

### 5. Which documentation changes (if any) need to be made because of this PR?
-/-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.