### PR TITLE
Added theme typehint to LessDefinition

### DIFF
--- a/engine/Shopware/Components/Theme/LessDefinition.php
+++ b/engine/Shopware/Components/Theme/LessDefinition.php
@@ -108,7 +108,7 @@ class LessDefinition
      * @param array $config          contains the less variables, has to be a key value array
      * @param array $files           contains the full file name paths
      * @param null  $importDirectory Full path to the import directory for less @import commands
-     * @param Theme $theme           the corresponding theme
+     * @param Theme|null $theme           the corresponding theme
      */
     public function __construct(array $config = [], array $files = [], $importDirectory = null, Theme $theme = null)
     {

--- a/engine/Shopware/Components/Theme/LessDefinition.php
+++ b/engine/Shopware/Components/Theme/LessDefinition.php
@@ -77,7 +77,8 @@ class LessDefinition
     /**
      * The corresponding theme
      *
-     * @var Theme */
+     * @var Theme
+     */
     private $theme;
 
     /**
@@ -107,9 +108,9 @@ class LessDefinition
      * @param array $config          contains the less variables, has to be a key value array
      * @param array $files           contains the full file name paths
      * @param null  $importDirectory Full path to the import directory for less @import commands
-     * @param null  $theme           the corresponding theme
+     * @param Theme $theme           the corresponding theme
      */
-    public function __construct(array $config = [], array $files = [], $importDirectory = null, $theme = null)
+    public function __construct(array $config = [], array $files = [], $importDirectory = null, Theme $theme = null)
     {
         $this->config = $config;
         $this->files = $files;
@@ -176,7 +177,7 @@ class LessDefinition
     /**
      * @param Theme $theme
      */
-    public function setTheme($theme)
+    public function setTheme(Theme $theme)
     {
         $this->theme = $theme;
     }

--- a/engine/Shopware/Components/Theme/LessDefinition.php
+++ b/engine/Shopware/Components/Theme/LessDefinition.php
@@ -107,7 +107,7 @@ class LessDefinition
     /**
      * @param array $config          contains the less variables, has to be a key value array
      * @param array $files           contains the full file name paths
-     * @param null  $importDirectory Full path to the import directory for less @import commands
+     * @param string|null  $importDirectory Full path to the import directory for less @import commands
      * @param Theme|null $theme           the corresponding theme
      */
     public function __construct(array $config = [], array $files = [], $importDirectory = null, Theme $theme = null)


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently you can pass everything, but the property only allows a Theme or null otherwise the LessCollector crashes.  (Call to a member function getDiscardedLessThemes() on array)

### 2. What does this change do, exactly?
Adds a simple Typehint to avoid that

### 3. Describe each step to reproduce the issue or behaviour.
Do $definition->setTheme(['shopware die']); and theme compile is broken with message "Call to a member function getDiscardedLessThemes() on array" which does not help

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.