### PR TITLE
Removed incorrect return type annotation

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -514,8 +514,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     /**
      * The loadStoresAction function is an ExtJs event listener method of the article backend module.
      * The function is used to load all required stores for the article detail page in one request.
-     *
-     * @return array
      */
     public function loadStoresAction()
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
This removes an incorrect return type annotation.

### 2. What does this change do, exactly?
It removes the "@return array" annotation, because the method does not return anything - it does not make use of the "return" keyword.

### 3. Describe each step to reproduce the issue or behaviour.
Search for the "return" keyword in the code of the loadStoresAction() method - you will not find it so there is no return value.

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [x] * I have written tests and verified that they fail without my change
- [x] * I have squashed any insignificant commits
- [x] * This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

`*` = Not relevant