### PR TITLE
Added backticks for reserved mysql keyword

### DIFF
--- a/engine/Shopware/Components/SitePageMenu.php
+++ b/engine/Shopware/Components/SitePageMenu.php
@@ -182,19 +182,19 @@ class SitePageMenu
         $query->leftJoin(
             'page',
             's_cms_static_groups',
-            'groups',
+            '`groups`',
             'groups.active = 1'
         );
 
         $query->leftJoin(
-            'groups',
+            '`groups`',
             's_cms_static_groups',
             'mapping',
             'groups.mapping_id = mapping.id'
         );
 
         $query->leftJoin(
-            'groups',
+            '`groups`',
             's_core_shop_pages',
             'shops',
             'groups.id = shops.group_id AND shops.shop_id = :shopId'


### PR DESCRIPTION
### 1. Why is this change necessary?
This patch fixes usage of reserved keywords in MySQL 8.0.2 or newer

### 2. What does this change do, exactly?
It escapes the MySQL keyword "groups" with backticks

### 3. Describe each step to reproduce the issue or behaviour.
WIthout this patch Shopware 5.4.4 won't work when using MySQL 8.0.11

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-21971

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.