### PR TITLE
Make search in orders hookable

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -662,6 +662,30 @@ class Repository extends ModelRepository
      *
      * @return int[]
      */
+    protected function searchInOrders($term)
+    {
+        $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $query->select('orders.id');
+        $query->from('s_order', 'orders');
+        $builder = Shopware()->Container()->get('shopware.model.search_builder');
+        $builder->addSearchTerm($query, $term, [
+            'orders.ordernumber^3',
+            'orders.transactionID^1',
+            'orders.comment^0.2',
+            'orders.customercomment^0.2',
+            'orders.internalcomment^0.2',
+        ]);
+
+        $query->setMaxResults(self::SEARCH_TERM_LIMIT);
+
+        return $query->execute()->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * @param string $term
+     *
+     * @return int[]
+     */
     private function searchOrderIds($term)
     {
         $orders = $this->searchInOrders($term);
@@ -751,27 +775,4 @@ class Repository extends ModelRepository
         return $query->execute()->fetchAll(\PDO::FETCH_COLUMN);
     }
 
-    /**
-     * @param string $term
-     *
-     * @return int[]
-     */
-    private function searchInOrders($term)
-    {
-        $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $query->select('orders.id');
-        $query->from('s_order', 'orders');
-        $builder = Shopware()->Container()->get('shopware.model.search_builder');
-        $builder->addSearchTerm($query, $term, [
-            'orders.ordernumber^3',
-            'orders.transactionID^1',
-            'orders.comment^0.2',
-            'orders.customercomment^0.2',
-            'orders.internalcomment^0.2',
-        ]);
-
-        $query->setMaxResults(self::SEARCH_TERM_LIMIT);
-
-        return $query->execute()->fetchAll(\PDO::FETCH_COLUMN);
-    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The searchInOrder function controlls the selection of orders in the backend order listing pane. Making it hookable will facilitate customization of the search without affecting larger parts of the order repository class. There is a customer request to be able to search for article ordernumbers in the backend orders list.

### 2. What does this change do, exactly?
Just changes visibility of searchInOrders from private to protected. 

### 3. Describe each step to reproduce the issue or behaviour.
Method searchInOrders not hookable.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.