### PR TITLE
Added automatic controller registration for namespaced controller

### DIFF
--- a/engine/Shopware/Components/Controller.php
+++ b/engine/Shopware/Components/Controller.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components;
+
+class Controller extends \Enlight_Controller_Action
+{
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Make controller registration easy like without namespaces

### 2. What does this change do, exactly?
Searches also in Controller folder (Symfony Convention) for Controller and use them as namespaced controller.
I also added a new class Shopware\Components\Controller which basic extends from Enlight_Controller_Action it looks better in namespaced way :+1: 

### 3. Describe each step to reproduce the issue or behaviour.
Create Plugin Test and create a controller in Test/Controller/Frontend/Test.php with following content
```php
<?php

namespace Test\Controller\Frontend;

use Shopware\Components\Controller;

class Test extends Controller
{
    public function indexAction()
    {
        die('Ich mag bananen');
    }
}
```
and request page /test after plugin activation :heart: 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
Document Controller registration also possible with namespaces in Controller folder instead Controllers

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.