### PR TITLE
Hide password from session

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Register.php
+++ b/engine/Shopware/Controllers/Frontend/Register.php
@@ -178,6 +178,7 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
         unset($data['register']['personal']['password']);
         unset($data['register']['personal']['passwordConfirmation']);
         unset($data['register']['billing']['password']);
+        unset($data['register']['billing']['passwordConfirmation']);
 
         $this->writeSession($data, $customer);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

When the "password must be entered twice" option is active, the password confirmation string is exposed as clear text in the session data.

### 2. What does this change do, exactly?

Unset sensitive information before it is written to session.

### 3. Describe each step to reproduce the issue or behaviour.

Activate the "password must be entered twice option", register as new customer, verify password string in session data.

### 4. Please link to the relevant issues (if any).

n.a.

### 5. Which documentation changes (if any) need to be made because of this PR?

n.a.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.