### PR TITLE
Use individual join alias for closeout variant join.

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/ConditionHandler/CloseoutConditionHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/ConditionHandler/CloseoutConditionHandler.php
@@ -37,6 +37,8 @@ use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
  */
 class CloseoutConditionHandler implements ConditionHandlerInterface
 {
+    const STATE_INCLUDES_VARIANT_TABLE = 'variant';
+
     /**
      * {@inheritdoc}
      */
@@ -53,7 +55,16 @@ class CloseoutConditionHandler implements ConditionHandlerInterface
         QueryBuilder $query,
         ShopContextInterface $context
     ) {
-        $query->innerJoin('product', 's_articles_details', 'variant', 'product.id = variant.articleID');
+        if (!$query->hasState(self::STATE_INCLUDES_VARIANT_TABLE)) {
+            $query->innerJoin(
+                'product',
+                's_articles_details',
+                'variant',
+                'product.id = variant.articleID'
+            );
+            $query->addState(self::STATE_INCLUDES_VARIANT_TABLE);
+        }
+
         $query->andWhere('variant.laststock = 1');
     }
 }

--- a/engine/Shopware/Bundle/SearchBundleDBAL/QueryBuilderFactory.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/QueryBuilderFactory.php
@@ -30,6 +30,7 @@ use Shopware\Bundle\SearchBundle\Condition\VariantCondition;
 use Shopware\Bundle\SearchBundle\ConditionInterface;
 use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\SearchBundle\SortingInterface;
+use Shopware\Bundle\SearchBundleDBAL\ConditionHandler\CloseoutConditionHandler;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Components\DependencyInjection\Container;
 
@@ -172,6 +173,7 @@ class QueryBuilderFactory implements QueryBuilderFactoryInterface
                  AND product.active = 1'
             );
         }
+        $query->addState(CloseoutConditionHandler::STATE_INCLUDES_VARIANT_TABLE);
         $query->innerJoin(
             'variant',
             's_articles_attributes',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently a fatal error occurs if one uses a product stream with a closeout condition (Abverkauf-Filter) for a category and requests that category in the shop:

```Uncaught Doctrine\DBAL\Query\QueryException: The given alias 'variant' is not unique in FROM and JOIN clause table. The currently registered aliases are: product, variant, avoidCustomerGroup, productCategory.```

This happens because `\Shopware\Bundle\SearchBundleDBAL\QueryBuilderFactory::createQuery` adds a join on `s_articles_details` with the alias `variants` and `\Shopware\Bundle\SearchBundleDBAL\ConditionHandler\CloseoutConditionHandler::generateCondition` also tries to join with that exact alias.

### 2. What does this change do, exactly?
I used an individual join alias in the condition handler (as that is more likely to not be in use) to prevent the collision.

An alternative solution would be to check if a join called `variant` is already present in the query builder and reuse that. Maybe a state can be introduced for that, like `\Shopware\Bundle\SearchBundleDBAL\ConditionHandler\SalesConditionHandler::STATE_INCLUDES_TOPSELLER_TABLE`. Please let me know if you prefer that solution. I wanted to fix the issue first and foremost. :-)

### 3. Describe each step to reproduce the issue or behaviour.
* Create a product stream and select the "Abverkauf-Filter"
* Create a category using that product stream
* Access the category in the shop frontend

### 4. Please link to the relevant issues (if any).
no issue

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.