### PR TITLE
Add ProductNumberSearch from SearchBundleDBAL as own service

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -13,6 +13,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
   * `Shopware_Controllers_Widgets_Listing_fetchPagination_preFetch`
 * Added a new category for the basic setting containing privacy options
 * Added possibility to enable/disable data protection information texts
+* Registed class `Shopware\Bundle\SearchBundleDBAL\ProductNumberSearch` additionally as service `shopware_searchdbal.product_number_search`
 
 ### Changes
 

--- a/engine/Shopware/Bundle/SearchBundleDBAL/services.xml
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/services.xml
@@ -14,6 +14,15 @@
             <argument type="service" id="service_container" />
         </service>
 
+        <service id="shopware_searchdbal.product_number_search" class="Shopware\Bundle\SearchBundleDBAL\ProductNumberSearch">
+            <argument type="service" id="shopware_searchdbal.dbal_query_builder_factory"/>
+            <argument type="service" id="events" />
+
+            <!--facet handler-->
+            <argument type="collection" />
+            <argument type="service" id="service_container" />
+        </service>
+
         <service id="shopware_searchdbal.search_price_helper_dbal" class="Shopware\Bundle\SearchBundleDBAL\PriceHelper">
             <argument type="service" id="config" />
         </service>


### PR DESCRIPTION
### 1. Why is this change necessary?
Add `Shopware\Bundle\SearchBundleDBAL\ProductNumberSearch` as own service to the service container to access it, even if the SearchBundleES is activated. 

### 2. What does this change do, exactly?
Add  `Shopware\Bundle\SearchBundleDBAL\ProductNumberSearch` as `shopware_searchdbal.product_number_search` to the DI container.

### 3. Describe each step to reproduce the issue or behaviour.
Request service `shopware_search.product_number_search` when you have the ElasticSearch activated 

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.