### PR TITLE
Fix execution model of `replace` hooks

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -84,6 +84,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
         - Frontend/Compare.php
         - Frontend/Note.php
         - Widgets/Listing.php
+* Changed the execution model of `replace` hooks to prevent multiple calls of the hooked method, if more than one `replace` hook on the same method exists and all of them call `executeParent()` once
 
 ### Removals
 

--- a/engine/Library/Enlight/Hook/HookExecutionContext.php
+++ b/engine/Library/Enlight/Hook/HookExecutionContext.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Enlight
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://enlight.de/license
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@shopware.de so we can send you a copy immediately.
+ *
+ * @category   Enlight
+ * @package    Enlight_Hook
+ * @copyright  Copyright (c) 2017, shopware AG (http://www.shopware.de)
+ * @license    http://enlight.de/license     New BSD License
+ * @version    $Id$
+ * @author     Heiner Lohaus
+ * @author     $Author$
+ */
+
+/**
+ * The Enlight_Hook_HookExecutionContext represents a single execution of a hook.
+ *
+ * In order to execute a proxy method and all its 'before', 'replace' and 'after' hooks, a new context must be created
+ * and executed.
+ *
+ * @category   Enlight
+ * @package    Enlight_Hook
+ * @copyright  Copyright (c) 2017, shopware AG (http://www.shopware.de)
+ * @license    http://enlight.de/license     New BSD License
+ */
+class Enlight_Hook_HookExecutionContext
+{
+    /**
+     * @var Enlight_Hook_HookManager
+     */
+    protected $hookManager;
+
+    /**
+     * @var Enlight_Hook_HookArgs
+     */
+    protected $args;
+
+    /**
+     * @var int
+     */
+    protected $parentExecutionLevel = 0;
+
+    /**
+     * @param string $className
+     * @param string $method
+     * @param string $hookType
+     * @return string
+     */
+    public static function createHookEventName($className, $method, $hookType)
+    {
+        return $className . '::' . $method . '::' . $hookType;
+    }
+
+    /**
+     * @param Enlight_Hook_HookManager $hookManager
+     * @param Enlight_Hook_Proxy $class
+     * @param string $method
+     * @param array $args
+     */
+    public function __construct(
+        Enlight_Hook_HookManager $hookManager,
+        Enlight_Hook_Proxy $class,
+        $method,
+        array $args
+    ) {
+        $this->hookManager = $hookManager;
+        $this->args = new Enlight_Hook_HookArgs(array_merge(
+            [
+                'class' => $class,
+                'method' => $method
+            ],
+            $args
+        ));
+    }
+
+    /*+
+     * @return Enlight_Hook_HookManager
+     */
+    public function getHookManager()
+    {
+        return $this->hookManager;
+    }
+
+    /**
+     * Executes this context by calling the  'before' hooks, 'replace' hooks and 'after' hooks in that order and
+     * returning the args' return value.
+     *
+     * @return mixed
+     */
+    public function execute()
+    {
+        // Save this context in the proxy
+        $proxy = $this->args->getSubject();
+        $proxy->pushHookExecutionContext($this->args->getMethod(), $this);
+
+        // Before hooks
+        $this->hookManager->getEventManager()->notify(
+            $this->getHookEventName(Enlight_Hook_HookHandler::TypeBefore),
+            $this->args
+        );
+
+        // Replace hooks and/or original method
+        $this->args->setProcessed(false);
+        $returnValue = $this->executeReplaceChain($this->args->getArgs());
+        $this->args->setReturn($returnValue);
+        $this->args->setProcessed(true);
+
+        // After hooks
+        $returnValue = $this->hookManager->getEventManager()->filter(
+            $this->getHookEventName(Enlight_Hook_HookHandler::TypeAfter),
+            $this->args->getReturn(),
+            $this->args
+        );
+
+        // Remove this context from the proxy
+        $proxy->popHookExecutionContext($this->args->getMethod());
+
+        return $returnValue;
+    }
+
+    /**
+     * Checks the event manager for any replace hooks on the 'replace' event of this context's method and, if found,
+     * executes the listener corresponding to the current 'parentExecutionLevel'. If no listeners exist of the end of
+     * the replace chain is reached (i.e. all levels have been executed), the original method is called. Finally the
+     * respective return value of the listener or original method is returned.
+     *
+     * @param array $args
+     * @return mixed
+     */
+    public function executeReplaceChain(array $args = array())
+    {
+        // Check for 'replace' hooks
+        $replaceEventName = $this->getHookEventName(Enlight_Hook_HookHandler::TypeReplace);
+        $listeners = $this->hookManager->getEventManager()->getListeners($replaceEventName);
+        if (count($listeners) === 0 || $this->parentExecutionLevel >= count($listeners)) {
+            // No 'replace' listeners or reached the end of the execution chain, hence execute the original method
+            // using a generated helper method. This allows us to call both public and protected methods.
+            $returnValue = $this->args->getSubject()->executeOriginalMethod($this->args->getMethod(), $args);
+            $this->args->setReturn($returnValue);
+
+            return $returnValue;
+        }
+
+        // Execute the current level of the chain. We increase the level before executing the listener, to allow
+        // recursive calls of this method to execute the next listeners in the cain. Finally, we reduce the level
+        // again, to allow repeated calls of 'executeParent()' in the same listener to call the whole chain again.
+        $currentLevel = $this->parentExecutionLevel;
+        $this->parentExecutionLevel++;
+        $listeners[$currentLevel]->execute($this->args);
+        $this->parentExecutionLevel--;
+
+        return $this->args->getReturn();
+    }
+
+    /**
+     * @param string $hookType
+     * @return string
+     */
+    protected function getHookEventName($hookType)
+    {
+        $originalClassName = get_parent_class($this->args->getSubject());
+
+        return self::createHookEventName(
+            ($this->hookManager->getAlias($originalClassName)) ?: $originalClassName,
+            $this->args->getMethod(),
+            $hookType
+        );
+    }
+}

--- a/engine/Library/Enlight/Hook/Proxy.php
+++ b/engine/Library/Enlight/Hook/Proxy.php
@@ -35,4 +35,39 @@
  */
 interface Enlight_Hook_Proxy
 {
+    /**
+     * @return string[]
+     */
+    public static function getHookMethods();
+
+    /**
+     * @param string $method
+     * @param Enlight_Hook_HookExecutionContext $context
+     */
+    public function pushHookExecutionContext($method, Enlight_Hook_HookExecutionContext $context);
+
+    /**
+     * @param string $method
+     */
+    public function popHookExecutionContext($method);
+
+    /**
+     * @param string $method
+     * @return Enlight_Hook_HookExecutionContext
+     */
+    public function getCurrentHookProxyExecutionContext($method);
+
+    /**
+     * @param string $method
+     * @param array $args
+     * @return mixed
+     */
+    public function executeParent($method, array $args = array());
+
+    /**
+     * @param string $method
+     * @param array $args
+     * @return mixed
+     */
+    public function executeOriginalMethod($method, array $args = array());
 }

--- a/tests/Unit/Components/Hook/EnlightHookProxyFactoryTest.php
+++ b/tests/Unit/Components/Hook/EnlightHookProxyFactoryTest.php
@@ -87,11 +87,11 @@ class EnlightHookProxyFactoryTest extends TestCase
 class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Shopware\Tests\Unit\Components\MyBasicTestClass implements \Enlight_Hook_Proxy
 {
 
-    public function executeParent($method, $args = array())
-    {
-        return call_user_func_array([$this, 'parent::' . $method], $args);
-    }
+    private $_hookProxyExecutionContexts = null;
 
+    /**
+     * @inheritdoc
+     */
     public static function getHookMethods()
     {
         return ['myPublic', 'myProtected'];
@@ -100,11 +100,71 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Sh
     /**
      * @inheritdoc
      */
+    public function pushHookExecutionContext($method, Enlight_Hook_HookExecutionContext $context)
+    {
+        $this->_hookProxyExecutionContexts[$method][] = $context;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function popHookExecutionContext($method)
+    {
+        if (isset($this->_hookProxyExecutionContexts[$method])) {
+            array_pop($this->_hookProxyExecutionContexts[$method]);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCurrentHookProxyExecutionContext($method)
+    {
+        if (!isset($this->_hookProxyExecutionContexts[$method]) || count($this->_hookProxyExecutionContexts[$method]) === 0) {
+            return null;
+        }
+
+        $contextCount = count($this->_hookProxyExecutionContexts[$method]);
+        $context = $this->_hookProxyExecutionContexts[$method][$contextCount - 1];
+
+        return $context;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function executeParent($method, array $args = array())
+    {
+        $context = $this->getCurrentHookProxyExecutionContext($method);
+        if (!$context) {
+            throw new Exception(
+                sprintf('Cannot execute parent without hook execution context for method "%s"', $method)
+            );
+        }
+
+        return $context->executeReplaceChain($args);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function executeOriginalMethod($method, array $args = array())
+    {
+        return parent::{$method}(...$args);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function myPublic($bar, $foo = 'bar', array $barBar = array(), \Shopware\Tests\Unit\Components\MyInterface $fooFoo = null)
     {
-        return Shopware()->Hooks()->executeHooks(
+        $method = 'myPublic';
+        $context = $this->getCurrentHookProxyExecutionContext($method);
+        $hookManager = ($context) ? $context->getHookManager() : Shopware()->Hooks();
+
+        return $hookManager->executeHooks(
             $this,
-            'myPublic',
+            $method,
             ['bar' => $bar, 'foo' => $foo, 'barBar' => $barBar, 'fooFoo' => $fooFoo]
         );
     }
@@ -114,9 +174,13 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Sh
      */
     protected function myProtected($bar)
     {
-        return Shopware()->Hooks()->executeHooks(
+        $method = 'myProtected';
+        $context = $this->getCurrentHookProxyExecutionContext($method);
+        $hookManager = ($context) ? $context->getHookManager() : Shopware()->Hooks();
+
+        return $hookManager->executeHooks(
             $this,
-            'myProtected',
+            $method,
             ['bar' => $bar]
         );
     }
@@ -136,11 +200,11 @@ EOT;
 class ShopwareTests_ShopwareTestsUnitComponentsMyReferenceTestClassProxy extends \Shopware\Tests\Unit\Components\MyReferenceTestClass implements \Enlight_Hook_Proxy
 {
 
-    public function executeParent($method, $args = array())
-    {
-        return call_user_func_array([$this, 'parent::' . $method], $args);
-    }
+    private $_hookProxyExecutionContexts = null;
 
+    /**
+     * @inheritdoc
+     */
     public static function getHookMethods()
     {
         return ['myPublic'];
@@ -149,11 +213,71 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyReferenceTestClassProxy extends
     /**
      * @inheritdoc
      */
+    public function pushHookExecutionContext($method, Enlight_Hook_HookExecutionContext $context)
+    {
+        $this->_hookProxyExecutionContexts[$method][] = $context;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function popHookExecutionContext($method)
+    {
+        if (isset($this->_hookProxyExecutionContexts[$method])) {
+            array_pop($this->_hookProxyExecutionContexts[$method]);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCurrentHookProxyExecutionContext($method)
+    {
+        if (!isset($this->_hookProxyExecutionContexts[$method]) || count($this->_hookProxyExecutionContexts[$method]) === 0) {
+            return null;
+        }
+
+        $contextCount = count($this->_hookProxyExecutionContexts[$method]);
+        $context = $this->_hookProxyExecutionContexts[$method][$contextCount - 1];
+
+        return $context;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function executeParent($method, array $args = array())
+    {
+        $context = $this->getCurrentHookProxyExecutionContext($method);
+        if (!$context) {
+            throw new Exception(
+                sprintf('Cannot execute parent without hook execution context for method "%s"', $method)
+            );
+        }
+
+        return $context->executeReplaceChain($args);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function executeOriginalMethod($method, array $args = array())
+    {
+        return parent::{$method}(...$args);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function myPublic(&$bar, $foo)
     {
-        return Shopware()->Hooks()->executeHooks(
+        $method = 'myPublic';
+        $context = $this->getCurrentHookProxyExecutionContext($method);
+        $hookManager = ($context) ? $context->getHookManager() : Shopware()->Hooks();
+
+        return $hookManager->executeHooks(
             $this,
-            'myPublic',
+            $method,
             ['bar' => &$bar, 'foo' => $foo]
         );
     }

--- a/tests/Unit/Components/Hook/HookManagerTest.php
+++ b/tests/Unit/Components/Hook/HookManagerTest.php
@@ -1,0 +1,937 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Unit\Components\Hook;
+
+use \Enlight_Hook_HookExecutionContext as HookExecutionContext;
+use \Enlight_Hook_HookHandler as HookHandler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class HookManagerTest extends TestCase
+{
+    const TEST_NAME_ARG = 'Test Name';
+    const TEST_VALUES_ARG = [
+        'foo' => 'bar'
+    ];
+    const TEST_ARGS = [
+        'name' => self::TEST_NAME_ARG,
+        'values' => self::TEST_VALUES_ARG
+    ];
+    const TEST_RETURN_VALUE = 'ReturnValue';
+    const RECURSIVE_TEST_LIMIT_ARG = 2;
+    const RECURSIVE_TEST_ARGS = [
+        'limit' => self::RECURSIVE_TEST_LIMIT_ARG
+    ];
+
+    /**
+     * @var \Enlight_Event_EventManager
+     */
+    private $eventManager;
+
+    /**
+     * @var \Enlight_Hook_HookManager
+     */
+    private $hookManager;
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp()
+    {
+        $this->eventManager = new \Enlight_Event_EventManager();
+        $proxyDir = rtrim(sys_get_temp_dir(), '\\/') . DIRECTORY_SEPARATOR . uniqid('hook-manager-test-' . rand(1000, 9000));
+        if (is_dir($proxyDir)) {
+            // Clear the directory
+            array_map('unlink', glob($proxyDir . DIRECTORY_SEPARATOR . '*.*'));
+        }
+        $this->hookManager = new \Enlight_Hook_HookManager(
+            $this->eventManager,
+            new \Enlight_Loader(),
+            [
+                'proxyDir' => $proxyDir,
+                'proxyNamespace' => 'Shopware_Test_Proxies'
+            ]
+        );
+        if (!class_exists($this->hookManager->getProxyFactory()->getProxyClassName(HookManagerTestTarget::class))) {
+            // Create a proxy after adding hooks on both its methods. It is necessary to do this here, because the name
+            // of the proxy class won't change between the tests and hence the generated class will loaded as soon as
+            // the first proxy is instanciated.
+            $this->addHookListener(HookManagerTestTarget::TEST_METHOD_NAME, HookHandler::TypeReplace);
+            $this->addHookListener(HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME, HookHandler::TypeReplace);
+            $this->addHookListener(HookManagerTestTarget::PROTECTED_TEST_METHOD_NAME, HookHandler::TypeReplace);
+            $proxyClass = $this->hookManager->getProxy(HookManagerTestTarget::class);
+            $proxy = new $proxyClass();
+        }
+    }
+
+    public function testCanCreateInstance()
+    {
+        $this->assertInstanceOf(\Enlight_Hook_HookManager::class, $this->hookManager);
+    }
+
+    public function testHasHooks()
+    {
+        // Assert that no hooks exist prior to this test
+        $hasHooks = $this->hookManager->hasHooks(HookManagerTestTarget::class, HookManagerTestTarget::TEST_METHOD_NAME);
+        $this->assertFalse($hasHooks);
+
+        // Test 'before' hook
+        $this->addHookListener(HookManagerTestTarget::TEST_METHOD_NAME, HookHandler::TypeBefore);
+        $hasHooks = $this->hookManager->hasHooks(HookManagerTestTarget::class, HookManagerTestTarget::TEST_METHOD_NAME);
+        $this->assertTrue($hasHooks);
+        $this->eventManager->reset();
+
+        // Test 'replace' hook
+        $this->addHookListener(HookManagerTestTarget::TEST_METHOD_NAME, HookHandler::TypeReplace);
+        $hasHooks = $this->hookManager->hasHooks(HookManagerTestTarget::class, HookManagerTestTarget::TEST_METHOD_NAME);
+        $this->assertTrue($hasHooks);
+        $this->eventManager->reset();
+
+        // Test 'after' hook
+        $this->addHookListener(HookManagerTestTarget::TEST_METHOD_NAME, HookHandler::TypeAfter);
+        $hasHooks = $this->hookManager->hasHooks(HookManagerTestTarget::class, HookManagerTestTarget::TEST_METHOD_NAME);
+        $this->assertTrue($hasHooks);
+        $this->eventManager->reset();
+    }
+
+    /**
+     * Tests the execution of a 'before' hook.
+     */
+    public function testExecuteHooksBefore()
+    {
+        $hookCallCounter = 0;
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeBefore,
+            function (\Enlight_Hook_HookArgs $args) use (&$hookCallCounter) {
+                $hookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalMethodCallCounter);
+                $this->assertNull($args->getReturn());
+
+                // Modify the 'name' arg to change the return value of the parent implementation
+                $args->name .= '_mod';
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals((self::TEST_NAME_ARG . '_mod'), $returnValue);
+        $this->assertEquals(1, $hookCallCounter);
+        $this->assertEquals(1, $proxy->originalMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of a 'before' hook on a protected method.
+     */
+    public function testExecuteHooksBeforeProtectedMethod()
+    {
+        $hookCallCounter = 0;
+        $this->addHookListener(
+            HookManagerTestTarget::PROTECTED_TEST_METHOD_NAME,
+            HookHandler::TypeBefore,
+            function (\Enlight_Hook_HookArgs $args) use (&$hookCallCounter) {
+                $hookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalProtectedMethodCallCounter);
+                $this->assertNull($args->getReturn());
+
+                // Modify the 'name' arg to change the return value of the parent implementation
+                $args->name .= '_mod';
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::PROTECTED_TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals((self::TEST_NAME_ARG . '_mod'), $returnValue);
+        $this->assertEquals(1, $hookCallCounter);
+        $this->assertEquals(1, $proxy->originalProtectedMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of a 'replace' hook.
+     */
+    public function testExecuteHooksReplace()
+    {
+        $hookCallCounter = 0;
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (&$hookCallCounter) {
+                $hookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalMethodCallCounter);
+                $this->assertNull($args->getReturn());
+
+                // Overwrite the return value
+                $args->setReturn(self::TEST_RETURN_VALUE);
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals(self::TEST_RETURN_VALUE, $returnValue);
+        $this->assertEquals(1, $hookCallCounter);
+        $this->assertEquals(0, $proxy->originalMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of a 'replace' hook, which calls the parent implementation and uses its return value.
+     */
+    public function testExecuteHooksReplaceWithParentExection()
+    {
+        $hookCallCounter = 0;
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (&$hookCallCounter) {
+                $hookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalMethodCallCounter);
+                $this->assertNull($args->getReturn());
+
+                // Modify the 'name' arg to change the return value of the parent implementation
+                $args->name .= '_mod';
+
+                // Call the parent
+                $args->getSubject()->executeParent(HookManagerTestTarget::TEST_METHOD_NAME, $args->getArgs());
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals((self::TEST_NAME_ARG . '_mod'), $returnValue);
+        $this->assertEquals(1, $hookCallCounter);
+        $this->assertEquals(1, $proxy->originalMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of a 'replace' hook, which calls the parent implementation repeatedly.
+     */
+    public function testExecuteHooksReplaceWithRepeatedParentExection()
+    {
+        $hookCallCounter = 0;
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (&$hookCallCounter) {
+                $hookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalMethodCallCounter);
+                $this->assertNull($args->getReturn());
+
+                // Call parent three times
+                $args->getSubject()->executeParent(HookManagerTestTarget::TEST_METHOD_NAME, $args->getArgs());
+                $args->getSubject()->executeParent(HookManagerTestTarget::TEST_METHOD_NAME, $args->getArgs());
+                $args->getSubject()->executeParent(HookManagerTestTarget::TEST_METHOD_NAME, $args->getArgs());
+
+                // Change the return value
+                $args->setReturn(self::TEST_RETURN_VALUE);
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals(self::TEST_RETURN_VALUE, $returnValue);
+        $this->assertEquals(1, $hookCallCounter);
+        $this->assertEquals(3, $proxy->originalMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of three 'replace' hooks on the same method. In particular the correct order of the hook
+     * calls as well as the respective return values are asserted.
+     */
+    public function testExecuteHooksReplaceMultiple()
+    {
+        $firstHookCallCounter = 0;
+        $secondHookCallCounter = 0;
+        $thirdHookCallCounter = 0;
+        $firstHookReturnValue = self::TEST_RETURN_VALUE . '_first';
+        $secondHookReturnValue = self::TEST_RETURN_VALUE . '_second';
+        $thirdHookReturnValue = self::TEST_RETURN_VALUE . '_third';
+
+        // Register first hook (to be executed first)
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (
+                &$firstHookCallCounter,
+                &$secondHookCallCounter,
+                &$thirdHookCallCounter,
+                $firstHookReturnValue,
+                $secondHookReturnValue
+            ) {
+                $firstHookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalMethodCallCounter);
+                $this->assertNull($args->getReturn());
+                // Second and third hooks should not have been called before this hook is called
+                $this->assertEquals(0, $secondHookCallCounter);
+                $this->assertEquals(0, $thirdHookCallCounter);
+
+                // Call parent
+                $parentReturnValue = $args->getSubject()->executeParent(
+                    HookManagerTestTarget::TEST_METHOD_NAME,
+                    $args->getArgs()
+                );
+
+                // Second and third hooks should have been called now
+                $this->assertEquals(1, $secondHookCallCounter);
+                $this->assertEquals(1, $thirdHookCallCounter);
+                $this->assertEquals($secondHookReturnValue, $parentReturnValue);
+
+                // Overwrite return value
+                $args->setReturn($firstHookReturnValue);
+            }
+        );
+
+        // Register second hook (to be executed second)
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (
+                &$firstHookCallCounter,
+                &$secondHookCallCounter,
+                &$thirdHookCallCounter,
+                $firstHookReturnValue,
+                $secondHookReturnValue,
+                $thirdHookReturnValue
+            ) {
+                $secondHookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalMethodCallCounter);
+                $this->assertNull($args->getReturn());
+                // First hook should have already been called when this hook is called
+                $this->assertEquals(1, $firstHookCallCounter);
+                // Third hook should not have been called before this hook is called
+                $this->assertEquals(0, $thirdHookCallCounter);
+
+                // Call parent
+                $parentReturnValue = $args->getSubject()->executeParent(
+                    HookManagerTestTarget::TEST_METHOD_NAME,
+                    $args->getArgs()
+                );
+
+                // Third hook should have been called now
+                $this->assertEquals(1, $thirdHookCallCounter);
+                $this->assertEquals($thirdHookReturnValue, $parentReturnValue);
+
+                // Overwrite return value
+                $args->setReturn($secondHookReturnValue);
+            }
+        );
+
+        // Register third hook (to be executed third, just before the original/parent method)
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (
+                &$firstHookCallCounter,
+                &$secondHookCallCounter,
+                &$thirdHookCallCounter,
+                $firstHookReturnValue,
+                $secondHookReturnValue,
+                $thirdHookReturnValue
+            ) {
+                $thirdHookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalMethodCallCounter);
+                $this->assertNull($args->getReturn());
+                // First and second hooks should have already been called when this hook is called
+                $this->assertEquals(1, $firstHookCallCounter);
+                $this->assertEquals(1, $secondHookCallCounter);
+
+                // Call parent
+                $parentReturnValue = $args->getSubject()->executeParent(
+                    HookManagerTestTarget::TEST_METHOD_NAME,
+                    $args->getArgs()
+                );
+                $this->assertEquals(self::TEST_NAME_ARG, $parentReturnValue);
+
+                // Overwrite return value
+                $args->setReturn($thirdHookReturnValue);
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals($firstHookReturnValue, $returnValue);
+        // All hooks as well as the original method should have only been called once
+        $this->assertEquals(1, $firstHookCallCounter);
+        $this->assertEquals(1, $secondHookCallCounter);
+        $this->assertEquals(1, $thirdHookCallCounter);
+        $this->assertEquals(1, $proxy->originalMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of tow 'replace' hooks on the same method, of which the first one executes its parent twice.
+     * This should result in the second hook and the original method to be called twice each.
+     */
+    public function testExecuteHooksReplaceMultipleWithRepeatedParentExection()
+    {
+        $firstHookCallCounter = 0;
+        $secondHookCallCounter = 0;
+        $firstHookReturnValue = self::TEST_RETURN_VALUE . '_first';
+        $secondHookReturnValue = self::TEST_RETURN_VALUE . '_second';
+
+        // Register first hook (to be executed first)
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (
+                &$firstHookCallCounter,
+                &$secondHookCallCounter,
+                $firstHookReturnValue,
+                $secondHookReturnValue
+            ) {
+                $firstHookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalMethodCallCounter);
+                $this->assertNull($args->getReturn());
+                // Second hook should not have been called before this hook is called
+                $this->assertEquals(0, $secondHookCallCounter);
+
+                // Call parent once
+                $parentReturnValue = $args->getSubject()->executeParent(
+                    HookManagerTestTarget::TEST_METHOD_NAME,
+                    $args->getArgs()
+                );
+
+                // Second hook should have been called once now
+                $this->assertEquals(1, $secondHookCallCounter);
+                $this->assertEquals($secondHookReturnValue, $parentReturnValue);
+
+                // Call parent again
+                $parentReturnValue = $args->getSubject()->executeParent(
+                    HookManagerTestTarget::TEST_METHOD_NAME,
+                    $args->getArgs()
+                );
+
+                // Second hook should have been called twice now
+                $this->assertEquals(2, $secondHookCallCounter);
+                $this->assertEquals($secondHookReturnValue, $parentReturnValue);
+
+                // Overwrite return value
+                $args->setReturn($firstHookReturnValue);
+            }
+        );
+
+        // Register second hook (to be executed second)
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (
+                &$firstHookCallCounter,
+                &$secondHookCallCounter,
+                $firstHookReturnValue,
+                $secondHookReturnValue
+            ) {
+                $secondHookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertTrue(in_array($args->getSubject()->originalMethodCallCounter, [0, 1]));
+                if ($secondHookCallCounter === 1) {
+                    $this->assertNull($args->getReturn());
+                } else {
+                    // Expect the own return value to be set already
+                    $this->assertEquals($secondHookReturnValue, $args->getReturn());
+                }
+                // First hook should have already been called exactly once when this hook is called
+                $this->assertEquals(1, $firstHookCallCounter);
+
+                // Call parent
+                $parentReturnValue = $args->getSubject()->executeParent(
+                    HookManagerTestTarget::TEST_METHOD_NAME,
+                    $args->getArgs()
+                );
+                $this->assertEquals(self::TEST_NAME_ARG, $parentReturnValue);
+
+                // Overwrite return value
+                $args->setReturn($secondHookReturnValue);
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals($firstHookReturnValue, $returnValue);
+        // The first hook should have been called only once, but the second hook and the original method should have
+        // been called twice, since the first hook calls 'executeParent()' twice!
+        $this->assertEquals(1, $firstHookCallCounter);
+        $this->assertEquals(2, $secondHookCallCounter);
+        $this->assertEquals(2, $proxy->originalMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of tow 'replace' hooks on the same method.
+     */
+    public function testExecuteHooksReplaceMultipleWithoutParentExection()
+    {
+        $firstHookCallCounter = 0;
+        $firstHookReturnValue = self::TEST_RETURN_VALUE . '_first';
+        $secondHookReturnValue = self::TEST_RETURN_VALUE . '_second';
+
+        // Register first hook (to be executed first)
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (&$firstHookCallCounter, $firstHookReturnValue) {
+                $firstHookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalMethodCallCounter);
+                $this->assertNull($args->getReturn());
+
+                // Overwrite return value
+                $args->setReturn($firstHookReturnValue);
+            }
+        );
+
+        // Register second hook (should never be executed)
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) {
+                // This hook should not be executed!
+                $this->assertTrue(false);
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals($firstHookReturnValue, $returnValue);
+        // Only first hook should have been called
+        $this->assertEquals(1, $firstHookCallCounter);
+        $this->assertEquals(0, $proxy->originalMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of a 'replace' hook on a recursive method.
+     */
+    public function testExecuteHooksReplaceRecursive()
+    {
+        $hookCallCounter = 0;
+        $this->addHookListener(
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (&$hookCallCounter) {
+                $hookCallCounter++;
+                $this->assertEquals(self::RECURSIVE_TEST_LIMIT_ARG, $args->limit);
+                $this->assertEquals(0, $args->getSubject()->originalRecursiveMethodCallCounter);
+                $this->assertNull($args->getReturn());
+
+                // Overwrite return value
+                $args->setReturn(0);
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            self::RECURSIVE_TEST_ARGS
+        );
+        $this->assertEquals(0, $returnValue);
+        $this->assertEquals(1, $hookCallCounter);
+        $this->assertEquals(0, $proxy->originalRecursiveMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of a 'replace' hook, which calls the parent implementation and uses its return value, on a
+     * recursive method
+     */
+    public function testExecuteHooksReplaceWithParentExectionRecursive()
+    {
+        $hookCallCounter = 0;
+        $this->addHookListener(
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (&$hookCallCounter) {
+                $hookCallCounter++;
+                // The limit should only be reduced after this hook is called
+                $this->assertEquals((self::RECURSIVE_TEST_LIMIT_ARG - $hookCallCounter + 1), $args->limit);
+                // The original method should have been called less often than this hook
+                $this->assertEquals(($hookCallCounter - 1), $args->getSubject()->originalRecursiveMethodCallCounter);
+                // The return value should not be set in any hook call, because it is recursively resovled
+                $this->assertNull($args->getReturn());
+
+                // Call the parent and expect its result to be equal to the current limit
+                $expectedReturnValue = $args->limit;
+                $returnValue = $args->getSubject()->executeParent(HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME, $args->getArgs());
+                $this->assertEquals($expectedReturnValue, $returnValue);
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            self::RECURSIVE_TEST_ARGS
+        );
+        $this->assertEquals(self::RECURSIVE_TEST_LIMIT_ARG, $returnValue);
+        $this->assertEquals((self::RECURSIVE_TEST_LIMIT_ARG + 1), $hookCallCounter);
+        $this->assertEquals((self::RECURSIVE_TEST_LIMIT_ARG + 1), $proxy->originalRecursiveMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of three 'replace' hooks on the same recursive method. In particular the correct order of the
+     * hook calls as well as the respective return values are asserted.
+     */
+    public function testExecuteHooksReplaceMultipleRecursive()
+    {
+        $firstHookCallCounter = 0;
+        $secondHookCallCounter = 0;
+        $thirdHookCallCounter = 0;
+
+        // Register first hook (to be executed first)
+        $this->addHookListener(
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (
+                &$firstHookCallCounter,
+                &$secondHookCallCounter,
+                &$thirdHookCallCounter
+            ) {
+                $firstHookCallCounter++;
+                // The limit should only be reduced after this hook is called
+                $this->assertEquals((self::RECURSIVE_TEST_LIMIT_ARG - $firstHookCallCounter + 1), $args->limit);
+                // The original method and the other hooks should have been called less often than this hook
+                $this->assertEquals(($firstHookCallCounter - 1), $args->getSubject()->originalRecursiveMethodCallCounter);
+                $this->assertEquals(($firstHookCallCounter - 1), $secondHookCallCounter);
+                $this->assertEquals(($firstHookCallCounter - 1), $thirdHookCallCounter);
+                // The return value should not be set in any hook call, because it is recursively resovled
+                $this->assertNull($args->getReturn());
+
+                // Call the parent and expect its result to be equal to the current limit
+                $expectedReturnValue = $args->limit;
+                $returnValue = $args->getSubject()->executeParent(HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME, $args->getArgs());
+                $this->assertEquals($expectedReturnValue, $returnValue);
+
+                // Second and third hooks should have been called as many times as this hook
+                $this->assertEquals($firstHookCallCounter, $secondHookCallCounter);
+                $this->assertEquals($firstHookCallCounter, $thirdHookCallCounter);
+            }
+        );
+
+        // Register second hook (to be executed second)
+        $this->addHookListener(
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (
+                &$firstHookCallCounter,
+                &$secondHookCallCounter,
+                &$thirdHookCallCounter
+            ) {
+                $secondHookCallCounter++;
+                // The limit should only be reduced after this hook is called
+                $this->assertEquals((self::RECURSIVE_TEST_LIMIT_ARG - $secondHookCallCounter + 1), $args->limit);
+                // The original method and the third hook should have been called less often than this hook
+                $this->assertEquals(($secondHookCallCounter - 1), $args->getSubject()->originalRecursiveMethodCallCounter);
+                $this->assertEquals(($secondHookCallCounter - 1), $thirdHookCallCounter);
+                // The first hook should have been called as many times as this hook
+                $this->assertEquals($secondHookCallCounter, $firstHookCallCounter);
+                // The return value should not be set in any hook call, because it is recursively resovled
+                $this->assertNull($args->getReturn());
+
+                // Call the parent and expect its result to be equal to the current limit
+                $expectedReturnValue = $args->limit;
+                $returnValue = $args->getSubject()->executeParent(HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME, $args->getArgs());
+                $this->assertEquals($expectedReturnValue, $returnValue);
+
+                // Third hook should have been called as many times as this hook
+                $this->assertEquals($secondHookCallCounter, $thirdHookCallCounter);
+            }
+        );
+
+        // Register third hook (to be executed third, just before the original/parent method)
+        $this->addHookListener(
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (
+                &$firstHookCallCounter,
+                &$secondHookCallCounter,
+                &$thirdHookCallCounter
+            ) {
+                $thirdHookCallCounter++;
+                // The limit should only be reduced after this hook is called
+                $this->assertEquals((self::RECURSIVE_TEST_LIMIT_ARG - $thirdHookCallCounter + 1), $args->limit);
+                // The original method should have been called less often than this hook
+                $this->assertEquals(($thirdHookCallCounter - 1), $args->getSubject()->originalRecursiveMethodCallCounter);
+                // The other hooks should have been called as many times as this hook
+                $this->assertEquals($thirdHookCallCounter, $firstHookCallCounter);
+                $this->assertEquals($thirdHookCallCounter, $secondHookCallCounter);
+                // The return value should not be set in any hook call, because it is recursively resovled
+                $this->assertNull($args->getReturn());
+
+                // Call the parent and expect its result to be equal to the current limit
+                $expectedReturnValue = $args->limit;
+                $returnValue = $args->getSubject()->executeParent(HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME, $args->getArgs());
+                $this->assertEquals($expectedReturnValue, $returnValue);
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            self::RECURSIVE_TEST_ARGS
+        );
+        $this->assertEquals(self::RECURSIVE_TEST_LIMIT_ARG, $returnValue);
+        $this->assertEquals((self::RECURSIVE_TEST_LIMIT_ARG + 1), $firstHookCallCounter);
+        $this->assertEquals((self::RECURSIVE_TEST_LIMIT_ARG + 1), $secondHookCallCounter);
+        $this->assertEquals((self::RECURSIVE_TEST_LIMIT_ARG + 1), $thirdHookCallCounter);
+        $this->assertEquals((self::RECURSIVE_TEST_LIMIT_ARG + 1), $proxy->originalRecursiveMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of tow 'replace' hooks on the same recursive method, of which the first one executes its
+     * parent twice. This should result in the second hook and the original method to be called twice as often as the
+     * first hook.
+     */
+    public function testExecuteHooksReplaceMultipleWithRepeatedParentExectionRecursive()
+    {
+        $firstHookCallCounter = 0;
+        $secondHookCallCounter = 0;
+
+        // Register first hook (to be executed first)
+        $this->addHookListener(
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (
+                &$firstHookCallCounter,
+                &$secondHookCallCounter
+            ) {
+                $firstHookCallCounter++;
+
+                // Call the parent and expect its result to be equal to the current limit
+                $expectedReturnValue = $args->limit;
+                $returnValue = $args->getSubject()->executeParent(HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME, $args->getArgs());
+                $this->assertEquals($expectedReturnValue, $returnValue);
+
+                // Call the parent again expect its result to be still equal to the current limit, because repeated
+                // calls to a recursive 'executeParent()' all spawn their own context
+                $returnValue = $args->getSubject()->executeParent(HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME, $args->getArgs());
+                $this->assertEquals($expectedReturnValue, $returnValue);
+            }
+        );
+
+        // Register second hook (to be executed second)
+        $this->addHookListener(
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (
+                &$firstHookCallCounter,
+                &$secondHookCallCounter
+            ) {
+                $secondHookCallCounter++;
+
+                // Call the parent and expect its result to be equal to the current limit
+                $expectedReturnValue = $args->limit;
+                $returnValue = $args->getSubject()->executeParent(HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME, $args->getArgs());
+                $this->assertEquals($expectedReturnValue, $returnValue);
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME,
+            self::RECURSIVE_TEST_ARGS
+        );
+        // Although the first hook calls 'executeParent()' twice, the result will still be correct, because repeated
+        // calls to a recursive parent all spawn their own context
+        $this->assertEquals(self::RECURSIVE_TEST_LIMIT_ARG, $returnValue);
+        // With a limit of 2, the first hook should have been called 7 times:
+        //      1 initial call
+        //    + 3 recursive calls triggered when calling 'executeParent()' for the first time in the initial hook call
+        //    + 3 recursive calls triggered when calling 'executeParent()' a second time in the initial hook call
+        $this->assertEquals((1 + 2 * (self::RECURSIVE_TEST_LIMIT_ARG + 1)), $firstHookCallCounter);
+        // Since every call of the first hook calls 'executeParent()' twice, all methods following in the execution
+        // chain should be called twice as often as the first hook. Hence, with a limit of 2, the second hook and the
+        // original method should have been called 14 times each.
+        $this->assertEquals((2 * $firstHookCallCounter), $secondHookCallCounter);
+        $this->assertEquals((2 * $firstHookCallCounter), $proxy->originalRecursiveMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of a 'replace' hook on a protected method.
+     */
+    public function testExecuteHooksReplaceProtectedMethod()
+    {
+        $hookCallCounter = 0;
+        $this->addHookListener(
+            HookManagerTestTarget::PROTECTED_TEST_METHOD_NAME,
+            HookHandler::TypeReplace,
+            function (\Enlight_Hook_HookArgs $args) use (&$hookCallCounter) {
+                $hookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(0, $args->getSubject()->originalProtectedMethodCallCounter);
+                $this->assertNull($args->getReturn());
+
+                // Overwrite the return value
+                $args->setReturn(self::TEST_RETURN_VALUE);
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::PROTECTED_TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals(self::TEST_RETURN_VALUE, $returnValue);
+        $this->assertEquals(1, $hookCallCounter);
+        $this->assertEquals(0, $proxy->originalProtectedMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of an 'after' hook.
+     */
+    public function testExecuteHooksAfter()
+    {
+        $hookCallCounter = 0;
+        $this->addHookListener(
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            HookHandler::TypeAfter,
+            function (\Enlight_Hook_HookArgs $args) use (&$hookCallCounter) {
+                $hookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(1, $args->getSubject()->originalMethodCallCounter);
+                $this->assertEquals(self::TEST_NAME_ARG, $args->getReturn());
+
+                // Overwrite the return value
+                return self::TEST_RETURN_VALUE;
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals(self::TEST_RETURN_VALUE, $returnValue);
+        $this->assertEquals(1, $hookCallCounter);
+        $this->assertEquals(1, $proxy->originalMethodCallCounter);
+    }
+
+    /**
+     * Tests the execution of an 'after' hook on a protected method.
+     */
+    public function testExecuteHooksAfterProtectedMethod()
+    {
+        $hookCallCounter = 0;
+        $this->addHookListener(
+            HookManagerTestTarget::PROTECTED_TEST_METHOD_NAME,
+            HookHandler::TypeAfter,
+            function (\Enlight_Hook_HookArgs $args) use (&$hookCallCounter) {
+                $hookCallCounter++;
+                $this->assertHookArgs($args);
+                $this->assertEquals(1, $args->getSubject()->originalProtectedMethodCallCounter);
+                $this->assertEquals(self::TEST_NAME_ARG, $args->getReturn());
+
+                // Overwrite the return value
+                return self::TEST_RETURN_VALUE;
+            }
+        );
+
+        $proxy = $this->createProxy();
+        $returnValue = $this->hookManager->executeHooks(
+            $proxy,
+            HookManagerTestTarget::PROTECTED_TEST_METHOD_NAME,
+            self::TEST_ARGS
+        );
+        $this->assertEquals(self::TEST_RETURN_VALUE, $returnValue);
+        $this->assertEquals(1, $hookCallCounter);
+        $this->assertEquals(1, $proxy->originalProtectedMethodCallCounter);
+    }
+
+    /**
+     * @param string $methodName
+     * @param string $hookType
+     * @param callable|null $callback
+     */
+    private function addHookListener($methodName, $hookType, callable $callback = null)
+    {
+        $callback = ($callback) ?: function (\Enlight_Hook_HookArgs $args) {
+            // pass
+        };
+        $this->eventManager->addListener(
+            HookExecutionContext::createHookEventName(HookManagerTestTarget::class, $methodName, $hookType),
+            $callback
+        );
+    }
+
+    /**
+     * @return Enlight_Hook_Proxy
+     */
+    private function createProxy()
+    {
+        $proxyClass = $this->hookManager->getProxy(HookManagerTestTarget::class);
+        $proxy = new $proxyClass();
+
+        return $proxy;
+    }
+
+    /**
+     * @param \Enlight_Hook_HookArgs $args
+     */
+    private function assertHookArgs(\Enlight_Hook_HookArgs $args)
+    {
+        $this->assertEquals(self::TEST_NAME_ARG, $args->name);
+        $this->assertArraySubset(self::TEST_VALUES_ARG, $args->values);
+    }
+}

--- a/tests/Unit/Components/Hook/HookManagerTestTarget.php
+++ b/tests/Unit/Components/Hook/HookManagerTestTarget.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Unit\Components\Hook;
+
+/**
+ * @category  Shopware
+ *
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class HookManagerTestTarget
+{
+    const TEST_METHOD_NAME = 'testMethod';
+    const RECURSIVE_TEST_METHOD_NAME = 'recursiveTestMethod';
+    const PROTECTED_TEST_METHOD_NAME = 'protectedTestMethod';
+
+    public $originalMethodCallCounter = 0;
+    public $originalRecursiveMethodCallCounter = 0;
+    public $originalProtectedMethodCallCounter = 0;
+
+    public function testMethod($name, array $values = array())
+    {
+        $this->originalMethodCallCounter++;
+
+        return $name;
+    }
+
+    public function recursiveTestMethod($limit)
+    {
+        $this->originalRecursiveMethodCallCounter++;
+
+        if ($limit === 0) {
+            return 0;
+        }
+
+        return 1 + $this->recursiveTestMethod($limit - 1);
+    }
+
+    protected function protectedTestMethod($name, array $values = array())
+    {
+        $this->originalProtectedMethodCallCounter++;
+
+        return $name;
+    }
+}


### PR DESCRIPTION
**This PR is an updated version of #1179 and fixes hooking of `protected` methods.**

### 1. Why is this change necessary?

Currently the execution model of `replace` hooks is broken, once more than one `replace` hook exists for the same method. The problem is that all `replace` hooks are executed sequentially and each of these hooks has the opportunity to call `executeParent()`. Hence, if all `replace` hooks do call `executeParent()`, the original (parent) implementation is executed more than once. This basically breaks `replace` hooks on methods that have side effects, because these side effects are applied for every call of `executeParent()`. As a result, it is currently very risky to have more than one `replace` hook on the same method. In fact, we at Pickware refrain from using `replace` hooks altogether because of that behaviour!

Example:

```php
class HookTarget
{
    public function fooBar()
    {
        echo "HookTarget: fooBar!\n";
    }
}

class FooSubscriber implements \Enlight\Event\SubscriberInterface
{
    //...

    /**
     * First hook
     */
    public function onHookTargetFooBar(\Enlight_Hook_HookArgs $args)
    {
        echo "FooSubscriber: before executeParent()\n";
        $args->getSubject()->executeParent($args->getMethod(), $args->getArgs());
        echo "FooSubscriber: after executeParent()\n";
    }
}

class BarSubscriber implements \Enlight\Event\SubscriberInterface
{
    //...

    /**
     * Second hook
     */
    public function onHookTargetFooBar(\Enlight_Hook_HookArgs $args)
    {
        echo "BarSubscriber: before executeParent()\n";
        $args->getSubject()->executeParent($args->getMethod(), $args->getArgs());
        echo "BarSubscriber: after executeParent()\n";
    }
}
```

Output:

```
FooSubscriber: before executeParent()
HookTarget: fooBar!
FooSubscriber: after executeParent()
BarSubscriber: before executeParent()
HookTarget: fooBar!
BarSubscriber: after executeParent()
```

The desired execution model of `replace` hooks prevents multiple calls of the original implementation, if all hooks call `executeParent()` only once. That said, the `replace` hooks should be parents of each other, based on the position they are sorted by in the event manager. This execution model is very similar to the one used by _ExtJS_ and hence should be more familiar and most importantly predictable to shopware developers.

### 2. What does this change do, exactly?

This PR refactors the whole hook manager as well as changes the generated proxy classes (which is easy now thanks to #1174) to add an execution context, which executes the registered `replace` hooks as a chain in which each call to `executeParent()` calls the respective next hook, if available. Only the last (highest position) hook’s call to `executeParent()` calls the original implementation of the hooked method. Finally the respective return values can be passed down the chain again. That is, the `replace` hook with the lowest position is able to ultimately override the return value, before it is passed to any `after` hooks:

```php
class HookTarget
{
    public function fooBar()
    {
        echo "HookTarget: fooBar!\n";
    }
}

class FooSubscriber implements \Enlight\Event\SubscriberInterface
{
    //...

    /**
     * First hook
     */
    public function onHookTargetFooBar(\Enlight_Hook_HookArgs $args)
    {
        echo "FooSubscriber: before executeParent()\n";
        $args->getSubject()->executeParent($args->getMethod(), $args->getArgs());
        echo "FooSubscriber: after executeParent()\n";
    }
}

class BarSubscriber implements \Enlight\Event\SubscriberInterface
{
    //...

    /**
     * Second hook
     */
    public function onHookTargetFooBar(\Enlight_Hook_HookArgs $args)
    {
        echo "BarSubscriber: before executeParent()\n";
        $args->getSubject()->executeParent($args->getMethod(), $args->getArgs());
        echo "BarSubscriber: after executeParent()\n";
    }
}
```

Output:

```
FooSubscriber: before executeParent()
BarSubscriber: before executeParent()
HookTarget: fooBar!
BarSubscriber: after executeParent()
FooSubscriber: after executeParent()
```

Of course it is still possible to execute the original implementation more than once, by calling `executeParent()` in the same hook repeatedly. This also works for recursive methods, which would result in a quite complex call tree. Example with calling `executeParent()` twice in a recursive method:

```
  recMethod()
       |
    HOOK_R0 ----------------------------------
       |                                     |
executeParent()                       executeParent()
       |                                     |
   METHOD_R0                             METHOD_R0
       |                                     |
  recMethod()                           recMethod()
       |                                     |
    HOOK_R1 ---------------               HOOK_R1 ---------------
       |                  |                  |                  |
executeParent()    executeParent()    executeParent()    executeParent()
       |                  |                  |                  |
   METHOD_R1          METHOD_R1          METHOD_R1          METHOD_R1
```

On a side note, this fix kind of makes `before` and `after` hooks obsolete, since it is now possible to just subscribe `replace` hooks, perform custom steps _before_ the original implementation, call `executeParent()` and then perform some more steps _after_ that call (just like in _ExtJS_).

### 3. Describe each step to reproduce the issue or behaviour.

See 1. and 2.

### 4. Please link to the relevant issues (if any).

n/a

### 5. Which documentation changes (if any) need to be made because of this PR?

The documentation on hooks should reflect

a) the execution model using a minimal example and
b) that `before` and `after` hooks are obsolete.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.