### PR TITLE
Product Overview- MultiEdit Component: Fix BackupDir Path for products so that the prod…

### DIFF
--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Backup.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Backup.php
@@ -96,7 +96,7 @@ class Backup
     public function setupBackupDir()
     {
         $projectDir = Shopware()->Container()->getParameter('shopware.app.rootdir');
-        $this->backupPath = $projectDir . 'files/backup/multi_edit';
+        $this->backupPath = $projectDir . '/files/backup/multi_edit';
         $this->backupPath = rtrim($this->backupPath, '/\\') . '/';
 
         if (!is_dir($this->backupPath)) {


### PR DESCRIPTION
### 1. Why is this change necessary?

The product overview in the backend didn't render, because the setupBackupDir method returned the wrong path.

### 2. What does this change do, exactly?

Shopware()->Container()->getParameter('shopware.app.rootdir') returns the project path without trailing slash, so the when concating a filepath you need to begin with a slash.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open Backend
2. Go to Articles / Overview

Without this fix, you get an exception that the backup dir can't be found.

### 4. Please link to the relevant issues (if any).

does not apply

### 5. Which documentation changes (if any) need to be made because of this PR?

does not apply

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.