### PR TITLE
Fix ProductSearchResult::__construct() error by Stream Listing

### DIFF
--- a/engine/Shopware/Controllers/Widgets/Listing.php
+++ b/engine/Shopware/Controllers/Widgets/Listing.php
@@ -430,7 +430,9 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
         return new ProductSearchResult(
             $result->getProducts(),
             $result->getTotalCount(),
-            $facetFilter->filter($result->getFacets(), $criteria)
+            $facetFilter->filter($result->getFacets(), $criteria),
+            $criteria,
+            $context
         );
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
because it breaks the listing streaming page by ajax request (listingCountAction)

### 2. What does this change do, exactly?
after this [Commit](https://github.com/shopware/shopware/commit/ae2c77c32b18b9c09d0715615c141f72776be408#diff-086d23a1c2e8dd882fbfb04c40b8926f) the `\Shopware\Bundle\SearchBundle\ProductSearchResult::__construct` requires now the used Criteria and ShopContext object.

you had this changed in 'engine/Shopware/Bundle/SearchBundle/ProductSearch.php' but not in 'engine/Shopware/Controllers/Widgets/Listing.php' exactly in **fetchStreamListing** line [430](https://github.com/shopware/shopware/blob/5.4/engine/Shopware/Controllers/Widgets/Listing.php#L430)

### 3. Describe each step to reproduce the issue or behaviour.
just add a product stream to a category then try to use the filter in the listing page this will fire the following error:

> Uncaught exception: Argument 4 passed to Shopware\Bundle\SearchBundle\ProductSearchResult::__construct() must be an instance of Shopware\Bundle\SearchBundle\Criteria, none given, called in ....../engine/Shopware/Controllers/Widgets/Listing.php on line xxxx

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
no

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.