### PR TITLE
[FIX] allow to remove an suppliers image via api

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Manufacturer.php
+++ b/engine/Shopware/Components/Api/Resource/Manufacturer.php
@@ -259,7 +259,7 @@ class Manufacturer extends Resource
             }
         }
 
-        $manufacturerModel->setImage($media->getPath());
+        $manufacturerModel->setImage($media ? $media->getPath() : "");
         unset($data['image']);
 
         return $data;

--- a/engine/Shopware/Models/Article/Supplier.php
+++ b/engine/Shopware/Models/Article/Supplier.php
@@ -119,7 +119,7 @@ class Supplier extends ModelEntity
      *
      * @var string
      *
-     * @ORM\Column(name="img", type="string", nullable=true)
+     * @ORM\Column(name="img", type="string", nullable=false)
      */
     private $image = '';
 
@@ -128,7 +128,7 @@ class Supplier extends ModelEntity
      *
      * @var string
      *
-     * @ORM\Column(name="link", type="string", nullable=true)
+     * @ORM\Column(name="link", type="string", nullable=false)
      */
     private $link = '';
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to remove an suppliers image via the manufacturers api endpoint.

### 2. What does this change do, exactly?
If image is defined as null, an empty string will be passed to method setImage().

### 3. Describe each step to reproduce the issue or behaviour.
Create a manufacturer inclusive an image via api or backend. To remove the image via the api, create a PUT Request with one of the following bodies:
{"name": "myname", "image":  {"mediaId": null}}
{"name": "myname", "image":  {"link": null}}
{"name": "myname", "image": null}
{"name": "myname", "image": {}}

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.