### PR TITLE
Removed deprecated order attributes

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -19,12 +19,12 @@ This changelog references changes done in Shopware 5.4 patch versions.
     - `shopware.release.revision`
         The revision of the Shopware installation (e.g. '20180081547')
 
-* Added new service in the DIC containing all parameters above 
+* Added new service in the DIC containing all parameters above
     - `shopware.release`
         A new struct of type `\Shopware\Components\ShopwareReleaseStruct` containing all parameters above
 
 * Added several paths to the DIC:
-	- `shopware.plugin_directories.projectplugins` 
+	- `shopware.plugin_directories.projectplugins`
 		Path to project specific plugins, see [Composer project](https://github.com/shopware/composer-project)
 	- `shopware.template.templatedir`
 		Path to the themes folder
@@ -37,8 +37,8 @@ This changelog references changes done in Shopware 5.4 patch versions.
 	- `shopware.web.webdir`
 		Path to the web folder
 	- `shopware.web.cachedir`
-		Path to the web-cache folder 
-	
+		Path to the web-cache folder
+
 	These paths are configurable in the `config.php`, see `engine/Shopware/Configs/Default.php` for defaults
 
 ### Changes
@@ -50,7 +50,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
 * Changed all writing actions to POST to be more HTTP compliant.
     * Checkout actions:
         - `finish`
-    
+
     * Basket actions
         - `addArticle`
         - `addAccessories`
@@ -62,7 +62,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
         - `ajaxAddArticleCart`
         - `ajaxDeleteArticle`
         - `ajaxDeleteArticleCart`
-        
+
 * Changed JSONP requests to JSON in the following Frontend controllers:
     * Controller List
         - Frontend/AjaxSearch.php
@@ -82,7 +82,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
         - `s_core_shops.secure_host`
         - `s_core_shops.secure_base_path`
         - `s_core_shops.always_secure`
-        
+
     * Removed methods
         - `\Shopware\Bundle\StoreFrontBundle\Struct\Shop::setSecureHost`
         - `\Shopware\Bundle\StoreFrontBundle\Struct\Shop::getSecureHost`
@@ -107,6 +107,14 @@ This changelog references changes done in Shopware 5.4 patch versions.
         - `\Shopware\Components\Theme\PathResolver::formatPathToUrl`
            The method signature no longer contains the `isSecureRequest` parameter
 
+    * Removed properties
+        - `\sOrder::o_attr_1`
+        - `\sOrder::o_attr_2`
+        - `\sOrder::o_attr_3`
+        - `\sOrder::o_attr_4`
+        - `\sOrder::o_attr_5`
+        - `\sOrder::o_attr_6`
+
 ### Deprecations
 
 * Deprecated `forceSecure` and `sUseSSL` smarty flags. They are now without function.
@@ -120,5 +128,5 @@ This changelog references changes done in Shopware 5.4 patch versions.
             The revision of the Shopware installation (e.g. '20180081547')
     * New, alternative DIC service:
         - `shopware.release`
-            A new struct of type `\Shopware\Components\ShopwareReleaseStruct` containing all parameters above 
+            A new struct of type `\Shopware\Components\ShopwareReleaseStruct` containing all parameters above
 * Deprecated `articleId` column in `s_articles_attributes` table, it will be removed in Shopware version 5.5 as it isn't used anymore since version 5.2

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -138,20 +138,6 @@ class sOrder
     /**
      * Custom attributes
      *
-     * @var string
-     *
-     * @deprecated since 5.2, remove in 5.3. Use orderAttributes instead
-     */
-    public $o_attr_1;
-    public $o_attr_2;
-    public $o_attr_3;
-    public $o_attr_4;
-    public $o_attr_5;
-    public $o_attr_6;
-
-    /**
-     * Custom attributes
-     *
      * @var array
      */
     public $orderAttributes = [];
@@ -377,8 +363,8 @@ class sOrder
 
         if ($this->isTaxFree(
             $this->sSYSTEM->sUSERGROUPDATA['tax'],
-            $this->sSYSTEM->sUSERGROUPDATA['id'])
-        ) {
+            $this->sSYSTEM->sUSERGROUPDATA['id']
+        )) {
             $net = '1';
         } else {
             $net = '0';
@@ -452,17 +438,7 @@ class sOrder
             throw new Enlight_Exception('##sOrder-sTemporaryOrder-#01: No rows affected or no order id saved', 0);
         }
 
