### PR TITLE
Removed legacy code from registerResources

### DIFF
--- a/engine/Shopware/Models/Shop/Shop.php
+++ b/engine/Shopware/Models/Shop/Shop.php
@@ -653,13 +653,6 @@ class Shop extends ModelEntity
 
             if ($template->getVersion() == 3) {
                 $this->registerTheme($template);
-            } elseif ($template->getVersion() == 2) {
-                $templateManager->addTemplateDir([
-                    'custom' => $template->toString(),
-                    'local' => '_emotion_local',
-                    'emotion' => '_emotion',
-                    'include_dir' => '.',
-                ]);
             } else {
                 throw new \Exception(sprintf(
                     'Tried to load unsupported template version %s for template: %s',


### PR DESCRIPTION
### 1. Why is this change necessary?
Template Version 2 (Emotion Template ) is removed since 5.2. I guess the legacy code should be away 😄 

### 2. What does this change do, exactly?
Removes legacy template stuff

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.