### PR TITLE
Bugfix for translation checkbox fallback state

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.plugin.Translation.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.plugin.Translation.js
@@ -299,6 +299,9 @@ Ext.define('Shopware.form.plugin.Translation',
                         config.emptyText = field.store.findRecord('id', config.emptyText).get('name');
                     }
                 }
+                if (config.xtype == 'checkbox') {
+                    config.checked = field.checked;
+                }
             }
             result.push(config)
         });


### PR DESCRIPTION
### 1. Why is this change necessary?
Because the backend translation module does not display the correct fallback state of boolean attributes (checkboxes): A checkbox element of a translation is still unchecked when the parent language checkbox is checked.
First this causes irritations. Second, to disable a checkbox in a translation that is enabled in the default/fallback language you have to change its state to `checked`, save it, revert its state to `unchecked` again and save it again. 

### 2. What does this change do, exactly?
Consider the parent state of checkbox elements during loading of the translations.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a new translatable attribute of type boolean.
2. Set the checkbox to `checked` in the main shop.
3. Open translation module.
4. the checkbox does not inherit the `checked` state of the fallback language.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.