### PR TITLE
Use the Minimum search term length for the Ajax Search

### DIFF
--- a/themes/Frontend/Bare/frontend/index/shop-navigation.tpl
+++ b/themes/Frontend/Bare/frontend/index/shop-navigation.tpl
@@ -12,7 +12,7 @@
 
         {* Search form *}
         {block name='frontend_index_search'}
-            <li class="navigation--entry entry--search" role="menuitem" data-search="true" aria-haspopup="true"{if $theme.focusSearch && {controllerName|lower} == 'index'} data-activeOnStart="true"{/if}>
+            <li class="navigation--entry entry--search" role="menuitem" data-search="true" aria-haspopup="true"{if $theme.focusSearch && {controllerName|lower} == 'index'} data-activeOnStart="true"{/if} data-minLength="{config name="MinSearchLenght"}">
                 <a class="btn entry--link entry--trigger" href="#show-hide--search" title="{"{s namespace='frontend/index/search' name="IndexTitleSearchToggle"}{/s}"|escape}">
                     <i class="icon--search"></i>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
ATM. You can set the minimum search term length in the backend but this value is not used for the Ajax search.

### 2. What does this change do, exactly?
It adds the config value (MinSearchLenght) for the minimum search term length to the Ajax search using data-minLength in the  `shop-navigation.tpl`

### 3. Describe each step to reproduce the issue or behaviour.
Set the "Configuration > Basic settings > Frontend > Search > Maximum search term length"
Without this commit the the default value '3' will be used and the Ajax search starts with 3 characters.

With this commit the value from the config will be used to trigger the Ajax search.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.