### PR TITLE
remove w3c errors

### DIFF
--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/tap-highlight-color.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/tap-highlight-color.less
@@ -13,8 +13,4 @@ Please refer to <http://www.browsersupport.net/CSS/-webkit-tap-highlight-color> 
 
 .tap-highlight-color(@color: rgba(0, 0, 0, 0)) {
     -webkit-tap-highlight-color: @color;
-    /*
-    Likely in future implemented in browsers:
-    tap-highlight-color: @color;
-    */
 }

--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/tap-highlight-color.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/tap-highlight-color.less
@@ -13,5 +13,8 @@ Please refer to <http://www.browsersupport.net/CSS/-webkit-tap-highlight-color> 
 
 .tap-highlight-color(@color: rgba(0, 0, 0, 0)) {
     -webkit-tap-highlight-color: @color;
+    /*
+    Likely in future implemented in browsers:
     tap-highlight-color: @color;
+    */
 }

--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/user-select.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/user-select.less
@@ -13,8 +13,5 @@ Please refer to <http://caniuse.com/user-select-none> to see the browser support
 
 .user-select(@type: none) {
 	-webkit-user-select: @type;
-	/*
-	Likely in future implemented in browsers:
 	user-select: @type;
-	*/
 }

--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/user-select.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/user-select.less
@@ -13,5 +13,8 @@ Please refer to <http://caniuse.com/user-select-none> to see the browser support
 
 .user-select(@type: none) {
 	-webkit-user-select: @type;
+	/*
+	Likely in future implemented in browsers:
 	user-select: @type;
+	*/
 }

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/address.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/address.less
@@ -6,7 +6,6 @@ Defines the styles for the address pages and the modals.
 .address-manager--modal {
 
     .header > .title {
-        .unitize(padding-left, 2%);
         padding-left: 2%;
     }
 

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/main-navigation.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/main-navigation.less
@@ -33,7 +33,7 @@ It contains the viewport specific styles inside media queries.
 		}
 
 		.navigation--link {
-            .transition(none 0);
+            .transition(none);
 			.unitize-padding(8, 14);
             .unitize(font-size, 16);
 			.border-radius-multi(3px, 3px, 0, 0);


### PR DESCRIPTION
### 1. Why is this change necessary?
There are unnessary errors in w3c: http://jigsaw.w3.org/css-validator/
Just a small fix. 

### 2. What does this change do, exactly?
".unitize(padding-left, 2%);" in address.less is a wrong definition. it results: padding-left: 2%px; padding-left: 0.125%rem;
"touch-callout" doesn't exist, so it has been removed
"tap-highlight-color" doesn't exist, so it has been removed
0 of ".transition(none 0);" is wrong

### 3. Describe each step to reproduce the issue or behaviour.
submit shopware-css to w3c-css-validator

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.