### PR TITLE
Allow admins to show inactive articles

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ListProductGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ListProductGateway.php
@@ -26,7 +26,6 @@ namespace Shopware\Bundle\StoreFrontBundle\Gateway\DBAL;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Bundle\StoreFrontBundle\Gateway;
-use Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct;
 
 /**
@@ -67,29 +66,21 @@ class ListProductGateway implements Gateway\ListProductGatewayInterface
     private $connection;
 
     /**
-     * @var Struct\ProductContextInterface
-     */
-    private $shopContext;
-
-    /**
      * @param Connection $connection
      * @param FieldHelper $fieldHelper
      * @param Hydrator\ProductHydrator $hydrator
      * @param \Shopware_Components_Config $config
-     * @param ContextServiceInterface $contextService
      */
     public function __construct(
         Connection $connection,
         FieldHelper $fieldHelper,
         Hydrator\ProductHydrator $hydrator,
-        \Shopware_Components_Config $config,
-        ContextServiceInterface $contextService
+        \Shopware_Components_Config $config
     ) {
         $this->hydrator = $hydrator;
         $this->fieldHelper = $fieldHelper;
         $this->connection = $connection;
         $this->config = $config;
-        $this->shopContext = $contextService->getShopContext();
     }
 
     /**
@@ -171,7 +162,7 @@ class ListProductGateway implements Gateway\ListProductGatewayInterface
             ->where('variant.ordernumber IN (:numbers)')
             ->setParameter(':numbers', $numbers, Connection::PARAM_STR_ARRAY);
 
-        if (!$this->shopContext->isAdmin()) {
+        if (!$context->isAdmin()) {
             $query
                 ->andWhere('variant.active = 1')
                 ->andWhere('product.active = 1');

--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/ContextService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/ContextService.php
@@ -138,7 +138,8 @@ class ContextService implements ContextServiceInterface
             $this->getStoreFrontAreaId(),
             $this->getStoreFrontCountryId(),
             $this->getStoreFrontStateId(),
-            $this->getStoreFrontStreamIds()
+            $this->getStoreFrontStreamIds(),
+            $this->getStoreFrontAdmin()
         );
     }
 
@@ -320,13 +321,15 @@ class ContextService implements ContextServiceInterface
     }
 
     /**
-     * @param string      $baseUrl
-     * @param int         $shopId
-     * @param null|int    $currencyId
+     * @param string $baseUrl
+     * @param int $shopId
+     * @param null|int $currencyId
      * @param null|string $currentCustomerGroupKey
-     * @param null|int    $areaId
-     * @param null|int    $countryId
-     * @param null|int    $stateId
+     * @param null|int $areaId
+     * @param null|int $countryId
+     * @param null|int $stateId
+     * @param array $streamIds
+     * @param bool $admin
      *
      * @return ShopContext
      */
@@ -338,12 +341,13 @@ class ContextService implements ContextServiceInterface
         $areaId = null,
         $countryId = null,
         $stateId = null,
-        $streamIds = []
+        $streamIds = [],
+        $admin = false
     ) {
         $shop = $this->shopGateway->get($shopId);
         $fallbackCustomerGroupKey = self::FALLBACK_CUSTOMER_GROUP;
 
-        if ($currentCustomerGroupKey == null) {
+        if ($currentCustomerGroupKey === null) {
             $currentCustomerGroupKey = $fallbackCustomerGroupKey;
         }
 
@@ -353,7 +357,7 @@ class ContextService implements ContextServiceInterface
         $fallbackCustomerGroup = $groups[$fallbackCustomerGroupKey];
 
         $currency = null;
-        if ($currencyId != null) {
+        if ($currencyId !== null) {
             $currency = $this->currencyGateway->getList([$currencyId]);
             $currency = array_shift($currency);
         }
@@ -392,7 +396,8 @@ class ContextService implements ContextServiceInterface
             $area,
             $country,
             $state,
-            $streamIds
+            $streamIds,
+            $admin
         );
     }
 
@@ -428,6 +433,17 @@ class ContextService implements ContextServiceInterface
         return $this->getStreamsOfCustomerId($customerId);
     }
 
