### PR TITLE
Set default PHP Version to 7.1 to fix Docker error

### DIFF
--- a/.psh.yaml.dist
+++ b/.psh.yaml.dist
@@ -33,7 +33,7 @@ const:
   DB_NAME: "shopware"
   SW_HOST: "127.0.0.1:8088"
   SW_BASE_PATH: ""
-  PHP_VERSION: "7.2"
+  PHP_VERSION: "7.1"
   MYSQL_VERSION: "5.7"
   APP_DEBUG: "1"
   APP_ENV: "dev"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Fix poor out-of-the box expierence when checking out the repo and following the README.


### 2. What does this change do, exactly?

Changes the default PHP Version to PHP 7.1

### 3. Describe each step to reproduce the issue or behaviour.

```
~/www (labs*) 
$ git clone -b labs https://github.com/shopware/shopware.git    

~/www (labs*)
$ cd shopware 

~/www/shopware (labs*) 
$ ./psh.phar docker:start

###################

SHOPWARE Developer Version

       _
      | |
   ___| |__   ___  _ ____      ____ _ _ __ ___
  / __| '_ \ / _ \| '_ \ \ /\ / / _` | '__/ _ \
  \__ \ | | | (_) | |_) \ V  V / (_| | | |  __/
  |___/_| |_|\___/| .__/ \_/\_/ \__,_|_|  \___|
                  | |
                  |_|

Using .psh.yaml.dist 

Starting Execution of 'docker:start' ('dev-ops/docker/actions/start.sh')


(1/6) Starting
> echo "COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}"
	COMPOSE_PROJECT_NAME: 
	
(2/6) Starting
> cp dev-ops/docker/docker-compose.override.yml .
	
(3/6) Starting
> docker-compose build && docker-compose up -d
	Building app_mysql
	Step 1/5 : FROM mysql:5.7
	 ---> f008d8ff927d
	Step 2/5 : ADD dev.cnf /etc/mysql/conf.d/dev.cnf
	 ---> Using cache
	 ---> c271922f9995
	Step 3/5 : ADD remote-access.cnf /etc/mysql/conf.d/remote-access.cnf
	 ---> Using cache
	 ---> e54f4af4f782
	Step 4/5 : ADD performance-schema.cnf /etc/mysql/conf.d/performance-schema.cnf
	 ---> Using cache
	 ---> b973fbc51dae
	Step 5/5 : COPY grant.sql /docker-entrypoint-initdb.d/grant.sql
	 ---> Using cache
	 ---> d10d4af256cb
	
	Successfully built d10d4af256cb
	Successfully tagged shopware_app_mysql:latest
	Building app_server
	Step 1/13 : FROM webdevops/php-apache-dev:7.2
	Service 'app_server' failed to build: manifest for webdevops/php-apache-dev:7.2 not found
	
Execution aborted, a subcommand failed!
```


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.