### PR TITLE
Added external redirect to blog controller

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Blog.php
+++ b/engine/Shopware/Controllers/Frontend/Blog.php
@@ -232,6 +232,11 @@ class Shopware_Controllers_Frontend_Blog extends Enlight_Controller_Action
         }
 
         $categoryContent = Shopware()->Modules()->Categories()->sGetCategoryContent($categoryId);
+        
+        if (!empty($categoryContent['external'])) {
+            return $this->redirect($categoryContent['external'], array('code' => 301));
+        }
+        
         $assigningData = [
             'sBanner' => Shopware()->Modules()->Marketing()->sBanner($categoryId),
             'sBreadcrumb' => $this->getCategoryBreadcrumb($categoryId),

--- a/engine/Shopware/Controllers/Frontend/Blog.php
+++ b/engine/Shopware/Controllers/Frontend/Blog.php
@@ -234,7 +234,7 @@ class Shopware_Controllers_Frontend_Blog extends Enlight_Controller_Action
         $categoryContent = Shopware()->Modules()->Categories()->sGetCategoryContent($categoryId);
         
         if (!empty($categoryContent['external'])) {
-            return $this->redirect($categoryContent['external'], array('code' => 301));
+            return $this->redirect($categoryContent['external'], ['code' => 301]);
         }
         
         $assigningData = [


### PR DESCRIPTION
### 1. Why is this change necessary?
When a blog category has a external link, it does not redirect. This feature is missing in the Blog Controller 😄 

### 2. What does this change do, exactly?
Redirects to that page if external link is defined in the current category

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.