### PR TITLE
Add smarty block around "back to shop" button

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -51,6 +51,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
     * Added new config parameters `write_backlog`, `enabled` and `backend` to `es` parameter
 * Added ability to translate shop forms
 * Added attributes to shop forms page
+* Added smarty block `frontend_register_index_back_to_shop_button` to `themes/Frontend/Bare/frontend/register/index.tpl`
 
 ### Changes
 

--- a/themes/Frontend/Bare/frontend/register/index.tpl
+++ b/themes/Frontend/Bare/frontend/register/index.tpl
@@ -13,14 +13,16 @@
 {* Back to the shop button *}
 {block name='frontend_index_logo_trusted_shops'}
     {$smarty.block.parent}
-    {if $theme.checkoutHeader && !$toAccount}
-        <a href="{url controller='index'}"
-           class="btn is--small btn--back-top-shop is--icon-left"
-           title="{"{s name='FinishButtonBackToShop' namespace='frontend/checkout/finish'}{/s}"|escape}">
-            <i class="icon--arrow-left"></i>
-            {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish"}{/s}
-        </a>
-    {/if}
+    {block name='frontend_register_index_back_to_shop_button'}
+        {if $theme.checkoutHeader && !$toAccount}
+            <a href="{url controller='index'}"
+               class="btn is--small btn--back-top-shop is--icon-left"
+               title="{"{s name='FinishButtonBackToShop' namespace='frontend/checkout/finish'}{/s}"|escape}">
+                <i class="icon--arrow-left"></i>
+                {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish"}{/s}
+            </a>
+        {/if}
+    {/block}
 {/block}
 
 {* Hide breadcrumb *}


### PR DESCRIPTION
### 1. Why is this change necessary?
Not a huge deal probably, but currently the "back to shop" button is appended to the block `frontend_index_logo_trusted_shops`, which means if you wanted to hide it, you'd have to hide the whole block. By default, the block is empty, but it might have been appended or edited, so I just feel that it would be a good idea to add an extra block here.

### 2. What does this change do, exactly?
Wrap the code for the "back to shop" button in a block `frontend_register_back_to_shop_button`.

### 3. Describe each step to reproduce the issue or behaviour.
-/-

### 4. Please link to the relevant issues (if any).
-/-

### 5. Which documentation changes (if any) need to be made because of this PR?
-/-

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.