### PR TITLE
wrong param sort in sAdmin::sUpdateNewsletter

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -536,13 +536,13 @@ class sAdmin
     /**
      * Add or remove an email address from the mailing list
      *
-     * @param bool   $status   True if insert, false if remove
      * @param string $email    Email address
+     * @param bool   $status   True if insert, false if remove
      * @param bool   $customer If email address belongs to a customer
      *
      * @return bool If operation was successful
      */
-    public function sUpdateNewsletter($status, $email, $customer = false)
+    public function sUpdateNewsletter($email, $status, $customer = false)
     {
         if (!$status) {
             // Delete email address from database


### PR DESCRIPTION
### 1. Why is this change necessary?
In the controller frontend/newsletter will be called the method Shopware()->Modules()->Admin()->sNewsletterSubscription(Shopware()->System()->_POST['newsletter'], true);

The first parameter is the email, the second the status of the subscription.

But the sAdmin::sUpdateNewsletter has actually as first parameter the status and as the second parameter the email.
So it doesn't work correct.

### 2. What does this change do, exactly?
This change edit the sort of the parameter in sAdmin::sUpdateNewsletter to the wrong call.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [- ] I have written tests and verified that they fail without my change
- [x ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.