### PR TITLE
Fix TemplateMails createMail for shops without templates

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -11,7 +11,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
 * Changed Tinymce editor to resolve placeholder images on initialization
 * Changed product notification to match the documented feature
 * Changed AJAX search to respect the basic setting for direct number searches and show the same results as the normal search 
-* Changed TemplateMail to work without shop context
+* Changed TemplateMail to work without shop context or shops without templates
 * Changed ReflectionHelper to work with Windows
 * Changed `Unknown path` Smarty error to work with Windows
 * Changed `Shopware\Recovery\UpdateFilePermissionChanger` to make it PHP 7 compatible

--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -164,16 +164,25 @@ class Shopware_Components_TemplateMail
         $inheritance = Shopware()->Container()->get('theme_inheritance');
 
         if ($this->getShop() !== null) {
-            $keys = ['mobileLogo' => true, 'tabletLogo' => true, 'tabletLandscapeLogo' => true, 'desktopLogo' => true, 'appleTouchIcon' => true];
-            $theme = $inheritance->buildConfig($this->getShop()->getTemplate(), $this->getShop(), false);
-            $theme = array_intersect_key($theme, $keys);
-
             $defaultContext = [
                 'sConfig' => $config,
                 'sShop' => $config->get('shopName'),
                 'sShopURL' => ($this->getShop()->getSecure() ? 'https://' : 'http://') . $this->getShop()->getHost() . $this->getShop()->getBaseUrl(),
-                'theme' => $theme,
             ];
+
+            // Add theme to the context if given shop (or its main shop) has a template.
+            $theme = null;
+            if ($this->getShop()->getTemplate()) {
+                $theme = $inheritance->buildConfig($this->getShop()->getTemplate(), $this->getShop(), false);
+            } elseif ($this->getShop()->getMain() && $this->getShop()->getMain()->getTemplate()) {
+                $theme = $inheritance->buildConfig($this->getShop()->getMain()->getTemplate(), $this->getShop(), false);
+            }
+            if ($theme) {
+                $keys = ['mobileLogo' => true, 'tabletLogo' => true, 'tabletLandscapeLogo' => true, 'desktopLogo' => true, 'appleTouchIcon' => true];
+                $theme = array_intersect_key($theme, $keys);
+                $defaultContext['theme'] = $theme;
+            }
+
             $isoCode = $this->getShop()->get('isocode');
             $translationReader = $this->getTranslationReader();
             $translation = $translationReader->read($isoCode, 'config_mails', $mailModel->getId());

--- a/tests/Functional/Components/TemplateMailTest.php
+++ b/tests/Functional/Components/TemplateMailTest.php
@@ -175,6 +175,57 @@ class Shopware_Tests_Components_TemplateMailTest extends Enlight_Components_Test
     }
 
     /**
+     * Tests the mail creation if the passed shop does not have a template, but its main shop does.
+     */
+    public function testCreateMailWithoutShopTemplate()
+    {
+        // Pepare new shop without template
+        $entityManager = Shopware()->Container()->get('models');
+        $defaultShop = $entityManager->find(\Shopware\Models\Shop\Shop::class, 1);
+        $newShop = new \Shopware\Models\Shop\Shop();
+        $newShop->setMain($defaultShop);
+        $newShop->setName('New Shop');
+        $entityManager->persist($newShop);
+        $entityManager->flush($newShop);
+
+        // Test mail creation
+        $registerConfirmationMail = $entityManager->find(\Shopware\Models\Mail\Mail::class, 1);
+        $mail = $this->mail->createMail($registerConfirmationMail, [], $newShop);
+        $this->assertInstanceOf(Enlight_Components_Mail::class, $mail);
+
+        // Revert changes in the database
+        $entityManager->remove($newShop);
+        $entityManager->flush($newShop);
+    }
+
+    /**
+     * Tests the mail creation if the passed shop and its main shop does not have templates.
+     */
+    public function testCreateMailWithoutMainShopTemplate()
+    {
+        // Prepare new shop and main shop without templates
+        $entityManager = Shopware()->Container()->get('models');
+        $newMainShop = new \Shopware\Models\Shop\Shop();
+        $newMainShop->setName('New Main Shop');
+        $entityManager->persist($newMainShop);
+        $newShop = new \Shopware\Models\Shop\Shop();
+        $newShop->setMain($newMainShop);
+        $newShop->setName('New Shop');
+        $entityManager->persist($newShop);
+        $entityManager->flush([$newMainShop, $newShop]);
+
+        // Test mail creation
+        $registerConfirmationMail = $entityManager->find(\Shopware\Models\Mail\Mail::class, 1);
+        $mail = $this->mail->createMail($registerConfirmationMail, [], $newShop);
+        $this->assertInstanceOf(Enlight_Components_Mail::class, $mail);
+
+        // Revert changes in the database
+        $entityManager->remove($newMainShop);
+        $entityManager->remove($newShop);
+        $entityManager->flush([$newMainShop, $newShop]);
+    }
+
+    /**
      * @return \Shopware\Models\Mail\Attachment
      */
     protected function getAttachmentMockObject()


### PR DESCRIPTION
### 1. Why is this change necessary?
With the recent changes in the `TemplateMail` component (https://github.com/shopware/shopware/commit/ed2e80e974470eb3451f1a9afd9d3dd1e34d2c14#diff-e8b4c5662b6e1a932d05d94187a75b70) a theme is added to the mail context that is built from the shop's template. But this theme addition will crash if the given shop has no own template (i.e. it is a language sub shop).
See https://github.com/shopware/shopware/commit/ed2e80e974470eb3451f1a9afd9d3dd1e34d2c14#diff-e8b4c5662b6e1a932d05d94187a75b70R167 

### 2. What does this change do, exactly?
This PR adds checks before adding a theme to the mail context: If the passed shop has no own template, the shop's main shop template is used. If even that shop has no template, no theme is added to the context at all (which was the behavior before https://github.com/shopware/shopware/commit/ed2e80e974470eb3451f1a9afd9d3dd1e34d2c14).

### 3. Describe each step to reproduce the issue or behaviour.
Create a sub shop that has no own template. Call `createMail` of the `TemplateMail` component with this shop as parameter. The mail creation will fail when trying to build the shop theme.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.