### PR TITLE
Dont allow upload incompatible plugins

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/DownloadService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/DownloadService.php
@@ -30,11 +30,11 @@ use Shopware\Bundle\PluginInstallerBundle\Context\MetaRequest;
 use Shopware\Bundle\PluginInstallerBundle\Context\RangeDownloadRequest;
 use Shopware\Bundle\PluginInstallerBundle\StoreClient;
 use Shopware\Bundle\PluginInstallerBundle\Struct\MetaStruct;
+use Shopware\Components\ShopwareReleaseStruct;
 use ShopwarePlugins\SwagUpdate\Components\Steps\DownloadStep;
 use ShopwarePlugins\SwagUpdate\Components\Steps\FinishResult;
 use ShopwarePlugins\SwagUpdate\Components\Steps\ValidResult;
 use ShopwarePlugins\SwagUpdate\Components\Struct\Version;
-use Symfony\Component\Filesystem\Filesystem;
 
 class DownloadService
 {
@@ -59,21 +59,29 @@ class DownloadService
     private $downloadsDir;
 
     /**
-     * @param string      $rootDir
-     * @param array       $pluginDirectories
+     * @var PluginExtractor
+     */
+    private $pluginExtractor;
+
+    /**
+     * @param string $rootDir
+     * @param array $pluginDirectories
      * @param StoreClient $storeClient
-     * @param Connection  $connection
+     * @param Connection $connection
+     * @param PluginExtractor $pluginExtractor
      */
     public function __construct(
         $rootDir,
         array $pluginDirectories,
         StoreClient $storeClient,
-        Connection $connection
+        Connection $connection,
+        PluginExtractor $pluginExtractor
     ) {
         $this->pluginDirectories = $pluginDirectories;
         $this->storeClient = $storeClient;
         $this->connection = $connection;
         $this->downloadsDir = $rootDir;
+        $this->pluginExtractor = $pluginExtractor;
     }
 
     /**
@@ -117,9 +125,7 @@ class DownloadService
             $extractor = new LegacyPluginExtractor();
             $extractor->extract($archive, $destination);
         } elseif ($pluginZipDetector->isPlugin($archive)) {
-            $pluginDir = $this->pluginDirectories['ShopwarePlugins'];
-            $extractor = new PluginExtractor($pluginDir, new Filesystem(), $this->pluginDirectories);
-            $extractor->extract($archive);
+            $this->pluginExtractor->extract($archive);
         } else {
             throw new \RuntimeException('No Plugin found in archive.');
         }

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginExtractor.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginExtractor.php
@@ -102,8 +102,8 @@ class PluginExtractor
         }
 
         $prefix = $this->getPluginPrefix($archive);
-        $this->validatePluginRequirements($prefix, $archive);
         $this->validatePluginZip($prefix, $archive);
+        $this->validatePluginRequirements($prefix, $archive);
 
         $oldFile = $this->findOldFile($prefix);
         $backupFile = $this->createBackupFile($oldFile);

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginExtractor.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginExtractor.php
@@ -259,7 +259,6 @@ class PluginExtractor
             } finally {
                 unlink($tmpFile);
             }
-            unlink($tmpFile);
         }
     }
 }

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginExtractor.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginExtractor.php
@@ -254,7 +254,11 @@ class PluginExtractor
         if ($xml = $archive->getFromName($prefix . '/plugin.xml')) {
             $tmpFile = $this->downloadDir . '/' . uniqid() . '.xml';
             file_put_contents($tmpFile, $xml);
-            $this->requirementsValidator->validate($tmpFile, $this->release->getVersion());
+            try {
+                $this->requirementsValidator->validate($tmpFile, $this->release->getVersion());
+            } finally {
+                unlink($tmpFile);
+            }
             unlink($tmpFile);
         }
     }

--- a/engine/Shopware/Bundle/PluginInstallerBundle/services.xml
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/services.xml
@@ -62,6 +62,7 @@
             <argument>%shopware.plugin_directories%</argument>
             <argument type="service" id="shopware_plugininstaller.store_client"/>
             <argument type="service" id="dbal_connection" />
+            <argument type="service" id="shopware_plugininstaller.plugin_extractor" />
         </service>
 
         <service id="shopware_plugininstaller.plugin_service_store" alias="shopware_plugininstaller.plugin_service_store_production" />
@@ -111,6 +112,15 @@
             <argument type="service" id="models"/>
             <argument type="service" id="shopware_plugininstaller.plugin_licence_service" />
             <argument type="service" id="shopware.release" />
+        </service>
+
+        <service id="shopware_plugininstaller.plugin_extractor" class="Shopware\Bundle\PluginInstallerBundle\Service\PluginExtractor">
+            <argument>%shopware.plugin_directories.ShopwarePlugins%</argument>
+            <argument type="service" id="file_system" />
+            <argument>%shopware.plugin_directories%</argument>
+            <argument>%shopware.app.downloadsdir%</argument>
+            <argument type="service" id="shopware.release" />
+            <argument type="service" id="shopware.plugin_requirement_validator" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
### 1. Why is this change necessary?
Its a earlier requirements check for the shop owner, to not upload incompatible plugins. Also some plugins depends on other plugins and needed installed before otherwise the shop throws a Exception #foundationplugins
The check in install is also too late, because already the plugin files are replaced. This should solve also the support requests like "I have installed the 5.4 version of the plugin on a 5.3 shop"

### 2. What does this change do, exactly?
Check for plugin requirements before unzipping the plugin.

Example screenshot ![Error](https://ipfs.io/ipfs/QmSS8JcRXaf3HA2by3pngFS2jMkYhqgL7gVFSNhpBXLfW1
)

### 3. Describe each step to reproduce the issue or behaviour.
Set a high minVersion in plugin.xml and try to upload it

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

200 Pull Requests 🙌 