### PR TITLE
Added new option showIdProperty to Shopware.grid.Panel

### DIFF
--- a/themes/Backend/ExtJs/backend/base/application/Shopware.grid.Panel.js
+++ b/themes/Backend/ExtJs/backend/base/application/Shopware.grid.Panel.js
@@ -509,7 +509,14 @@ Ext.define('Shopware.grid.Panel', {
              *          description: { header: 'MyOwnDescription' }
              *      }
              */
-            columns: { }
+            columns: { },
+
+            /**
+             * Shows the id property as column
+             * @type { Boolean }
+             */
+            showIdProperty: false
+
         },
 
         /**
@@ -1174,7 +1181,7 @@ Ext.define('Shopware.grid.Panel', {
     createColumn: function (model, field) {
         var me = this, column = {}, config, customConfig;
 
-        if (model.idProperty === field.name) {
+        if (model.idProperty === field.name && !me.getConfig('showIdProperty')) {
             return null;
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It should be possible to show the id of the record without overriding the entire function

### 2. What does this change do, exactly?
Adds a new config option showIdProperty to Shopware.grid.Panel

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.