-        // Create order attributes
-        $attributeData = [
-            'attribute1' => $this->o_attr_1,
-            'attribute2' => $this->o_attr_2,
-            'attribute3' => $this->o_attr_3,
-            'attribute4' => $this->o_attr_4,
-            'attribute5' => $this->o_attr_5,
-            'attribute6' => $this->o_attr_6,
-        ];
-        $attributeData = array_merge($attributeData, $this->orderAttributes);
-        $this->attributePersister->persist($attributeData, 's_order_attributes', $orderID);
+        $this->attributePersister->persist($this->orderAttributes, 's_order_attributes', $orderID);
 
         $position = 0;
         foreach ($this->sBasketData['content'] as $basketRow) {
@@ -635,27 +611,15 @@ class sOrder
             //Payment method code failure
         }
 
-        $attributeData = [
-            'attribute1' => $this->o_attr_1,
-            'attribute2' => $this->o_attr_2,
-            'attribute3' => $this->o_attr_3,
-            'attribute4' => $this->o_attr_4,
-            'attribute5' => $this->o_attr_5,
-            'attribute6' => $this->o_attr_6,
-        ];
-
-        $attributeData = array_merge($attributeData, $this->orderAttributes);
-
         $attributeData = $this->eventManager->filter(
             'Shopware_Modules_Order_SaveOrder_FilterAttributes',
-            $attributeData,
+            $this->orderAttributes,
             [
                 'subject' => $this,
                 'orderID' => $orderID,
                 'orderParams' => $orderParams,
             ]
         );
-        
         $this->attributePersister->persist($attributeData, 's_order_attributes', $orderID);
         $attributes = $this->attributeLoader->load('s_order_attributes', $orderID);
         unset($attributes['id']);
@@ -689,7 +653,8 @@ class sOrder
                 VALUES (%d, %s, %d, %s, %f, %d, %s, %d, %s, %d, %d, %d, %f, %s, %s, %s)
             ';
 
-            $sql = sprintf($preparedQuery,
+            $sql = sprintf(
+                $preparedQuery,
                 $orderID,
                 $this->db->quote((string) $orderNumber),
                 $basketRow['articleID'],
@@ -886,9 +851,8 @@ class sOrder
 
         // Support for individual payment means with custom-tables
         if ($variables['additional']['payment']['table']) {
-            $paymentTable = $this->db->fetchRow("
-                  SELECT * FROM {$variables['additional']['payment']['table']}
-                  WHERE userID=?",
+            $paymentTable = $this->db->fetchRow(
+                "SELECT * FROM {$variables['additional']['payment']['table']} WHERE userID=?",
                 [$variables['additional']['user']['id']]
             );
             $context['sPaymentTable'] = $paymentTable ?: [];
@@ -903,7 +867,7 @@ class sOrder
         if ($variables['sBookingID']) {
             $context['sBookingID'] = $variables['sBookingID'];
         }
-        
+
         $context = $this->eventManager->filter(
             'Shopware_Modules_Order_SendMail_FilterContext',
             $context,
@@ -1819,8 +1783,8 @@ EOT;
      */
     private function refreshOrderedVariant($orderNumber, $quantity)
     {
-        $this->db->executeUpdate('
-            UPDATE s_articles_details
+        $this->db->executeUpdate(
+            'UPDATE s_articles_details
             SET sales = sales + :quantity,
                 instock = instock - :quantity
             WHERE ordernumber = :number',


### PR DESCRIPTION
### 1. Why is this change necessary?
Cleanup old stuff

### 2. What does this change do, exactly?
Removes the deprecated properties `o_attr_1` - `o_attr_6` of the class `\sOrder`, which should actually be removed in version 5.3

### 3. Describe each step to reproduce the issue or behaviour.
None

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

*Note*: I hope the code style changes are fine, my editor does them by default, if not I will reconfigure it and change the commit.