### PR TITLE
Allow hiding of blog category filter

### DIFF
--- a/themes/Frontend/Bare/frontend/blog/listing.tpl
+++ b/themes/Frontend/Bare/frontend/blog/listing.tpl
@@ -5,17 +5,19 @@
 
     {* Blog Filter Button *}
     {block name='frontend_blog_listing_filter_button'}
-        <div class="blog--filter-btn">
-            <a href="#"
-               title="{"{s namespace='frontend/listing/listing_actions' name='ListingFilterButton'}{/s}"|escape}"
-               class="filter--trigger btn is--icon-left"
-               data-collapseTarget=".blog--filter-options"
-               data-offcanvas="true"
-               data-offCanvasSelector=".blog--filter-options"
-               data-closeButtonSelector=".blog--filter-close-btn">
-                <i class="icon--filter"></i> {s namespace='frontend/listing/listing_actions' name='ListingFilterButton'}{/s}
-            </a>
-        </div>
+        {if !$sCategoryInfo.hideFilter}
+            <div class="blog--filter-btn">
+                <a href="#"
+                   title="{"{s namespace='frontend/listing/listing_actions' name='ListingFilterButton'}{/s}"|escape}"
+                   class="filter--trigger btn is--icon-left"
+                   data-collapseTarget=".blog--filter-options"
+                   data-offcanvas="true"
+                   data-offCanvasSelector=".blog--filter-options"
+                   data-closeButtonSelector=".blog--filter-close-btn">
+                    <i class="icon--filter"></i> {s namespace='frontend/listing/listing_actions' name='ListingFilterButton'}{/s}
+                </a>
+            </div>
+        {/if}
     {/block}
 
     {if $sBlogArticles}

--- a/themes/Frontend/Bare/frontend/blog/listing_sidebar.tpl
+++ b/themes/Frontend/Bare/frontend/blog/listing_sidebar.tpl
@@ -52,7 +52,9 @@
 
                             {* Blog filter *}
                             {block name='frontend_blog_index_filter'}
-                                {include file="frontend/blog/filter.tpl"}
+                                {if !$sCategoryInfo.hideFilter}
+                                    {include file="frontend/blog/filter.tpl"}
+                                {/if}
                             {/block}
                         </div>
                     {/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
Enable hide filters in category, in blog listing filters are shown. This option is ignored in blog categories

### 2. What does this change do, exactly?
Hides the filters if the "hide filters" checkbox is checked

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-21425

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.