### PR TITLE
Fixed missing attributes in sORDER mail

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -1918,15 +1918,9 @@ EOT;
      */
     private function getUserDataForMail($userData)
     {
-        foreach ($userData['billingaddress'] as $key => $value) {
-            $userData['billingaddress'][$key] = html_entity_decode($value);
-        }
-        foreach ($userData['shippingaddress'] as $key => $value) {
-            $userData['shippingaddress'][$key] = html_entity_decode($value);
-        }
-        foreach ($userData['additional']['country'] as $key => $value) {
-            $userData['additional']['country'][$key] = html_entity_decode($value);
-        }
+        $userData['billingaddress'] = array_walk_recursive($userData['billingaddress'], 'html_entity_decode');
+        $userData['shippingaddress'] = array_walk_recursive($userData['shippingaddress'], 'html_entity_decode');
+        $userData['additional']['country'] = array_walk_recursive($userData['additional']['country'], 'html_entity_decode');
 
         $userData['additional']['payment']['description'] = html_entity_decode(
             $userData['additional']['payment']['description']


### PR DESCRIPTION
### 1. Why is this change necessary?
Without this fix the variables `{$billingaddress.attributes}` and `{$shippingaddress.attributes}` are always `null` because `html_entity_decode([])` returns `null`.

### 2. What does this change do, exactly?
Recursively apply `html_entity_decode()` to the passed data.

### 3. Describe each step to reproduce the issue or behaviour.
Place an order in the frontend. After that, look at the variables for the sORDER mail.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.