### PR TITLE
Add cache clear hint

### DIFF
--- a/engine/Shopware/Commands/PluginActivateCommand.php
+++ b/engine/Shopware/Commands/PluginActivateCommand.php
@@ -87,6 +87,6 @@ EOF
 
         $pluginManager->activatePlugin($plugin);
 
-        $output->writeln(sprintf('Plugin %s has been activated', $pluginName));
+        $output->writeln(sprintf('Plugin %s has been activated. Consider sw:cache:clear to enable possible behaviors that come with the plugin.', $pluginName));
     }
 }

--- a/engine/Shopware/Commands/PluginInstallCommand.php
+++ b/engine/Shopware/Commands/PluginInstallCommand.php
@@ -95,6 +95,6 @@ EOF
 
         $pluginManager->activatePlugin($plugin);
 
-        $output->writeln(sprintf('Plugin %s has been activated successfully.', $pluginName));
+        $output->writeln(sprintf('Plugin %s has been activated successfully. Consider sw:cache:clear to enable possible behaviors that come with the plugin.', $pluginName));
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Just installing a plugin via CLI without clearing the cache afterwards does not pick up
possible changes in e.g. service configurations, leading to possible confusion when installing.

### 2. What does this change do, exactly?
Just print a hint to the console suggesting clearing the cache via `sw:cache:clear`.

### 3. Describe each step to reproduce the issue or behaviour.
Have a plugin that introduces service container modifications; `sw:plugin:active` or `sw:plugin:install --activate` it, try it and realise the service container modifications don't affect.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.