### PR TITLE
Fixed search results count bug

### DIFF
--- a/engine/Shopware/Bundle/SearchBundle/ProductSearch.php
+++ b/engine/Shopware/Bundle/SearchBundle/ProductSearch.php
@@ -70,7 +70,7 @@ class ProductSearch implements ProductSearchInterface
 
         $result = new ProductSearchResult(
             $products,
-            $numberResult->getTotalCount(),
+            count($products),
             $numberResult->getFacets()
         );
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
In ProductSearch.php on line 65 you start the search and store the products and the products count in $numberResult. Then in line 68 you call the getList function from `Shopware/Bundle/StoreFrontBundle/Service/Core/ListProductService.php` and here you use the function isProductValid from that class. And if this function returns false for one article, the total count of all search results drops by one. But in ProductSearch.php you return `$numberResult->getTotalCount()`. But that is the count before the validation and not after. So if I have 2 search results and one of them is not valid, then I have one search result in the frontend but sArticlesCount tells me that there are 2 search results. Thats why you should consider the search result count after the validation.

### 2. What does this change do, exactly?
Return the count of the search results after the article validation.

### 3. Describe each step to reproduce the issue or behaviour.

- Create two valid articles with similar names
- Make one of them invalid. Remove the prices in the database for example.
- Search for the product name
- The search will tell you that you have 2 results, but only the valid article is listed.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.