### PR TITLE
Added event plugin/swAjaxVariant/onRequestDataCompleted

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -160,8 +160,9 @@
                         window.history.pushState(stateObj.state, stateObj.title, location);
                     }
                 },
-                complete: function () {
+                complete: function (response, status) {
                     $.loadingIndicator.close();
+                    $.publish('plugin/swAjaxVariant/onRequestDataCompleted', [me, response, status, values, stateObj.location]);
                 }
             });
         },


### PR DESCRIPTION
### 1. Why is this change necessary?
Execute code after the request is completed also loading indicator closed. Currently we use plugin/swAjaxVariant/onRequestData with a setTimeout to avoid this problem. 

See example code https://github.com/FriendsOfShopware/FroshCodeCeptionTests/blob/master/tests/_support/DetailHelper.php#L56

### 2. What does this change do, exactly?
Adds a new new event

### 3. Describe each step to reproduce the issue or behaviour.
Click in plugin/swAjaxVariant/onRequestData event a another variant option 👍 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.