### PR TITLE
Added basketId to sExport shipping

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -1399,6 +1399,7 @@ class sExport
                 , b.articleID
             FROM (
                 SELECT
+                    NULL as id,
                     NULL as sessionID,
                     ? as articleID,
                     ? as ordernumber,


### PR DESCRIPTION
### 1. Why is this change necessary?
We have used the basket id in custom shipping calculation and now the product feed exports to google broken, because the id is not defined

### 2. What does this change do, exactly?
Adds id as null

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.