### PR TITLE
repair the Shopware_Form_Builder event according to the documentation

### DIFF
--- a/engine/Shopware/Bundle/FormBundle/Extension/EventExtension.php
+++ b/engine/Shopware/Bundle/FormBundle/Extension/EventExtension.php
@@ -51,7 +51,10 @@ class EventExtension extends AbstractTypeExtension
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, [$this, 'triggerEvent']);
+        $this->eventManager->notify('Shopware_Form_Builder', [
+            'reference' => $builder->getForm()->getConfig()->getType()->getName(),
+            'builder' => $builder,
+        ]);
     }
 
     /**
@@ -62,18 +65,5 @@ class EventExtension extends AbstractTypeExtension
     public function getExtendedType()
     {
         return 'Symfony\Component\Form\Extension\Core\Type\FormType';
-    }
-
-    /**
-     * Trigger general form builder event with reference of the form type
-     *
-     * @param FormEvent $event
-     */
-    public function triggerEvent(FormEvent $event)
-    {
-        $this->eventManager->notify('Shopware_Form_Builder', [
-            'reference' => $event->getForm()->getConfig()->getType()->getName(),
-            'builder' => $event->getForm(),
-        ]);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

With the current splitting of events, it is not possible to capture events from the namespace Symfony\Component\Form\FormEvents from the plugins. You have `Shopware_Form_Builder`, but this event is based on `PRE_SET_DATA`. If programmer needs form event like `POST_SUBMIT`, he can't do that cleanly.

Something you need it, for example if constraints depending on another form field.

### 2. What does this change do, exactly?
Probably repair bug, cause your documentation (here https://developers.shopware.com/developers-guide/address-management-guide/ , part `Create the Subscriber file`) said:

```
    /** @var \Symfony\Component\Form\FormBuilderInterface $builder */
    $builder = $event->getBuilder();
```

But thats not true, cause `$event->getBuilder()` returns `Symfony\Component\Form\FormInterface`

### 3. Describe each step to reproduce the issue or behaviour.

If you adding something into `Shopware\Bundle\AccountBundle\Form\Account\AddressFormType`, which is depending on `customer_type` filed.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?

If you accept the PR documentation will correspond to reality.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.