### PR TITLE
Fixed image thumbnail href

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/images.tpl
+++ b/themes/Frontend/Bare/frontend/detail/images.tpl
@@ -18,7 +18,7 @@
                             {$alt = $sArticle.image.description|escape}
                         {/if}
 
-                        <a href="{$sArticle.image.src.1}"
+                        <a href="{$sArticle.image.source}"
                            title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt}"
                            class="thumbnail--link is--active">
                             {block name='frontend_detail_image_thumbs_main_img'}
@@ -42,7 +42,7 @@
                                 {$alt = $image.description|escape}
                             {/if}
 
-                            <a href="{$image.src.1}"
+                            <a href="{$image.source}"
                                title="{s name="DetailThumbnailText" namespace="frontend/detail/index"}{/s}: {$alt}"
                                class="thumbnail--link">
                                 {block name='frontend_detail_image_thumbs_images_img'}


### PR DESCRIPTION
### 1. Why is this change necessary?
Google does not index all detail images

### 2. What does this change do, exactly?
Adds missing href from image thumbnails (current variable is empty)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.