### PR TITLE
don't ignore get parameter in paging url

### DIFF
--- a/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
+++ b/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
@@ -9,16 +9,15 @@
     {* Pagination - Frist page *}
     {block name="frontend_listing_actions_paging_first"}
         {if strpos($baseUrl, '?') !== false}
-            {assign var='pagingFirstPage' value="{$baseUrl}&p=1"}
-            {assign var='pagingPrevPage' value="{$baseUrl}&p={$sPage - 1}"}
-            {assign var='pagingNextPage' value="{$baseUrl}&p={$sPage + 1}"}
-            {assign var='pagingLastPage' value="{$baseUrl}&p={$sPages}"}
+            {assign var='baseUrlParamChar' value='&'}
         {else}
-            {assign var='pagingFirstPage' value="{$baseUrl}?p=1"}
-            {assign var='pagingPrevPage' value="{$baseUrl}?p={$sPage - 1}"}
-            {assign var='pagingNextPage' value="{$baseUrl}?p={$sPage + 1}"}
-            {assign var='pagingLastPage' value="{$baseUrl}?p={$sPages}"}
+            {assign var='baseUrlParamChar' value='?'}
         {/if}
+
+        {assign var='pagingFirstPage' value="{$baseUrl}{$baseUrlParamChar}p=1"}
+        {assign var='pagingPrevPage' value="{$baseUrl}{$baseUrlParamChar}p={$sPage - 1}"}
+        {assign var='pagingNextPage' value="{$baseUrl}{$baseUrlParamChar}p={$sPage + 1}"}
+        {assign var='pagingLastPage' value="{$baseUrl}{$baseUrlParamChar}p={$sPages}"}
 
         {if $sPage > 1}
             <a href="{$pagingFirstPage}" title="{"{s name='ListingLinkFirst'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">

--- a/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
+++ b/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
@@ -8,8 +8,20 @@
 
     {* Pagination - Frist page *}
     {block name="frontend_listing_actions_paging_first"}
+        {if strpos($baseUrl, '?') !== false}
+            {assign var='pagingFirstPage' value="{$baseUrl}&p=1"}
+            {assign var='pagingPrevPage' value="{$baseUrl}&p={$sPage - 1}"}
+            {assign var='pagingNextPage' value="{$baseUrl}&p={$sPage + 1}"}
+            {assign var='pagingLastPage' value="{$baseUrl}&p={$sPages}"}
+        {else}
+            {assign var='pagingFirstPage' value="{$baseUrl}?p=1"}
+            {assign var='pagingPrevPage' value="{$baseUrl}?p={$sPage - 1}"}
+            {assign var='pagingNextPage' value="{$baseUrl}?p={$sPage + 1}"}
+            {assign var='pagingLastPage' value="{$baseUrl}?p={$sPages}"}
+        {/if}
+
         {if $sPage > 1}
-            <a href="{$baseUrl}?p=1" title="{"{s name='ListingLinkFirst'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">
+            <a href="{$pagingFirstPage}" title="{"{s name='ListingLinkFirst'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">
                 <i class="icon--arrow-left"></i>
                 <i class="icon--arrow-left"></i>
             </a>
@@ -19,7 +31,7 @@
     {* Pagination - Previous page *}
     {block name='frontend_listing_actions_paging_previous'}
         {if $sPage > 1}
-            <a href="{$baseUrl}?p={$sPage-1}" title="{"{s name='ListingLinkPrevious'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">
+            <a href="{$pagingPrevPage}" title="{"{s name='ListingLinkPrevious'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">
                 <i class="icon--arrow-left"></i>
             </a>
         {/if}
@@ -35,7 +47,7 @@
     {* Pagination - Next page *}
     {block name='frontend_listing_actions_paging_next'}
         {if $sPage < $pages}
-            <a href="{$baseUrl}?p={$sPage+1}" title="{"{s name='ListingLinkNext'}{/s}"|escape}" class="paging--link paging--next" data-action-link="true">
+            <a href="{$pagingNextPage}" title="{"{s name='ListingLinkNext'}{/s}"|escape}" class="paging--link paging--next" data-action-link="true">
                 <i class="icon--arrow-right"></i>
             </a>
         {/if}
@@ -44,7 +56,7 @@
     {* Pagination - Last page *}
     {block name="frontend_listing_actions_paging_last"}
         {if $sPage < $pages}
-            <a href="{$baseUrl}?p={$pages}" title="{"{s name='ListingLinkLast'}{/s}"|escape}" class="paging--link paging--next" data-action-link="true">
+            <a href="{$pagingLastPage}" title="{"{s name='ListingLinkLast'}{/s}"|escape}" class="paging--link paging--next" data-action-link="true">
                 <i class="icon--arrow-right"></i>
                 <i class="icon--arrow-right"></i>
             </a>


### PR DESCRIPTION
1. Why is this change necessary?
When paging is enabled and you have already get paraemter in you listing controller request, just adding the page parameter with `? ` does not make sense.
2. What does this change do, exactly?
This pull request code takes care about it in a simple way. Basically I think that is not something that should be done in the view. However, any other solution would raise the complexity unneccessarily. So I did it this way.
3. Describe each step to reproduce the issue or behaviour.
Go to you shop backend, enable paging (instead of ajax scrolling). Call the listing controller with some parameters (with many articles in it, for at least 3 pages in order to see the effect). Look at the generated url, they contain two `?` in it, which normally indicates the start of get parameter part in an url.
4. Please link to the relevant issues (if any).
none
5. Which documentation changes (if any) need to be made because of this PR?
none
6. Checklist
- [x] I have written tests and verified that they fail without my change
- [x]  I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

Test code (just write it anywhere in your smarty template; 100% test coverage):
`
        {assign var='sPages' value=5}
        {assign var='baseUrl' value='http://www.example.com/controller/action'}
        {assign var='sPage' value=2}

        {if strpos($baseUrl, '?') !== false}
            {assign var='baseUrlParamChar' value='&'}
        {else}
            {assign var='baseUrlParamChar' value='?'}
        {/if}

        {assign var='pagingFirstPage' value="{$baseUrl}{$baseUrlParamChar}p=1"}
        {assign var='pagingPrevPage' value="{$baseUrl}{$baseUrlParamChar}p={$sPage - 1}"}
        {assign var='pagingNextPage' value="{$baseUrl}{$baseUrlParamChar}p={$sPage + 1}"}
        {assign var='pagingLastPage' value="{$baseUrl}{$baseUrlParamChar}p={$sPages}"}
        {$pagingFirstPage|var_dump}
        {$pagingPrevPage|var_dump}
        {$pagingNextPage|var_dump}
        {$pagingLastPage|var_dump}

        {assign var='baseUrl' value='http://www.example.com/controller/action?param1=val1&param2=val2'}
        {if strpos($baseUrl, '?') !== false}
            {assign var='baseUrlParamChar' value='&'}
        {else}
            {assign var='baseUrlParamChar' value='?'}
        {/if}

        {assign var='pagingFirstPage' value="{$baseUrl}{$baseUrlParamChar}p=1"}
        {assign var='pagingPrevPage' value="{$baseUrl}{$baseUrlParamChar}p={$sPage - 1}"}
        {assign var='pagingNextPage' value="{$baseUrl}{$baseUrlParamChar}p={$sPage + 1}"}
        {assign var='pagingLastPage' value="{$baseUrl}{$baseUrlParamChar}p={$sPages}"}
        {$pagingFirstPage|var_dump}
        {$pagingPrevPage|var_dump}
        {$pagingNextPage|var_dump}
        {$pagingLastPage|var_dump}
`
I tested it in a single view and it worked! :-)