### PR TITLE
Collect width and height for SVG

### DIFF
--- a/engine/Shopware/Models/Media/MediaSubscriber.php
+++ b/engine/Shopware/Models/Media/MediaSubscriber.php
@@ -93,32 +93,62 @@ class MediaSubscriber implements EventSubscriber
     {
         $media = $eventArgs->getEntity();
 
-        if (!($media instanceof Media)) {
-            return;
-        }
-
-        if ($media->getType() !== Media::TYPE_IMAGE) {
+        if (!$this->isFormatSupported($media)) {
             return;
         }
 
         $mediaService = $this->container->get('shopware_media.media_service');
 
         if ((!$media->getHeight() || !$media->getWidth()) && $mediaService->has($media->getPath())) {
-            list($width, $height) = getimagesizefromstring($mediaService->read($media->getPath()));
 
-            if ($media->getId()) {
-                $eventArgs->getEntityManager()->getConnection()->executeUpdate(
-                    'UPDATE s_media SET width = :width, height = :height WHERE id = :id',
-                    [
-                        ':width' => $width,
-                        ':height' => $height,
-                        ':id' => $media->getId(),
-                    ]
-                );
+            switch ($media->getType()) {
+                case Media::TYPE_IMAGE:
+                    list($width, $height) = getimagesizefromstring($mediaService->read($media->getPath()));
+                    break;
+
+                case Media::TYPE_VECTOR:
+                    if ($media->getExtension() === 'svg') {
+                        $xml = simplexml_load_string($mediaService->read($media->getPath()));
+                        $attr = $xml->attributes();
+
+                        if ($attr->width > 0 && $attr->height > 0) {
+                            $width = (int)$attr->width;
+                            $height = (int)$attr->height;
+                        } elseif ($attr->viewBox && count($size = explode(' ', $attr->viewBox)) === 4) {
+                            $width = (int)$size[2];
+                            $height = (int)$size[3];
+                        }
+                    }
             }
 
-            $media->setWidth($width);
-            $media->setHeight($height);
+            if (!empty($height) && !empty($width)) {
+                if ($media->getId()) {
+                    $eventArgs->getEntityManager()->getConnection()->executeUpdate(
+                        'UPDATE s_media SET width = :width, height = :height WHERE id = :id',
+                        [
+                            ':width' => $width,
+                            ':height' => $height,
+                            ':id' => $media->getId(),
+                        ]
+                    );
+                }
+
+                $media->setWidth($width);
+                $media->setHeight($height);
+            }
         }
+    }
+
+    /**
+     * Test file for instance Media and has supported types
+     *
+     * @param object $media
+     * @return bool
+     */
+    private function isFormatSupported($media)
+    {
+        return $media instanceof Media
+            && ($media->getType() === Media::TYPE_IMAGE
+                || ($media->getType() === Media::TYPE_VECTOR && $media->getExtension() === 'svg'));
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Shopping worlds and other components need width and height for correct calculations like image mapping.

### 2. What does this change do, exactly?
Add to supported type image also type vector with extension svg. Svg is most common supported vector format in browsers. Svg is XML based and has different ways to add width and height. Directly width and height attribute or viewbox (second and third value).

### 3. Describe each step to reproduce the issue or behaviour.
Add a shopping world banner and try to add an SVG with a image map.

### 4. Please link to the relevant issues (if any).
Is closed

### 5. Which documentation changes (if any) need to be made because of this PR?
SVG support is improved for example in shopping world. This allows modern light weight vector images for highDPI displays with less traffic and no need thumbnails.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change -
-> No existing tests for migrateMeta

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.