### PR TITLE
Added link to Shopmogifyware

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - **License**: Dual license AGPL v3 / Proprietary
 - **Github Repository**: <https://github.com/shopware/shopware>
 - **Issue Tracker**: <https://issues.shopware.com>
+- **Shopmogifyware** Get your shopware shop in your favourite emoji!: <https://shyware.de/>
 
 ## Overview
 


### PR DESCRIPTION
### 1. Why is this change necessary?
After getting so much feedback on PR #1073 i decided to build a more generic solution. So i created the project  Shopmogifyware, i guess everyone ❤️ Emojis but shopware does not allow store emojis 😟 . But! With this change we can use your favourite Emoji in our Code 😱

Get your shopware installation with your favourite [Emoji!](https://shyware.de)

### 2. What does this change do, exactly?
Adds the link to Shopmogifyware to readme

### 3. Describe each step to reproduce the issue or behaviour.
Use your emoji in a normal installation, it does not work. Function is not defined 👎 

### 4. Please link to the relevant issues (if any).
#1073 

### 5. Which documentation changes (if any) need to be made because of this PR?
Shopware() is deprecated its triggers a DEPRECATED error, so you can fix your plugins

### 6. Checklist

- [X] 😄 
- [X] 🐱 
- [X] 🌮 
- [X] ⛏ 
- [X] 🙈 