### PR TITLE
Update sendMailAction

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -815,7 +815,10 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
         }
 
         $mail->setFrom($this->Request()->getParam('fromMail', ''), $this->Request()->getParam('fromName', ''));
-        $mail->addTo($this->Request()->getParam('to', ''));
+        $addTo = explode(',',$this->Request()->getParam('to', ''));
+        foreach($addTo as $add){
+            $mail->addTo(trim($add));
+        }
 
         Shopware()->Modules()->Order()->sendStatusMail($mail);
 


### PR DESCRIPTION
added the ability to add multiple receivers

### 1. Why is this change necessary?
you may want to inform more than one receiver about the Order state

### 2. What does this change do, exactly?
loop through the param 'to' and perform for each receiver a $mail->addTo()
