### PR TITLE
Enable smarty 3 on codemirror mode

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.CodeMirror.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.CodeMirror.js
@@ -178,6 +178,15 @@ Ext.define('Shopware.form.field.CodeMirror',
 
         me.config = config;
 
+        if (me.config.mode === 'smarty') {
+            me.config.mode = {
+                name: 'smarty',
+                version: 3
+            }
+        } else if(me.config.mode.name === 'smarty') {
+            me.config.mode.version = 3;
+        }
+
         if (!Ext.isDefined(CodeMirror.loadedModes)) {
             CodeMirror.loadedModes = {}
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
The default mode is smarty 2, see https://github.com/shopware/shopware/blob/5.4/engine/Library/CodeMirror/mode/smarty/smarty.js#L21

### 2. What does this change do, exactly?
Changes the default mode to smarty 3

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.