### PR TITLE
Labs administration dump plugins command dump relative path

### DIFF
--- a/src/Administration/Resources/administration/build/webpack.dev.conf.js
+++ b/src/Administration/Resources/administration/build/webpack.dev.conf.js
@@ -30,8 +30,6 @@ try {
     Object.keys(plugins).forEach(function (pluginName) {
         baseWebpackConfig.entry[pluginName] = path.join('../../../../', plugins[pluginName]);
     });
-
-    console.log(baseWebpackConfig.entry);
 } catch(e) {}
 
 baseWebpackConfig.entry.app = appEntry;

--- a/src/Administration/Resources/administration/build/webpack.dev.conf.js
+++ b/src/Administration/Resources/administration/build/webpack.dev.conf.js
@@ -28,8 +28,10 @@ try {
 
     // add hot-reload related code to entry chunks
     Object.keys(plugins).forEach(function (pluginName) {
-        baseWebpackConfig.entry[pluginName] = plugins[pluginName];
+        baseWebpackConfig.entry[pluginName] = path.join('../../../../', plugins[pluginName]);
     });
+
+    console.log(baseWebpackConfig.entry);
 } catch(e) {}
 
 baseWebpackConfig.entry.app = appEntry;

--- a/src/Administration/Resources/administration/build/webpack.prod.conf.js
+++ b/src/Administration/Resources/administration/build/webpack.prod.conf.js
@@ -21,7 +21,7 @@ try {
 
     // add hot-reload related code to entry chunks
     Object.keys(plugins).forEach(function (pluginName) {
-        baseWebpackConfig.entry[pluginName] = plugins[pluginName];
+        baseWebpackConfig.entry[pluginName] = path.join('../../../../', plugins[pluginName]);
     });
 } catch(e) {}
 


### PR DESCRIPTION
This PR changes the way the `bin/console administration:dump:plugins` command exports paths. The original behaviour was to dump paths absolute to the docker instance, but this doesn't work in case the user runs webpack from outside the docker machine. So in order to be able to use webpack more flexible we dump paths relative to the projectDir

### 1. Why is this change necessary?
In order to run webpack from outside docker

### 2. What does this change do, exactly?
Add a new private function `getPathRelativeToProjectDir(string $absolute): string` to `AdministrationDumpPluginsCommand` in order to export universal relative paths.

### 3. Describe each step to reproduce the issue or behaviour.
```bash
./psh.phar docker:ssh
bin/console administration:dump:plugins
exit
npm run --prefix src/Administration/Resources/administration/ dev shopware.next:8088
```

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.