### PR TITLE
Plugin config with DI

### DIFF
--- a/engine/Shopware/Components/Plugin/PluginConfigFactory.php
+++ b/engine/Shopware/Components/Plugin/PluginConfigFactory.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin;
+
+use Shopware\Components\DependencyInjection\Container;
+
+/**
+ * Class PluginConfigFactory
+ */
+class PluginConfigFactory
+{
+    /**
+     * @param CachedConfigReader $cachedConfigReader
+     * @param Container $container
+     * @param $pluginName
+     * @return array
+     */
+    public function factory(CachedConfigReader $cachedConfigReader, Container $container, $pluginName)
+    {
+        return $cachedConfigReader->getByPluginName($pluginName, $container->initialized('shop') ? $container->get('shop') : null);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Every plugin with a config has a %prefix%.config service where the plugin can get the plugin config.

### 2. What does this change do, exactly?
Allows to inject plugin config

### 3. Describe each step to reproduce the issue or behaviour.
Example subscriber which uses the plugin config (better inject it)
```php
<?php

namespace Test\Subscriber;

use Enlight\Event\SubscriberInterface;

class FrontendSubscriber implements SubscriberInterface
{
    public static function getSubscribedEvents()
    {
        return [
            'Enlight_Controller_Action_PostDispatch_Frontend' => 'onll'
        ];
    }

    public function onll(\Enlight_Event_EventArgs $args)
    {
        var_dump(Shopware()->Container()->get('test.config'));
    }
}
```

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.