### PR TITLE
Fixed checkbox checked state in plugin config

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.PluginPanel.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.PluginPanel.js
@@ -271,14 +271,23 @@ Ext.define('Shopware.form.PluginPanel',
 
                 if (field.xtype == "base-element-boolean" || field.xtype == "base-element-checkbox") {
                     field = me.convertCheckBoxToComboBox(field, shop, initialValue);
-                }
-                else if ((field.xtype == "base-element-datetime" ||
+                } else if ((field.xtype == "base-element-datetime" ||
                         field.xtype == "base-element-date" ||
                         field.xtype == "base-element-time") && field.value) {
 
                     field.value += '+00:00';
                     field.value = new Date(field.value);
                     field.value = new Date((field.value.getTime() + (field.value.getTimezoneOffset() * 60 * 1000)));
+                } else if(field.xtype === 'checkbox') {
+                    field.checked = !!(value ? value.get('value') : element.get('value'));
+
+                    if (field.inputValue === undefined) {
+                        field.inputValue = true;
+                    }
+
+                    if (field.uncheckedValue === undefined) {
+                        field.uncheckedValue = false;
+                    }
                 }
 
                 fields.push(field);


### PR DESCRIPTION
### 1. Why is this change necessary?
Checkboxes needs "checked" attribute to be checked by creation

### 2. What does this change do, exactly?
Adds checked attribute when the xtype is checkbox

### 3. Describe each step to reproduce the issue or behaviour.
```xml
<?xml version="1.0" encoding="utf-8"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.3/engine/Shopware/Components/Plugin/schema/config.xsd">

    <elements>
        <element type="boolean">
            <name>lolYay</name>
            <label lang="de">Bildauswahl</label>
            <label lang="en">MediaSelection</label>
            <value>true</value>
            <options>
                <inputValue>true</inputValue>
                <uncheckedValue>false</uncheckedValue>
                <xtype>checkbox</xtype>
            </options>
        </element>
    </elements>

</config>
```

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.