### PR TITLE
Emit events during plugin lifecycle

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PluginEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PluginEvent.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+use Shopware\Components\Plugin;
+use Shopware\Components\Plugin\Context\InstallContext;
+
+abstract class PluginEvent extends \Enlight_Event_EventArgs
+{
+    const PRE_INSTALL = PrePluginInstallEvent::class;
+    const POST_INSTALL = PostPluginInstallEvent::class;
+    const PRE_UNINSTALL = PrePluginUninstallEvent::class;
+    const POST_UNINSTALL = PostPluginUninstallEvent::class;
+    const PRE_UPDATE = PrePluginUpdateEvent::class;
+    const POST_UPDATE = PostPluginUpdateEvent::class;
+    const PRE_ACTIVATE = PrePluginActivateEvent::class;
+    const POST_ACTIVATE = PostPluginActivateEvent::class;
+    const PRE_DEACTIVATE = PrePluginDeactivateEvent::class;
+    const POST_DEACTIVATE = PostPluginDeactivateEvent::class;
+
+    /**
+     * PluginEvent constructor.
+     *
+     * @param InstallContext $context
+     * @param Plugin         $plugin
+     */
+    public function __construct(InstallContext $context, Plugin $plugin)
+    {
+        parent::__construct(['context' => $context, 'plugin' => $plugin]);
+    }
+
+    /**
+     * @return InstallContext
+     */
+    public function getContext()
+    {
+        return $this->get('context');
+    }
+
+    /**
+     * @return Plugin
+     */
+    public function getPlugin()
+    {
+        return $this->get('plugin');
+    }
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PostPluginActivateEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PostPluginActivateEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+class PostPluginActivateEvent extends PluginEvent
+{
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PostPluginDeactivateEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PostPluginDeactivateEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+class PostPluginDeactivateEvent extends PluginEvent
+{
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PostPluginInstallEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PostPluginInstallEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+class PostPluginInstallEvent extends PluginEvent
+{
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PostPluginUninstallEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PostPluginUninstallEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+class PostPluginUninstallEvent extends PluginEvent
+{
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PostPluginUpdateEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PostPluginUpdateEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+class PostPluginUpdateEvent extends PluginEvent
+{
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PrePluginActivateEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PrePluginActivateEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+class PrePluginActivateEvent extends PluginEvent
+{
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PrePluginDeactivateEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PrePluginDeactivateEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+class PrePluginDeactivateEvent extends PluginEvent
+{
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PrePluginInstallEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PrePluginInstallEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+class PrePluginInstallEvent extends PluginEvent
+{
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PrePluginUninstallEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PrePluginUninstallEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+class PrePluginUninstallEvent extends PluginEvent
+{
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Events/PrePluginUpdateEvent.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Events/PrePluginUpdateEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Events;
+
+class PrePluginUpdateEvent extends PluginEvent
+{
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/services.xml
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/services.xml
@@ -33,6 +33,7 @@
             <argument type="service" id="shopware.snippet_database_handler" />
             <argument type="service" id="shopware.plugin_requirement_validator" />
             <argument type="service" id="db_connection" />
+            <argument type="service" id="events" />
             <argument type="collection">
                 <argument type="string">%shopware.plugin_directories.ShopwarePlugins%</argument>
                 <argument type="string">%shopware.plugin_directories.ProjectPlugins%</argument>

--- a/tests/Unit/Bundle/PluginInstallerBundle/PluginInstallerTest.php
+++ b/tests/Unit/Bundle/PluginInstallerBundle/PluginInstallerTest.php
@@ -89,6 +89,7 @@ class PluginInstallerTest extends TestCase
             $databaseHandler,
             $requirementValidator,
             $pdo,
+            new \Enlight_Event_EventManager(),
             __DIR__ . '/Fixtures',
             new ShopwareReleaseStruct($releaseArray['version'], $releaseArray['version_text'], $releaseArray['revision'])
         );


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently it is very hard to hook into plugin installation process in order to provide cross-plugin-functionality. 
In addition, further plugin-related functionality could be made self-contained (i am looking at you, PluginInstaller).

### 2. What does this change do, exactly?
During plugin lifecycle changes, events are emitted indicating these. 

### 3. Describe each step to reproduce the issue or behaviour.
No issue

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
Maybe
https://github.com/shopware/devdocs/blob/master/source/developers-guide/event-guide/index.md
or in a seperate section.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.