### PR TITLE
bugfix and perfomance improve

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/GarbageCollector.php
+++ b/engine/Shopware/Bundle/MediaBundle/GarbageCollector.php
@@ -110,7 +110,7 @@ class GarbageCollector
      */
     private function createTempTable()
     {
-        $this->connection->exec('CREATE TEMPORARY TABLE IF NOT EXISTS s_media_used (id int auto_increment, mediaId int NOT NULL, PRIMARY KEY pkid (id))');
+        $this->connection->exec('CREATE TEMPORARY TABLE IF NOT EXISTS s_media_used (id int auto_increment, mediaId int NOT NULL, PRIMARY KEY pkid (id), INDEX media (mediaId))');
     }
 
     /**
@@ -313,7 +313,7 @@ class GarbageCollector
             $this->connection->executeQuery(
                 $sql,
                 [':mediaPaths' => $paths],
-                [':mediaPaths' => Connection::PARAM_INT_ARRAY]
+                [':mediaPaths' => Connection::PARAM_STR_ARRAY]
             );
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The main problem was that media files, that where supposed to get collected by the garbage collector, where NOT collected properly.
Also the debugging process was pretty slow due to the missing sql index for the mediaId column inside of the temp table.

### 2. What does this change do, exactly?
- added a index to the temporary media_used table for increasing performance
- use str_array instead of a int array at the select by path query

### 3. Describe each step to reproduce the issue or behaviour.
Execute the `sw:media:cleanup` command on a strictly configured sql environment.
Depending on your configuration the cleanup will be EXTREMLY slow or not working at all because the files are not getting indexed correctly.

### 4. Please link to the relevant issues (if any).
- 

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ / ] I have written tests and verified that they fail without my change
- [ / ] I have squashed any insignificant commits
- [ x ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.