### PR TITLE
Display no link and remove-button for modus 3 = Shopping basket discount

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/ajax_cart_item.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/ajax_cart_item.tpl
@@ -89,7 +89,7 @@
                 {$deleteUrl = {url controller="checkout" action="ajaxDeleteArticleCart" sDelete="voucher"}}
             {/if}
 
-            {if $basketItem.modus != 4}
+            {if $basketItem.modus != 4 && $basketItem.modus != 3}
                 <form action="{$deleteUrl}" method="post">
                     <button type="submit" class="btn is--small action--remove" title="{s name="AjaxCartRemoveArticle"}{/s}">
                         <i class="icon--cross"></i>
@@ -101,7 +101,7 @@
 
     {* Article name *}
     {block name='frontend_checkout_ajax_cart_articlename'}
-        {$useAnchor = ($basketItem.modus != 4 && $basketItem.modus != 2)}
+        {$useAnchor = ($basketItem.modus != 4 && $basketItem.modus != 2 && $basketItem.modus != 3)}
         {if $useAnchor}
             <a class="item--link" href="{$detailLink}" title="{$basketItem.articlename|escapeHtml}">
         {else}


### PR DESCRIPTION
### 1. Why is this change necessary?
In offcanvas: a link with articleID=0 and the unnessary remove-button are displayed

### 2. What does this change do, exactly?
It removes both

### 3. Describe each step to reproduce the issue or behaviour.
Apply Shopping basket discount for customer group and check offcanvas

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.