### PR TITLE
Fix ajax number search

### DIFF
--- a/engine/Shopware/Controllers/Frontend/AjaxSearch.php
+++ b/engine/Shopware/Controllers/Frontend/AjaxSearch.php
@@ -61,11 +61,11 @@ class Shopware_Controllers_Frontend_AjaxSearch extends Enlight_Controller_Action
         $result = $this->get('shopware_search.product_search')->search($criteria, $context);
 
         //check if search-tearm is a valid product-number
-        if ((Shopware()->Config()->get('activateNumberSearch') == "1")) {
-        $directhit = Shopware()->Container()->get('shopware_storefront.list_product_service')
-            ->get($term, $context);
+        if (($this->get("config")->get('activateNumberSearch') == "1")) {
+            $directhit = $this->get('shopware_storefront.list_product_service')
+                ->get($term, $context);
         }
-        if ((Shopware()->Config()->get('activateNumberSearch') == "1") && $directhit) {
+        if (($this->get("config")->get('activateNumberSearch') == "1") && $directhit) {
             $result = new ProductSearchResult([$directhit], 1, []);
             $data = $this->get('legacy_struct_converter')->convertListProductStruct($directhit);
             //change name for compatibility reasons
@@ -77,6 +77,16 @@ class Shopware_Controllers_Frontend_AjaxSearch extends Enlight_Controller_Action
                 'sArticlesCount' => 1,
             ]);
             return;
+        }
+
+        if ($result->getTotalCount() > 0) {
+            $articles = $this->convertProducts($result);
+            $this->View()->assign('searchResult', $result);
+            $this->View()->assign('sSearchRequest', ['sSearch' => $term]);
+            $this->View()->assign('sSearchResults', [
+                'sResults' => $articles,
+                'sArticlesCount' => $result->getTotalCount(),
+            ]);
         }
         
         if ($result->getTotalCount() > 0) {

--- a/engine/Shopware/Controllers/Frontend/AjaxSearch.php
+++ b/engine/Shopware/Controllers/Frontend/AjaxSearch.php
@@ -60,6 +60,25 @@ class Shopware_Controllers_Frontend_AjaxSearch extends Enlight_Controller_Action
         /** @var ProductSearchResult $result */
         $result = $this->get('shopware_search.product_search')->search($criteria, $context);
 
+        //check if search-tearm is a valid product-number
+        if ((Shopware()->Config()->get('activateNumberSearch') == "1")) {
+        $directhit = Shopware()->Container()->get('shopware_storefront.list_product_service')
+            ->get($term, $context);
+        }
+        if ((Shopware()->Config()->get('activateNumberSearch') == "1") && $directhit) {
+            $result = new ProductSearchResult([$directhit], 1, []);
+            $data = $this->get('legacy_struct_converter')->convertListProductStruct($directhit);
+            //change name for compatibility reasons
+            $data['name'] = $data['articleName'];
+            $this->View()->assign('searchResult', $result);
+            $this->View()->assign('sSearchRequest', ['sSearch' => $term]);
+            $this->View()->assign('sSearchResults', [
+                'sResults' => [$data],
+                'sArticlesCount' => 1,
+            ]);
+            return;
+        }
+        
         if ($result->getTotalCount() > 0) {
             $articles = $this->convertProducts($result);
             $this->View()->assign('searchResult', $result);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When a product number matches the search term, the product search redirects directly to this product. You can activate this product matching with the setting "activateNumberSearch". The ajax search does no consider this setting and will show no products or unrelated products. This change will make the ajax-search behave like the product search.

### 2. What does this change do, exactly?
Add a check for a direct match if the setting is activated

### 3. Describe each step to reproduce the issue or behaviour.
Activate number search and search for a valid article number in the ajax-search. 

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-16189

Since I messed up with my branches, this is the same pull-request as https://github.com/shopware/shopware/pull/1424 that was closed by me.

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ x] I have written tests and verified that they fail without my change
- [ x] I have squashed any insignificant commits
- [ x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x] I have read the contribution requirements and fulfil them.