### PR TITLE
misc - fix issue with typ text2 and php7.1 and above

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Forms.php
+++ b/engine/Shopware/Controllers/Frontend/Forms.php
@@ -455,6 +455,7 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
             $valid = true;
             $value = '';
             if ($element['typ'] === 'text2') {
+                $value = [];
                 $element['name'] = explode(';', $element['name']);
                 if (!empty($inputs[$element['name'][0]])) {
                     $value[0] = $inputs[$element['name'][0]];


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Without this change, you receive only the first character from input fields with typ text2. For more details see https://3v4l.org/Zduk7

### 2. What does this change do, exactly?
Fix typing issue

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.