### PR TITLE
Changes `for` attribute in privacy checkbox label

### DIFF
--- a/themes/Frontend/Bare/frontend/_includes/privacy.tpl
+++ b/themes/Frontend/Bare/frontend/_includes/privacy.tpl
@@ -3,7 +3,7 @@
         {if {config name=ACTDPRCHECK}}
             {block name="frontend_data_protection_information_checkbox"}
                 <input name="privacy-checkbox" type="checkbox" id="privacy-checkbox" required="required" aria-required="true" value="1" class="is--required" />
-                <label for="privacy-text">
+                <label for="privacy-checkbox">
                     {s name="PrivacyText" namespace="frontend/index/privacy"}{/s}
                 </label>
             {/block}

--- a/themes/Frontend/Bare/frontend/register/index.tpl
+++ b/themes/Frontend/Bare/frontend/register/index.tpl
@@ -182,7 +182,7 @@
                                                 {* Privacy checkbox *}
                                                 {block name="frontend_register_index_form_privacy_content_checkbox"}
                                                     <input name="register[personal][dpacheckbox]" type="checkbox" id="dpacheckbox"{if $form_data.dpacheckbox} checked="checked"{/if} required="required" aria-required="true" value="1" class="is--required" />
-                                                    <label for="privacy-text">
+                                                    <label for="dpacheckbox">
                                                         {s name="PrivacyText" namespace="frontend/index/privacy"}{/s}
                                                     </label>
                                                 {/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
The `for` attribute should be the same as the `id` of the corresponding checkbox input element to be correctly bound to it.

### 2. What does this change do, exactly?
Changes the `for` attribute.

### 3. Describe each step to reproduce the issue or behaviour.
Try to click on the label next to the privacy checkbox and see that is is not bound to the checkbox.

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.