### PR TITLE
fix sorting of customer overview

### DIFF
--- a/themes/Backend/ExtJs/backend/customer/store/quick_view.js
+++ b/themes/Backend/ExtJs/backend/customer/store/quick_view.js
@@ -42,7 +42,7 @@ Ext.define('Shopware.apps.Customer.store.QuickView', {
     model: 'Shopware.apps.Customer.model.QuickView',
 
     sorters: [{
-        property: 'number',
+        property: 'firstlogin',
         direction: 'DESC'
     }],
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Since shopware 5.3 the newest customers won't be listed as first entries. The sorting was changed to customernumber. This is a problem since the customernumber is optional and can be deactivated in the basic settings.

### 2. What does this change do, exactly?
Change the sorting to firstlogin (= creation date)

### 3. Describe each step to reproduce the issue or behaviour.
Add a few customers and change one customernumber to 99999, this entry will be listed as first customer in the grid

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-19907

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.