### PR TITLE
[TASK] Replace deprecated table helper

### DIFF
--- a/engine/Shopware/Commands/CronListCommand.php
+++ b/engine/Shopware/Commands/CronListCommand.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Commands;
 
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -70,10 +71,10 @@ EOF
             ];
         }
 
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(['Name', 'Action', 'Active', 'Interval', 'Next run', 'Last run'])
               ->setRows($rows);
 
-        $table->render($output);
+        $table->render();
     }
 }

--- a/engine/Shopware/Commands/ListProductFeedCommand.php
+++ b/engine/Shopware/Commands/ListProductFeedCommand.php
@@ -26,6 +26,7 @@
 namespace Shopware\Commands;
 
 use Shopware\Models\ProductFeed\ProductFeed;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -66,11 +67,11 @@ class ListProductFeedCommand extends ShopwareCommand
             ];
         }
 
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(['Product Feed', 'Id', 'Last export', 'Interval', 'Active'])
             ->setRows($rows);
 
-        $table->render($output);
+        $table->render();
     }
 
     private function formatInterval($interval)

--- a/engine/Shopware/Commands/PluginListCommand.php
+++ b/engine/Shopware/Commands/PluginListCommand.php
@@ -26,6 +26,7 @@ namespace Shopware\Commands;
 
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Plugin\Plugin;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -125,10 +126,10 @@ class PluginListCommand extends ShopwareCommand
             ];
         }
 
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(['Plugin', 'Label', 'Version', 'Author', 'Active', 'Installed'])
               ->setRows($rows);
 
-        $table->render($output);
+        $table->render();
     }
 }

--- a/engine/Shopware/Commands/RebuildCategoryTreeCommand.php
+++ b/engine/Shopware/Commands/RebuildCategoryTreeCommand.php
@@ -25,6 +25,7 @@
 namespace Shopware\Commands;
 
 use Shopware\Components\Model\CategoryDenormalization;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -77,9 +78,8 @@ EOF
         $count = $component->rebuildAllAssignmentsCount();
         $output->writeln("\rCounted {$count} items");
 
-        /** @var ProgressHelper $progressHelper */
-        $progressHelper = $this->getHelper('progress');
-        $progressHelper->setFormat(ProgressHelper::FORMAT_VERBOSE);
+        $progressHelper = new ProgressBar($output);
+        $progressHelper->setFormat('verbose');
         $progressHelper->start($output, $count);
         $progressHelper->advance($progress);
 

--- a/engine/Shopware/Commands/StoreListCommand.php
+++ b/engine/Shopware/Commands/StoreListCommand.php
@@ -26,6 +26,7 @@ namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Context\LicenceRequest;
 use Shopware\Bundle\PluginInstallerBundle\Struct\LicenceStruct;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -89,10 +90,10 @@ class StoreListCommand extends StoreCommand
             ];
         }
 
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(['Technical name', 'Description', 'domain', 'Creation date', 'Type'])
               ->setRows($result);
 
-        $table->render($output);
+        $table->render();
     }
 }

--- a/engine/Shopware/Commands/StoreListDomainsCommand.php
+++ b/engine/Shopware/Commands/StoreListDomainsCommand.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Commands;
 
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -66,10 +67,10 @@ class StoreListDomainsCommand extends StoreCommand
             ];
         }
 
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(['Domain', 'Balance'])
               ->setRows($domains);
 
-        $table->render($output);
+        $table->render();
     }
 }

--- a/engine/Shopware/Commands/StoreListIntegratedCommand.php
+++ b/engine/Shopware/Commands/StoreListIntegratedCommand.php
@@ -25,6 +25,7 @@
 namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Context\ListingRequest;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -67,10 +68,10 @@ class StoreListIntegratedCommand extends StoreCommand
             ];
         }
 
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(['Id', 'Technical name', 'Label', 'Installed', 'Version', 'Update available'])
             ->setRows($result);
 
-        $table->render($output);
+        $table->render();
     }
 }

--- a/engine/Shopware/Commands/StoreListUpdatesCommand.php
+++ b/engine/Shopware/Commands/StoreListUpdatesCommand.php
@@ -26,6 +26,7 @@ namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Context\UpdateListingRequest;
 use Shopware\Bundle\PluginInstallerBundle\Struct\UpdateResultStruct;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -78,10 +79,10 @@ class StoreListUpdatesCommand extends StoreCommand
             ];
         }
 
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(['Id', 'Technical name', 'Label',  'CurrentVersion', 'AvailableVersion'])
               ->setRows($result);
 
-        $table->render($output);
+        $table->render();
     }
 }


### PR DESCRIPTION
This replaces the table helper with the Table class
from all Cli command since the helper has become
obsolete since symfony/console version 2.5 [1].

[1] https://github.com/symfony/console/commit/e26f6047403a494afb64d378921fae0e38732d41#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR7

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Initial code unnecessarily used deprecated functionality

### 2. What does this change do, exactly?
Replace the deprecated functionality with its successor.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.