### PR TITLE
Add filter event for search fields in the backend customer list

### DIFF
--- a/engine/Shopware/Controllers/Backend/CustomerQuickView.php
+++ b/engine/Shopware/Controllers/Backend/CustomerQuickView.php
@@ -138,7 +138,7 @@ class Shopware_Controllers_Backend_CustomerQuickView extends Shopware_Controller
 
         if ($search) {
             $builder = $this->container->get('shopware.model.search_builder');
-            $builder->addSearchTerm($query, $search, [
+            $searchfields = [
                 'customer.number^2',
                 'customer.email^2',
                 'customer.firstname^3',
@@ -146,7 +146,12 @@ class Shopware_Controllers_Backend_CustomerQuickView extends Shopware_Controller
                 'billing.zipcode^0.5',
                 'billing.city^0.5',
                 'billing.company^0.5',
-            ]);
+            ];
+            $searchfields = $this->get('events')->filter(
+                'Shopware_Controllers_Backend_CustomerQuickView_listQuerySearchFields',
+                $searchfields
+            );
+            $builder->addSearchTerm($query, $search, $searchfields);
         }
 
         return $query;


### PR DESCRIPTION
### 1. Why is this change necessary?
This change makes it easier to extend the search for customer in the customer list. E.g. custom attributes that are selected anyways. Without this event there is no real access because the fields are hardcoded.

### 2. What does this change do, exactly?
Adds a filter event to edit the fields being searched in the customer list.

### 3. Describe each step to reproduce the issue or behaviour.
Subscribe to the new event and add something like this:
```
$searchfields = $args->getReturn();
$searchfields[] = 'attribute.fooBar^2';
return $searchfields;
```

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.