### PR TITLE
Add nooperner to external links

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/PostFilter/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/PostFilter/Bootstrap.php
@@ -180,7 +180,7 @@ class Shopware_Plugins_Core_PostFilter_Bootstrap extends Shopware_Components_Plu
             if ($src[1] === 'a' && preg_match('#^https?://#', $src[3])) {
                 $host = @parse_url($src[3], PHP_URL_HOST);
                 if (!strstr($src[0], 'rel=') && !in_array($host, $this->backLinkWhiteList)) {
-                    $src[0] = rtrim($src[0], '>') . ' rel="nofollow">';
+                    $src[0] = rtrim($src[0], '>') . ' rel="nofollow noopener">';
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Improves security by not providing a opener js property. Currently this could be manipulated on the new page to change the location of the opener. See https://developers.google.com/web/tools/lighthouse/audits/noopener for more details

### 2. What does this change do, exactly?
Add noopener where currently nofollow is set

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
N/A

### 5. Which documentation changes (if any) need to be made because of this PR?
N/A

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.