### PR TITLE
Bugfix wrong entity in from condition

### DIFF
--- a/engine/Shopware/Models/Site/Repository.php
+++ b/engine/Shopware/Models/Site/Repository.php
@@ -168,8 +168,8 @@ class Repository extends ModelRepository
     {
         $builder = $this->getEntityManager()->createQueryBuilder();
         $builder->select(['attribute'])
-                      ->from(\Shopware\Models\Site\Site::class, 'attribute')
-                      ->where('attribute.cmsStaticID = ?1')
+                      ->from('Shopware\Models\Attribute\Site', 'attribute')
+                      ->where('attribute.siteId = ?1')
                       ->setParameter(1, $siteId);
 
         return $builder;

--- a/engine/Shopware/Models/Site/Repository.php
+++ b/engine/Shopware/Models/Site/Repository.php
@@ -169,7 +169,7 @@ class Repository extends ModelRepository
         $builder = $this->getEntityManager()->createQueryBuilder();
         $builder->select(['attribute'])
                       ->from(\Shopware\Models\Site\Site::class, 'attribute')
-                      ->where('attribute.siteId = ?1')
+                      ->where('attribute.cmsStaticID = ?1')
                       ->setParameter(1, $siteId);
 
         return $builder;


### PR DESCRIPTION
### 1. Why is this change necessary?
Because there is an error that Shopware\Models\Site\Site model does not have a field "siteId" when using the repository's getAttributesQuery() method it came up, that the from condition was wrong. Instead of Shopware\Models\Site\Site we need to select Shopware\Models\Attribute\Site.

### 2. What does this change do, exactly?
Therefor we need to replace the wrong entity in the from condition of the getAttributesQueryBuilder method.

### 3. Describe each step to reproduce the issue or behaviour.
Just try to call the Site Repository's getAttributesQuery($siteId) method to retrieve attributes for a specific static cms page. An exception will be thrown because the model has no field "siteId"

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.