### PR TITLE
Fix SW-20939

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-add.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-add.js
@@ -53,12 +53,8 @@
                 return;
             }
 
-            $.overlay.open({
-                closeOnClick: false
-            });
-
             $.loadingIndicator.open({
-                openOverlay: false
+                openOverlay: true
             });
 
             $.publish('plugin/swProductCompareAdd/onAddArticleCompareBefore', [me, event]);


### PR DESCRIPTION
### 1. Why is this change necessary?
The alert modal for comparison view (e.g. too many products) does not close as expected. 
The overlay still is visible after the modal is closed.

### 2. What does this change do, exactly?
Remove additional overlay, that's not closing.

### 3. Describe each step to reproduce the issue or behaviour.
1. Goto Listing
2. Try to compare more products as allowed
3. Close alert modal

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20939

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.