### PR TITLE
Check for already created options

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -1764,7 +1764,19 @@ class Article extends Resource implements BatchInterface
                         /** @var \Shopware\Models\Property\Relation $relation */
                         $relation = $query->getOneOrNullResult(self::HYDRATE_OBJECT);
                         if (!$relation) {
-                            $propertyGroup->addOption($option);
+                            //checks if a new option was created
+                            //because the new option is not written to the database at this point
+                            $groupOption = $this->getCollectionElementByProperty(
+                                $propertyGroup->getOptions(),
+                                'id',
+                                $valueData['option']['id']
+                            );
+                            //creates a new option
+                            if ($groupOption === null) {
+                                $propertyGroup->addOption($option);
+                            } else {
+                                $option = $groupOption;
+                            }
                         }
                         // get/create option depending on associated filtergroups
                     } elseif (isset($valueData['option']['name'])) {


### PR DESCRIPTION
Check for already created but not yet written options when passing option IDs too.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Adding multiple property values with the same option ID in a single API request causes SQL constraint errors like the following:
```
An exception occurred while executing 'INSERT INTO s_filter_relations (groupID, optionID) VALUES (?, ?)' with params [2, 12]:                                                                                                                             
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '2-12' for key 'groupID'
```

### 2. What does this change do, exactly?

It applies the same check, whether an option had already been added to the property-group-option-relation during the current database transaction, that's already done when passing the property option by name.

### 3. Describe each step to reproduce the issue or behaviour.

Send a PUT request like the following the articles API:
```
[
    {
        "name": "Longsleeve mit Animalprint",
        "tax": {
            "name": "19"
        },
        "mainDetail": {
            "number": "4055386498411",
            "active": true
        },
        "supplier": "Marc Aurel",
        "filterGroupId": 1,
        "active": true,
        "propertyValues": [
            {
                "value": "754870007274235001",
                "option": {
                    "id": 1
                }
            },
            {
                "value": "38",
                "option": {
                    "id": 2
                }
            },
            {
                "value": "MA",
                "option": {
                    "id": 3
                }
            },
            {
                "value": "Longsleeve mit Animalprint | Farbe: gr\u00fcn | Gr\u00f6\u00dfe: 38",
                "option": {
                    "id": 4
                }
            },
            {
                "value": "Ja",
                "option": {
                    "id": 5
                }
            },
            {
                "value": "100% Leinen",
                "option": {
                    "id": 6
                }
            },
            {
                "value": "FS18",
                "option": {
                    "id": 7
                }
            },
            {
                "value": "A29681",
                "option": {
                    "id": 8
                }
            },
            {
                "value": "6002",
                "option": {
                    "id": 9
                }
            },
            {
                "value": "0",
                "option": {
                    "id": 10
                }
            },
            {
                "value": "WEAR",
                "option": {
                    "id": 11
                }
            },
            {
                "value": "B018",
                "option": {
                    "id": 12
                }
            },
            {
                "value": "C0x8",
                "option": {
                    "id": 12
                }
            },
            {
                "value": "D008",
                "option": {
                    "id": 12
                }
            },
            {
                "value": "N008",
                "option": {
                    "id": 12
                }
            },
            {
                "value": "R0x8",
                "option": {
                    "id": 12
                }
            },
            {
                "value": "T0x8",
                "option": {
                    "id": 12
                }
            },
            {
                "value": "Ws38",
                "option": {
                    "id": 12
                }
            }
        ],
        "categories": [
            {
                "id": 12,
                "active": true
            }
        ]
    }
]
```
See the multiple options with ID 12.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.