### PR TITLE
Added remove event hint to UPGRADE-5.5.md

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -22,6 +22,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 
 * Removed tables `s_user_billingaddress_attributes` and `s_user_shippingaddress_attributes`
 * Removed class `Shopware\Bundle\EmotionBundle\ComponentHandler\EventComponentHandler`
+* Removed event `Shopware_Controllers_Widgets_Emotion_AddElement`
 * Removed methods `getByCategory` and `getListByCategory` of interface `Shopware\Bundle\StoreFrontBundle\Gateway\SimilarProductsGatewayInterface`
 * Removed `sSelfCanonical` of `Shopware\Components\Compatibility\LegacyStructConverter`
 * Removed method `getSourceSet` of `Shopware\Bundle\StoreFrontBundle\Struct\Thumbnail`


### PR DESCRIPTION
### 1. Why is this change necessary?
I guess Shopware_Controllers_Widgets_Emotion_AddElement is easier to understand than Shopware\Bundle\EmotionBundle\ComponentHandler\EventComponentHandler 😄 (Who used this event)

### 2. What does this change do, exactly?
Adds removed event hint to upgrade

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.