### PR TITLE
add tax rule handling to amount invoice calculation

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -543,10 +543,12 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
             $position = $detailRepository->find($id);
         }
 
+        $actualTaxID = ($position->getTax() ? $position->getTax()->getId() : NULL);
+
         $data = $this->Request()->getParams();
         $data['number'] = $order->getNumber();
 
-        $data = $this->getPositionAssociatedData($data);
+        $data = $this->getPositionAssociatedData($data, $actualTaxID);
         // If $data === null, the article was not found
         if ($data === null) {
             $this->View()->assign([
@@ -1588,9 +1590,11 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
      *
      * @param array $data
      *
+     * @param $formerTaxId
      * @return array
+     * @throws Exception
      */
-    private function getPositionAssociatedData($data)
+    private function getPositionAssociatedData($data, $formerTaxId)
     {
         //checks if the status id for the position is passed and search for the assigned status model
         if ($data['statusId'] >= 0) {
@@ -1602,7 +1606,7 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
         //checks if the tax id for the position is passed and search for the assigned tax model
         if (!empty($data['taxId'])) {
             $tax = Shopware()->Models()->find(Tax::class, $data['taxId']);
-            if ($tax instanceof \Shopware\Models\Tax\Tax) {
+            if ($data['taxId'] !== $formerTaxId && $tax instanceof \Shopware\Models\Tax\Tax) {
                 $data['tax'] = $tax;
                 $data['taxRate'] = $tax->getTax();
             }


### PR DESCRIPTION
### 1. Why is this change necessary?
Shopware does not handle tax rules correctly in invoice amount calculation after changes to an order via backend.


### 2. What does this change do, exactly?
This changes adds tax rule handling to the Order model and prevents the Order backend controller from setting order positions to possibly wrong tax rates, if there was no actual change to the assigned tax.

### 3. Describe each step to reproduce the issue or behaviour.
- Place an order with an applying tax rule, where the tax is different to the article default tax value.
- Change an order position via backend (for Example, change the price)
- The calculated gross and net invoice amounts in s_order were calculated with the wrong tax

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.