### PR TITLE
Updated URL & removed 'Jira' from title

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For more information about contributing to Shopware, please see [CONTRIBUTING.md
 
 We've always had a sympathetic ear for our community, so please feel free to submit tickets with bug reports or feature requests. In order to have a single issue tracking tool, we've decided to close the GitHub issue panel in favor of our Jira issue tracker, which is directly connected to our development division.
 
-* [Shopware Jira ticket submit form](https://issues.shopware.com)
+* [Shopware ticket submit form](https://issues.shopware.com/createissue)
 
 # Copying / License
 


### PR DESCRIPTION
### 1. Why is this change necessary?
SWAG does not use Jira for public issue tracking anymore

### 2. What does this change do, exactly?
Changes link title and adds /createissue to URL
