### PR TITLE
Calculate NET of shipping cost with 4 digits

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -3140,7 +3140,7 @@ class sAdmin
             $result['tax'] = $dispatch['tax_calculation_value'];
         }
         $result['tax'] = (float) $result['tax'];
-        $result['netto'] = round($result['brutto'] * 100 / (100 + $result['tax']), 2);
+        $result['netto'] = round($result['brutto'] * 100 / (100 + $result['tax']), 4);
 
         return $result;
     }


### PR DESCRIPTION
When creating a document for an order, the tax for the shipping is calculated with the difference between invoice_shipping and invoice_shipping_net. In CH the tax is 7.7% and it result in an rounding error with a shipping cost of 2.9 CHF. The PDF is generated with a tax of 8%.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Rounding error in CH

### 2. What does this change do, exactly?
Change the presission of the shipping net cost

### 3. Describe each step to reproduce the issue or behaviour.
Set the tax to 7.7% and add a shipping cost of 2.9

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x ] I have squashed any insignificant commits
- [x ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.