### PR TITLE
account orders unrelated to showEsd setting

### DIFF
--- a/themes/Frontend/Bare/frontend/account/sidebar.tpl
+++ b/themes/Frontend/Bare/frontend/account/sidebar.tpl
@@ -102,13 +102,11 @@
 
                                 {* Link to the user orders *}
                                 {block name="frontend_account_menu_link_orders"}
-                                    {if {config name=showEsd}}
-                                        <li class="navigation--entry">
-                                            <a href="{url module='frontend' controller='account' action='orders'}" title="{s name="AccountLinkPreviousOrders"}{/s}" class="navigation--link{if $sAction == 'orders'} is--active{/if}" rel="nofollow">
-                                                {s name="AccountLinkPreviousOrders"}{/s}
-                                            </a>
-                                        </li>
-                                    {/if}
+                                    <li class="navigation--entry">
+                                        <a href="{url module='frontend' controller='account' action='orders'}" title="{s name="AccountLinkPreviousOrders"}{/s}" class="navigation--link{if $sAction == 'orders'} is--active{/if}" rel="nofollow">
+                                            {s name="AccountLinkPreviousOrders"}{/s}
+                                        </a>
+                                    </li>
                                 {/block}
 
                                 {* Link to the user downloads *}


### PR DESCRIPTION
sorry, if there already is a pr, just to be sure... 

### 1. Why is this change necessary?

The showEsd config setting affects whether or not the link to both, esd downloads AND regular orders
are shown in the account sidebar. Previously it would only affect whether the link to the downloads would be shown in the account sidebar, which is the expected behavior.

### 2. What does this change do, exactly?

Remove the condition on showEsd in the template for the account orders menu entry.

### 3. Describe each step to reproduce the issue or behaviour.

Enable showEsd, try to access previous orders in storefront account.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.