### PR TITLE
Allow attributes be readonly in backend

### DIFF
--- a/_sql/migrations/1219-add-readonly-to-attribute-field.php
+++ b/_sql/migrations/1219-add-readonly-to-attribute-field.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration1219 extends Shopware\Components\Migrations\AbstractMigration {
+    public function up($modus) {
+        $this->addSQL('ALTER TABLE `s_attribute_configuration` ADD `readonly` TINYINT NOT NULL DEFAULT 0 AFTER `label`;');
+
+        $sql = <<<EOT
+SET @locale_de_DE = (SELECT id FROM s_core_locales WHERE locale = 'de_DE');
+SET @locale_en_GB = (SELECT id FROM s_core_locales WHERE locale = 'en_GB');
+INSERT IGNORE INTO s_core_snippets (namespace, shopID, localeID, name, value, created, updated, dirty) VALUES
+('backend/attributes/main', 1, @locale_en_GB, 'readonly', 'Readonly in backend', '2018-04-24 09:43:14', '2018-04-24 09:43:14', 0),
+('backend/attributes/main', 1, @locale_de_DE, 'readonly', 'Schreibgeschützt im Backend', '2018-04-24 09:43:14', '2018-04-24 09:43:14', 0);
+EOT;
+
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Bundle/AttributeBundle/Service/ConfigurationStruct.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/ConfigurationStruct.php
@@ -234,7 +234,7 @@ class ConfigurationStruct implements \JsonSerializable
     /**
      * @return bool
      */
-    public function readonly()
+    public function isReadonly()
     {
         return $this->readonly;
     }

--- a/engine/Shopware/Bundle/AttributeBundle/Service/ConfigurationStruct.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/ConfigurationStruct.php
@@ -60,6 +60,10 @@ class ConfigurationStruct implements \JsonSerializable
      * @var bool
      */
     private $displayInBackend = false;
+    /**
+     * @var bool
+     */
+    private $readonly = false;
 
     /**
      * @var bool
@@ -225,6 +229,22 @@ class ConfigurationStruct implements \JsonSerializable
     public function setDisplayInBackend($displayInBackend)
     {
         $this->displayInBackend = $displayInBackend;
+    }
+
+    /**
+     * @return bool
+     */
+    public function readonly()
+    {
+        return $this->readonly;
+    }
+
+    /**
+     * @param bool $readonly
+     */
+    public function setReadonly($readonly)
+    {
+        $this->readonly = $readonly;
     }
 
     /**

--- a/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/CrudService.php
@@ -217,6 +217,7 @@ class CrudService
                 $item->setSupportText($config['supportText']);
                 $item->setHelpText($config['helpText']);
                 $item->setDisplayInBackend((bool) $config['displayInBackend']);
+                $item->setReadonly((bool) $config['readonly']);
                 $item->setLabel($config['label']);
                 $item->setPosition((int) $config['position']);
                 $item->setCustom((bool) $config['custom']);

--- a/engine/Shopware/Models/Attribute/Configuration.php
+++ b/engine/Shopware/Models/Attribute/Configuration.php
@@ -78,6 +78,12 @@ class Configuration extends ModelEntity
     private $label;
 
     /**
+     * @var boolean
+     * @ORM\Column(name="readonly", type="boolean", nullable=false)
+     */
+    private $readonly = false;
+
+    /**
      * @var string
      * @ORM\Column(name="help_text", type="string", nullable=true)
      */
@@ -189,6 +195,22 @@ class Configuration extends ModelEntity
     public function setLabel($label)
     {
         $this->label = $label;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isReadonly()
+    {
+        return $this->readonly;
+    }
+
+    /**
+     * @param bool $readonly
+     */
+    public function setReadonly($readonly)
+    {
+        $this->readonly = $readonly;
     }
 
     /**

--- a/themes/Backend/ExtJs/backend/attributes/view/detail.js
+++ b/themes/Backend/ExtJs/backend/attributes/view/detail.js
@@ -374,6 +374,7 @@ Ext.define('Shopware.apps.Attributes.view.Detail', {
                         helpText: { fieldLabel: '{s name="help_text"}{/s}', translatable: true },
                         position: '{s name="position"}{/s}',
                         displayInBackend: '{s name="display_in_backend"}{/s}',
+                        readonly: '{s name="readonly"}{/s}',
                         translatable: '{s name="translatable"}{/s}',
                         arrayStore: me.createArrayStore
                     }

--- a/themes/Backend/ExtJs/backend/base/attribute/Shopware.attribute.Form.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/Shopware.attribute.Form.js
@@ -341,18 +341,19 @@ Ext.define('Shopware.attribute.Form', {
         var me = this, fields = [];
 
         Ext.each(attributes, function(attribute) {
-            var field = {
-                name: '__attribute_' + attribute.get('columnName'),
-                translatable: attribute.get('translatable'),
-                fieldLabel: attribute.get('label'),
-                supportText: attribute.get('supportText'),
-                helpText: attribute.get('helpText'),
-                labelWidth: 155,
-                value: attribute.get('defaultValue')
-            };
             var handler = me.getTypeHandler(attribute);
 
             if (handler && attribute.get('displayInBackend')) {
+                var field = {
+                    name: '__attribute_' + attribute.get('columnName'),
+                    translatable: attribute.get('translatable'),
+                    fieldLabel: attribute.get('label'),
+                    supportText: attribute.get('supportText'),
+                    helpText: attribute.get('helpText'),
+                    labelWidth: 155,
+                    value: attribute.get('defaultValue'),
+                    disabled: attribute.get('readonly')
+                };
                 fields.push(handler.create(field, attribute));
             }
         });

--- a/themes/Backend/ExtJs/backend/base/model/attribute_config.js
+++ b/themes/Backend/ExtJs/backend/base/model/attribute_config.js
@@ -18,6 +18,7 @@ Ext.define('Shopware.model.AttributeConfig', {
         { name: 'supportText', type: 'string' },
         { name: 'translatable', type: 'boolean' },
         { name: 'displayInBackend', type: 'boolean', defaultValue: true },
+        { name: 'readonly', type: 'boolean', defaultValue: false },
         { name: 'pluginId', type: 'integer' },
         { name: 'configured', type: 'boolean' },
         { name: 'position', type: 'integer' },


### PR DESCRIPTION
### 1. Why is this change necessary?
Sometimes you want to add a attribute that should not be editable for your users but still visible in backend. This allows to make that attribute be readonly.

### 2. What does this change do, exactly?
Adding a new attribute configuration option that marks that attribute as readonly. This setting is then used to disable the input field in extjs. Therefore changes by code are of course still possible

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
New option "readonly" for attribute cru(d).

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.