### PR TITLE
Add number range for doc_3/storno bill

### DIFF
--- a/_sql/demo/latest.sql
+++ b/_sql/demo/latest.sql
@@ -7925,7 +7925,8 @@ INSERT INTO `s_order_number` (`id`, `number`, `name`, `desc`) VALUES
 (925, 10001, 'articleordernumber', 'Artikelbestellnummer  '),
 (926, 10000, 'sSERVICE1', 'Service - 1'),
 (927, 10000, 'sSERVICE2', 'Service - 2'),
-(928, 110, 'blogordernumber', 'Blog - ID');
+(928, 110, 'blogordernumber', 'Blog - ID'),
+(929, 20000, 'doc_3', 'Stornorechnungen');
 
 TRUNCATE TABLE `s_order_shippingaddress`;
 INSERT INTO `s_order_shippingaddress` (`id`, `userID`, `orderID`, `company`, `department`, `salutation`, `firstname`, `lastname`, `street`, `zipcode`, `city`, `countryID`, `stateID`) VALUES

--- a/_sql/install/latest.sql
+++ b/_sql/install/latest.sql
@@ -5635,7 +5635,8 @@ INSERT INTO `s_order_number` (`id`, `number`, `name`, `desc`) VALUES
 (925, 10000, 'articleordernumber', 'Artikelbestellnummer  '),
 (926, 10000, 'sSERVICE1', 'Service - 1'),
 (927, 10000, 'sSERVICE2', 'Service - 2'),
-(928, 110, 'blogordernumber', 'Blog - ID');
+(928, 110, 'blogordernumber', 'Blog - ID'),
+(929, 20000, 'doc_3', 'Stornorechnungen');
 
 -- --------------------------------------------------------
 

--- a/recovery/install/data/sql/en.sql
+++ b/recovery/install/data/sql/en.sql
@@ -1705,6 +1705,7 @@ UPDATE s_order_number SET `desc` = 'Packing list' WHERE id = 921;
 UPDATE s_order_number SET `desc` = 'Credits' WHERE id = 922;
 UPDATE s_order_number SET `desc` = 'Invoices' WHERE id = 924;
 UPDATE s_order_number SET `desc` = 'Article order number' WHERE id = 925;
+UPDATE s_order_number SET `desc` = 'Storno bill' WHERE id = 929;
 
 -- s_crontab --
 UPDATE s_crontab SET `name` = 'Birthday wishes' WHERE id = 1;


### PR DESCRIPTION
### 1. Why is this change necessary?
Add default number range for storno bills as this is lacking right now. Therefore storno bills title read _"Reversal invoice for invoice No. "_.

### 2. What does this change do, exactly?
Add entry to s_order_number table to have a concrete number range for storno bills

### 3. Describe each step to reproduce the issue or behaviour.
Without this PR create a storno bill and you will see that the created document has no number range (therefore name _0.pdf_) and inside the document is the addressed title without a number.
With an added number range index the functionality can find a valid number.

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/1561 Addressing same issue but with migration instead

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.