### PR TITLE
Update jquery.storage-field.js

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-field.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-field.js
@@ -103,7 +103,7 @@
             }
 
             // When the field is just a pseudo field also fill the original field.
-            if (me.$el.is('[data-selector]')) {
+            if (me.$el.is('[data-selector]') && value && value.length) {
                 $(me.$el.attr('data-selector')).val(value);
             }
 

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-field.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-field.js
@@ -100,11 +100,11 @@
 
             if (value && value.length) {
                 me.$el.val(value);
-            }
-
-            // When the field is just a pseudo field also fill the original field.
-            if (me.$el.is('[data-selector]') && value && value.length) {
-                $(me.$el.attr('data-selector')).val(value);
+                
+                // When the field is just a pseudo field also fill the original field.
+                if (me.$el.is('[data-selector]')) {
+                    $(me.$el.attr('data-selector')).val(value);
+                }
             }
 
             $.publish('plugin/swStorageField/setFieldValueFromStorage', [ me ]);


### PR DESCRIPTION

### 1. Why is this change necessary?
This is a bug. If value is empty and a pseudo field exists "null" is set to the pseudo field.

### 2. What does this change do, exactly?
It fixes this behavior.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x ] I have squashed any insignificant commits
- [x ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.