### PR TITLE
small improvement in handling a new newsletter subscription

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2247,7 +2247,6 @@ class sAdmin
     public function sNewsletterSubscription($email, $unsubscribe = false, $groupID = null)
     {
         if (empty($unsubscribe)) {
-            $errorFlag = [];
             $config = Shopware()->Container()->get('config');
 
             if ($this->shouldVerifyCaptcha($config) && $this->front->Request()->getParam('voteConfirmed', false) == false) {
@@ -2261,20 +2260,15 @@ class sAdmin
                 }
             }
 
-            $fields = ['newsletter'];
-            foreach ($fields as $field) {
-                $fieldData = $this->front->Request()->getPost($field);
-                if (isset($fieldData) && empty($fieldData)) {
-                    $errorFlag[$field] = true;
-                }
-            }
-
-            if (!empty($errorFlag)) {
+            $subscribe = $this->front->Request()->getPost('newsletter');
+            if ($subscribe !== null && empty($subscribe)) {
                 return [
                     'code' => 5,
                     'message' => $this->snippetManager->getNamespace('frontend/account/internalMessages')
                         ->get('ErrorFillIn', 'Please fill in all red fields'),
-                    'sErrorFlag' => $errorFlag,
+                    'sErrorFlag' => [
+                        'newsletter' => true,
+                    ],
                 ];
             }
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
a foreach is used to get the params of a newsletter subscription, but there is only one parameter used

### 2. What does this change do, exactly?
remove the foreach and get the parameter directly

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.