### PR TITLE
Add Terminate Event to Shopware Kernel

### DIFF
--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -63,9 +63,12 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+use Symfony\Component\HttpKernel\TerminableInterface;
 
 /**
  * Middleware class between the old Shopware bootstrap mechanism
@@ -75,7 +78,7 @@ use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
  *
  * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
-class Kernel implements HttpKernelInterface
+class Kernel implements HttpKernelInterface, TerminableInterface
 {
     /**
      * @Deprecated Since 5.4, to be removed in 5.6
@@ -228,6 +231,17 @@ class Kernel implements HttpKernelInterface
         $response->prepare($request);
 
         return $response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function terminate(Request $request, Response $response)
+    {
+        $this->container->get('events')->notify(KernelEvents::TERMINATE, [
+            'request' => $request,
+            'response' => $response
+        ]);
     }
 
     /**

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -63,11 +63,11 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\TerminableInterface;
 
 /**
@@ -235,13 +235,15 @@ class Kernel implements HttpKernelInterface, TerminableInterface
 
     /**
      * {@inheritdoc}
+     * @throws \Enlight_Event_Exception
      */
-    public function terminate(Request $request, Response $response)
+    public function terminate(SymfonyRequest $request, SymfonyResponse $response)
     {
-        $this->container->get('events')->notify(KernelEvents::TERMINATE, [
-            'request' => $request,
-            'response' => $response
-        ]);
+        if ($this->container->has('events')) {
+            $this->container->get('events')->notify(KernelEvents::TERMINATE, [
+                'postResponseEvent' => new PostResponseEvent($this, $request, $response)
+            ]);
+        }
     }
 
     /**

--- a/shopware.php
+++ b/shopware.php
@@ -119,5 +119,7 @@ if (PHP_SAPI === 'cli' && isset($_SERVER['argv'][1])) {
 
 $request = Request::createFromGlobals();
 
-$kernel->handle($request)
-       ->send();
+$response = $kernel->handle($request);
+$response->send();
+
+$kernel->terminate($request, $response);


### PR DESCRIPTION
### 1. Why is this change necessary?
Symfony brings a Terminate Kernel Event so you can execute expensive post-response code. This Pull-Request adds it to the Shopware Kernel

### 2. What does this change do, exactly?
Adding the 

### 3. Describe each step to reproduce the issue or behaviour.
Adding the TerminableInterface to the Shopware Kernel and notify the listener

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.