### PR TITLE
Remove unused ajax_validate_billing

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
@@ -505,9 +505,6 @@
             case 'register_personal_emailConfirmation':
                 action = 'ajax_validate_email';
                 break;
-            case 'register_billing_ustid':
-                action = 'ajax_validate_billing';
-                break;
             case 'register_personal_password':
             case 'register_personal_passwordConfirmation':
                 action = 'ajax_validate_password';


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Removes code that is unused.
The feature ajax_validate_billing got removed from SW4 to SW5 and only caused no errors because the naming of the field changed from 'register_billing_ustid' to 'register_billing_vatid' in https://github.com/shopware/shopware/blob/5.3/themes/Frontend/Bare/frontend/register/billing_fieldset.tpl#L46

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.
none

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.