### PR TITLE
Ask hidden for admin password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,5 @@ Thumbs.db
 /build
 !/build/artifacts/.gitkeep
 !/build/logs/mink/.gitkeep
+!/build/build.xml
 /tests/nightwatch/node_modules

--- a/build/build.xml
+++ b/build/build.xml
@@ -121,6 +121,7 @@
             <arg value="--email=demo@example.com"/>
             <arg value="--username=demo"/>
             <arg value="--password=demo"/>
+            <arg value="--password-confirm=demo"/>
             <arg value="--locale=de_DE"/>
         </exec>
     </target>

--- a/engine/Shopware/Commands/AdminCreateCommand.php
+++ b/engine/Shopware/Commands/AdminCreateCommand.php
@@ -92,7 +92,7 @@ class AdminCreateCommand extends ShopwareCommand
         $this->fillOption('username', 'Username', $input, $output);
         $this->fillOption('name', 'Fullname', $input, $output);
         $this->fillOption('locale', 'Locale', $input, $output);
-        $this->fillOption('password', 'Password', $input, $output);
+        $this->fillSensitiveOption('password', 'Password', $input, $output);
     }
 
     /**
@@ -131,6 +131,16 @@ class AdminCreateCommand extends ShopwareCommand
         $input->setOption(
             $field,
             $io->ask($label, $input->getOption($field))
+        );
+    }
+
+    private function fillSensitiveOption($field, $label, InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $input->setOption(
+            $field,
+            $io->askHidden($label, $input->getOption($field))
         );
     }
 

--- a/engine/Shopware/Commands/AdminCreateCommand.php
+++ b/engine/Shopware/Commands/AdminCreateCommand.php
@@ -66,7 +66,6 @@ class AdminCreateCommand extends ShopwareCommand
                 InputOption::VALUE_REQUIRED,
                 'User full name'
             )
-
             ->addOption(
                 'locale',
                 null,
@@ -79,6 +78,12 @@ class AdminCreateCommand extends ShopwareCommand
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Password'
+            )
+            ->addOption(
+                'password-confirm',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Password Confirmation'
             )
         ;
     }
@@ -93,6 +98,7 @@ class AdminCreateCommand extends ShopwareCommand
         $this->fillOption('name', 'Fullname', $input, $output);
         $this->fillOption('locale', 'Locale', $input, $output);
         $this->fillSensitiveOption('password', 'Password', $input, $output);
+        $this->fillSensitiveOption('password-confirm', 'Password Confirmation', $input, $output);
     }
 
     /**
@@ -111,7 +117,12 @@ class AdminCreateCommand extends ShopwareCommand
         $user->setUsername($input->getOption('username'));
         $user->setName($input->getOption('name'));
         $user->setLockedUntil(new \DateTime('2010-01-01 00:00:00'));
-        $this->setPassword($user, $input->getOption('password'));
+
+        if ($this->passwordsAreValid($input)) {
+            $this->setPassword($user, $input->getOption('password'));
+        } else {
+            throw new \RuntimeException('Passwords do not match. Please try again.');
+        }
 
         $this->persistUser($user);
 
@@ -134,6 +145,12 @@ class AdminCreateCommand extends ShopwareCommand
         );
     }
 
+    /**
+     * @param string          $field
+     * @param string          $label
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     */
     private function fillSensitiveOption($field, $label, InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);
@@ -252,5 +269,15 @@ class AdminCreateCommand extends ShopwareCommand
         if (empty($option)) {
             throw new \InvalidArgumentException('Password is required');
         }
+    }
+
+    /**
+     * @param InputInterface $input
+     *
+     * @return bool
+     */
+    private function passwordsAreValid(InputInterface $input)
+    {
+        return $input->getOption('password') === $input->getOption('password-confirm');
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Asking for admin-password should use the recommended mehtod by symfony for [asking for sensitive data. - search for askHidden()](https://symfony.com/doc/2.8/console/style.html)

### 2. What does this change do, exactly?
the admin-password for a Admin-User created through bin/console sw:admin:create will now don't show the password typed by the user, but hide it from all eyes. The user will have to confirm his password to avoid saving passwords with typos

### 3. Describe each step to reproduce the issue or behaviour.
create a admin-user through the sw:admin:create-command and follow the steps. When typing your password you - and everyone else who is maybe passing by - will see the typed password

### 4. Please link to the relevant issues (if any).
found none

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change <-- No tests for Commands could be found, but the build.xml was changed where the admin:create-Command is used
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.