### PR TITLE
Removed hidden elements from emotion-rows calculations

### DIFF
--- a/themes/Frontend/Bare/widgets/emotion/index.tpl
+++ b/themes/Frontend/Bare/widgets/emotion/index.tpl
@@ -80,7 +80,7 @@
                                             {$emotionRows[$viewport.alias] = 0}
                                         {/if}
 
-                                        {if $emotionRows[$viewport.alias] < $viewport.endRow}
+                                        {if $viewport.visible && ($emotionRows[$viewport.alias] < $viewport.endRow)}
                                             {$emotionRows[$viewport.alias] = $viewport.endRow}
                                         {/if}
                                     {/foreach}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

- You have an emotion with 15 rows
- On mobile landscape for example you create an element over all 15 rows
- Then you hide the element and create a new element over 13 rows, which is the correct number
- Right now in the frontend the emotion on mobile landscape will still go over 15 rows with a white area below the element, because shopware also takes the hidden element into account. And I think that is wrong.

### 2. What does this change do, exactly?

On the rows-calculation for an emotion hidden elements are no longer considered.

### 3. Describe each step to reproduce the issue or behaviour.

See 1.

### 4. Please link to the relevant issues (if any).

\-

### 5. Which documentation changes (if any) need to be made because of this PR?

\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 7. Note

I think tests and comments were not necessary for this brief and self-explanatory change. And I was not sure which Upgrade.md you mean in the contribution guidelines, so I didn't touched any Upgrade.md.