### PR TITLE
Fixed wrong deprecated notice on widgets

### DIFF
--- a/engine/Shopware/Models/Widget/Widget.php
+++ b/engine/Shopware/Models/Widget/Widget.php
@@ -99,7 +99,7 @@ class Widget extends ModelEntity
     }
 
     /**
-     * @deprecated Use 'label' snippet from 'backend/widget/<your-widget-name>' namespace instead
+     * @deprecated Use '<your-widget-name>' snippet from 'backend/widget/labels' namespace instead
      *
      * @return string
      */
@@ -109,7 +109,7 @@ class Widget extends ModelEntity
     }
 
     /**
-     * @deprecated Use 'label' snippet from 'backend/widget/<your-widget-name>' namespace instead
+     * @deprecated Use '<your-widget-name>' snippet from 'backend/widget/labels' namespace instead
      *
      * @param string $label
      */


### PR DESCRIPTION
### 1. Why is this change necessary?
I searched so long how to set a label 😦 

### 2. What does this change do, exactly?
Corrects the deprecated message

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.