### PR TITLE
Fix emotions not loading in listings with GET parameter p=1

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -222,7 +222,7 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
      */
     protected function getEmotionConfiguration($categoryId, $withStreams = false, $streamId = null)
     {
-        if ($this->Request()->getParam('sPage')) {
+        if ($this->Request()->has('sPage') && (int)$this->Request()->getParam('sPage') > 1) {
             return [
                 'hasEmotion' => false,
                 'showListing' => true,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

If infinite scrolling is enabled, the jQuery plugin will instantly set the GET parameter `p=1` if the user scrolls.
If the user then reloads the page, there is no emotion anymore.

### 2. What does this change do, exactly?

This fix changes the condition that disables emotions in listings if a page parameter is set in the request.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable infinite scrolling in your theme
2. Assign an emotion to a category that has more than 1 page in its frontend listing
    - Make sure the checkbox to show products under the emotion is **checked**!
3. Open the category in frontend
    - The emotion should be visible.
4. Scroll down a little on the page: The parameter `p=1` will be appended to your URL.
5. Reload the page now.
    - The emotion won't be visible.

### 4. Please link to the relevant issues (if any).

:heavy_minus_sign: 

### 5. Which documentation changes (if any) need to be made because of this PR?

:heavy_minus_sign: 

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.