### PR TITLE
Update FontFaceKit and using woff2 + src:local fix

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -64,7 +64,7 @@ DirectoryIndex shopware.php
     AddOutputFilterByType DEFLATE text/html text/xml text/plain text/css text/javascript application/javascript application/json application/font-woff application/font-woff2 image/svg+xml
 </IfModule>
 
-<Files ~ "\.(jpe?g|png|gif|css|js|woff|eot)$">
+<Files ~ "\.(jpe?g|png|gif|css|js|woff|woff2|ttf|eot)$">
     <IfModule mod_expires.c>
         ExpiresActive on
         ExpiresDefault "access plus 1 month"

--- a/.htaccess
+++ b/.htaccess
@@ -64,7 +64,7 @@ DirectoryIndex shopware.php
     AddOutputFilterByType DEFLATE text/html text/xml text/plain text/css text/javascript application/javascript application/json application/font-woff application/font-woff2 image/svg+xml
 </IfModule>
 
-<Files ~ "\.(jpe?g|png|gif|css|js|woff|woff2|ttf|eot)$">
+<Files ~ "\.(jpe?g|png|gif|css|js|woff|woff2|ttf|svg|eot)$">
     <IfModule mod_expires.c>
         ExpiresActive on
         ExpiresDefault "access plus 1 month"

--- a/themes/Frontend/Responsive/Gruntfile.js
+++ b/themes/Frontend/Responsive/Gruntfile.js
@@ -109,6 +109,7 @@ module.exports = function (grunt) {
                     cwd: nodeDir + '/open-sans-fontface/fonts',
                     src: [
                         '*/**.ttf',
+                        '*/**.woff2',
                         '*/**.woff'
                     ],
                     dest: vendorDir + '/fonts/open-sans-fontface'
@@ -143,7 +144,7 @@ module.exports = function (grunt) {
         if (!grunt.file.isFile(htaccessFile)) {
 
             grunt.file.write(htaccessFile,
-                '<FilesMatch "\\.(ttf|eot|svg|woff)$">' + "\n    " +
+                '<FilesMatch "\\.(ttf|eot|svg|woff|woff2)$">' + "\n    " +
                     '<IfModule mod_expires.c>' + "\n        " +
                         'ExpiresActive on' + "\n        " +
                         'ExpiresDefault "access plus 1 year"' + "\n    " +

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/fonts.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/fonts.less
@@ -4,7 +4,8 @@
 @font-face {
     font-family: 'Open Sans';
     src: local('Open Sans Regular'),
-    local('Open Sans'),
+    local('OpenSans-Regular'),
+    url('@{OpenSansPath}/Regular/OpenSans-Regular.woff2?@{shopware-revision}') format('woff2'),
     url('@{OpenSansPath}/Regular/OpenSans-Regular.woff?@{shopware-revision}') format('woff'),
     url('@{OpenSansPath}/Regular/OpenSans-Regular.ttf?@{shopware-revision}') format('truetype');
     font-weight: normal;
@@ -16,7 +17,8 @@
 @font-face {
     font-family: 'Open Sans';
     src: local('Open Sans Semibold'),
-    local('Open Sans'),
+    local('OpenSans-SemiBold'),
+    url('@{OpenSansPath}/Semibold/OpenSans-Semibold.woff2?@{shopware-revision}') format('woff2'),
     url('@{OpenSansPath}/Semibold/OpenSans-Semibold.woff?@{shopware-revision}') format('woff'),
     url('@{OpenSansPath}/Semibold/OpenSans-Semibold.ttf?@{shopware-revision}') format('truetype');
     font-weight: 600;
@@ -28,7 +30,8 @@
 @font-face {
     font-family: 'Open Sans';
     src: local('Open Sans Bold'),
-    local('Open Sans'),
+    local('OpenSans-Bold'),
+    url('@{OpenSansPath}/Bold/OpenSans-Bold.woff2?@{shopware-revision}') format('woff2'),
     url('@{OpenSansPath}/Bold/OpenSans-Bold.woff?@{shopware-revision}') format('woff'),
     url('@{OpenSansPath}/Bold/OpenSans-Bold.ttf?@{shopware-revision}') format('truetype');
     font-weight: bold;

--- a/themes/Frontend/Responsive/package.json
+++ b/themes/Frontend/Responsive/package.json
@@ -35,7 +35,7 @@
     "jquery.event.swipe": "^0.5.4",
     "jquery.transit": "^0.9.12",
     "normalize.css.less": "^3.0.3",
-    "open-sans-fontface": "^1.4.0",
+    "open-sans-fontface": "^1.4.2",
     "picturefill": "^3.0.1",
     "pocketgrid-less": "^1.0.1"
   },


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Speeds up a bit... woff2 is smaler and used by modern Browsers like edge:) as of 04/06/2016
And fixing local source for the font.

### 2. What does this change do, exactly?

-Updating the FontFaceKit from https://github.com/FontFaceKit/open-sans as of 2018-01-10

-Adding .woff2 files in font.less

-Fixing src:local in font.less as seen on https://fonts.googleapis.com/css?family=Open+Sans:400,600,700 / https://developer.mozilla.org/de/docs/Web/CSS/@font-face
May fix this ISSUES: https://issues.shopware.com/issues/SW-20451 / https://issues.shopware.com/issues/SW-20548

-Adding .woff2 to the Expire Files in the .htaccess (Responsive/Gruntfile)
-Adding .woff2 to the Expire Files in the .htaccess (sw root)

### 3. Describe each step to reproduce the issue or behaviour.

Slow... as webpagetest, dareboost or gtmetrix shows up fonts are big and slow.
https://issues.shopware.com/issues/SW-20548
https://issues.shopware.com/issues/SW-20451

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.