### PR TITLE
Api-Resources were not configured properly when accessed via Service-…

### DIFF
--- a/engine/Shopware/Components/Api/Manager.php
+++ b/engine/Shopware/Components/Api/Manager.php
@@ -53,13 +53,13 @@ class Manager
 
             /** @var $resource Resource\Resource */
             $resource = new $class();
-        }
 
-        if ($resource instanceof ContainerAwareInterface) {
-            $resource->setContainer($container);
-        }
+            if ($resource instanceof ContainerAwareInterface) {
+                $resource->setContainer($container);
+            }
 
-        $resource->setManager($container->get('models'));
+            $resource->setManager($container->get('models'));
+        }
 
         if ($container->initialized('Auth')) {
             $resource->setAcl($container->get('acl'));

--- a/engine/Shopware/Components/Api/Resource/Resource.php
+++ b/engine/Shopware/Components/Api/Resource/Resource.php
@@ -100,7 +100,7 @@ abstract class Resource
     /**
      * @param $container
      */
-    public function setContainer($container)
+    public function setContainer(Container $container = null)
     {
         $this->container = $container;
     }

--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -35,7 +35,7 @@ use Shopware\Models\Article\Detail;
 use Shopware\Models\Article\Image;
 use Shopware\Models\Article\Price;
 use Shopware\Models\Article\Unit;
-use Shopware\Models\Customer\Group as CustomerGroup;
+use Shopware\Models\Customer\Group as CustomerGroupModel;
 use Shopware\Models\Media\Media as MediaModel;
 use Shopware\Models\Tax\Tax;
 
@@ -716,8 +716,8 @@ class Variant extends Resource implements BatchInterface
                 ->getRepository('Shopware\Models\Customer\Group')
                 ->findOneBy(['key' => $priceData['customerGroupKey']]);
 
-            /** @var CustomerGroup $customerGroup */
-            if (!$customerGroup instanceof CustomerGroup) {
+            /** @var CustomerGroupModel $customerGroup */
+            if (!$customerGroup instanceof CustomerGroupModel) {
                 throw new ApiException\CustomValidationException(sprintf('Customer Group by key %s not found', $priceData['customerGroupKey']));
             }
 
@@ -838,7 +838,7 @@ class Variant extends Resource implements BatchInterface
                 throw new ApiException\CustomValidationException(sprintf('Unit by id %s not found', $data['unitId']));
             }
 
-        //new unit data send? create new unit for this variant
+            //new unit data send? create new unit for this variant
         } elseif (!empty($data['unit'])) {
             $data['unit'] = $this->updateUnitReference($data['unit']);
         }

--- a/engine/Shopware/Components/DependencyInjection/Compiler/ConfigureApiResourcesPass.php
+++ b/engine/Shopware/Components/DependencyInjection/Compiler/ConfigureApiResourcesPass.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\DependencyInjection\Compiler;
+
+use Shopware\Components\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class ConfigureApiResourcesPass
+ */
+class ConfigureApiResourcesPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getServiceIds() as $id) {
+            if (strpos($id, 'shopware.api.') === 0) {
+                $definition = $container->getDefinition($id);
+                if (in_array(ContainerAwareInterface::class, class_implements($definition->getClass()))) {
+                    $definition->addMethodCall('setContainer', [new Reference('service_container')]);
+                }
+
+                $definition->addMethodCall('setManager', [new Reference('models')]);
+            }
+        }
+    }
+}

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -564,7 +564,7 @@
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="shopware.api.resource" class="Shopware\Components\Api\Resource\Resource" shared="false" />
+        <service id="shopware.api.resource" class="Shopware\Components\Api\Resource\Resource" shared="false" abstract="true" />
         <service id="shopware.api.address" class="Shopware\Components\Api\Resource\Address" shared="false" />
         <service id="shopware.api.article" class="Shopware\Components\Api\Resource\Article" shared="false">
             <argument type="service" id="translation" />

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -46,6 +46,7 @@ use Shopware\Bundle\SearchBundleES\DependencyInjection\CompilerPass\SearchHandle
 use Shopware\Components\ConfigLoader;
 use Shopware\Components\DependencyInjection\Compiler\AddCaptchaCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\AddConsoleCommandPass;
+use Shopware\Components\DependencyInjection\Compiler\ConfigureApiResourcesPass;
 use Shopware\Components\DependencyInjection\Compiler\DoctrineEventSubscriberCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EmotionPresetCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EventListenerCompilerPass;
@@ -649,6 +650,7 @@ class Kernel implements HttpKernelInterface
         $container->addCompilerPass(new SearchHandlerCompilerPass());
         $container->addCompilerPass(new EmotionPresetCompilerPass());
         $container->addCompilerPass(new RouterCompilerPass());
+        $container->addCompilerPass(new ConfigureApiResourcesPass());
 
         $container->setParameter('active_plugins', $this->activePlugins);
 

--- a/tests/Functional/Components/DependencyInjection/Compiler/ConfigureApiResourcesPassTest.php
+++ b/tests/Functional/Components/DependencyInjection/Compiler/ConfigureApiResourcesPassTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\DependencyInjection\Compiler;
+
+use Enlight_Components_Test_Controller_TestCase;
+use Shopware\Components\Api\Resource\Resource;
+
+/**
+ * Class ConfigureApiResourcesPassTest
+ */
+class ConfigureApiResourcesPassTest extends Enlight_Components_Test_Controller_TestCase
+{
+    /**
+     * @param string $serviceId
+     * @dataProvider provideApiResourceIds
+     */
+    public function testApiResourcesAreSetUpCorrect($serviceId)
+    {
+        /** @var resource $service */
+        $resource = Shopware()->Container()->get($serviceId);
+        $this->assertNotNull($resource->getManager());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideApiResourceIds()
+    {
+        $services = array_map(
+            function ($id) {
+                return [$id];
+            },
+            array_filter(Shopware()->Container()->getServiceIds(), function ($id) {
+                return strpos($id, 'shopware.api.') === 0;
+            })
+        );
+
+        return $services;
+    }
+}


### PR DESCRIPTION
…Container:

- Added CompilerPass to perform necessary set up of these services
- Changed Resource\Manager to perform setup only on newly instantiated resources

### 1. Why is this change necessary?
api-resources obtained via dependency-injection ("shopware.api.*") are dysfunctional.

### 2. What does this change do, exactly?
Configure api-resources with Model_Manager and Container (where necessary)

### 3. Describe each step to reproduce the issue or behaviour.
inject any api-resource into another service, then try to use any method involving $this->manager.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None. 

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.