### PR TITLE
fix race condition on overdue cronjob list

### DIFF
--- a/engine/Library/Enlight/Components/Cron/Adapter/DBAL.php
+++ b/engine/Library/Enlight/Components/Cron/Adapter/DBAL.php
@@ -147,7 +147,12 @@ class Enlight_Components_Cron_Adapter_DBAL implements Enlight_Components_Cron_Ad
             $this->overdueJobsList = $this->getOverdueJobs();
         }
 
-        return array_pop($this->overdueJobsList);
+        while (($nextJob = array_pop($this->overdueJobsList)) !== null) {
+            if ($this->isJobStillOverdue($nextJob->getId())) {
+                return $nextJob;
+            }
+        }
+        return null;
     }
 
     /**
@@ -247,5 +252,26 @@ class Enlight_Components_Cron_Adapter_DBAL implements Enlight_Components_Cron_Ad
         }
 
         return $overdueJobsList;
+    }
+
+    /**
+     * @return boolean
+     */
+    private function isJobStillOverdue($jobId)
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('*')
+            ->from($this->tableName, 'c')
+            ->andWhere('c.active = 1')
+            ->andWhere('c.end IS NOT NULL')
+            ->andWhere('c.id = :jobId')
+            ->andWhere('c.next <= :dateNow')
+            ->setParameter('jobId', $jobId)
+            ->setParameter('dateNow', new DateTime(), 'datetime');
+        $row = $qb->execute()->fetch();
+        if (!$row) {
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
To fix a race condition in the cronjob execution logic. Longer running jobs and a short cron:run frequency might lead to running the same cronjob more than once.   

### 2. What does this change do, exactly?
Before executing a cronjobs a added function checks, if the job is still overdue. If another thread already executed the cronjob it will skip and prevent double execution.

### 3. Describe each step to reproduce the issue or behaviour.
#### Setup:
System cronjob runs every minute
```
*/1 * * * * php /pathToShopware/bin/console sw:cron:run
```
3 or more Cronjobs setup in Shopware Backend.

#### Scenario
```
0:00 cron:run (Thread 1) will select all 3 jobs as overdue and keep them in memory.
0:01 Job1 runs in Thread 1 for 90 seconds.

1:00  cron:run (Thread 2) will select 2 jobs as overdue and keep them in memory.
1:01  Job2 runs in Thread 2 for 10 seconds.
1:11  Job3 runs in Thread 2 for 10 seconds.
**1:30 Job3 runs in Thread 1 for 10 seconds** (because it was selected earlier)
```
### 4. Please link to the relevant issues (if any).
### 5. Which documentation changes (if any) need to be made because of this PR?
None?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.