### PR TITLE
Fix vouchers with conditions

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -237,12 +237,12 @@ class sBasket
      */
     public function sGetAmountRestrictedArticles($articles, $supplier)
     {
-        if (!is_array($articles) && empty($supplier)) {
+        if (empty($articles) && empty($supplier)) {
             return $this->sGetAmountArticles();
         }
 
         $extraConditions = [];
-        if (is_array($articles)) {
+        if (!empty($articles)) {
             $extraConditions[] = $this->db->quoteInto('ordernumber IN (?) ', $articles);
         }
         if (!empty($supplier)) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently it is not possible to add a voucher with conditions to your basket, because $articles is always an array and this will lead to a wrong MySQL-query.

... 
AND ( ordernumber IN ()  OR s_articles.supplierID = '2' )
...

Because ordernumber IN () is an invalid MySQL-syntax

### 2. What does this change do, exactly?
Change the checks from "is_array" to "!empty" in order to restore the functionality.

### 3. Describe each step to reproduce the issue or behaviour.
Restrict your voucher to a specific supplier and then add this voucher to your cart. You will see an error like this:

SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') OR s_articles.supplierID = '320' ) GROUP BY sessionID' at line 6 in engine/Library/Zend/Db/Statement/Pdo.php on line 224

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20965
https://forum.shopware.com/discussion/51237/gutscheineingabe-im-checkout-seit-5-3-5-fuehrt-zu-ups-ein-fehler-ist-aufgetreten#latest

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.