### PR TITLE
Add arguments to SEO rebuild event

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -51,6 +51,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
     * Added new config parameters `write_backlog`, `enabled` and `backend` to `es` parameter
 * Added ability to translate shop forms
 * Added attributes to shop forms page
+* Added the following arguments to `notify` event `Shopware_CronJob_RefreshSeoIndex_CreateRewriteTable`: `shopContext` – The context of the shop being processed; `cachedTime` – `\DateTime` instance used for the new entries
 
 ### Changes
 

--- a/engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php
@@ -180,7 +180,13 @@ class Shopware_Plugins_Core_RebuildIndex_Bootstrap extends Shopware_Components_P
             $this->RewriteTable()->createManufacturerUrls($context);
             $this->RewriteTable()->sCreateRewriteTableStatic();
 
-            Shopware()->Events()->notify('Shopware_CronJob_RefreshSeoIndex_CreateRewriteTable');
+            Shopware()->Events()->notify(
+                'Shopware_CronJob_RefreshSeoIndex_CreateRewriteTable',
+                [
+                    'shopContext' => $context,
+                    'cachedTime' => $currentTime,
+                ]
+            );
         }
 
         return true;


### PR DESCRIPTION
Found by @maltepeters

### 1. Why is this change necessary?
`Shopware_CronJob_RefreshSeoIndex_CreateRewriteTable` is called for every shop. But currently, the event does not provide a way to identify which shop it is being called for. 

### 2. What does this change do, exactly?
It adds two event arguments to `Shopware_CronJob_RefreshSeoIndex_CreateRewriteTable`: a `ShopContext`-Instance for the shop being processed and the `\DateTime`-instance created at the start of the process to allow for consistency in the database.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.