### PR TITLE
automatically add attributes for customers created via the rest api

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Customer.php
+++ b/engine/Shopware/Components/Api/Resource/Customer.php
@@ -26,6 +26,7 @@ namespace Shopware\Components\Api\Resource;
 
 use Doctrine\ORM\Query\Expr\Join;
 use Shopware\Components\Api\Exception as ApiException;
+use Shopware\Models\Attribute\Customer as CustomerAttribute;
 use Shopware\Models\Country\Country as CountryModel;
 use Shopware\Models\Country\State as StateModel;
 use Shopware\Models\Customer\Address as AddressModel;
@@ -197,6 +198,8 @@ class Customer extends Resource
 
         // create models
         $customer = new CustomerModel();
+        $customer->setAttribute(new CustomerAttribute());
+
         $params = $this->prepareCustomerData($params, $customer);
         $params = $this->prepareAssociatedData($params, $customer);
         $customer->fromArray($params);

--- a/tests/Functional/Components/Api/CustomerTest.php
+++ b/tests/Functional/Components/Api/CustomerTest.php
@@ -26,6 +26,7 @@ namespace Shopware\Tests\Functional\Components\Api;
 
 use Shopware\Components\Api\Resource\Customer;
 use Shopware\Components\Api\Resource\Resource;
+use Shopware\Models\Attribute\Customer as CustomerAttribute;
 
 /**
  * @category  Shopware
@@ -594,5 +595,33 @@ class CustomerTest extends TestCase
 
         $customer = $this->resource->create($data);
         $this->assertEquals($context->getShop()->getCustomerGroup()->getKey(), $customer->getGroup()->getKey());
+    }
+
+    /**
+     * @group failing
+     */
+    public function testCreateCustomerCreatesCustomerAttribute()
+    {
+        $data = [
+            'email' => __FUNCTION__ . uniqid(rand()) . '@foobar.com',
+            'number' => __FUNCTION__,
+            'salutation' => 'mr',
+            'firstname' => 'Max',
+            'lastname' => 'Mustermann',
+            'billing' => [
+                'salutation' => 'mr',
+                'zipcode' => '12345',
+                'city' => 'Musterhausen',
+                'firstname' => 'Max',
+                'lastname' => 'Mustermann',
+                'street' => 'Musterstr. 123',
+                'country' => '2',
+            ],
+        ];
+
+        $customer = $this->resource->create($data);
+
+        $this->assertNotNull($customer->getAttribute());
+        $this->assertInstanceOf(CustomerAttribute::class, $customer->getAttribute());
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When a customer is created via the API, the attributes table is not populated automatically with a new record for the new customer. This leads to problems with Plugins depending on a existing attributes record for the new customer. For Example https://github.com/portrino/shopware-hybrid-auth

### 2. What does this change do, exactly?
it adds a empty attribute record for the new customer

### 3. Describe each step to reproduce the issue or behaviour.
create a new customer via the api, try to login with the same customer via the hybridAuth Plugin

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.