### PR TITLE
Removed check for sTAXAUTOMODE

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -356,10 +356,6 @@ class sBasket
             $tax = $this->config->get('sDISCOUNTTAX');
         }
 
-        $taxAutoMode = $this->config->get('sTAXAUTOMODE');
-        if (!empty($taxAutoMode)) {
-            $tax = $this->getMaxTax();
-        }
         if (!$tax) {
             $tax = 19;
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
removes an unnecessary if clause

### 2. What does this change do, exactly?
Just removes the call for `sTAXAUTOMODE` and the following if clause. The same stuff is already made 6 lines above
```
$taxMode = $this->config->get('sTAXAUTOMODE');
if (!empty($taxMode)) {
     $tax = $this->getMaxTax();
}
```
### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.