### PR TITLE
Put icon in ajax_cart right as it is classed

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/ajax_cart.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/ajax_cart.tpl
@@ -93,8 +93,8 @@
                         {/if}
                         {block name='frontend_checkout_ajax_cart_open_basket'}
                             <a href="{url controller='checkout' action='cart'}" class="btn button--open-basket is--icon-right" title="{"{s name='AjaxCartLinkBasket'}{/s}"|escape}">
-                                <i class="icon--arrow-right"></i>
                                 {s name='AjaxCartLinkBasket'}{/s}
+                                <i class="icon--arrow-right"></i>
                             </a>
                         {/block}
                     {/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
Icon isn't displayed.

### 2. What does this change do, exactly?
it moves the icon right, as it is defined in class.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.