### PR TITLE
Added containerCollection to widget

### DIFF
--- a/themes/Backend/ExtJs/backend/index/view/widgets/window.js
+++ b/themes/Backend/ExtJs/backend/index/view/widgets/window.js
@@ -515,7 +515,8 @@ Ext.define('Shopware.apps.Index.view.widgets.Window', {
                     columnId: record.column,
                     rowId: record.position
                 },
-                draggable: me.createWidgetDragZone()
+                draggable: me.createWidgetDragZone(),
+                containerCollection: me.containerCollection
             };
 
         return Ext.widget(name, config);


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently its not possible to get another widgets from inside a widget

### 2. What does this change do, exactly?
It makes possible to loop all widgets which are shown using containerCollection

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.