### PR TITLE
add custom product layout

### DIFF
--- a/themes/Backend/ExtJs/backend/base/store/product_box_layout.js
+++ b/themes/Backend/ExtJs/backend/base/store/product_box_layout.js
@@ -77,7 +77,17 @@ Ext.define('Shopware.apps.Base.store.ProductBoxLayout', {
         var me = this,
             data = [];
 
-        if (this.getConfigValue(config, 'displayExtendLayout')) {
+        data = me.createLayoutData(config);
+        me.data = data;
+
+        me.callParent(arguments);
+    },
+
+    createLayoutData: function(config) {
+        var me = this,
+            data = [];
+
+        if (me.getConfigValue(config, 'displayExtendLayout')) {
             data.push({
                 key: 'extend',
                 label: me.snippets.displayExtendLayout.label,
@@ -85,7 +95,7 @@ Ext.define('Shopware.apps.Base.store.ProductBoxLayout', {
                 image: '{link file="backend/_resources/images/category/layout_box_parent.png"}'
             });
         }
-        if (this.getConfigValue(config, 'displayBasicLayout')) {
+        if (me.getConfigValue(config, 'displayBasicLayout')) {
             data.push({
                 key: 'basic',
                 label: me.snippets.displayBasicLayout.label,
@@ -93,7 +103,7 @@ Ext.define('Shopware.apps.Base.store.ProductBoxLayout', {
                 image: '{link file="backend/_resources/images/category/layout_box_basic.png"}'
             });
         }
-        if (this.getConfigValue(config, 'displayMinimalLayout')) {
+        if (me.getConfigValue(config, 'displayMinimalLayout')) {
             data.push({
                 key: 'minimal',
                 label: me.snippets.displayMinimalLayout.label,
@@ -101,7 +111,7 @@ Ext.define('Shopware.apps.Base.store.ProductBoxLayout', {
                 image: '{link file="backend/_resources/images/category/layout_box_minimal.png"}'
             });
         }
-        if (this.getConfigValue(config, 'displayImageLayout')) {
+        if (me.getConfigValue(config, 'displayImageLayout')) {
             data.push({
                 key: 'image',
                 label: me.snippets.displayImageLayout.label,
@@ -109,7 +119,7 @@ Ext.define('Shopware.apps.Base.store.ProductBoxLayout', {
                 image: '{link file="backend/_resources/images/category/layout_box_image.png"}'
             });
         }
-        if (this.getConfigValue(config, 'displayListLayout')) {
+        if (me.getConfigValue(config, 'displayListLayout')) {
             data.push({
                 key: 'list',
                 label: me.snippets.displayListLayout.label,
@@ -118,9 +128,7 @@ Ext.define('Shopware.apps.Base.store.ProductBoxLayout', {
             });
         }
 
-        this.data = data;
-
-        this.callParent(arguments);
+        return data;
     },
 
     getConfigValue: function(config, property) {

--- a/themes/Frontend/Bare/frontend/listing/box_article.tpl
+++ b/themes/Frontend/Bare/frontend/listing/box_article.tpl
@@ -1,6 +1,5 @@
 {block name="frontend_listing_box_article_includes"}
-    {$path = ''}
-    
+
     {if $productBoxLayout == 'minimal'}
         {$path = "frontend/listing/product-box/box-minimal.tpl"}
 
@@ -15,6 +14,12 @@
 
     {elseif $productBoxLayout == 'list'}
         {$path = "frontend/listing/product-box/box-list.tpl"}
+
+    {elseif $path == ''}
+        {$path = "frontend/listing/product-box/box-$productBoxLayout.tpl"}
+        {if !$path|template_exists}
+            {$path = ''}
+        {/if}
     {/if}
     
     {if $path == ''}


### PR DESCRIPTION
### 1. Why is this change necessary?
Because it's not possible to create own custom product box templates to category.
Actual $path will be overwritten.

### 2. What does this change do, exactly?
1. Implements override function to extjs store to add new product box.
2. Modifiy product box template to load dynamically $productBoxLayout Template or custom by $path

### 3. Describe each step to reproduce the issue or behaviour.
It's a feature :)

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
I will do if pr is accepted :)

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.