### PR TITLE
AddVoucher restriction error

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -242,7 +242,7 @@ class sBasket
         }
 
         $extraConditions = [];
-        if (is_array($articles)) {
+        if (is_array($articles) && !empty($articles)) {
             $extraConditions[] = $this->db->quoteInto('ordernumber IN (?) ', $articles);
         }
         if (!empty($supplier)) {


### PR DESCRIPTION
If clause only checks if is_array but not if it is empty or not - leads to Fatal Error and should be fixed.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Leads to fatal error:

`
Fatal error: Uncaught PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ') OR s_articles.supplierID = '38' ) GROUP BY sessionID' at line 6 in /var/www/shopware/engine/Library/Zend/Db/Statement/Pdo.php:219 Stack trace: #0 /var/www/shopware/engine/Library/Zend/Db/Statement/Pdo.php(219): PDOStatement->execute(Array) #1 /var/www/shopware/engine/Library/Zend/Db/Statement.php(297): Zend_Db_Statement_Pdo->_execute(Array) #2 /var/www/shopware/engine/Library/Zend/Db/Adapter/Abstract.php(470): Zend_Db_Statement->execute(Array) #3 /var/www/shopware/engine/Library/Zend/Db/Adapter/Pdo/Abstract.php(232): Zend_Db_Adapter_Abstract->query('SELECT SUM(quan...', Array) #4 /var/www/shopware/engine/Library/Enlight/Components/Db/Adapter/Pdo/Mysql.php(96): Zend_Db_Adapter_Pdo_Abstract->query('SELECT SUM(quan...', Array) #5 /var/www/shopware/engine/Library/Zend/Db/Adapter/Ab in /var/www/shopware/engine/Library/Zend/Db/Statement/Pdo.php on line 224`

### 2. What does this change do, exactly?
It checks if the array is empty - if so it does not add the line 'ordernumber IN (X)'


### 3. Describe each step to reproduce the issue or behaviour.
Add a voucher with manufacturer and without article limitation.

### 4. Please link to the relevant issues (if any).
I checked, already fixed in 5.4 but should def. be fixed and pulled into newest 5.3.x Version

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.