### PR TITLE
Update jquery.emotion.js

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
@@ -129,7 +129,6 @@
              * Hide the emotion world if it is not defined for the current device.
              */
             if (devices.indexOf(types[state]) === -1) {
-                me.$overlay.remove();
                 me.hideEmotion();
                 return;
             }


### PR DESCRIPTION
Do not remove me.$overlay when the emotion never shown me.$overlay yet

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
It fixes a visibility bug.

### 2. What does this change do, exactly?
It prevents the emotion loader overlay from beeing hidden by another emotion worlds which will not be shown for the current device.

### 3. Describe each step to reproduce the issue or behaviour.
You need to create an emotion for two devices - e.g. desktop and mobile and associate it to the same category. Now when you open the emotion world in the frontend. The loading indicator/overlay is removed too early - even before the emotion world was loaded - because of the emotion world for mobile is hiding it before.

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.