### PR TITLE
Remove IE check for history API support for ajax-variants

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -40,29 +40,12 @@
          * Initializes the plugin and sets up the necessary event handler
          */
         init: function () {
-            var ie;
-
             // Check if we have a variant configurator
             if (!this.$el.find('.product--configurator').length) {
                 return;
             }
 
             this.applyDataAttributes();
-
-            // Detecting IE version using feature detection (IE7+, browsers prior to IE7 are detected as 7)
-            ie = (function () {
-                if (window.ActiveXObject === undefined) return null;
-                if (!document.querySelector) return 7;
-                if (!document.addEventListener) return 8;
-                if (!window.atob) return 9;
-                /* eslint no-proto: "off" */
-                if (!document.__proto__) return 10;
-                return 11;
-            })();
-
-            if (ie && ie <= 9) {
-                this.hasHistorySupport = false;
-            }
 
             this.$el
                 .on(this.getEventName('click'), '*[data-ajax-variants="true"]', $.proxy(this.onChange, this))


### PR DESCRIPTION
### 1. Why is this change necessary?
Cleanup old code, since Shopware version 5.3 even IE 9 is not supported anymore.

In my opinion the complete history support check can be skipped, since it should be now supported by all major browsers, see here: https://caniuse.com/#feat=history
If so, I will be happy to clean up the code, I am not sure, because of "Opera Mini".

### 2. What does this change do, exactly?
Removes the IE check

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.