### PR TITLE
Avoid PHP notice in postfilter

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/PostFilter/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/PostFilter/Bootstrap.php
@@ -121,7 +121,7 @@ class Shopware_Plugins_Core_PostFilter_Bootstrap extends Shopware_Components_Plu
      *
      * @return string
      */
-    public function &filterSource($source)
+    public function filterSource($source)
     {
         $source = preg_replace_callback('#<(a|form|iframe|link|img)[^<>]*(href|src|action)="([^"]*)".*>#Umsi', [$this, 'rewriteSrc'], $source);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
[2018-01-17 19:54:34] core.CRITICAL: Notice: Only variable references should be returned by reference [] []
Symfony\Component\Debug\Exception\ContextErrorException: Notice: Only variable references should be returned by reference in /shopware/vendor/shopware/shopware/engine/Shopware/Plugins/Default/Core/PostFilter/Bootstrap.php:151

### 2. What does this change do, exactly?
Removes reference on function

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.