### PR TITLE
Allow plugin confirmation cancel

### DIFF
--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/plugin_helper.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/plugin_helper.js
@@ -331,13 +331,16 @@ Ext.define('Shopware.apps.PluginManager.view.PluginHelper', {
         var me = this;
 
         Ext.MessageBox.confirm(title, message, function (apply) {
+            if (apply === 'cancel') {
+                return;
+            }
             if (apply !== 'yes') {
+
                 me.hideLoadingMask();
-
                 if (Ext.isFunction(declineCallback)) {
-                     declineCallback();
-                }
+                    declineCallback();
 
+                }
                 return;
             }
             callback();

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/plugin_helper.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/plugin_helper.js
@@ -328,30 +328,34 @@ Ext.define('Shopware.apps.PluginManager.view.PluginHelper', {
     },
 
     confirmMessage: function(title, message, callback, declineCallback) {
-        var me = this,
-            cfg = {
-                title: title,
-                icon: Ext.Msg.QUESTION,
-                msg: message,
-                buttons: Ext.Msg.YESNOCANCEL,
-                callback: function (apply) {
-                    if (apply === 'cancel') {
-                        return;
-                    }
-                    if (apply !== 'yes') {
+        var me = this;
+        var confirmationCallback = function (apply) {
+            if (apply === 'cancel') {
+                return;
+            }
+            if (apply !== 'yes') {
 
-                        me.hideLoadingMask();
-                        if (Ext.isFunction(declineCallback)) {
-                            declineCallback();
+                me.hideLoadingMask();
+                if (Ext.isFunction(declineCallback)) {
+                    declineCallback();
 
-                        }
-                        return;
-                    }
-                    callback();
                 }
-            };
+                return;
+            }
+            callback();
+        };
 
-        Ext.MessageBox.confirm(cfg);
+        Ext.MessageBox.confirm(me.getMessageBoxConfig(title, message, confirmationCallback));
+    },
+
+    getMessageBoxConfig: function(title, message, callback) {
+        return {
+            title: title,
+            icon: Ext.Msg.QUESTION,
+            msg: message,
+            buttons: Ext.Msg.YESNOCANCEL,
+            callback: callback
+        };
     },
 
     displayErrorMessage: function(response, callback) {

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/plugin_helper.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/plugin_helper.js
@@ -328,23 +328,30 @@ Ext.define('Shopware.apps.PluginManager.view.PluginHelper', {
     },
 
     confirmMessage: function(title, message, callback, declineCallback) {
-        var me = this;
+        var me = this,
+            cfg = {
+                title: title,
+                icon: Ext.Msg.QUESTION,
+                msg: message,
+                buttons: Ext.Msg.YESNOCANCEL,
+                callback: function (apply) {
+                    if (apply === 'cancel') {
+                        return;
+                    }
+                    if (apply !== 'yes') {
 
-        Ext.MessageBox.confirm(title, message, function (apply) {
-            if (apply === 'cancel') {
-                return;
-            }
-            if (apply !== 'yes') {
+                        me.hideLoadingMask();
+                        if (Ext.isFunction(declineCallback)) {
+                            declineCallback();
 
-                me.hideLoadingMask();
-                if (Ext.isFunction(declineCallback)) {
-                    declineCallback();
-
+                        }
+                        return;
+                    }
+                    callback();
                 }
-                return;
-            }
-            callback();
-        });
+            };
+
+        Ext.MessageBox.confirm(cfg);
     },
 
     displayErrorMessage: function(response, callback) {


### PR DESCRIPTION
### 1. Why is this change necessary?
I have clicked on plugin uninstall accidentally (mouse is too fast and so) and see this wonderful confirm message.
![image](https://user-images.githubusercontent.com/6224096/38637639-0a3ec3e6-3dcc-11e8-9300-d49126ad3bee.png)
and pressed ESC and my plugin got uninstalled :scream: 

### 2. What does this change do, exactly?
Do not uninstall plugin on ESC (cancel) confirmation callback :worried: 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.