### PR TITLE
Set default selected for Variant with one item in stock

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -871,6 +871,12 @@ class LegacyStructConverter
             $groupData = $this->convertConfiguratorGroupStruct($group);
 
             $options = [];
+            $activeOptions = 0;
+            foreach ($group->getOptions() as $option) {
+                if ($option->getActive()) {
+                    $activeOptions++;
+                }
+            }
             foreach ($group->getOptions() as $option) {
                 $optionData = $this->convertConfiguratorOptionStruct(
                     $group,
@@ -881,7 +887,12 @@ class LegacyStructConverter
                     $groupData['selected_value'] = $option->getId();
                 }
 
+
                 $options[$option->getId()] = $optionData;
+                if ($option->getActive() && $activeOptions == 1) {
+                    $groupData['selected_value'] = $option->getId();
+                    $options[$option->getId()]['selected'] = true;
+                }
             }
 
             $groupData['values'] = $options;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
User friendlier in the frontend

### 2. What does this change do, exactly?
When an Item with Variants only has 1 item in Stock set it to be the default Selected

### 3. Describe each step to reproduce the issue or behaviour.
n/a

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
n/a

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.