### PR TITLE
Fixed note count on first click

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1325,10 +1325,10 @@ class sBasket
      */
     public function sCountNotes()
     {
-        $responseCookies = $this->front->Response()->getCookies();
+        $responseUniqueId = $this->getUniqueFromResponse();
 
-        if (isset($responseCookies['sUniqueID']['value']) && $responseCookies['sUniqueID']['value']) {
-            $uniqueId = $responseCookies['sUniqueID']['value'];
+        if (!empty($responseUniqueId)) {
+            $uniqueId = $responseUniqueId;
         } else {
             $uniqueId = $this->front->Request()->getCookie('sUniqueID');
         }
@@ -2936,5 +2936,19 @@ class sBasket
         }
 
         return $newQuantity;
+    }
+
+    /**
+     * @return string
+     */
+    private function getUniqueFromResponse()
+    {
+        foreach ($this->front->Response()->getCookies() as $cookie) {
+            if ($cookie['name'] === 'sUniqueID') {
+                return $cookie['value'];
+            }
+        }
+
+        return '';
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
First click on mark product in note returns count 0, because response sUniqueID cookie cannot be found since 5.3.0 RC1.

SW-18393 added support for Cookies for paths and this broke that functionality (https://github.com/shopware/shopware/commit/e01d43cfc84b66f59c28540b3de3157f745996a2#diff-8ee74466675cdfac64b39296cf3020ccR127),

https://github.com/shopware/shopware/blob/5.3/engine/Shopware/Core/sBasket.php#L1330 does not contain "-/" at end of the key for the path.

### 2. What does this change do, exactly?
Loop throught all cookies to find the right one without using the key.


### 3. Describe each step to reproduce the issue or behaviour.
Clear all Cookies, mark a product as note and you get 0 as count

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.