### PR TITLE
Fixed emotion preview attributes

### DIFF
--- a/engine/Shopware/Bundle/EmotionBundle/Service/Gateway/EmotionGateway.php
+++ b/engine/Shopware/Bundle/EmotionBundle/Service/Gateway/EmotionGateway.php
@@ -93,7 +93,7 @@ class EmotionGateway
                 ->addSelect($this->fieldHelper->getEmotionTemplateFields());
 
         $builder->from('s_emotion', 'emotion')
-                ->leftJoin('emotion', 's_emotion_attributes', 'emotionAttribute', 'emotion.id = emotionAttribute.emotionID')
+                ->leftJoin('emotion', 's_emotion_attributes', 'emotionAttribute', 'IFNULL(emotion.preview_id, emotion.id) = emotionAttribute.emotionID')
                 ->leftJoin('emotion', 's_emotion_categories', 'emotion_categories', 'emotion.id = emotion_categories.emotion_id')
                 ->leftJoin('emotion', 's_emotion_shops', 'emotion_shops', 'emotion.id = emotion_shops.emotion_id')
                 ->leftJoin('emotion', 's_emotion_templates', 'emotionTemplate', 'emotion.template_id = emotionTemplate.id');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Emotion preview attributes are always null although the main emotion world has attributes set.
The preview should use the attributes of the main emotion world.

### 2. What does this change do, exactly?
The emotion preview uses now the attributes of the main emotion.

### 3. Describe each step to reproduce the issue or behaviour.
Add attributes to the s_emotion_attribute table and fill them for an emotion world. If you now look at the preview of it, the attributes will not be loaded.

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.