### PR TITLE
Fix price rounding to prevent errors in PriceCount

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ListProductGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ListProductGateway.php
@@ -187,7 +187,7 @@ class ListProductGateway implements Gateway\ListProductGatewayInterface
         if ($this->config->get('calculateCheapestPriceWithMinPurchase')) {
             $query->addSelect('COUNT(DISTINCT ROUND(prices.price * priceVariant.minpurchase, 2)) as priceCount');
         } else {
-            $query->addSelect('COUNT(DISTINCT prices.price) as priceCount');
+            $query->addSelect('COUNT(DISTINCT ROUND(prices.price, 2)) as priceCount');
         }
 
         $query->from('s_articles_prices', 'prices')


### PR DESCRIPTION
### 1. Why is this change necessary?
This change ensures, that when retrieving the distinct PriceCount of an article the prices will always be rounded. This prevents comparision errors when using prices with more than 2 decimals.

This way a Shop can use more than two digits of precision for prices while still ensuring, that the "starting at" badge for prices works correctly.

Our current workaround is to activate the `calculateCheapestPriceWithMinPurchase` config, even though this is not the most optimal solution.

### 2. What does this change do, exactly?
Modify `ListProductGateway::getPriceCountQuery()` to add a `ROUND` to the query.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a new article with variants
2. Edit the prices in the database to have small differences, e.g.:
    Article A: 50.378151260504
    Article B: 50.378151260503
3. Visit a Category containing the article.
4. The Article will show a "starting at" next to the price.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] I have read the contribution requirements and fulfil them.