### PR TITLE
Update chokidar.js

### DIFF
--- a/themes/grunt-tasks/config/chokidar.js
+++ b/themes/grunt-tasks/config/chokidar.js
@@ -18,7 +18,8 @@ module.exports = {
         files: [
             '../themes/Frontend/**/_public/src/js/*.js',
             '../engine/Shopware/Plugins/**/frontend/**/src/js/**/*.js',
-            '../custom/plugins/**/frontend/**/src/js/**/*.js'
+            '../custom/plugins/**/frontend/**/src/js/**/*.js',
+            '../custom/plugins/**/frontend/js/**/*.js'
         ],
         tasks: ['uglify:development'],
         options: {


### PR DESCRIPTION
Autoloaded JS Files from frontend/js Folder are not watched by grunt.
This addition lets grunt also watch those.


### 1. Why is this change necessary?
Because grunt did not watch plugin autoloaded js files.

### 2. What does this change do, exactly?
Adds the frontend/js folder to grunts watch sources.

### 3. Describe each step to reproduce the issue or behaviour.
Make a js file in a plugin that gets autoloaded by shopware.
Start grunt.
Make changes to the js file.
See that nothing happens.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist
