### PR TITLE
SW-21637 - Only search active products

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/SearchTermQueryBuilder.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/SearchTermQueryBuilder.php
@@ -183,7 +183,7 @@ class SearchTermQueryBuilder implements SearchTermQueryBuilderInterface
 
         $query = $this->connection->createQueryBuilder();
         $query->from('(' . $subQuery->getSQL() . ')', 'sr')
-            ->innerJoin('sr', 's_articles', 'a', 'a.id = sr.articleID');
+            ->innerJoin('sr', 's_articles', 'a', 'a.id = sr.articleID AND a.active = 1');
 
         return $query;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Atm inactive products are searched as well, but will not be displayed in the frontend.

### 2. What does this change do, exactly?
This change limits the search result to active prodcuts

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-21637

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.