### PR TITLE
Fix customer greeting if not logged in

### DIFF
--- a/engine/Shopware/Bundle/AccountBundle/Service/StoreFrontCustomerGreetingService.php
+++ b/engine/Shopware/Bundle/AccountBundle/Service/StoreFrontCustomerGreetingService.php
@@ -63,6 +63,9 @@ class StoreFrontCustomerGreetingService implements StoreFrontCustomerGreetingSer
      */
     public function fetch()
     {
+        if (!$this->session->offsetGet('sUserId')) {
+            return null;
+        }
         if (!$this->config->get('useSltCookie')) {
             return null;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If the session expires the customer is greeted in the header account box but has to login when clicking a link which is very confusing. 

### 2. What does this change do, exactly?
Add another condition to the `CustomerGreetingService`.

### 3. Describe each step to reproduce the issue or behaviour.
Login in frontend and let the session expire.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.