### PR TITLE
fix casting tax rate to float instead of int

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2161,7 +2161,7 @@ class sBasket
                     [$temporaryTax]
                 );
                 $taxRate = $getTaxRate;
-                $tax = round($voucherDetails['value'] / (100 + ((int) $getTaxRate)) * 100, 3) * -1;
+                $tax = round($voucherDetails['value'] / (100 + ((float) $getTaxRate)) * 100, 3) * -1;
             } else {
                 // No tax
                 $tax = $voucherDetails['value'] * -1;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The tax rate can not be cast to an integer. Some countries have decimal taxes (i.e. Switzerland -> 7.7%). When cast to an integer the 7.7% become 7% which then results in a wrong calculation of the net price and taxes when adding a voucher. This can be fined by law.

### 2. What does this change do, exactly?
Not casting the tax rate to an integer. Now casts a float value so the tax calculation for the voucher works in countries that have decimal tax rates.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a tax rate with decimals (i.e. 7.7%)
- Create a voucher and set it to use the created tax rate (fixed discount or percentage doesn't matter)
- Add some articles to your basket
- Add the generated voucher
- Check the prices in the frontend, net price and tax amount will be wrong. (Database table s_order_basket you can see the entry for the voucher which states 7.7 in the tax column but the net price is calculated from the price with the integer casted tax (in this example 7))

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.