### PR TITLE
add grunt development task

### DIFF
--- a/themes/grunt-tasks/tasks/default.js
+++ b/themes/grunt-tasks/tasks/default.js
@@ -1,3 +1,3 @@
 module.exports = (grunt) => {
-    grunt.registerTask('default', [ 'fileExists:js', 'less:development', 'uglify:development', 'chokidar' ]);
+    grunt.registerTask('default', [ 'development', 'chokidar' ]);
 };

--- a/themes/grunt-tasks/tasks/development.js
+++ b/themes/grunt-tasks/tasks/development.js
@@ -1,0 +1,3 @@
+module.exports = (grunt) => {
+    grunt.registerTask('development', ['fileExists:js', 'less:development', 'uglify:development']);
+};

--- a/themes/package.json
+++ b/themes/package.json
@@ -8,18 +8,17 @@
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-node": "^4.2.2",
     "grunt": "^1.0.1",
     "grunt-chokidar": "^1.0.0",
     "grunt-contrib-less": "^1.4.1",
     "grunt-contrib-uglify": "^2.3.0",
     "grunt-file-exists": "^0.1.4",
     "gruntify-eslint": "^3.1.0",
-    "jit-grunt": "^0.10.0",
+    "grunt-subgrunt": "^1.2.0",
+    "grunt-contrib-eslint": "0.0.5",
     "load-grunt-config": "^0.19.2",
-    "grunt-subgrunt": "^1.2.0"
-  },
-  "dependencies": {
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-node": "^4.2.2"
+    "jit-grunt": "^0.10.0"
   }
 }


### PR DESCRIPTION
"+" add development task
"+" add grunt-contrib-eslint
"-" gruntify-eslint

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Since we want to compile shopware without a watcher, a development task was added.
Also in production mode the gruntify-eslint package broke the compile process, since jit-grunt can't resolve the package.

### 2. What does this change do, exactly?
+ add development task
+ add grunt-contrib-eslint
- gruntify-eslint

### 3. Describe each step to reproduce the issue or behaviour.
1. dump config themes
2. execute grunt with the default task

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
The only thing i could imagine is this one https://developers.shopware.com/designers-guide/best-practice-theme-development/. Although the commands don't differ from the documentation, it might be useful for others, to know about the "grunt development" task.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.