### PR TITLE
Publish app server ports in docker environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     volumes:
       - .:/app
       - ~/.composer/cache:/.composer/cache
+    ports:
+      - "8088:80"
 
   app_mysql:
     build: dev-ops/docker/containers/mysql


### PR DESCRIPTION
### 1. Why is this change necessary?
The webserver of the docker container can't be reached at `localhost:8088` under MacOS because the ports are not published. Thanks to @Crease29 for helping me with the docker config!

### 2. What does this change do, exactly?
I changed the `docker-compose.yml` to publish the ports of the app server. I'm not sure if it's possible to access the variables set in `.psh.yaml.dist` so that we can make this configurable via a new variable like `SW_HOST_PORT`.

### 3. Describe each step to reproduce the issue or behaviour.
Run the docker container with or without my change. Shopware can only be reached with my change oder MacOS.

### 4. Please link to the relevant issues (if any).
No

### 5. Which documentation changes (if any) need to be made because of this PR?
No

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.