### PR TITLE
Fix Uncaught TypeError when passing null to addFacet() method

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleES/FacetHandler/CategoryFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/FacetHandler/CategoryFacetHandler.php
@@ -31,6 +31,7 @@ use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\SearchBundle\CriteriaPartInterface;
 use Shopware\Bundle\SearchBundle\Facet\CategoryFacet;
 use Shopware\Bundle\SearchBundle\FacetResult\CategoryTreeFacetResultBuilder;
+use Shopware\Bundle\SearchBundle\FacetResultInterface;
 use Shopware\Bundle\SearchBundle\ProductNumberSearchResult;
 use Shopware\Bundle\SearchBundleES\HandlerInterface;
 use Shopware\Bundle\SearchBundleES\ResultHydratorInterface;
@@ -142,7 +143,9 @@ class CategoryFacetHandler implements HandlerInterface, ResultHydratorInterface
             $categoryFacet
         );
 
-        $result->addFacet($facet);
+        if($facet instanceof FacetResultInterface){
+            $result->addFacet($facet);
+        }
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Since Shopware allows to search (and open detail page) for articles that are mapped to inactive categories only an "Fatal error: Uncaught TypeError: Argument 1 passed to Shopware\Bundle\SearchBundle\ProductNumberSearchResult::addFacet() must implement interface Shopware\Bundle\SearchBundle\FacetResultInterface, null given, called in /var/www/shop/htdocs/engine/Shopware/Bundle/SearchBundleES/FacetHandler/CategoryFacetHandler.php on line 145 and defined in /var/www/shop/htdocs/engine/Shopware/Bundle/SearchBundle/ProductNumberSearchResult.php:87" occurs when trying to search for the article via Elasticsearch.

### 2. What does this change do, exactly?
Wrapping the addFacet() methods call inside a instanceof FacetResultInterface condition will avoid that the fatal error occurs in case of $facet would be NULL.

### 3. Describe each step to reproduce the issue or behaviour.
First of all this error occurs only when using Elasticsearch. Create an article "foo" that is mapped to an inactive category. The article itself needs to be active. When trying to open "/search?sSearch=foo" the error described above should be thrown. This happens because the buildFacetResult() method of the CategoryTreeFacetResultBuilder returns both, an TreeFacetResult object or NULL. Therefor it's possible that a $facet of type NULL is going to be injected to the ProductNumberSearchResult's addFacet() method.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.