### PR TITLE
Use getRawBody() instead php://input

### DIFF
--- a/engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
+++ b/engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
@@ -85,7 +85,7 @@ class Enlight_Controller_Plugins_JsonRequest_Bootstrap extends Enlight_Plugin_Bo
             $this->parseInput === true
             && ($contentType = $request->getHeader('Content-Type')) !== false
             && strpos($contentType, 'application/json') === 0
-            && ($input = file_get_contents('php://input')) !== false
+            && ($input = $request->getRawBody()) !== false
         ) {
             if ($input != '') {
                 $input = Zend_Json::decode($input);


### PR DESCRIPTION
### 1. Why is this change necessary?
I am working currently on a shopware php-ppm compability, php-ppm does not set php://input

### 2. What does this change do, exactly?
So i changed it to $request->getRawBody() which can be manipulated with right data. (Example usage: https://github.com/shyim/shopware-ppm/commit/6202a67222dab31e45689ff45251d6b4faba4d89#diff-c23da96dc8986a4cee89980f3aad30e0R80)

**Addional idea for a improvement:**
A addional setter to Enlight Request something like setRawBody, to set the content from Symfony request at that place https://github.com/shopware/shopware/blob/5.4/engine/Shopware/Kernel.php#L250
If i get a go it would implement that too in this pull request :smile: 

### 3. Describe each step to reproduce the issue or behaviour.
Have a JSON in Symfony Request getContent, shopware does not transform that in Enlight request

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.