### PR TITLE
IMP allow to set a PropertyValues relations position via api

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -1810,6 +1810,17 @@ class Article extends Resource implements BatchInterface
                 if (isset($valueData['position'])) {
                     $value->setPosition($valueData['position']);
                 }
+                if (isset($valueData['relationPosition'])) {
+                    // Relation positions controls the order of property values if the group is configured for position
+                    $filters = [
+                        ['property' => 'options.id', 'expression' => '=', 'value' => $value->getOption()->getId()],
+                        ['property' => 'groups.id', 'expression' => '=', 'value' => $propertyGroup->getId()],
+                    ];
+                    $query = $propertyRepository->getPropertyRelationQuery($filters, null, 1, 0);
+                    /** @var \Shopware\Models\Property\Relation $relation */
+                    $relation = $query->getOneOrNullResult(self::HYDRATE_OBJECT);
+                    $relation->setPosition($valueData['relationPosition']);
+                }
                 $this->getManager()->persist($value);
             } else {
                 throw new ApiException\CustomValidationException('Name or id for property value required');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
To control the order of property values, it is necessary to set the position attribute of the values related \Shopware\Models\Property\Relation 

### 2. What does this change do, exactly?
It introduces a new field to API resource **PropertyValue** named _relationPosition_ , which will be used to set the relations position when creating or updating propertyValues via the articles API.

### 3. Describe each step to reproduce the issue or behaviour.
There is no possibility to control the order of property values before this feature.

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
https://developers.shopware.com/developers-guide/rest-api/models/#property-value
Documentation of property value needs to be extended

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 7. TODO (Sorry, it was to complicated to me, because I'm new to shopware)
The field _relationPosition_ should also be returned inside  **PropertyValue** by a GET request to articles API.