### PR TITLE
fix fallback translation for config store options element

### DIFF
--- a/engine/Shopware/Controllers/Backend/Config.php
+++ b/engine/Shopware/Controllers/Backend/Config.php
@@ -184,7 +184,7 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
                 continue;
             }
 
-            $values['options']['store'] = $this->translateStore('en', $values['options']['store']);
+            $values['options']['store'] = $this->translateStore('en_GB', $values['options']['store']);
             $values['options']['store'] = $this->translateStore($language, $values['options']['store']);
             $values['options']['queryMode'] = 'remote';
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
without this change the option label translation will not work and return always the first translation in the array

### 2. What does this change do, exactly?
change the fallback lang string from 'en' to 'en_GB' , because the store option label user the full lang str not the short one.

### 3. Describe each step to reproduce the issue or behaviour.
just check the example hier https://forum.shopware.com/discussion/53062/mehrsprachigkeit-bei-select-options-in-config-xml

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?
no changes

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.