### PR TITLE
Inherit highDpi and quality settings from Album

### DIFF
--- a/engine/Shopware/Controllers/Backend/MediaManager.php
+++ b/engine/Shopware/Controllers/Backend/MediaManager.php
@@ -750,6 +750,9 @@ class Shopware_Controllers_Backend_MediaManager extends Shopware_Controllers_Bac
             $parentSettings = $data['parent']->getSettings();
 
             $thumbnailSizes = $parentSettings->getThumbnailSize();
+            $thumbnailHighDpi = $parentSettings->isThumbnailHighDpi();
+            $thumbnailHighDpiQuality = $parentSettings->getThumbnailHighDpiQuality();
+            $thumbnailQuality = $parentSettings->getThumbnailQuality();
             $createThumbnails = $parentSettings->getCreateThumbnails();
         }
 

--- a/tests/Functional/Controllers/Backend/MediaManagerTest.php
+++ b/tests/Functional/Controllers/Backend/MediaManagerTest.php
@@ -79,6 +79,9 @@ class Shopware_Tests_Controllers_Backend_MediaManagerTest extends Enlight_Compon
         $newAlbum = $parentNode['data'][count($parentNode['data']) - 1];
 
         $this->assertEquals($parentNode['thumbnailSize'], $newAlbum['thumbnailSize']);
+        $this->assertEquals($parentNode['thumbnailHighDpi'], $newAlbum['thumbnailHighDpi']);
+        $this->assertEquals($parentNode['thumbnailHighDpiQuality'], $newAlbum['thumbnailHighDpiQuality']);
+        $this->assertEquals($parentNode['thumbnailQuality'], $newAlbum['thumbnailQuality']);
         $this->assertEquals($parentNode['createThumbnails'], $newAlbum['createThumbnails']);
         $this->assertEquals($parentNode['id'], $newAlbum['parentId']);
         $this->assertEquals(1, $newAlbum['leaf']);


### PR DESCRIPTION
### 1. Why is this change necessary?
People create sub-albums all the time, without realizing their settings with respect to highDpi thumbnails are being lost. Effectively disabling highDpi thumbnails for everyone ever using sub-albums, with the exception of the few that check the settings manually. 

### 2. What does this change do, exactly?
Not only 'thumbnail size' and 'should we create a thumbnail' are being inherited upon creation from the parent, but also the 'thumbnail quality', 'should we create a highDpi thumbnail' and the 'highDpi thumbnail quality'. 

### 3. Describe each step to reproduce the issue or behaviour.
- configure something for some album
- create a subalbum
- notice the highDpi-settings are not inherited from the parent.

### 4. Please link to the relevant issues (if any).
N / A

### 5. Which documentation changes (if any) need to be made because of this PR?
N / A

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.