### PR TITLE
Removed unused constructor parameter

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -465,7 +465,6 @@
 
         <service id="shopware_product_stream.facet_filter" class="Shopware\Components\ProductStream\FacetFilter" >
             <argument type="service" id="config" />
-            <argument type="service" id="shopware_storefront.custom_facet_service" />
         </service>
 
         <service id="shopware.upload_max_size_validator" class="Shopware\Components\UploadMaxSizeValidator">


### PR DESCRIPTION
### 1. Why is this change necessary?
Constructor only accepts one argument, services.xml gives 2.

### 2. What does this change do, exactly?
Removes unneeded constructor parameter

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-21326

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.