### PR TITLE
[BUGFIX] Explicit exception when class could not be found

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Compiler/AddConsoleCommandPass.php
+++ b/engine/Shopware/Components/DependencyInjection/Compiler/AddConsoleCommandPass.php
@@ -48,6 +48,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
             }
 
             $class = $container->getParameterBag()->resolveValue($definition->getClass());
+            if (!class_exists($class)) {
+                throw new \InvalidArgumentException(sprintf('The service "%s" tagged "console.command" resolves to class "%s" which can not be found.', $id, $class));
+            }
+
             if (!is_subclass_of($class, 'Symfony\\Component\\Console\\Command\\Command')) {
                 throw new \InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must be a subclass of "Symfony\\Component\\Console\\Command\\Command".', $id));
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Using an incorrectly configured class as a console command leads to a confusing error message because it's wrongly assumed that the command would not extend the base command class when it actually is.

### 2. What does this change do, exactly?
Introduce an additional check whether the given class is actually present.

### 3. Describe each step to reproduce the issue or behaviour.
* Configure a service tagged as `console.command`
* Make the service some arbitrary class name that can not be located/autoloaded
* When running anything, the compiler pass will kick in and claim the service would not extend `\Symfony\Component\Console\Command\Command` no matter that the actual class can be found.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.