### PR TITLE
Added symfony/http-foundation to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,12 @@
         "ramsey/uuid": "3.5.2",
         "setasign/fpdf": "1.8.1",
         "setasign/fpdi": "1.6.2",
-        "ocramius/proxy-manager": "^1.0"
+        "ocramius/proxy-manager": "^1.0",
+        "zendframework/zend-code": "2.6.3",
+        "doctrine/annotations": "^1.4",
+        "doctrine/collections": "^1.4",
+        "symfony/options-resolver": "2.8.34",
+        "symfony/http-foundation": "3.1.10"
     },
     "suggest": {
         "ext-apcu": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "059026f8397b561bd98b42c99113f8c6",
+    "content-hash": "8441246ef99f35abe55d73c5a62738ad",
     "packages": [
         {
             "name": "bcremer/line-reader",


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently shopware uses symfony/http-foundation in 3.1 version, all other symfony components are 2.8 lol (https://github.com/shopware/shopware/blob/5.4/composer.lock#L2204). Also phpstorm added a new warning which is annoying 😊 . That fixes it 😄 
![bildschirmfoto 2018-04-09 um 15 43 47](https://user-images.githubusercontent.com/6224096/38501586-ab95a766-3c0d-11e8-8a35-7f18dae6a1ee.png)


### 2. What does this change do, exactly?
Adds symfony/http-foundation to composer.json and downgrade it to 2.8 like other symfony dependencies

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.