### PR TITLE
Set default shop in article detail toolbar combobox

### DIFF
--- a/themes/Backend/ExtJs/backend/article/view/detail/toolbar.js
+++ b/themes/Backend/ExtJs/backend/article/view/detail/toolbar.js
@@ -230,10 +230,36 @@ Ext.define('Shopware.apps.Article.view.detail.Toolbar', {
      * @param stores
      */
     onStoresLoaded: function(article, stores) {
-        var me = this;
+        var me = this,
+            defaultShopId = me.getDefaultShopId();
+
         me.article = article;
         me.shopStore = stores['shops'];
         me.shopComboBox.bindStore(me.shopStore);
+
+        if (defaultShopId !== null) {
+            me.shopComboBox.setValue(defaultShopId);
+        }
+    },
+
+    /**
+     * Iterates through the shopStore and searches for the default shop.
+     *
+     * @returns number
+     */
+    getDefaultShopId: function() {
+        var me = this,
+            defaultShop = null;
+
+        me.shopStore.each(function(record) {
+            if (record.get('default') === true) {
+                defaultShop = record.get('id');
+
+                return;
+            }
+        });
+
+        return defaultShop;
     }
 });
 //{/block}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

This automatically pre-selects the default shop in the article detail window for the preview mode.

### 2. What does this change do, exactly?

This automatically pre-selects the default shop in the article detail window for the preview mode.

### 3. Describe each step to reproduce the issue or behaviour.

:heavy_minus_sign: 

### 4. Please link to the relevant issues (if any).

:heavy_minus_sign: 

### 5. Which documentation changes (if any) need to be made because of this PR?

:heavy_minus_sign: 

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.