### PR TITLE
Fix illogical count implementation in Enlight_Collection_ArrayCollection

### DIFF
--- a/engine/Library/Enlight/Collection/ArrayCollection.php
+++ b/engine/Library/Enlight/Collection/ArrayCollection.php
@@ -52,13 +52,13 @@ class Enlight_Collection_ArrayCollection implements Enlight_Collection_Collectio
     }
 
     /**
-     * Counts the stored items or checks whether elements are deposited.
+     * Counts the stored items.
      *
      * @return int
      */
     public function count()
     {
-        return isset($this->_elements) ? 0 : count($this->_elements);
+        return count($this->_elements);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
This change is necessary, because the method returns a not expected value.

### 2. What does this change do, exactly?
The implemented count method return in every case 0.

### 3. Describe each step to reproduce the issue or behaviour.
Add some elements to the collection and call the count method.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.