### PR TITLE
SW-21760 - Backend: Shipping Costs countries to use position column

### DIFF
--- a/themes/Backend/ExtJs/backend/shipping/view/edit/country.js
+++ b/themes/Backend/ExtJs/backend/shipping/view/edit/country.js
@@ -104,6 +104,8 @@ Ext.define('Shopware.apps.Shipping.view.edit.Country', {
         });
         me.availableCountries.filters.clear();
         me.availableCountries.filter('usedIds', ids);
+        me.availableCountries.sort('position','ASC');
+        me.usedCountriesStore.sort('position','ASC');
 
         // Create the view
         me.items = me.getItems();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Shipping Costs Countries lists don't use position field, with full country list it's nearly impossible to use the controls as the list will be unordered.

### 2. What does this change do, exactly?
Sets sorting for the lists in the Backend ExtJS to the position field in countries table.

### 3. Describe each step to reproduce the issue or behaviour.
From Backend -> Configuration -> Shipping Costs choose a shipping cost and go to countries tab, when having not only the standard set of countries it's apparent that it's not ordered by position field.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist
Well, I had no time for all of these (just about to launch Mywalit, sorry)
- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.