### PR TITLE
Set backend order navigation to 360px width

### DIFF
--- a/themes/Backend/ExtJs/backend/order/view/list/navigation.js
+++ b/themes/Backend/ExtJs/backend/order/view/list/navigation.js
@@ -64,7 +64,7 @@ Ext.define('Shopware.apps.Order.view.list.Navigation', {
      * Sets the width of the panel
      * @integer
      */
-    width:300,
+    width:360,
 
     /**
      * Initialed the info panel is collapsed


### PR DESCRIPTION
### 1. Why is this change necessary?
The navigation (sidebar left with filters) is too small, not all pagination buttons are visible

### 2. What does this change do, exactly?

### Currently
![](https://files.gitter.im/shopware/offtopic/5aGu/thumb/Shopware-5-2-27-_Rev-201707131430_---Backend-_c_-shopware-AG.png)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.