### PR TITLE
Added possibility to set sTarget for Detail/ratingAction

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -13,6 +13,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
   * `Shopware_Controllers_Widgets_Listing_fetchPagination_preFetch`
 * Added a new category for the basic setting containing privacy options
 * Added possibility to enable/disable data protection information texts
+* Added possibility to set sTarget for Detail/ratingAction
 
 ### Changes
 

--- a/engine/Shopware/Controllers/Frontend/Detail.php
+++ b/engine/Shopware/Controllers/Frontend/Detail.php
@@ -262,7 +262,10 @@ class Shopware_Controllers_Frontend_Detail extends Enlight_Controller_Action
 
         $this->View()->sAction = 'ratingAction';
 
-        $this->forward('index');
+        $this->forward(
+            $this->Request()->getParam('sTargetAction', 'index'),
+            $this->Request()->getParam('sTarget', 'detail')
+        );
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
I'd like to give a user the possibility to rate an already bought article in his account. After rating he should be routed back to the account and not to the article's detail page.

### 2. What does this change do, exactly?
If sTarget and sTargetAction are set, the user is forwarded.
If not, it works as before.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.