### PR TITLE
Extra space for classes in shopping world container. Improve functionality with shyim

### DIFF
--- a/themes/Frontend/Bare/frontend/index/index.tpl
+++ b/themes/Frontend/Bare/frontend/index/index.tpl
@@ -83,7 +83,7 @@
             {/block}
 
             {block name='frontend_index_content_main'}
-                <section class="{block name="frontend_index_content_main_classes"}content-main container block-group{/block}">
+                <section class="{block name="frontend_index_content_main_classes"} content-main container block-group {/block}">
 
                     {* Breadcrumb *}
                     {block name='frontend_index_breadcrumb'}


### PR DESCRIPTION
added spaces so content-main and block-group css classes actually work.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Improve dynamic functionality for shopping world full-screen

### 2. What does this change do, exactly?
add a space infront and after "content-main container block-group". Currently content-main and block-group are not working when for example the plugin ShyimProfiler is used. 

### 3. Describe each step to reproduce the issue or behaviour

Create a shopping world emotion with full screen enabled
Enable ShyimProfiler

### 4. Please link to the relevant issues (if any).

#937

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [x ] I have written tests and verified that they fail without my change
- [x ] I have squashed any insignificant commits
- [x ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.