### PR TITLE
Update sArticles getArticleMainCover() docblock

### DIFF
--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -1371,7 +1371,7 @@ class sArticles
     }
 
     /**
-     * Returns the the absolute main article image
+     * Returns the absolute main article image
      * This method returns the main cover depending on the main flag no matter if any variant restriction is set
      *
      * @param $articleId


### PR DESCRIPTION
Removed double usage "the" in docblock

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

It's cleaner

### 2. What does this change do, exactly?

Nothing but update the docblock

### 3. Describe each step to reproduce the issue or behaviour.

-

### 4. Please link to the relevant issues (if any).

-

### 5. Which documentation changes (if any) need to be made because of this PR?

none

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.