### PR TITLE
Use thumbnails on manufacturer page

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/Product/Manufacturer.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/Product/Manufacturer.php
@@ -25,6 +25,7 @@
 namespace Shopware\Bundle\StoreFrontBundle\Struct\Product;
 
 use Shopware\Bundle\StoreFrontBundle\Struct\Extendable;
+use Shopware\Bundle\StoreFrontBundle\Struct\Media;
 
 /**
  * @category  Shopware
@@ -91,6 +92,12 @@ class Manufacturer extends Extendable
      * @var string
      */
     protected $coverFile;
+
+    /**
+     * Returns a Media struct with the thumbnails
+     * @var Media
+     */
+    protected $coverMedia;
 
     /**
      * @param string $description
@@ -238,10 +245,32 @@ class Manufacturer extends Extendable
 
     /**
      * @param string $coverFile
+     * @return Manufacturer
      */
     public function setCoverFile($coverFile)
     {
         $this->coverFile = $coverFile;
+
+        return $this;
+    }
+
+    /**
+     * @param Media $media
+     * @return Manufacturer
+     */
+    public function setCoverMedia(Media $media)
+    {
+        $this->coverMedia = $media;
+
+        return $this;
+    }
+
+    /**
+     * @return Media
+     */
+    public function getCoverMedia()
+    {
+        return $this->coverMedia;
     }
 
     /**

--- a/engine/Shopware/Bundle/StoreFrontBundle/services.xml
+++ b/engine/Shopware/Bundle/StoreFrontBundle/services.xml
@@ -177,6 +177,7 @@
             <argument type="service" id="dbal_connection"/>
             <argument type="service" id="shopware_storefront.field_helper_dbal"/>
             <argument type="service" id="shopware_storefront.manufacturer_hydrator_dbal"/>
+            <argument type="service" id="shopware_storefront.media_service"/>
         </service>
 
         <service id="shopware_storefront.shop_page_gateway" class="Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\ShopPageGateway">

--- a/themes/Frontend/Bare/frontend/listing/manufacturer.tpl
+++ b/themes/Frontend/Bare/frontend/listing/manufacturer.tpl
@@ -67,19 +67,21 @@
 
                 {if $manufacturer->getCoverMedia()}
                     <div class="vendor--image-wrapper">
-                        {$imgSrc = $manufacturer->getCoverFile()}
-                        {$imgSrcSet = ''}
+                        {block name="frontend_listing_list_filter_supplier_content_image"}
+                            {$imgSrc = $manufacturer->getCoverFile()}
+                            {$imgSrcSet = ''}
 
-                        {if $manufacturer->getCoverMedia()->getThumbnails()}
-                            {$imgSrc = $manufacturer->getCoverMedia()->getThumbnail(0)->getSource()}
-                            {if $manufacturer->getCoverMedia()->getThumbnail(0)->hasRetinaSource()}
-                                {$retinaSource = $manufacturer->getCoverMedia()->getThumbnail(0)->getRetinaSource()}
-                                {$imgSrcSet = "$imgSrc, $retinaSource 2x"}
+                            {if $manufacturer->getCoverMedia()->getThumbnails()}
+                                {$imgSrc = $manufacturer->getCoverMedia()->getThumbnail(0)->getSource()}
+                                {if $manufacturer->getCoverMedia()->getThumbnail(0)->hasRetinaSource()}
+                                    {$retinaSource = $manufacturer->getCoverMedia()->getThumbnail(0)->getRetinaSource()}
+                                    {$imgSrcSet = "$imgSrc, $retinaSource 2x"}
+                                {/if}
                             {/if}
-                        {/if}
 
 
-                        <img class="vendor--image" src="{$imgSrc}" {if !empty($imgSrcSet)}srcset="{$imgSrcSet}" {/if}alt="{$manufacturer->getName()|escape}">
+                            <img class="vendor--image" src="{$imgSrc}" {if !empty($imgSrcSet)}srcset="{$imgSrcSet}" {/if}alt="{$manufacturer->getName()|escape}">
+                        {/block}
                     </div>
                 {/if}
 

--- a/themes/Frontend/Bare/frontend/listing/manufacturer.tpl
+++ b/themes/Frontend/Bare/frontend/listing/manufacturer.tpl
@@ -68,7 +68,7 @@
                 {if $manufacturer->getCoverMedia()}
                     <div class="vendor--image-wrapper">
                         {block name="frontend_listing_list_filter_supplier_content_image"}
-                            {$imgSrc = $manufacturer->getCoverFile()}
+                            {$imgSrc = $manufacturer->getCoverMedia()->getFile()}
                             {$imgSrcSet = ''}
 
                             {if $manufacturer->getCoverMedia()->getThumbnails()}

--- a/themes/Frontend/Bare/frontend/listing/manufacturer.tpl
+++ b/themes/Frontend/Bare/frontend/listing/manufacturer.tpl
@@ -65,9 +65,21 @@
         {block name="frontend_listing_list_filter_supplier_content"}
             <div class="panel--body is--wide">
 
-                {if $manufacturer->getCoverFile()}
+                {if $manufacturer->getCoverMedia()}
                     <div class="vendor--image-wrapper">
-                        <img class="vendor--image" src="{$manufacturer->getCoverFile()}" alt="{$manufacturer->getName()|escape}">
+                        {$imgSrc = $manufacturer->getCoverFile()}
+                        {$imgSrcSet = ''}
+
+                        {if $manufacturer->getCoverMedia()->getThumbnails()}
+                            {$imgSrc = $manufacturer->getCoverMedia()->getThumbnail(0)->getSource()}
+                            {if $manufacturer->getCoverMedia()->getThumbnail(0)->hasRetinaSource()}
+                                {$retinaSource = $manufacturer->getCoverMedia()->getThumbnail(0)->getRetinaSource()}
+                                {$imgSrcSet = "$imgSrc, $retinaSource 2x"}
+                            {/if}
+                        {/if}
+
+
+                        <img class="vendor--image" src="{$imgSrc}" {if !empty($imgSrcSet)}srcset="{$imgSrcSet}" {/if}alt="{$manufacturer->getName()|escape}">
                     </div>
                 {/if}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Use a 1920x1920 image as manufacturer image, it uses the 1920x1920 image and resizes in template to 200pixel.

### 2. What does this change do, exactly?
This pull request adds thumbnail support to manufacturers

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
To use this feature thumbnails must be activated in media manager for manufacturer album

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.