### PR TITLE
Fixed combobox store loading with value null

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/element/select.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/select.js
@@ -81,13 +81,15 @@ Ext.define('Shopware.apps.Base.view.element.Select', {
     setValue:function (value) {
         var me = this;
 
-        if (value !== null && !me.store.loading && me.store.getCount() == 0) {
+        if (!me.store.loading && me.store.getCount() == 0) {
             me.store.load({
                 callback:function () {
-                    if(me.store.getCount() > 0) {
-                        me.setValue(value);
-                    } else {
-                        me.setValue(null);
+                    if (value !== null) {
+                        if(me.store.getCount() > 0) {
+                            me.setValue(value);
+                        } else {
+                            me.setValue(null);
+                        }
                     }
                 }
             });


### PR DESCRIPTION
### 1. Why is this change necessary?
After plugin installation with a remote combobox, the store will be never loaded when the value is null

### 2. What does this change do, exactly?
Load the combobox store also when the value is null

### 3. Describe each step to reproduce the issue or behaviour.
Create a new plugin use the example from wiki https://developers.shopware.com/developers-guide/plugin-configuration/#selectionfield-/-remote-combobox and see the combobox is empty

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.