### PR TITLE
Fix applyDataAttributes() in jQuery plugin

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
@@ -308,7 +308,7 @@
                     return;
                 }
 
-                attr = me.$el.attr('data-' + key);
+                attr = me.$el.data(key);
 
                 if (typeof attr === 'undefined') {
                     return true;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

The attr() method doesn't convert dash-case (html) attribute name to camel case (javascript) names like described in the dev docs.

### 2. What does this change do, exactly?

Before this change a html attribute like ```data-myExample``` would be parsed into javascript variable ```myexample``` not in ```myExample``` as expected. An attribute ```data-my-example``` would be parsed into ```my-example```. Under this circumstances one can not use camel cased javascript variable names.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?

Documentaion is already right.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.