### PR TITLE
Add article details to api variant enpoint

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -88,7 +88,8 @@ class Variant extends Resource implements BatchInterface
         }
 
         $builder = $this->getRepository()->getVariantDetailQuery();
-        $builder->andWhere('variants.id = :variantId')
+        $builder->addSelect('article')
+                ->andWhere('variants.id = :variantId')
                 ->addOrderBy('variants.id', 'ASC')
                 ->addOrderBy('customerGroup.id', 'ASC')
                 ->addOrderBy('prices.from', 'ASC')
@@ -126,10 +127,11 @@ class Variant extends Resource implements BatchInterface
         /** @var \Doctrine\DBAL\Query\QueryBuilder */
         $builder = $this->getRepository()->createQueryBuilder('detail');
 
-        $builder->addSelect(['prices', 'attribute', 'customerGroup'])
+        $builder->addSelect(['prices', 'attribute', 'partial article.{id,name,active,taxId}', 'customerGroup'])
                 ->leftJoin('detail.prices', 'prices')
                 ->innerJoin('prices.customerGroup', 'customerGroup')
                 ->leftJoin('detail.attribute', 'attribute')
+                ->innerJoin('detail.article', 'article')
                 ->addFilter($criteria)
                 ->addOrderBy($orderBy)
                 ->setFirstResult($offset)


### PR DESCRIPTION
### 1. Why is this change necessary?
The `/variants` endpoint response doesn't contain all relevant data to work effectively with the API. This PR adds some useful additions from the `article` entity to the variant list and detail queries.

### 2. What does this change do, exactly?
The `/variants` list result will be extended by a partial join containing
- article.id
- article.taxId
- article.name
- article.active

The `/variants/[id]` detail result will be extended by a full article join.

### 3. Describe each step to reproduce the issue or behaviour.
A use case could be the query of active variants. Since both the variant and the article have an `active` state it is necessary to filter for both the variant.active and variant.article.active flag.

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.