### PR TITLE
Added ico files to mod expires

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -64,7 +64,7 @@ DirectoryIndex shopware.php
     AddOutputFilterByType DEFLATE text/html text/xml text/plain text/css text/javascript application/javascript application/json application/font-woff application/font-woff2 image/svg+xml
 </IfModule>
 
-<Files ~ "\.(jpe?g|png|gif|css|js|woff|eot|ico)$">
+<Files ~ "\.(jpe?g|png|gif|css|js|woff|woff2|ttf|svg|webp|eot|ico)$">
     <IfModule mod_expires.c>
         ExpiresActive on
         ExpiresDefault "access plus 1 month"

--- a/.htaccess
+++ b/.htaccess
@@ -64,7 +64,7 @@ DirectoryIndex shopware.php
     AddOutputFilterByType DEFLATE text/html text/xml text/plain text/css text/javascript application/javascript application/json application/font-woff application/font-woff2 image/svg+xml
 </IfModule>
 
-<Files ~ "\.(jpe?g|png|gif|css|js|woff|eot)$">
+<Files ~ "\.(jpe?g|png|gif|css|js|woff|eot|ico)$">
     <IfModule mod_expires.c>
         ExpiresActive on
         ExpiresDefault "access plus 1 month"


### PR DESCRIPTION
### 1. Why is this change necessary?
In default configuration ico files doesn't have a expires (Browser Caching)

### 2. What does this change do, exactly?
Adds expires to ico files

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.