### PR TITLE
Updated style.css for the license agreement

### DIFF
--- a/recovery/common/assets/styles/style.css
+++ b/recovery/common/assets/styles/style.css
@@ -133,6 +133,7 @@ button:disabled {
 .license--agreement {
     font-size: 12px;
     font-family: Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace;
+	background-color: white;
 }
 
 label {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Under Linux you can choose between a bright and a dark style.
When the dark style is activated, the text of the license agreement is hard to read.

### 2. What does this change do, exactly?
Colors the background of the license agreement white

**Before the change**
![Before the change](http://storage1.static.itmages.com/i/18/0427/h_1524814318_3624586_389a228924.png)

**After the change**
![After the change](http://storage3.static.itmages.com/i/18/0427/h_1524814340_4750419_864db17411.png)

### 3. Describe each step to reproduce the issue or behaviour.
Install Linux (Linux Mint) and activate the dark theme. Then visit the install process.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.