### PR TITLE
Show correct default value in description of option sw:rebuild:category:tree --limit

### DIFF
--- a/engine/Shopware/Commands/RebuildCategoryTreeCommand.php
+++ b/engine/Shopware/Commands/RebuildCategoryTreeCommand.php
@@ -44,7 +44,7 @@ class RebuildCategoryTreeCommand extends ShopwareCommand
             ->setName('sw:rebuild:category:tree')
             ->setDescription('Rebuild the category tree')
              ->addOption('offset', 'o', InputOption::VALUE_OPTIONAL, 'Offset to start with.')
-             ->addOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'Categories to build per batch. Default: 3000')
+             ->addOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'Categories to build per batch. Default: 1000')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command will rebuild your category tree.
 EOF


### PR DESCRIPTION
### 1. Why is this change necessary?
Description does not match implementation.

### 2. What does this change do, exactly?
Display the implemented value.

### 3. Describe each step to reproduce the issue or behaviour.
* `bin/console help sw:rebuild:category:tree`
* See 3000 as default for limit option
* `bin/console sw:rebuild:category:tree`
* 💥 
* have 1000 as limit

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
This is a documentation fix.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.