### PR TITLE
Removed deprecated label from widgets

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -96,6 +96,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
         - `s_core_shops.secure_host`
         - `s_core_shops.secure_base_path`
         - `s_core_shops.always_secure`
+        - `s_core_widgets.label`
         
     * Removed methods
         - `\Shopware\Bundle\StoreFrontBundle\Struct\Shop::setSecureHost`
@@ -116,6 +117,8 @@ This changelog references changes done in Shopware 5.4 patch versions.
         - `\Shopware\Models\Shop\Shop::setSecureBaseUrl`
         - `\Shopware\Models\Shop\Shop::getAlwaysSecure`
         - `\Shopware\Models\Shop\Shop::setAlwaysSecure`
+        - `\Shopware\Models\Widget\Widget::setLabel`
+        - `\Shopware\Models\Widget\Widget::getLabel`
 
     * Changed methods
         - `\Shopware\Components\Theme\PathResolver::formatPathToUrl`

--- a/_sql/demo/latest.sql
+++ b/_sql/demo/latest.sql
@@ -6147,14 +6147,14 @@ INSERT INTO `s_core_units` (`id`, `unit`, `description`) VALUES
 (10, 'ml', 'Milliliter');
 
 TRUNCATE TABLE `s_core_widgets`;
-INSERT INTO `s_core_widgets` (`id`, `name`, `label`) VALUES
-(1, 'swag-sales-widget', 'Umsatz Heute und Gestern'),
-(2, 'swag-upload-widget', 'Drag and Drop Upload'),
-(3, 'swag-visitors-customers-widget', 'Besucher online'),
-(4, 'swag-last-orders-widget', 'Letzte Bestellungen'),
-(5, 'swag-notice-widget', 'Notizzettel'),
-(6, 'swag-merchant-widget', 'Händlerfreischaltung'),
-(7, 'swag-shopware-news-widget', 'shopware News');
+INSERT INTO `s_core_widgets` (`id`, `name`) VALUES
+(1, 'swag-sales-widget'),
+(2, 'swag-upload-widget'),
+(3, 'swag-visitors-customers-widget'),
+(4, 'swag-last-orders-widget'),
+(5, 'swag-notice-widget'),
+(6, 'swag-merchant-widget'),
+(7, 'swag-shopware-news-widget');
 
 TRUNCATE TABLE `s_core_widget_views`;
 INSERT INTO `s_core_widget_views` (`id`, `widget_id`, `auth_id`, `column`, `position`) VALUES

--- a/_sql/migrations/1209-remove-widget-label.php
+++ b/_sql/migrations/1209-remove-widget-label.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration1209 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('ALTER TABLE `s_core_widgets` DROP `label`;');
+    }
+}

--- a/engine/Shopware/Controllers/Backend/Widgets.php
+++ b/engine/Shopware/Controllers/Backend/Widgets.php
@@ -66,7 +66,7 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
             }
 
             $widgetData['label'] = Shopware()->Container()->get('snippets')->getNamespace('backend/widget/labels')
-                ->get($widgetData['name'], $widgetData['label']);
+                ->get($widgetData['name'], $widgetData['name']);
 
             $widgets[] = $widgetData;
         }

--- a/engine/Shopware/Models/Widget/Widget.php
+++ b/engine/Shopware/Models/Widget/Widget.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Models\Widget;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
 
@@ -48,15 +49,7 @@ class Widget extends ModelEntity
     private $name;
 
     /**
-     * @var string
-     * @ORM\Column(name="label", type="string", nullable=false)
-     *
-     * @deprecated
-     */
-    private $label;
-
-    /**
-     * @var
+     * @var ArrayCollection
      * @ORM\OneToMany(targetEntity="Shopware\Models\Widget\View", mappedBy="widget")
      */
     private $views;
@@ -99,27 +92,7 @@ class Widget extends ModelEntity
     }
 
     /**
-     * @deprecated Use 'label' snippet from 'backend/widget/<your-widget-name>' namespace instead
-     *
-     * @return string
-     */
-    public function getLabel()
-    {
-        return $this->label;
-    }
-
-    /**
-     * @deprecated Use 'label' snippet from 'backend/widget/<your-widget-name>' namespace instead
-     *
-     * @param string $label
-     */
-    public function setLabel($label)
-    {
-        $this->label = $label;
-    }
-
-    /**
-     * @return
+     * @return ArrayCollection
      */
     public function getViews()
     {
@@ -127,7 +100,7 @@ class Widget extends ModelEntity
     }
 
     /**
-     * @param  $views
+     * @param ArrayCollection $views
      */
     public function setViews($views)
     {

--- a/snippets/backend/widget/labels.ini
+++ b/snippets/backend/widget/labels.ini
@@ -5,6 +5,7 @@ swag-notice-widget = "Notepad"
 swag-sales-widget = "Turnover for yesterday and today"
 swag-upload-widget = "Drag and Drop Upload"
 swag-visitors-customers-widget = "Online visitors"
+swag-shopware-news-widget = "shopware News"
 
 [de_DE]
 swag-last-orders-widget = "Letzte Bestellungen"
@@ -13,3 +14,4 @@ swag-notice-widget = "Notizzettel"
 swag-sales-widget = "Umsatz Heute und Gestern"
 swag-upload-widget = "Drag and Drop Upload"
 swag-visitors-customers-widget = "Besucher online"
+swag-shopware-news-widget = "shopware News"


### PR DESCRIPTION
### 1. Why is this change necessary?
Its deprecated and snippets should be used to make it translateable

### 2. What does this change do, exactly?
Removes setLabel, getLabel from Widget model and the database column

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
Document how to use snippets to set a label

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.