### PR TITLE
Added random sorting option to emotion article slider

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -26,6 +26,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
   * Added Cronjob, which deletes every registered but not verified user after a configurable amount of days
   * Added two new Smarty-Blocks in `frontend/register/index.tpl`: `frontend_register_index_form_optin_success` & `frontend_register_index_form_optin_invalid_hash`
 * Added new Cronjob `OptinCleanup`, which uses the interval-setting from Double-Opt-In register to cleanup every shopware opt-in from the `s_core_optin` table except Double-Opt-In register
+* Added random sorting option to emotion products slider
 
 
 ### Changes

--- a/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php
+++ b/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php
@@ -29,6 +29,7 @@ use Shopware\Bundle\EmotionBundle\Struct\Collection\ResolvedDataCollection;
 use Shopware\Bundle\EmotionBundle\Struct\Element;
 use Shopware\Bundle\SearchBundle\Sorting\PopularitySorting;
 use Shopware\Bundle\SearchBundle\Sorting\PriceSorting;
+use Shopware\Bundle\SearchBundle\Sorting\RandomSorting;
 use Shopware\Bundle\SearchBundle\Sorting\ReleaseDateSorting;
 use Shopware\Bundle\SearchBundle\SortingInterface;
 use Shopware\Bundle\SearchBundle\StoreFrontCriteriaFactoryInterface;
@@ -43,6 +44,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
     const TYPE_PRODUCT_STREAM = 'product_stream';
     const TYPE_STATIC_PRODUCT = 'selected_article';
     const TYPE_STATIC_VARIANT = 'selected_variant';
+    const TYPE_RANDOM = 'random_product';
     const TYPE_NEWCOMER = 'newcomer';
     const TYPE_TOPSELLER = 'topseller';
     const TYPE_LOWEST_PRICE = 'price_asc';
@@ -119,6 +121,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
 
             case self::TYPE_TOPSELLER:
             case self::TYPE_NEWCOMER:
+            case self::TYPE_RANDOM:
             case self::TYPE_LOWEST_PRICE:
             case self::TYPE_HIGHEST_PRICE:
                 $criteria = $this->generateCriteria($element, $context);
@@ -159,6 +162,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
         switch ($type) {
             case self::TYPE_PRODUCT_STREAM:
             case self::TYPE_NEWCOMER:
+            case self::TYPE_RANDOM:
             case self::TYPE_TOPSELLER:
             case self::TYPE_HIGHEST_PRICE:
             case self::TYPE_LOWEST_PRICE:
@@ -251,6 +255,9 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
                 break;
             case self::TYPE_NEWCOMER:
                 $criteria->addSorting(new ReleaseDateSorting(SortingInterface::SORT_DESC));
+                break;
+            case self::TYPE_RANDOM:
+                $criteria->addSorting(new RandomSorting());
                 break;
         }
 

--- a/snippets/backend/emotion/view/components/article_slider_type.ini
+++ b/snippets/backend/emotion/view/components/article_slider_type.ini
@@ -11,6 +11,7 @@ article_slider_sort_criteria/store/price_desc = "Price (high to low)"
 article_slider_type/store/price_asc = "Price (low to high)"
 article_slider_type/store/price_desc = "Price (high to low)"
 article_slider_type/store/product_stream = "Product stream"
+article_slider_type/store/random_product = "Random products"
 
 [de_DE]
 article_slider_type/fields/article_slider_type = "Listentyp"
@@ -25,3 +26,4 @@ article_slider_sort_criteria/store/price_desc = "Preis (absteigend)"
 article_slider_type/store/price_asc = "Preis (aufsteigend)"
 article_slider_type/store/price_desc = "Preis (absteigend)"
 article_slider_type/store/product_stream = "Product Stream"
+article_slider_type/store/random_product = "Zufällige Artikel"

--- a/themes/Backend/ExtJs/backend/emotion/view/components/fields/article_slider_type.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/components/fields/article_slider_type.js
@@ -43,7 +43,8 @@ Ext.define('Shopware.apps.Emotion.view.components.fields.ArticleSliderType', {
             'topseller': '{s name=article_slider_type/store/topseller}{/s}',
             'price_asc': '{s name=article_slider_type/store/price_asc}{/s}',
             'price_desc': '{s name=article_slider_type/store/price_desc}{/s}',
-            'product_stream': '{s name=article_slider_type/store/product_stream}{/s}'
+            'product_stream': '{s name=article_slider_type/store/product_stream}{/s}',
+            'random_product': '{s name=article_slider_type/store/random_product}{/s}'
         }
     },
 
@@ -102,6 +103,9 @@ Ext.define('Shopware.apps.Emotion.view.components.fields.ArticleSliderType', {
             }, {
                 value: 'product_stream',
                 display: snippets.product_stream
+            }, {
+                value: 'random_product',
+                display: snippets.random_product
             }]
         });
     }

--- a/themes/Backend/ExtJs/backend/emotion/view/detail/elements/article_slider.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/detail/elements/article_slider.js
@@ -44,7 +44,8 @@ Ext.define('Shopware.apps.Emotion.view.detail.elements.ArticleSlider', {
         'topseller': '{s name="article_slider_type/store/topseller" namespace="backend/emotion/view/components/article_slider_type"}{/s}',
         'price_asc': '{s name="article_slider_type/store/price_asc" namespace="backend/emotion/view/components/article_slider_type"}{/s}',
         'price_desc': '{s name="article_slider_type/store/price_desc" namespace="backend/emotion/view/components/article_slider_type"}{/s}',
-        'product_stream': '{s name="article_slider_type/store/product_stream" namespace="backend/emotion/view/components/article_slider_type"}{/s}'
+        'product_stream': '{s name="article_slider_type/store/product_stream" namespace="backend/emotion/view/components/article_slider_type"}{/s}',
+        'random_product': '{s name="article_slider_type/store/random_product" namespace="backend/emotion/view/components/article_slider_type"}{/s}'
     },
 
     createPreview: function() {


### PR DESCRIPTION
### 1. Why is this change necessary?
If Customer comes on an landing page its good to sort random article slider that not always see the same article

### 2. What does this change do, exactly?
The change add an option to the article slider type named ramdom_article

### 3. Describe each step to reproduce the issue or behaviour.
there is no option for random in article slider but on article box

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.