### PR TITLE
Hide reference price if referenceUnit = 0

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/block_price.tpl
+++ b/themes/Frontend/Bare/frontend/detail/block_price.tpl
@@ -4,7 +4,7 @@
         {* @deprecated *}
         {block name='frontend_detail_data_block_prices_headline'}{/block}
 
-        {$hasReferencePrice = ($sArticle.referenceprice > 0)}
+        {$hasReferencePrice = ($sArticle.referenceprice > 0 && $sArticle.referenceunit)}
 
         {block name="frontend_detail_data_block_prices_table"}
             <table class="block-prices--table">
@@ -65,7 +65,7 @@
                                                         {$blockPrice.price|currency} {s name="Star" namespace="frontend/listing/box_article"}{/s}
                                                     </td>
                                                 {/block}
-                                                {if $hasReferencePrice && $sArticle.referenceunit }
+                                                {if $hasReferencePrice }
                                                     {block name="frontend_detail_data_block_prices_table_body_cell_reference_price"}
                                                         <td class="block-prices--cell">
                                                             {$blockPrice.referenceprice|currency}

--- a/themes/Frontend/Bare/frontend/detail/block_price.tpl
+++ b/themes/Frontend/Bare/frontend/detail/block_price.tpl
@@ -65,7 +65,7 @@
                                                         {$blockPrice.price|currency} {s name="Star" namespace="frontend/listing/box_article"}{/s}
                                                     </td>
                                                 {/block}
-                                                {if $hasReferencePrice}
+                                                {if $hasReferencePrice && $sArticle.referenceunit }
                                                     {block name="frontend_detail_data_block_prices_table_body_cell_reference_price"}
                                                         <td class="block-prices--cell">
                                                             {$blockPrice.referenceprice|currency}

--- a/themes/Frontend/Bare/frontend/detail/data.tpl
+++ b/themes/Frontend/Bare/frontend/detail/data.tpl
@@ -81,7 +81,7 @@
                 {/block}
 
                 {* Unit price is based on a reference unit *}
-                {if $sArticle.purchaseunit && $sArticle.purchaseunit != $sArticle.referenceunit}
+                {if $sArticle.purchaseunit && $sArticle.referenceunit && $sArticle.purchaseunit != $sArticle.referenceunit}
 
                     {* Reference unit price content *}
                     {block name='frontend_detail_data_price_unit_reference_content'}

--- a/themes/Frontend/Bare/frontend/listing/product-box/product-price-unit.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/product-price-unit.tpl
@@ -21,7 +21,7 @@
     {/if}
 
     {* Unit price is based on a reference unit *}
-    {if $sArticle.purchaseunit && $sArticle.purchaseunit != $sArticle.referenceunit}
+    {if $sArticle.purchaseunit && $sArticle.referenceunit && $sArticle.purchaseunit != $sArticle.referenceunit}
 
         {* Reference unit price content *}
         {block name='frontend_listing_box_article_unit_reference_content'}


### PR DESCRIPTION
### 1. Why is this change necessary?
Without this PR price calculations per unit result in 0,00/unit prices.

### 2. What does this change do, exactly?
Add check to check if sArticle.referenceunit is defined if not hide those calculations.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create/edit an article to have purchaseunit set to 1 (or anything other) but leave referenceunit empty.
2. Load up articles detail page on frontend
3. Without this PR it will state something like _1 piece (0.00€ / 1 piece)_ below the price. With this PR this infobox won't show up.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.