### PR TITLE
Change Content-Type header for statistics XHR

### DIFF
--- a/engine/Shopware/Controllers/Widgets/Index.php
+++ b/engine/Shopware/Controllers/Widgets/Index.php
@@ -34,6 +34,7 @@ class Shopware_Controllers_Widgets_Index extends Enlight_Controller_Action
     {
         if ($this->Request()->getActionName() === 'refreshStatistic') {
             $this->Front()->Plugins()->ViewRenderer()->setNoRender();
+            $this->Response()->setHeader('Content-Type', 'application/javascript');
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Because you will get the following error in Chrome: `Refused to execute script from '/widgets/index/refreshStatistic?requestPage=/&requestController=index' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.`

After a deeper investigation this issued has already been fixed in cb9355113550988176a48ab4290757a2e866c01c but got reverted in 8712c61e418ceab7ede1f7a19279784314f9e62c. Perhaps we should discuss here if the problem "Removed content header leading to endless request" could be fixed in an other way.

### 2. What does this change do, exactly?
This PR adds the correct Content-Type header for the `refreshStatistic` action in the `Index` controller.

### 3. Describe each step to reproduce the issue or behaviour.
Activate Shopware statistics and browse a random page with Chrome having strict MIME type checking enabled.

### 4. Please link to the relevant issues (if any).
I have found this ticket: https://issues.shopware.com/issues/SW-18506 The ticket status is "solved" but the problem remains.

### 5. Which documentation changes (if any) need to be made because of this PR?
No.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.