### PR TITLE
Allow to use multiple receivers for forms

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Forms.php
+++ b/engine/Shopware/Controllers/Frontend/Forms.php
@@ -120,7 +120,7 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
 
         $mail->setFrom(Shopware()->Config()->Mail);
         $mail->clearRecipients();
-        $mail->addTo($content['email']);
+        $mail->addTo(explode(';', $content['email']));
         $mail->setBodyText($mailBody);
         $mail->setSubject($mailSubject);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Send one message to multiple deparments (different mail addresses)

### 2. What does this change do, exactly?
Allows to use ";" as seperator for multiple emails

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-21314

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.