### PR TITLE
SW-21724 notify event sGetPremiumDispatchSurcharge

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2949,16 +2949,22 @@ class sAdmin
             GROUP BY d.id
         ";
 
-        return $this->calculateDispatchSurcharge(
-            $basket,
-            $this->db->fetchAll(
-                $sql,
-                [
-                    'billingAddressId' => $this->getBillingAddressId(),
-                    'shippingAddressId' => $this->getShippingAddressId(),
-                ]
-            )
+        $dispatches = $this->db->fetchAll(
+            $sql, 
+            [
+                'billingAddressId' => $this->getBillingAddressId(),
+                'shippingAddressId' => $this->getShippingAddressId(),
+            ]
         );
+        
+        $surcharge = $this->calculateDispatchSurcharge($basket, $dispatches);
+        
+        $this->eventManager->notify(
+            'Shopware_Modules_Admin_PremiumDispatchSurcharge_Calculated',
+            ['subject' => $this, 'dispatches' => $dispatches, 'surcharge' => $surcharge]
+        );
+        
+        return $surcharge;
     }
 
     /**

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2958,10 +2958,11 @@ class sAdmin
         );
         
         $surcharge = $this->calculateDispatchSurcharge($basket, $dispatches);
-        
-        $this->eventManager->notify(
-            'Shopware_Modules_Admin_PremiumDispatchSurcharge_Calculated',
-            ['subject' => $this, 'dispatches' => $dispatches, 'surcharge' => $surcharge]
+ 
+        $surcharge = $this->eventManager->filter(
+            'Shopware_Modules_Admin_sGetPremiumDispatchSurcharge_FilterSurcharge',
+            $surcharge,
+            ['subject' => $this, 'dispatches' => $dispatches]
         );
         
         return $surcharge;


### PR DESCRIPTION
Adds a filter-event to sAdmin::sGetPremiumDispatchSurcharge ~~Adds a notify event to sAdmin::sGetPremiumDispatchSurcharge~~ (Issue SW-21724) that plugins can get the information about which surcharges have been added to the shipping costs. Introduces Event ~~Shopware_Modules_Admin_PremiumDispatchSurcharge_Calculated~~  `Shopware_Modules_Admin_sGetPremiumDispatchSurcharge_FilterSurcharge` 
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
There is a notify event missing that makes it possible for plugins to see what dispatch surcharges exactly have been applied. See Issue SW-21724

### 2. What does this change do, exactly?
~~Adds a notify event to `sAdmin::sGetPremiumDispatchSurcharge` thats hands over the db result and the final surcharge result via the event `Shopware_Modules_Admin_PremiumDispatchSurcharge_Calculated`~~
Adds a filter event to `sAdmin::sGetPremiumDispatchSurcharge`´that hands over the db result and the final surcharge for filtering and custom references

### 3. Describe each step to reproduce the issue or behaviour.
Since the db result (the IDs of the dispatch surcharges needed) are directly send to the calculateSurcharge function and calculateSurcharge function is private (so you cannot hook them), a plugin developer is not able to get the result of the db query (surcharge ids) without recreating the function.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-21724

### 5. Which documentation changes (if any) need to be made because of this PR?
~~New Notify Event `Shopware_Modules_Admin_PremiumDispatchSurcharge_Calculated` that hands over the fields `subject`, `dispatches `and `surcharge`~~
New filter Event `Shopware_Modules_Admin_sGetPremiumDispatchSurcharge_FilterSurcharge` that hands over the surcharges as filter return, together with the `dispatches ` and `subject`

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

EDIT:

The Notify Event was changed to a filter Event `Shopware_Modules_Admin_sGetPremiumDispatchSurcharge_FilterSurcharge` that hands over the surcharges as filter return, together with the `dispatches ` and `subject`