+    /**
+     * @return bool
+     */
+    private function getStoreFrontAdmin()
+    {
+        return $this->container->get('session')->get('Admin', false);
+    }
+
+    /**
+     * @return int|null
+     */
     private function getStoreFrontCustomerId()
     {
         $session = $this->container->get('session');

--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/ShopContext.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/ShopContext.php
@@ -92,6 +92,11 @@ class ShopContext extends Extendable implements ProductContextInterface
     protected $customerStreamIds;
 
     /**
+     * @var bool
+     */
+    protected $admin = false;
+
+    /**
      * @param string       $baseUrl
      * @param Shop         $shop
      * @param Currency     $currency
@@ -102,6 +107,7 @@ class ShopContext extends Extendable implements ProductContextInterface
      * @param Area|null    $area
      * @param Country|null $country
      * @param State|null   $state
+     * @param bool         $admin
      * @param int[]        $customerStreamIds
      */
     public function __construct(
@@ -115,7 +121,8 @@ class ShopContext extends Extendable implements ProductContextInterface
         Area $area = null,
         Country $country = null,
         State $state = null,
-        $customerStreamIds = []
+        $customerStreamIds = [],
+        $admin = false
     ) {
         $this->baseUrl = $baseUrl;
         $this->shop = $shop;
@@ -128,6 +135,7 @@ class ShopContext extends Extendable implements ProductContextInterface
         $this->country = $country;
         $this->state = $state;
         $this->customerStreamIds = $customerStreamIds;
+        $this->admin = $admin;
     }
 
     /**
@@ -220,9 +228,20 @@ class ShopContext extends Extendable implements ProductContextInterface
         return $this->state;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getActiveCustomerStreamIds()
     {
         return $this->customerStreamIds;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAdmin()
+    {
+        return $this->admin;
     }
 
     /**

--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/ShopContext.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/ShopContext.php
@@ -247,6 +247,14 @@ class ShopContext extends Extendable implements ProductContextInterface
     /**
      * {@inheritdoc}
      */
+    public function setAdmin($admin)
+    {
+        $this->admin = $admin;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function jsonSerialize()
     {
         return get_object_vars($this);

--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/ShopContextInterface.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/ShopContextInterface.php
@@ -126,4 +126,9 @@ interface ShopContextInterface
      * @return int[]
      */
     public function getActiveCustomerStreamIds();
+
+    /**
+     * @return bool
+     */
+    public function isAdmin();
 }

--- a/engine/Shopware/Bundle/StoreFrontBundle/services.xml
+++ b/engine/Shopware/Bundle/StoreFrontBundle/services.xml
@@ -19,6 +19,7 @@
         <service id="shopware_storefront.product_number_service" class="Shopware\Bundle\StoreFrontBundle\Service\Core\ProductNumberService">
             <argument type="service" id="dbal_connection" />
             <argument type="service" id="config" />
+            <argument type="service" id="shopware_storefront.context_service" />
         </service>
 
         <service id="shopware_storefront.list_product_service" class="Shopware\Bundle\StoreFrontBundle\Service\Core\ListProductService">
@@ -147,6 +148,7 @@
             <argument type="service" id="shopware_storefront.field_helper_dbal"/>
             <argument type="service" id="shopware_storefront.product_hydrator_dbal"/>
             <argument type="service" id="config" />
+            <argument type="service" id="shopware_storefront.context_service" />
         </service>
 
         <service id="shopware_storefront.media_gateway" class="Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\MediaGateway">

--- a/engine/Shopware/Bundle/StoreFrontBundle/services.xml
+++ b/engine/Shopware/Bundle/StoreFrontBundle/services.xml
@@ -19,7 +19,6 @@
         <service id="shopware_storefront.product_number_service" class="Shopware\Bundle\StoreFrontBundle\Service\Core\ProductNumberService">
             <argument type="service" id="dbal_connection" />
             <argument type="service" id="config" />
-            <argument type="service" id="shopware_storefront.context_service" />
         </service>
 
         <service id="shopware_storefront.list_product_service" class="Shopware\Bundle\StoreFrontBundle\Service\Core\ListProductService">
@@ -148,7 +147,6 @@
             <argument type="service" id="shopware_storefront.field_helper_dbal"/>
             <argument type="service" id="shopware_storefront.product_hydrator_dbal"/>
             <argument type="service" id="config" />
-            <argument type="service" id="shopware_storefront.context_service" />
         </service>
 
         <service id="shopware_storefront.media_gateway" class="Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\MediaGateway">

--- a/tests/Functional/Bundle/StoreFrontBundle/ListProductTest.php
+++ b/tests/Functional/Bundle/StoreFrontBundle/ListProductTest.php
@@ -26,9 +26,15 @@ namespace Shopware\Tests\Functional\Bundle\StoreFrontBundle;
 
 use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContext;
+use Shopware\Bundle\StoreFrontBundle\Struct\Product\Unit;
+use Shopware\Bundle\StoreFrontBundle\Struct\Product\Manufacturer;
+use Shopware\Bundle\StoreFrontBundle\Struct\Product\Price;
+use Shopware\Bundle\StoreFrontBundle\Struct\Product\PriceRule;
 
 class ListProductTest extends TestCase
 {
+    const INACTIVE_PRODUCTNUMBER = 'SW10239';
+
     public function testProductRequirements()
     {
         $number = 'List-Product-Test';
@@ -55,25 +61,25 @@ class ListProductTest extends TestCase
         $this->assertNotEmpty($product->getTax());
         $this->assertNotEmpty($product->getUnit());
 
-        $this->assertInstanceOf('Shopware\Bundle\StoreFrontBundle\Struct\ListProduct', $product);
-        $this->assertInstanceOf('Shopware\Bundle\StoreFrontBundle\Struct\Product\Unit', $product->getUnit());
-        $this->assertInstanceOf('Shopware\Bundle\StoreFrontBundle\Struct\Product\Manufacturer', $product->getManufacturer());
+        $this->assertInstanceOf(ListProduct::class, $product);
+        $this->assertInstanceOf(Unit::class, $product->getUnit());
+        $this->assertInstanceOf(Manufacturer::class, $product->getManufacturer());
 
         $this->assertNotEmpty($product->getPrices());
         $this->assertNotEmpty($product->getPriceRules());
         foreach ($product->getPrices() as $price) {
-            $this->assertInstanceOf('Shopware\Bundle\StoreFrontBundle\Struct\Product\Price', $price);
-            $this->assertInstanceOf('Shopware\Bundle\StoreFrontBundle\Struct\Product\Unit', $price->getUnit());
+            $this->assertInstanceOf(Price::class, $price);
+            $this->assertInstanceOf(Unit::class, $price->getUnit());
             $this->assertGreaterThanOrEqual(1, $price->getUnit()->getMinPurchase());
         }
 
         foreach ($product->getPriceRules() as $price) {
-            $this->assertInstanceOf('Shopware\Bundle\StoreFrontBundle\Struct\Product\PriceRule', $price);
+            $this->assertInstanceOf(PriceRule::class, $price);
         }
 
-        $this->assertInstanceOf('Shopware\Bundle\StoreFrontBundle\Struct\Product\Price', $product->getCheapestPrice());
-        $this->assertInstanceOf('Shopware\Bundle\StoreFrontBundle\Struct\Product\PriceRule', $product->getCheapestPriceRule());
-        $this->assertInstanceOf('Shopware\Bundle\StoreFrontBundle\Struct\Product\Unit', $product->getCheapestPrice()->getUnit());
+        $this->assertInstanceOf(Price::class, $product->getCheapestPrice());
+        $this->assertInstanceOf(PriceRule::class, $product->getCheapestPriceRule());
+        $this->assertInstanceOf(Unit::class, $product->getCheapestPrice()->getUnit());
         $this->assertGreaterThanOrEqual(1, $product->getCheapestPrice()->getUnit()->getMinPurchase());
 
         $this->assertNotEmpty($product->getCheapestPriceRule()->getPrice());
@@ -83,6 +89,20 @@ class ListProductTest extends TestCase
 
         $this->assertGreaterThanOrEqual(1, $product->getUnit()->getMinPurchase());
         $this->assertNotEmpty($product->getManufacturer()->getName());
+    }
+
+    public function testInactiveArticleWithoutAdminMode()
+    {
+        $context = Shopware()->Container()->get('shopware_storefront.context_service')->getShopContext();
+        $this->assertNull($this->getListProduct(self::INACTIVE_PRODUCTNUMBER, $context));
+    }
+
+    public function testInactiveArticleWithAdminMode()
+    {
+        $context = Shopware()->Container()->get('shopware_storefront.context_service')->getShopContext();
+        $context->setAdmin(true);
+        $this->assertInstanceOf(ListProduct::class, $this->getListProduct(self::INACTIVE_PRODUCTNUMBER, $context));
+        $context->setAdmin(false);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Allow to show inactive articles like in shopware 4 in admin mode.

### 2. What does this change do, exactly?
Allow to show inactive articles like in shopware 4 in admin mode.


### 3. Describe each step to reproduce the issue or behaviour.
Set a article to inactive and show the article with loggedin backend

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.