### PR TITLE
Require search terms keywords to have a minimum length to be indexed

### DIFF
--- a/_sql/migrations/1448-add-minsearch-index-length.php
+++ b/_sql/migrations/1448-add-minsearch-index-length.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+use Shopware\Components\Migrations\AbstractMigration;
+
+class Migrations_Migration1448 extends AbstractMigration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function up($modus)
+    {
+        $sql = <<<SQL
+INSERT INTO `s_core_config_elements` (`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`, `options`)
+VALUES
+	((SELECT form.id FROM s_core_config_elements element JOIN s_core_config_forms form ON form.id = element.`form_id` WHERE form.`name` = "Search" AND element.name = "minsearchlenght" LIMIT 1), 'minSearchIndexLength', 's:1:\"0\";', 'Minimale Suchwortlänge', NULL, 'text', 0, 0, 0, NULL);
+
+SQL;
+
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/TermHelper.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/TermHelper.php
@@ -124,7 +124,7 @@ class TermHelper implements TermHelperInterface
         $result = [];
 
         foreach ($words as $word) {
-            if ($this->filterBadWordFromString($word)) {
+            if (strlen($word) >= $this->config->get('minSearchIndexLength') && $this->filterBadWordFromString($word)) {
                 $result[] = $word;
             }
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
We realised that (especially with SwagFuzzy search enabled) our search results were quite bad as the indexed keywords often contained only 1 or 2 characters and therefore produced bad alternatives or even worse ranked high as partial matches.
By reusing the already in place term min length config to filter search terms we could improve drastically the results as false positives got minimised a lot.

### 2. What does this change do, exactly?
The PR extends the filter mechanism of the _TermHelper_'s _filterBadWordsFromString_ to also filter out terms that are shorter than the value in _minsearchlenght_ (that typo is already in Shopware sometime and would require its own PR). Those then won't turn up in s_search_keywords.
This approach is quite bruteforce but with default settings (min 3 chars) still very effective versus a hand made list of all _badwords_ which will miss most cases.

### 3. Describe each step to reproduce the issue or behaviour.
Check your s_search_keywords table without this PR and you might see lots of 2 digits numbers or english words etc. that aren't part of your _badwords_ list.
After truncating your keyword index and rebuilding it with this PR in place those low quality keywords should be history.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
As this PR reuses _minsearchlenght_ the description of this field should mentions this functionality.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.