### PR TITLE
Labs: Administration, sw-grid - Add indeterminate select state

### DIFF
--- a/src/Administration/Resources/administration/src/app/component/grid/sw-grid/index.js
+++ b/src/Administration/Resources/administration/src/app/component/grid/sw-grid/index.js
@@ -2,7 +2,6 @@ import './sw-grid.less';
 import template from './sw-grid.html.twig';
 
 Shopware.Component.register('sw-grid', {
-
     data() {
         return {
             columns: []
@@ -30,6 +29,12 @@ Shopware.Component.register('sw-grid', {
             default: true
         },
 
+        selectIndeterminateEnabled: {
+            type: Boolean,
+            required: false,
+            default: true
+        },
+
         sidebar: {
             type: Boolean,
             required: false,
@@ -50,6 +55,10 @@ Shopware.Component.register('sw-grid', {
     },
 
     computed: {
+        SELECT_STATE_UNCHECKED: () => 0,
+        SELECT_STATE_CHECKED: () => 1,
+        SELECT_STATE_INDETERMINATE: () => 2,
+
         columnFlex() {
             let flex = (this.selectable === true) ? '50px ' : '';
 
@@ -68,6 +77,20 @@ Shopware.Component.register('sw-grid', {
             return {
                 'grid-template-columns': flex.trim()
             };
+        },
+
+        selectionStatus() {
+            const selectedCount = this.items.filter(item => item.selected).length;
+            const isAnyEnabled = selectedCount > 0;
+            const isAllEnabled = isAnyEnabled && selectedCount === this.items.length;
+
+            if (!isAllEnabled && isAnyEnabled && this.selectIndeterminateEnabled) {
+                return this.SELECT_STATE_INDETERMINATE;
+            }
+            if (isAllEnabled) {
+                return this.SELECT_STATE_CHECKED;
+            }
+            return this.SELECT_STATE_UNCHECKED;
         }
     },
 
@@ -82,7 +105,9 @@ Shopware.Component.register('sw-grid', {
     },
 
     methods: {
-        selectAll(selected) {
+        toggleSelection() {
+            const selected = this.selectionStatus !== this.SELECT_STATE_CHECKED;
+
             this.items.forEach((item) => {
                 this.$set(item, 'selected', selected);
             });

--- a/src/Administration/Resources/administration/src/app/component/grid/sw-grid/sw-grid.html.twig
+++ b/src/Administration/Resources/administration/src/app/component/grid/sw-grid/sw-grid.html.twig
@@ -5,7 +5,9 @@
 
             <slot name="header" v-if="header">
                 <div class="sw-grid--header" :style="columnFlex">
-                    <div class="sw-grid--cell" v-if="selectable"><input type="checkbox" v-on:change="selectAll($event.target.checked)"></div>
+                    <div class="sw-grid--cell" v-if="selectable">
+                        <input type="checkbox" v-on:change="toggleSelection()" :indeterminate.prop="selectionStatus == SELECT_STATE_INDETERMINATE" :checked="selectionStatus == SELECT_STATE_CHECKED">
+                    </div>
                     <div class="sw-grid--cell" v-for="column in columns">{{ column.label }}</div>
                     <div class="sw-grid--cell" v-if="actions.length > 0">Actions</div>
                 </div>


### PR DESCRIPTION
This PR adds the indeterminate state to the head-selectbox in the sw-grid component

### 1. Why is this change necessary?
Properly show the user the state of the selection of items in the grid

### 2. What does this change do, exactly?
It adds 3 constants, indicating the state of the head select based. It also adds a computed property indicating the current state of the items in the sw-grid.

* If all items in the grid are checked the head-selectbox is checked
* If some are checked it is indeterminate
* If none are checked it's unchecked.

It's also possible to disable the use of the indeterminate state, by setting the prop `selectIndeterminateEnabled` to false (default true)

### 3. Describe each step to reproduce the issue or behaviour.
Try selecting grid-items in the administration

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
There's currently none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.