### PR TITLE
Remove plugin backend widgets after uninstall

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -55,6 +55,8 @@ This changelog references changes done in Shopware 5.4 patch versions.
 	
 	These paths are configurable in the `config.php`, see `engine/Shopware/Configs/Default.php` for defaults
 
+* Backend widgets of plugins will be now removed after uninstall
+
 ### Changes
 
 * Updated mPDF to v6.1.4 and included it via composer

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
@@ -173,6 +173,7 @@ class PluginInstaller
         $this->removeMenuEntries($pluginId);
         $this->removeTemplates($pluginId);
         $this->removeEmotionComponents($pluginId);
+        $this->removeWidgetEntries($pluginId);
 
         $this->removeSnippets($bootstrap, $removeData);
         if ($removeData) {
@@ -567,6 +568,19 @@ SQL;
     private function removeEventSubscribers($pluginId)
     {
         $sql = 'DELETE FROM s_core_subscribes WHERE pluginID = :pluginId';
+        $this->connection->executeUpdate($sql, [':pluginId' => $pluginId]);
+    }
+
+    /**
+     * @param int $pluginId
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    private function removeWidgetEntries($pluginId)
+    {
+        $sql = 'DELETE FROM s_core_widget_views WHERE widget_id IN(SELECT id FROM s_core_widgets WHERE plugin_id = :pluginId)';
+        $this->connection->executeUpdate($sql, [':pluginId' => $pluginId]);
+        $sql = 'DELETE FROM s_core_widgets WHERE plugin_id = :pluginId';
         $this->connection->executeUpdate($sql, [':pluginId' => $pluginId]);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Most parts of a plugin will be automaticly deleted after uninstall. Its missing for widgets

### 2. What does this change do, exactly?
Removes all widgets of a plugin after uninstall

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
That the process is now handled by plugin manager

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.