### PR TITLE
Add custom listing product box

### DIFF
--- a/box_article.tpl
+++ b/box_article.tpl
@@ -1,0 +1,32 @@
+{block name="frontend_listing_box_article_includes"}
+
+    {if $productBoxLayout == 'minimal'}
+        {$path = "frontend/listing/product-box/box-minimal.tpl"}
+
+    {elseif $productBoxLayout == 'image'}
+        {$path = "frontend/listing/product-box/box-big-image.tpl"}
+
+    {elseif $productBoxLayout == 'slider'}
+        {$path = "frontend/listing/product-box/box-product-slider.tpl"}
+
+    {elseif $productBoxLayout == 'emotion'}
+        {$path = "frontend/listing/product-box/box-emotion.tpl"}
+
+    {elseif $productBoxLayout == 'list'}
+        {$path = "frontend/listing/product-box/box-list.tpl"}
+
+    {elseif $path == ''}
+        {$path = "frontend/listing/product-box/box-"|cat:$productBoxLayout|cat:".tpl"}
+        {if !$path|template_exists}
+            {$path = ''}
+        {/if}
+    {/if}
+    
+    {if $path == ''}
+        {block name="frontend_listing_box_article_includes_additional"}
+            {include file="frontend/listing/product-box/box-basic.tpl" productBoxLayout="basic"}
+        {/block}
+    {else}
+        {include file=$path}
+    {/if}
+{/block}

--- a/product_box_layout.js
+++ b/product_box_layout.js
@@ -1,0 +1,147 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category   Shopware
+ * @package    Base
+ * @subpackage Store
+ * @version    $Id$
+ * @author shopware AG
+ */
+
+/**
+ * Shopware Store - Global Stores and Models
+ */
+//{namespace name=backend/base/product_box_layout}
+Ext.define('Shopware.apps.Base.store.ProductBoxLayout', {
+    extend: 'Ext.data.Store',
+
+    alternateClassName: 'Shopware.store.ProductBoxLayout',
+
+    storeId: 'base.ProductBoxLayout',
+
+    model: 'Shopware.apps.Base.model.ProductBoxLayout',
+
+    pageSize: 1000,
+
+    defaultLayouts: {
+        displayExtendLayout: false,
+        displayBasicLayout: true,
+        displayMinimalLayout: true,
+        displayImageLayout: true,
+        displayListLayout: false
+    },
+
+    snippets: {
+        displayExtendLayout: {
+            label: '{s name=settings_box_layout_parent_title}Parent setting{/s}',
+            description: '{s name=settings_box_layout_parent_description}The layout of the product box will be set by the value of the parent category.{/s}'
+        },
+        displayBasicLayout: {
+            label: '{s name=settings_box_layout_basic_title}Detailed information{/s}',
+            description: '{s name=settings_box_layout_basic_description}The layout of the product box will show very detailed information.{/s}'
+        },
+        displayMinimalLayout: {
+            label: '{s name=settings_box_layout_minimal_title}Only important information{/s}',
+            description: '{s name=settings_box_layout_minimal_description}The layout of the product box will only show the most important information.{/s}'
+        },
+        displayImageLayout: {
+            label: '{s name=settings_box_layout_image_title}Big image{/s}',
+            description: '{s name=settings_box_layout_image_description}The layout of the product box is based on a big image of the product.{/s}'
+        },
+        displayListLayout: {
+            label: '{s name=settings_box_layout_list_title}Product list{/s}',
+            description: '{s name=settings_box_layout_list_description}The layout of the product box shows a small image and only one product in a row.{/s}'
+        }
+    },
+
+    constructor: function(config) {
+        var me = this,
+            data = [];
+
+        data = me.createLayoutData(config);
+        me.data = data;
+
+        me.callParent(arguments);
+    },
+
+    createLayoutData: function(config) {
+        var me = this,
+            data = [];
+
+        if (me.getConfigValue(config, 'displayExtendLayout')) {
+            data.push({
+                key: 'extend',
+                label: me.snippets.displayExtendLayout.label,
+                description: me.snippets.displayExtendLayout.description,
+                image: '{link file="backend/_resources/images/category/layout_box_parent.png"}'
+            });
+        }
+        if (me.getConfigValue(config, 'displayBasicLayout')) {
+            data.push({
+                key: 'basic',
+                label: me.snippets.displayBasicLayout.label,
+                description: me.snippets.displayBasicLayout.description,
+                image: '{link file="backend/_resources/images/category/layout_box_basic.png"}'
+            });
+        }
+        if (me.getConfigValue(config, 'displayMinimalLayout')) {
+            data.push({
+                key: 'minimal',
+                label: me.snippets.displayMinimalLayout.label,
+                description: me.snippets.displayMinimalLayout.description,
+                image: '{link file="backend/_resources/images/category/layout_box_minimal.png"}'
+            });
+        }
+        if (me.getConfigValue(config, 'displayImageLayout')) {
+            data.push({
+                key: 'image',
+                label: me.snippets.displayImageLayout.label,
+                description: me.snippets.displayImageLayout.description,
+                image: '{link file="backend/_resources/images/category/layout_box_image.png"}'
+            });
+        }
+        if (me.getConfigValue(config, 'displayListLayout')) {
+            data.push({
+                key: 'list',
+                label: me.snippets.displayListLayout.label,
+                description: me.snippets.displayListLayout.description,
+                image: '{link file="backend/_resources/images/category/layout_box_list.png"}'
+            });
+        }
+
+        return data;
+    },
+
+    getConfigValue: function(config, property) {
+        if (!Ext.isObject(config)) {
+            return this.defaultLayouts[property];
+        }
+
+        if (!config.hasOwnProperty(property)) {
+            return this.defaultLayouts[property];
+        }
+
+        return config[property];
+    }
+
+});
+


### PR DESCRIPTION
### 1. Why is this change necessary?
Because it's not possible to create own custom product box templates to category.
Actual $path will be overwritten.

### 2. What does this change do, exactly?
1. Implements override function to extjs store to add new product box.
2. Modifiy product box template to load dynamically $productBoxLayout Template or custom by $path

### 3. Describe each step to reproduce the issue or behaviour.
It's a feature :)

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
I will do if pr is accepted :)

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.