### PR TITLE
Added defaultValue handling in attributes

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
@@ -332,6 +332,7 @@ class CrudService
             'tableName' => $table,
             'columnName' => $column,
             'columnType' => $unifiedType,
+            'defaultValue' => $defaultValue,
         ]);
 
         $configId = null;

--- a/themes/Backend/ExtJs/backend/base/attribute/Shopware.attribute.Form.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/Shopware.attribute.Form.js
@@ -191,7 +191,7 @@ Ext.define('Shopware.attribute.Form', {
 
         Ext.each(fields.items, function(field) {
             try {
-                field.setValue(null);
+                field.setValue(typeof field.defaultValue === 'undefined' ? null : field.defaultValue);
             } catch (e) {
             }
         });

--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.BooleanFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.BooleanFieldHandler.js
@@ -31,13 +31,19 @@ Ext.define('Shopware.attribute.BooleanFieldHandler', {
     extend: 'Shopware.attribute.FieldHandlerInterface',
 
     supports: function(attribute) {
-        return (attribute.get('columnType') == 'boolean');
+        return (attribute.get('columnType') === 'boolean');
     },
 
     create: function(field, attribute) {
         field.xtype = 'checkbox';
         field.uncheckedValue = 0;
         field.inputValue = 1;
+
+        if (attribute.get('defaultValue') !== null) {
+            field.checked = parseInt(attribute.get('defaultValue')) === 1;
+            field.defaultValue = field.checked;
+        }
+
         return field;
     }
 });

--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.FloatFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.FloatFieldHandler.js
@@ -31,12 +31,18 @@ Ext.define('Shopware.attribute.FloatFieldHandler', {
     extend: 'Shopware.attribute.FieldHandlerInterface',
 
     supports: function(attribute) {
-        return (attribute.get('columnType') == 'float');
+        return (attribute.get('columnType') === 'float');
     },
 
     create: function(field, attribute) {
         field.xtype = 'numberfield';
         field.align = 'right';
+
+        if (attribute.get('defaultValue') !== null) {
+            field.value = parseFloat(attribute.get('defaultValue'));
+            field.defaultValue = field.value;
+        }
+
         return field;
     }
 });

--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.HtmlFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.HtmlFieldHandler.js
@@ -37,12 +37,6 @@ Ext.define('Shopware.attribute.HtmlFieldHandler', {
     create: function(field, attribute) {
         field.xtype = 'tinymce';
         field.height = 150;
-
-        if (attribute.get('defaultValue') !== null) {
-            field.value = attribute.get('defaultValue');
-            field.defaultValue = field.value;
-        }
-
         return field;
     }
 });

--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.HtmlFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.HtmlFieldHandler.js
@@ -31,12 +31,18 @@ Ext.define('Shopware.attribute.HtmlFieldHandler', {
     extend: 'Shopware.attribute.FieldHandlerInterface',
 
     supports: function(attribute) {
-        return (attribute.get('columnType') == 'html');
+        return (attribute.get('columnType') === 'html');
     },
 
     create: function(field, attribute) {
         field.xtype = 'tinymce';
         field.height = 150;
+
+        if (attribute.get('defaultValue') !== null) {
+            field.value = attribute.get('defaultValue');
+            field.defaultValue = field.value;
+        }
+
         return field;
     }
 });

--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.IntegerFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.IntegerFieldHandler.js
@@ -31,12 +31,18 @@ Ext.define('Shopware.attribute.IntegerFieldHandler', {
     extend: 'Shopware.attribute.FieldHandlerInterface',
 
     supports: function(attribute) {
-        return (attribute.get('columnType') == 'integer');
+        return (attribute.get('columnType') === 'integer');
     },
 
     create: function(field, attribute) {
         field.xtype = 'numberfield';
         field.align = 'right';
+
+        if (attribute.get('defaultValue') !== null) {
+            field.value = parseInt(attribute.get('defaultValue'));
+            field.defaultValue = field.value;
+        }
+
         return field;
     }
 });

--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.StringFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.StringFieldHandler.js
@@ -36,12 +36,6 @@ Ext.define('Shopware.attribute.StringFieldHandler', {
 
     create: function(field, attribute) {
         field.xtype = 'textfield';
-
-        if (attribute.get('defaultValue') !== null) {
-            field.value = attribute.get('defaultValue');
-            field.defaultValue = field.value;
-        }
-
         return field;
     }
 });

--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.StringFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.StringFieldHandler.js
@@ -31,11 +31,17 @@ Ext.define('Shopware.attribute.StringFieldHandler', {
     extend: 'Shopware.attribute.FieldHandlerInterface',
 
     supports: function(attribute) {
-        return (attribute.get('columnType') == 'string');
+        return (attribute.get('columnType') === 'string');
     },
 
     create: function(field, attribute) {
         field.xtype = 'textfield';
+
+        if (attribute.get('defaultValue') !== null) {
+            field.value = attribute.get('defaultValue');
+            field.defaultValue = field.value;
+        }
+
         return field;
     }
 });

--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.TextAreaFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.TextAreaFieldHandler.js
@@ -37,12 +37,6 @@ Ext.define('Shopware.attribute.TextAreaFieldHandler', {
     create: function(field, attribute) {
         field.xtype = 'textarea';
         field.height = 90;
-
-        if (attribute.get('defaultValue') !== null) {
-            field.value = attribute.get('defaultValue');
-            field.defaultValue = field.value;
-        }
-
         return field;
     }
 });

--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.TextAreaFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.TextAreaFieldHandler.js
@@ -31,12 +31,18 @@ Ext.define('Shopware.attribute.TextAreaFieldHandler', {
     extend: 'Shopware.attribute.FieldHandlerInterface',
 
     supports: function(attribute) {
-        return (attribute.get('columnType') == 'text');
+        return (attribute.get('columnType') === 'text');
     },
 
     create: function(field, attribute) {
         field.xtype = 'textarea';
         field.height = 90;
+
+        if (attribute.get('defaultValue') !== null) {
+            field.value = attribute.get('defaultValue');
+            field.defaultValue = field.value;
+        }
+
         return field;
     }
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
Respecting default values on created fields

### 2. What does this change do, exactly?
Uses the defaultValue field in backend 😊 

### 3. Describe each step to reproduce the issue or behaviour.
```php
 foreach ($this->container->getParameter('shopware_attribute.table_entity_mapping') as $table => $item) {
            $this->container->get('shopware_attribute.crud_service')->update($table, 'test', TypeMapping::TYPE_BOOLEAN, [
                'displayInBackend' => true,
                'label' => 'LOL'
            ], null, false, true);

            $this->container->get('shopware_attribute.crud_service')->update($table, 'test2', TypeMapping::TYPE_STRING, [
                'displayInBackend' => true,
                'label' => 'LOL TEXT'
            ], null, false, 'Hi i am a Text');

            $this->container->get('shopware_attribute.crud_service')->update($table, 'test3', TypeMapping::TYPE_INTEGER, [
                'displayInBackend' => true,
                'label' => 'LOL INT'
            ], null, false, 1);

            $this->container->get('shopware_attribute.crud_service')->update($table, 'test4', TypeMapping::TYPE_FLOAT, [
                'displayInBackend' => true,
                'label' => 'LOL FLOAT'
            ], null, false, 1.5);

            $this->container->get('shopware_attribute.crud_service')->update($table, 'test5', TypeMapping::TYPE_HTML, [
                'displayInBackend' => true,
                'label' => 'LOL HTML'
            ], null, false, '<h1>Hii i am html</h1>');

            $this->container->get('shopware_attribute.crud_service')->update($table, 'test6', TypeMapping::TYPE_TEXT, [
                'displayInBackend' => true,
                'label' => 'LOL TEXTAREA'
            ], null, false, 'AREAA');
        }
```

![Image](https://i.imgur.com/JwsqEGi.png)

### 4. Please link to the relevant issues (if any).
#1165 

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.