### PR TITLE
Set Retry-After-Header for serviceAction

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Error.php
+++ b/engine/Shopware/Controllers/Frontend/Error.php
@@ -196,6 +196,7 @@ class Shopware_Controllers_Frontend_Error extends Enlight_Controller_Action impl
     public function serviceAction()
     {
         $this->Response()->setHttpResponseCode(503);
+        $this->Response()->setHeader('Retry-After', 1800);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
If a shout is set in maintenance, HTTP-Code 503 will be send. But there is missing a Retry-After. This results unwanted errors f.e. in Google Search Console.
https://webmasters.googleblog.com/2011/01/how-to-deal-with-planned-site-downtime.html

### 2. What does this change do, exactly?
Adding Header Retry-After: 1800 (seconds)

### 3. Describe each step to reproduce the issue or behaviour.
- Register Shop in "Google Search Console"
- Wait some days until google indexed some pages
- Set Shop in maintenance-mode for 1 hour
- after a few days "Search Console" reports errors while indexing links, causing 503 errors with no "Retry-After-Header"

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.