### PR TITLE
Add articleDetailId to s_order_details

### DIFF
--- a/_sql/migrations/1218-add-article-detail-id-to-s-order-details.php
+++ b/_sql/migrations/1218-add-article-detail-id-to-s-order-details.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration1218 extends Shopware\Components\Migrations\AbstractMigration
+{
+    /**
+     * @inheritdoc
+     */
+    public function up($modus)
+    {
+        $this->addSql(
+            'ALTER TABLE `s_order_details`
+            ADD
+                articleDetailId INT(11) UNSIGNED NULL'
+        );
+    }
+}

--- a/_sql/migrations/1402-add-article-detail-id-to-s-order-details.php
+++ b/_sql/migrations/1402-add-article-detail-id-to-s-order-details.php
@@ -22,7 +22,7 @@
  * our trademarks remain entirely with us.
  */
 
-class Migrations_Migration1218 extends Shopware\Components\Migrations\AbstractMigration
+class Migrations_Migration1402 extends Shopware\Components\Migrations\AbstractMigration
 {
     /**
      * @inheritdoc

--- a/_sql/migrations/1402-add-article-detail-id-to-s-order-details.php
+++ b/_sql/migrations/1402-add-article-detail-id-to-s-order-details.php
@@ -32,7 +32,7 @@ class Migrations_Migration1402 extends Shopware\Components\Migrations\AbstractMi
         $this->addSql(
             'ALTER TABLE `s_order_details`
             ADD
-                articleDetailId INT(11) UNSIGNED NULL'
+                articledetailsID INT(11) UNSIGNED NULL'
         );
     }
 }

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -485,6 +485,7 @@ class sOrder
                 'orderID' => $orderID,
                 'ordernumber' => 0,
                 'articleID' => $basketRow['articleID'],
+                'articleDetailId' => $basketRow['additional_details']['articleDetailsID'],
                 'articleordernumber' => $basketRow['ordernumber'],
                 'price' => $basketRow['priceNumeric'],
                 'quantity' => $basketRow['quantity'],
@@ -667,9 +668,10 @@ class sOrder
                 tax_rate,
                 ean,
                 unit,
-                pack_unit
+                pack_unit,
+                articleDetailId
                 )
-                VALUES (%d, %s, %d, %s, %f, %d, %s, %d, %s, %d, %d, %d, %f, %s, %s, %s)
+                VALUES (%d, %s, %d, %s, %f, %d, %s, %d, %s, %d, %d, %d, %f, %s, %s, %s, %d)
             ';
 
             $sql = sprintf($preparedQuery,
@@ -688,7 +690,8 @@ class sOrder
                 $basketRow['tax_rate'],
                 $this->db->quote((string) $basketRow['ean']),
                 $this->db->quote((string) $basketRow['itemUnit']),
-                $this->db->quote((string) $basketRow['packunit'])
+                $this->db->quote((string) $basketRow['packunit']),
+                $basketRow['additional_details']['articleDetailsID']
             );
 
             $sql = $this->eventManager->filter('Shopware_Modules_Order_SaveOrder_FilterDetailsSQL', $sql, ['subject' => $this, 'row' => $basketRow, 'user' => $this->sUserData, 'order' => ['id' => $orderID, 'number' => $orderNumber]]);

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -485,7 +485,7 @@ class sOrder
                 'orderID' => $orderID,
                 'ordernumber' => 0,
                 'articleID' => $basketRow['articleID'],
-                'articleDetailId' => $basketRow['additional_details']['articleDetailsID'],
+                'articledetailsID' => $basketRow['additional_details']['articleDetailsID'],
                 'articleordernumber' => $basketRow['ordernumber'],
                 'price' => $basketRow['priceNumeric'],
                 'quantity' => $basketRow['quantity'],
@@ -669,7 +669,7 @@ class sOrder
                 ean,
                 unit,
                 pack_unit,
-                articleDetailId
+                articledetailsID
                 )
                 VALUES (%d, %s, %d, %s, %f, %d, %s, %d, %s, %d, %d, %d, %f, %s, %s, %s, %d)
             ';

--- a/engine/Shopware/Models/Order/Detail.php
+++ b/engine/Shopware/Models/Order/Detail.php
@@ -96,11 +96,11 @@ class Detail extends ModelEntity
     /**
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Article\Detail")
-     * @ORM\JoinColumn(name="articleDetailId", referencedColumnName="id")
+     * @ORM\JoinColumn(name="articledetailsID", referencedColumnName="id")
      *
      * @var ArticleDetail|null
      */
-    protected $articleDetail;
+    protected $articleDetail = null;
 
     /**
      * @var int
@@ -152,7 +152,7 @@ class Detail extends ModelEntity
     /**
      * @var int|null
      *
-     * @ORM\Column(name="articleDetailId", type="integer", nullable=true)
+     * @ORM\Column(name="articledetailsID", type="integer", nullable=true)
      */
     private $articleDetailId;
 

--- a/engine/Shopware/Models/Order/Detail.php
+++ b/engine/Shopware/Models/Order/Detail.php
@@ -91,6 +91,16 @@ class Detail extends ModelEntity
      * @var \Shopware\Models\Order\Esd
      */
     protected $esd;
+
+    /**
+     *
+     * @ORM\ManyToOne(targetEntity="Shopware\Models\Article\Detail")
+     * @ORM\JoinColumn(name="articleDetailId", referencedColumnName="id")
+     *
+     * @var \Shopware\Models\Article\Detail|null
+     */
+    protected $articleDetail;
+
     /**
      * @var int
      *
@@ -137,6 +147,13 @@ class Detail extends ModelEntity
      * @ORM\Column(name="status", type="integer", nullable=false)
      */
     private $statusId;
+
+    /**
+     * @var int|null
+     *
+     * @ORM\Column(name="articleDetailId", type="integer", nullable=true)
+     */
+    private $articleDetailId;
 
     /**
      * @var string

--- a/engine/Shopware/Models/Order/Detail.php
+++ b/engine/Shopware/Models/Order/Detail.php
@@ -26,6 +26,7 @@ namespace Shopware\Models\Order;
 
 use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
+use Shopware\Models\Article\Detail as ArticleDetail;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -97,7 +98,7 @@ class Detail extends ModelEntity
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Article\Detail")
      * @ORM\JoinColumn(name="articleDetailId", referencedColumnName="id")
      *
-     * @var \Shopware\Models\Article\Detail|null
+     * @var ArticleDetail|null
      */
     protected $articleDetail;
 
@@ -389,6 +390,22 @@ class Detail extends ModelEntity
     public function getArticleName()
     {
         return $this->articleName;
+    }
+
+    /**
+     * @return null|ArticleDetail
+     */
+    public function getArticleDetail()
+    {
+        return $this->articleDetail;
+    }
+
+    /**
+     * @param null|ArticleDetail $articleDetail
+     */
+    public function setArticleDetail(ArticleDetail $articleDetail = null)
+    {
+        $this->articleDetail = $articleDetail;
     }
 
     /**

--- a/themes/Backend/ExtJs/backend/order/controller/detail.js
+++ b/themes/Backend/ExtJs/backend/order/controller/detail.js
@@ -369,6 +369,7 @@ Ext.define('Shopware.apps.Order.controller.Detail', {
 
         // Update articleId for row
         editor.context.record.set('articleId', record.get('articleId'));
+        editor.context.record.set('articleDetailId', record.get('id'));
     },
 
 

--- a/themes/Backend/ExtJs/backend/order/model/position.js
+++ b/themes/Backend/ExtJs/backend/order/model/position.js
@@ -58,6 +58,7 @@ Ext.define('Shopware.apps.Order.model.Position', {
         { name: 'orderId', type:'int' },
         { name: 'mode', type:'int' },
         { name: 'articleId', type:'int' },
+        { name: 'articleDetailId', type:'int', useNull: true, default: null},
         { name: 'articleNumber', type:'string' },
         { name: 'articleName', type:'string' },
         { name: 'quantity', type:'int' },


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`OrderDetails` only have an association to an `Article` and not to an `ArticleDetail`. A backtrace from the `OrderDetail` to the `ArticleDetail` is only possible via the ordernumber of the `OrderDetail`.

### 2. What does this change do, exactly?
This adds a field to the `OrderDetail` model containing the connected `ArticleDetail`

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.