### PR TITLE
Changed default value of "required" in config.xsd

### DIFF
--- a/engine/Shopware/Components/Plugin/schema/config.xsd
+++ b/engine/Shopware/Components/Plugin/schema/config.xsd
@@ -33,7 +33,7 @@
             <xsd:element name="options" type="options" minOccurs="0"/>
         </xsd:sequence>
         <xsd:attribute name="type" type="type" default="text"/>
-        <xsd:attribute name="required" type="xsd:boolean" default="true"/>
+        <xsd:attribute name="required" type="xsd:boolean" default="false"/>
         <xsd:attribute name="scope" type="scope" default="locale"/>
     </xsd:complexType>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The `config.xsd` and `XmlConfigDefinitionReader.php` have different default values for the `required`-property of configuration elements. This leads to unexpected behaviour if you omit the property from your plugin's `config.xml`, and to irritating notifications from IDEs if you manually set it to `true`

https://github.com/shopware/shopware/blob/a2dfabd84566195c9413aa6ef41977f89c2cf17c/engine/Shopware/Components/Plugin/XmlConfigDefinitionReader.php#L115
https://github.com/shopware/shopware/blob/a2dfabd84566195c9413aa6ef41977f89c2cf17c/engine/Shopware/Components/Plugin/schema/config.xsd#L36

### 2. What does this change do, exactly?
In the `config.xsd`, the default value of the property is now defined as `false`. I would much rather have set the default value in `XmlConfigDefinitionReader.php` to `true`, since I believe optional configurations are the exception, however, that might break existing plugins.

### 3. Describe each step to reproduce the issue or behaviour.
A picture is worth a thousand words:
![A picture is worth a thousand words](https://i.imgur.com/2hM6zah.png)

### 4. Please link to the relevant issues (if any).
None that I know of

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.