### PR TITLE
Added default table options for SchemaTool

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Db.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Db.php
@@ -103,6 +103,11 @@ class Db
         $options['user'] = $options['username'];
 
         unset($options['username'], $options['adapter']);
+        
+        $options['defaultTableOptions'] = [
+            'charset' => 'utf8',
+            'collate' => 'utf8_unicode_ci'
+        ];
 
         return DriverManager::getConnection($options, $config, $eventManager);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Doctrine should prefer defaultTableOptions instead of mysql server configuration

### 2. What does this change do, exactly?
Adds defaultTableOptions to Doctrine connection (https://symfony.com/doc/master/bundles/DoctrineBundle/configuration.html search for default_table_options)

### 3. Describe each step to reproduce the issue or behaviour.
There was many forum threads, with illegal mix of collates because incorrect collates between default shopware tables and generated using SchemaTool. I hope that fixes it.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.