### PR TITLE
Fix creating duplicate item export entries when running cached export

### DIFF
--- a/engine/Shopware/Controllers/Backend/Export.php
+++ b/engine/Shopware/Controllers/Backend/Export.php
@@ -61,8 +61,10 @@ class Shopware_Controllers_Backend_Export extends Enlight_Controller_Action impl
     {
         $this->prepareExport();
         $this->sendHeaders();
-
-        $productFeed = Shopware()->Models()->getRepository('\Shopware\Models\ProductFeed\ProductFeed')->find((int) $this->Request()->feedID);
+        /** @var \Shopware\Components\Model\ModelManager $em */
+        $em = $this->container->get('models');
+        /** @var \Shopware\Models\ProductFeed\ProductFeed $productFeed */
+        $productFeed = $em->getRepository('\Shopware\Models\ProductFeed\ProductFeed')->find((int) $this->Request()->feedID);
 
         // Live generation
         if ($productFeed->getInterval() === 0) {
@@ -91,8 +93,9 @@ class Shopware_Controllers_Backend_Export extends Enlight_Controller_Action impl
 
             // update last refresh
             $productFeed->setCacheRefreshed('now');
-            Shopware()->Models()->persist($productFeed);
-            Shopware()->Models()->flush($productFeed);
+            $productFeed->setLastExport('now');
+            $productFeed = $em->merge($productFeed);
+            $em->flush($productFeed);
         }
 
         if (!file_exists($filePath)) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Stop creating duplicate entries in s_export

### 2. What does this change do, exactly?
After calling `$this->generateExport($filePath);` the `$productFeed` becomes detached entity.
`$productFeed = $em->merge($productFeed);` attaches it back to the Entity Manager.
`$productFeed->setLastExport('now');` sets last_export which would be overridden after calling `EntityManager::merge()`

Singleton `Shopware()->Models()` is refactored to `$em = $this->container->get('models');`

### 3. Describe each step to reproduce the issue or behaviour.
Create an item export with Caching interval set to anyhing other than "Live" and "Only cron". Run the export, it will crate a duplicate entry in s_export table

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.