### PR TITLE
calculateVoucherValues with tax 7.7

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2161,7 +2161,7 @@ class sBasket
                     [$temporaryTax]
                 );
                 $taxRate = $getTaxRate;
-                $tax = round($voucherDetails['value'] / (100 + ((int) $getTaxRate)) * 100, 3) * -1;
+                $tax = round($voucherDetails['value'] / (100 + (number_format($getTaxRate, 2))) * 100, 3) * -1;
             } else {
                 // No tax
                 $tax = $voucherDetails['value'] * -1;


### PR DESCRIPTION
### 1. Why is this change necessary?
This creates incorrect amounts with vouchers in the shopping cart.

### 2. What does this change do, exactly?
As a result, the tax is calculated not with 7% but with 7.7%.

### 3. Describe each step to reproduce the issue or behaviour.
Just create the tax of 7.7% and select it on a voucher. As a result, you should be able to recognize the wrong calculation with 7%.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22036

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.