### PR TITLE
Dont throw model exception on Backend_Application while showException is off

### DIFF
--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -142,6 +142,13 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
     public function init()
     {
         if (empty($this->model)) {
+            if (!$this->Front()->getParam('showException')) {
+                throw new Enlight_Controller_Exception(
+                    'Controller "' . $this->Request()->getControllerName() . '" not found',
+                    Enlight_Controller_Exception::Controller_Dispatcher_Controller_Not_Found
+                );
+            }
+
             throw new Exception(
                 'The `model` property of your PHP controller is not configured!'
             );


### PR DESCRIPTION
### 1. Why is this change necessary?
It can spam logs or services like rollbar, sentry etc,  If someone requests /backend/application

### 2. What does this change do, exactly?
Throws the exception only if showException is enabled in config.php

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
#1418

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.