### PR TITLE
Fixed infinite scroll with initial property conditions

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.listing-actions.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.listing-actions.js
@@ -987,6 +987,7 @@
          */
         sendListingRequest: function (params, loadFacets, loadProducts, callback, appendDefaults) {
             if (typeof params === 'object') {
+                params = this.cleanParams(params);
                 params = '?' + $.param(params);
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Infinite Scroll Listing with a prechosed property filter, will not resolve the properties because they are "escaped" "__f__373=373". The CritieraRequestHandler must have the data as ?f=373.

### 2. What does this change do, exactly?
Just cleans the parameters on listing request (__f__373=373 => f=373)

### 3. Describe each step to reproduce the issue or behaviour.
Create a own listing or a plugin which adds a BaseCondition with PropertyCondition.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.