### PR TITLE
add parallel mode to cache warmer

### DIFF
--- a/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
+++ b/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
@@ -24,11 +24,11 @@
 
 namespace Shopware\Commands;
 
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\ProgressBar;
 
 class WarmUpHttpCacheCommand extends ShopwareCommand
 {

--- a/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
+++ b/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
@@ -24,11 +24,11 @@
 
 namespace Shopware\Commands;
 
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 class WarmUpHttpCacheCommand extends ShopwareCommand
 {
@@ -42,6 +42,8 @@ class WarmUpHttpCacheCommand extends ShopwareCommand
             ->setDescription('Warm up http cache')
             ->addArgument('shopId', InputArgument::OPTIONAL, 'The Id of the shop')
             ->addOption('clear-cache', 'c', InputOption::VALUE_NONE, 'Clear complete httpcache before warmup')
+            ->addOption('parallel-mode', 'p', InputOption::VALUE_NONE, 'Send more than one HTTP request at a time. The amount of parallel requests is determined by the batch size. This is faster as sending one request after another.')
+            ->addOption('batch-size', 'b', InputOption::VALUE_REQUIRED, 'The amount of URLs handled in one program cycle. To many URLs at a time may cause script timeouts, memory issues or block your HTTP server (when using parallel mode)', 10)
             ->setHelp('The <info>%command.name%</info> warms up the http cache')
         ;
     }
@@ -68,7 +70,7 @@ class WarmUpHttpCacheCommand extends ShopwareCommand
         $cacheWarmer = $this->container->get('http_cache_warmer');
 
         foreach ($shopIds as $shopId) {
-            $limit = 10;
+            $limit = intval($input->getOption('batch-size'));
             $offset = 0;
             $totalUrlCount = $cacheWarmer->getAllSEOUrlCount($shopId);
             $output->writeln("\n Calling URLs for shop with id " . $shopId);
@@ -78,7 +80,7 @@ class WarmUpHttpCacheCommand extends ShopwareCommand
             while ($offset < $totalUrlCount) {
                 $urls = $cacheWarmer->getAllSEOUrls($shopId, $limit, $offset);
 
-                $cacheWarmer->callUrls($urls, $shopId);
+                $cacheWarmer->callUrls($urls, $shopId, $input->getOption('parallel-mode'));
                 $progressBar->advance(count($urls));
                 $offset += count($urls);
             }

--- a/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
+++ b/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
@@ -70,7 +70,8 @@ class WarmUpHttpCacheCommand extends ShopwareCommand
         $cacheWarmer = $this->container->get('http_cache_warmer');
 
         foreach ($shopIds as $shopId) {
-            $limit = intval($input->getOption('batch-size'));
+            // Help message for this command may be confusing about using an equal sign. So better strip it.
+            $limit = (int) trim($input->getOption('batch-size'), '=');
             $offset = 0;
             $totalUrlCount = $cacheWarmer->getAllSEOUrlCount($shopId);
             $output->writeln("\n Calling URLs for shop with id " . $shopId);

--- a/engine/Shopware/Components/HttpCache/CacheWarmer.php
+++ b/engine/Shopware/Components/HttpCache/CacheWarmer.php
@@ -124,6 +124,7 @@ class CacheWarmer
      * @param int  $shopId
      * @param null $limit
      * @param null $offset
+     *
      * @return string[]
      */
     public function getAllSEOUrls($shopId, $limit = null, $offset = null)
@@ -215,10 +216,9 @@ class CacheWarmer
         foreach ($urls as $url) {
             $request = $this->guzzleClient->createRequest('GET', $url, $guzzleConfig);
 
-            if($parallelMode) {
+            if ($parallelMode) {
                 $requests[] = $request;
-            }
-            else {
+            } else {
                 try {
                     $this->guzzleClient->send($request);
                 } catch (\Exception $e) {
@@ -229,13 +229,13 @@ class CacheWarmer
             }
         }
 
-        if($parallelMode) {
+        if ($parallelMode) {
             $pool = new Pool(
                 $this->guzzleClient,
                 $requests,
                 [
                     'pool_size' => count($urls),
-                    'error' => function(ErrorEvent $event) use ($shopId) {
+                    'error' => function (ErrorEvent $event) use ($shopId) {
                         $this->logger->error(
                             'Warm up http-cache error with shopId ' . $shopId . ' ' . $event->getException()->getMessage()
                         );


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

The cache warmer calls each seo URL to warm up the cache. Calling one URL at a time is really slow on a big shopware installation (> 10k products, > 40k variants, 3 sub shops). Firing more than on request in parallel will speed things up.

### 2. What does this change do, exactly?

This change adds two options to the console command "sw:warm:http:cache".
* -p let you use the parallel mode
* -b let you change the batch size

Current behavior will not be touched. So no breaking changes.

I'd not include this option to the backend GUI. It should be available for pro's only, since one can easily block the whole webserver with a high batch size.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?

I didn't find any page description the options for this command. Maybe a hint at https://developers.shopware.com/sysadmins-guide/shopware-5-performance-for-sysadmins/#shopware-http-cache would be usefull.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.