### PR TITLE
Use find in ajax variant for footer javascript inline

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -134,7 +134,7 @@
 
                     // Update global variables
                     window.controller = window.snippets = window.themeConfig = window.lastSeenProductsConfig = window.csrfConfig = null;
-                    $(me.opts.footerJavascriptInlineSelector).replaceWith($response.filter(me.opts.footerJavascriptInlineSelector));
+                    $(me.opts.footerJavascriptInlineSelector).replaceWith($response.find(me.opts.footerJavascriptInlineSelector));
 
                     StateManager.addPlugin('*[data-image-slider="true"]', 'swImageSlider')
                         .addPlugin('.product--image-zoom', 'swImageZoom', 'xl')


### PR DESCRIPTION
### 1. Why is this change necessary?
I have no idea, why i get with filter null, but with find it works 🤣 , every call about that place uses find, but that one uses filter. Find can also handle selector so i changed it to that.

### 2. What does this change do, exactly?
Changes filter to find on javascript inline element search.

### 3. Describe each step to reproduce the issue or behaviour.
I have no idea why i have this issue 😟 and what introduces that.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.