### PR TITLE
Added theme configuration to mail template

### DIFF
--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -173,6 +173,9 @@ class Shopware_Components_TemplateMail
             $translationReader = $this->getTranslationReader();
             $translation = $translationReader->read($isoCode, 'config_mails', $mailModel->getId());
             $mailModel->setTranslation($translation);
+
+            $inheritance = Shopware()->Container()->get('theme_inheritance');
+            $defaultContext['theme'] = $inheritance->buildConfig($this->getShop()->getTemplate(), $this->getShop(), false);
         } else {
             $defaultContext = [
                 'sConfig' => $config,
@@ -180,7 +183,7 @@ class Shopware_Components_TemplateMail
         }
 
         // save current context to mail model
-        $mailContext = json_decode(json_encode($context), true);
+        $mailContext = json_decode(json_encode(array_merge($defaultContext, $context)), true);
         $mailModel->setContext($mailContext);
         $this->getModelManager()->flush($mailModel);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Makes easier to make a default Mail Template using Theme configurations like color for ci of the mail, directly use logo from theme config. 

Possible now: ``<img src="{link file=$theme.tabletLandscapeLogo fullPath}"/>``

### 2. What does this change do, exactly?
Adds theme configuration to mail template

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.