### PR TITLE
Fix typo

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Shop.php
+++ b/engine/Shopware/Components/Api/Resource/Shop.php
@@ -216,7 +216,7 @@ class Shop extends Resource
                 }
             } else {
                 if (isset($params[$param]) && empty($params[$param])) {
-                    throw new \Exception('param $param may not be empty');
+                    throw new \Exception("param $param may not be empty");
                 }
             }
         }

--- a/engine/Shopware/Components/Api/Resource/Shop.php
+++ b/engine/Shopware/Components/Api/Resource/Shop.php
@@ -72,7 +72,7 @@ class Shop extends Resource
         $shop = $query->getOneOrNullResult($this->getResultMode());
 
         if (!$shop) {
-            throw new ApiException\NotFoundException("Shop by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Shop by id %s not found', $id));
         }
 
         return $shop;
@@ -161,7 +161,7 @@ class Shop extends Resource
         $shop = $this->getRepository()->find($id);
 
         if (!$shop) {
-            throw new ApiException\NotFoundException("Shop by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Shop by id %s not found', $id));
         }
 
         $params = $this->prepareShopData($params, $shop);
@@ -197,7 +197,7 @@ class Shop extends Resource
         $shop = $this->getRepository()->find($id);
 
         if (!$shop) {
-            throw new ApiException\NotFoundException("Shop by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Shop by id %s not found', $id));
         }
 
         $this->getManager()->remove($shop);
@@ -216,7 +216,7 @@ class Shop extends Resource
                 }
             } else {
                 if (isset($params[$param]) && empty($params[$param])) {
-                    throw new \Exception("param $param may not be empty");
+                    throw new \Exception(sprintf('param %s may not be empty', $param));
                 }
             }
         }
@@ -226,7 +226,7 @@ class Shop extends Resource
             if ($currency !== null) {
                 $params['currency'] = $currency;
             } else {
-                throw new \Exception("{$params['currencyId']} is not a valid currency id");
+                throw new \Exception(sprintf('%s is not a valid currency id', $params['currencyId']));
             }
         }
 
@@ -235,7 +235,7 @@ class Shop extends Resource
             if ($locale !== null) {
                 $params['locale'] = $locale;
             } else {
-                throw new \Exception("{$params['localeId']} is not a valid locale id");
+                throw new \Exception(sprintf('%s is not a valid locale id', $params['localeId']));
             }
         }
 
@@ -244,7 +244,7 @@ class Shop extends Resource
             if ($customerGroup !== null) {
                 $params['customerGroup'] = $customerGroup;
             } else {
-                throw new \Exception("{$params['customerGroupId']} is not a valid customerGroup id");
+                throw new \Exception(sprintf('%s is not a valid customerGroup id', $params['customerGroupId']));
             }
         }
 
@@ -253,7 +253,7 @@ class Shop extends Resource
             if ($shop !== null) {
                 $params['main'] = $shop;
             } else {
-                throw new \Exception("{$params['mainId']} is not a valid shop id");
+                throw new \Exception(sprintf('%s is not a valid shop id', $params['mainId']));
             }
         }
 
@@ -262,7 +262,7 @@ class Shop extends Resource
             if ($template !== null) {
                 $params['template'] = $template;
             } else {
-                throw new \Exception("{$params['templateId']} is not a valid template id");
+                throw new \Exception(sprintf('%s is not a valid template id', $params['templateId']));
             }
         }
 
@@ -271,7 +271,7 @@ class Shop extends Resource
             if ($template !== null) {
                 $params['documentTemplate'] = $template;
             } else {
-                throw new \Exception("{$params['documentTemplateId']} is not a valid template id");
+                throw new \Exception(sprintf('%s is not a valid template id', $params['documentTemplateId']));
             }
         }
 
@@ -280,7 +280,7 @@ class Shop extends Resource
             if ($category !== null) {
                 $params['category'] = $category;
             } else {
-                throw new \Exception("{$params['categoryId']} is not a valid category id");
+                throw new \Exception(sprintf('%s is not a valid category id', $params['categoryId']));
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
With `'` enclosed string doesn't expand variables

### 2. What does this change do, exactly?
Replace `'` with `"` in shop resource

### 3. Describe each step to reproduce the issue or behaviour.
Send invalid request to shop resource, like `{ "id": 1, "categoryId": 0 }`

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.