### PR TITLE
Fix typo in great britain country name

### DIFF
--- a/_sql/migrations/1410-update-great-britain-country-name.php
+++ b/_sql/migrations/1410-update-great-britain-country-name.php
@@ -1,0 +1,16 @@
+<?php
+
+class Migrations_Migration1410 extends Shopware\Components\Migrations\AbstractMigration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+UPDATE s_core_countries SET `countryname` = 'Great Britain' WHERE `countryiso` = 'GB' AND `countryname` = 'Great britain';
+EOD;
+        $this->addSql($sql);
+	}
+
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Because it fixes a typo

### 2. What does this change do, exactly?
It fixes a typo in the s_core_countries table from 'Great britain' to 'Great Britain'

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.