### PR TITLE
FIX: block closed tag on wrong line for comparing products

### DIFF
--- a/themes/Frontend/Bare/frontend/compare/col.tpl
+++ b/themes/Frontend/Bare/frontend/compare/col.tpl
@@ -92,7 +92,6 @@
                                 {$sArticle.price|currency}
                                 {s name="Star" namespace="frontend/listing/box_article"}{/s}
                             </span>
-                        {/block}
                     {/block}
 
                     {* Article unit price *}
@@ -112,6 +111,7 @@
                                 {/if}
                             </div>
                         {/if}
+                        {/block}
                     </li>
                 {/block}
 

--- a/themes/Frontend/Bare/frontend/compare/col.tpl
+++ b/themes/Frontend/Bare/frontend/compare/col.tpl
@@ -19,14 +19,15 @@
                                         {if $sArticle.image.description}
                                             {$desc = $sArticle.image.description|escape}
                                         {/if}
-
                                         <img srcset="{$sArticle.image.thumbnails[0].sourceSet}"
                                              alt="{$desc}"
-                                             title="{$desc|truncate:160}" />
+                                             title="{$desc|truncate:160}"/>
+                                            
                                     {else}
+                                        
                                         <img src="{link file='frontend/_public/src/img/no-picture.jpg'}"
                                              alt="{$desc}"
-                                             title="{$desc|truncate:160}" />
+                                             title="{$desc|truncate:160}"/>
                                     {/if}
                                 </span>
                             </span>
@@ -36,10 +37,12 @@
 
                 {block name='frontend_compare_article_name'}
                     <li class="list--entry entry--name">
-                        <a class="link--name" href="{$sArticle.linkDetails}" title="{$sArticle.articleName|escape}">{$sArticle.articleName|truncate:47}</a>
+                        <a class="link--name" href="{$sArticle.linkDetails}"
+                           title="{$sArticle.articleName|escape}">{$sArticle.articleName|truncate:47}</a>
 
                         {block name='frontend_compare_article_name_button'}
-                            <a href="{$sArticle.linkDetails}" title="{$sArticle.articleName|escape}" class="btn is--primary is--center is--full is--icon-right btn--product">
+                            <a href="{$sArticle.linkDetails}" title="{$sArticle.articleName|escape}"
+                               class="btn is--primary is--center is--full is--icon-right btn--product">
                                 {s name='ListingBoxLinkDetails' namespace="frontend/listing/box_article"}{/s}
                                 <i class="icon--arrow-right"></i>
                             </a>
@@ -72,7 +75,7 @@
 
                                     <span class="price--pseudoprice">
                                         {$sArticle.pseudoprice|currency}
-                                        {s name="Star" namespace="frontend/listing/box_article"}{/s}<br />
+                                        {s name="Star" namespace="frontend/listing/box_article"}{/s}<br/>
                                     </span>
 
                                     {block name='frontend_compare_price_pseudoprice_after'}
@@ -92,25 +95,28 @@
                                 {$sArticle.price|currency}
                                 {s name="Star" namespace="frontend/listing/box_article"}{/s}
                             </span>
-                    {/block}
-
-                    {* Article unit price *}
-                    {block name='frontend_compare_unitprice'}
-                        {if $sArticle.purchaseunit}
-                            <div class="price--unit">
-                                <strong class="price--unit-commpare">{s name="CompareContent"}{/s}:</strong> {$sArticle.purchaseunit} {$sArticle.sUnit.description}
-                                {if $sArticle.purchaseunit != $sArticle.referenceunit}
-                                    {if $sArticle.referenceunit}
-                                        <span class="is--nowrap">
-                                            <strong class="price--unit-baseprice">{s name="CompareBaseprice"}{/s}:</strong>
+                        {/block}
+                        
+                        {* Article unit price *}
+                        {block name='frontend_compare_unitprice'}
+                            {if $sArticle.purchaseunit}
+                                <div class="price--unit">
+                                    <strong class="price--unit-commpare">{s name="CompareContent"}{/s}
+                                        :</strong> {$sArticle.purchaseunit} {$sArticle.sUnit.description}
+                                    {if $sArticle.purchaseunit != $sArticle.referenceunit}
+                                        {if $sArticle.referenceunit}
+                                            <span class="is--nowrap">
+                                            <strong class="price--unit-baseprice">{s name="CompareBaseprice"}{/s}
+                                                :</strong>
                                         </span>
-                                        <span class="is--nowrap">
-                                            {$sArticle.referenceunit} {$sArticle.sUnit.description} = {$sArticle.referenceprice|currency} {s name="Star" namespace="frontend/listing/box_article"}{/s}
+                                            <span class="is--nowrap">
+                                            {$sArticle.referenceunit} {$sArticle.sUnit.description}
+                                                = {$sArticle.referenceprice|currency} {s name="Star" namespace="frontend/listing/box_article"}{/s}
                                         </span>
+                                        {/if}
                                     {/if}
-                                {/if}
-                            </div>
-                        {/if}
+                                </div>
+                            {/if}
                         {/block}
                     </li>
                 {/block}


### PR DESCRIPTION
this fix the right block close tag for comparing products

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.