### PR TITLE
Use short description in ajax loaded listing boxes

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -24,6 +24,8 @@ This changelog references changes done in Shopware 5.4 patch versions.
 * Changed detail page behaviour with preselection variants which onsale-flag is active
 * Changed note counting to fix an error which displays 0 notes when adding the first note
 * Changed construction of ProductSearchResult-object to fix error in stream listing count
+* Changed content of listing boxes loaded by ajax requests: 
+    * if config value 'useShortDescriptionInListing' is true, short description gets loaded now 
 
 ## 5.4.1
 

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -1155,7 +1155,9 @@ class LegacyStructConverter
             'ordernumber' => $product->getNumber(),
             'highlight' => $product->highlight(),
             'description' => $product->getShortDescription(),
-            'description_long' => $product->getLongDescription(),
+            'description_long' => ($this->config->get('useShortDescriptionInListing') && strlen($product->getShortDescription()) > 5)
+                ? $product->getShortDescription()
+                : $product->getLongDescription(),
             'esd' => $product->hasEsd(),
             'articleName' => $product->getName(),
             'taxID' => $product->getTax()->getId(),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When listings are loaded by ajax, the long description is loaded instead of the short description if the config flag useShortDescriptionInListing is set to true

### 2. What does this change do, exactly?
The config value 'useShortDescriptionInListing' only
was implemented in initial loaded listing boxes. If listing
gets loaded with ajax, the LegacyStructConverter is used
to build the article array. This class did ignore the config value.

### 3. Describe each step to reproduce the issue or behaviour.
Make sure, category load on scroll is activated. Load category page, make sure to scroll to "page 2" - in the new loaded listing boxes, the long description will appear.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.