### PR TITLE
adds possibility to use boolean keywords when defining boolean attributes

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
@@ -400,6 +400,9 @@ class CrudService
         $types = $this->typeMapping->getTypes();
         $type = $types[$type];
 
+        if ($type['unified'] === TypeMapping::TYPE_BOOLEAN) {
+            return (bool)$defaultValue === true ? 1 : 0;
+        }
         if (!$type['allowDefaultValue'] || $defaultValue === null) {
             return self::NULL_STRING;
         }

--- a/tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
+++ b/tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
@@ -93,6 +93,12 @@ class SchemaOperatorTest extends \PHPUnit\Framework\TestCase
         $this->iterateTypeArray(['boolean' => 0]);
         $this->iterateTypeArray(['boolean' => true]);
         $this->iterateTypeArray(['boolean' => false]);
+        $this->iterateTypeArray(['boolean' => null]);
+        $this->iterateTypeArray(['boolean' => '1']);
+        $this->iterateTypeArray(['boolean' => '0']);
+        $this->iterateTypeArray(['boolean' => 'true']);
+        $this->iterateTypeArray(['boolean' => 'false']);
+        $this->iterateTypeArray(['boolean' => 'null']);
     }
 
     /**

--- a/tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
+++ b/tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
@@ -84,6 +84,18 @@ class SchemaOperatorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers CrudService::parseDefaultValue
+     * @throws \Exception
+     */
+    public function testDefaultValuesBoolean()
+    {
+        $this->iterateTypeArray(['boolean' => 1]);
+        $this->iterateTypeArray(['boolean' => 0]);
+        $this->iterateTypeArray(['boolean' => true]);
+        $this->iterateTypeArray(['boolean' => false]);
+    }
+
+    /**
      * @param $types
      *
      * @throws \Exception


### PR DESCRIPTION
### 1. Why is this change necessary?

for better developer experience it should be possible to use the standard boolean keywords true and false, when defining a new article attribute of type boolean, currently one must use 0 or 1

### 2. What does this change do, exactly?

during parsing of the default value ask it its true other wise its false

### 3. Describe each step to reproduce the issue or behaviour.
- define a new article attribute in  a plugin
- set type to boolean
- set defaultValue to false
- install plugin
- there will be a mysql error

### 4. Please link to the relevant issues (if any).

there is no issue

### 5. Which documentation changes (if any) need to be made because of this PR?

none

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.