### PR TITLE
Fixing 0% Vat Problem

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1031,7 +1031,7 @@ class sBasket
             $tax = $this->config->get('sDISCOUNTTAX');
         }
 
-        if (!$tax) {
+        if (!$tax && $tax != 0) {
             $tax = 19;
         }
 


### PR DESCRIPTION
If a user group is set to 0% VAT, the surcharge tax will set to 19%. This results in a negativ VAT and the Total is less then the price net.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.