### PR TITLE
Give jQuery-Plugin constructor necessary arguments

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
@@ -377,7 +377,7 @@
                 if (!pluginData) {
                     if (typeof plugin === 'function') {
                         /* eslint new-cap: "off" */
-                        pluginData = new plugin();
+                        pluginData = new plugin(name, element, options);
                     } else {
                         var Plugin = function () {
                             PluginBase.call(this, name, element, options);


### PR DESCRIPTION
This change is necessary in order to call `$.plugin` with a Class as second argument.

Use case possible with this change:
```javascript
$.plugin('scnFoobar', class ScnFoobar extends $.PluginBase {
    init(){
        console.log('hello world from class');
    }
});
```

This is currently impossible due to the nature of `$.PluginBase`, which requires the parameters `name, element, options` which are not given to the class constructor. This happens because of a different codepath for `$.plugin(name: string, constructor: function)` as opposed to `$.plugin(name: string, prototype: object)`.

### 1. Why is this change necessary?
In order to stay up-to-date with valid JavaScript use-cases. The current handling of functions as second parameter to `$.plugin` is broken and supports zero use-cases.

### 2. What does this change do, exactly?
If `$.plugin(name: string, constructor: function)` is called, a new instance of `constructor` is created, with `name, element, options` given as arguments to the constructor.

### 3. Describe each step to reproduce the issue or behaviour.
```javascript
$.plugin('scnFoobar', class ScnFoobar extends $.PluginBase {
    init(){
        console.log('hello world from class');
    }
});
$('document').scnFoobar();
```
Should: Create an instance of `ScnFoobar`

Does: Throw a TypeError, because `name` is not given to the constructor of `$.PluginBase`, because it's not given to the implied constructor of `ScnFoobar`

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
[The docs](https://developers.shopware.com/designers-guide/javascript-statemanager-and-pluginbase/) currently don't mention the possibility to call `$.plugin` with a function as second argument. This should be changed to signify, that Shopware supports this.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.