### PR TITLE
Add number range for doc_3/storno bill

### DIFF
--- a/_sql/migrations/1214-add-stornobill-numberrange.php
+++ b/_sql/migrations/1214-add-stornobill-numberrange.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration1214 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSQL('INSERT INTO `s_order_number`(`number`, `name`, `desc`) VALUES (20000, "doc_3", "Stornorechnungen")');
+    }
+}

--- a/_sql/migrations/1214-add-stornobill-numberrange.php
+++ b/_sql/migrations/1214-add-stornobill-numberrange.php
@@ -26,6 +26,6 @@ class Migrations_Migration1214 extends Shopware\Components\Migrations\AbstractMi
 {
     public function up($modus)
     {
-        $this->addSQL('INSERT INTO `s_order_number`(`number`, `name`, `desc`) VALUES (20000, "doc_3", "Stornorechnungen")');
+        $this->addSQL('INSERT IGNORE INTO `s_order_number`(`number`, `name`, `desc`) VALUES (20000, "doc_3", "Stornorechnungen")');
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Add default number range for storno bills as this is lacking right now. Therefore storno bills title read _"Reversal invoice for invoice No. "_.

### 2. What does this change do, exactly?
Add entry to s_order_number table to have a concrete number range for storno bills

### 3. Describe each step to reproduce the issue or behaviour.
Without this PR create a storno bill and you will see that the created document has no number range (therefore name _0.pdf_) and inside the document is the addressed title without a number.
With an added number range index the functionality can find a valid number.

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/1560 This PR does basically the same as the referenced PR just using migrations instead of direct editing the install sql.

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.