### PR TITLE
Adds snippet for times sign in ajax cart

### DIFF
--- a/snippets/frontend/checkout/ajax_cart.ini
+++ b/snippets/frontend/checkout/ajax_cart.ini
@@ -8,6 +8,7 @@ AjaxCartContinueShopping = "Continue shopping"
 AjaxCartTotalAmount = "Subtotal amount"
 AjaxCartRemoveArticle = "Remove product"
 AjaxCartSuccessText = "The product was successfully added to your shopping cart"
+AjaxCartQuantityTimes = "&times;"
 Star = "*"
 
 [de_DE]
@@ -20,4 +21,5 @@ AjaxCartContinueShopping = "Weiter einkaufen"
 AjaxCartTotalAmount = "Zwischensumme"
 AjaxCartRemoveArticle = "Artikel entfernen"
 AjaxCartSuccessText = "Der Artikel wurde erfolgreich in den Warenkorb gelegt"
+AjaxCartQuantityTimes = "&times;"
 Star = "*"

--- a/themes/Frontend/Bare/frontend/checkout/ajax_cart_item.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/ajax_cart_item.tpl
@@ -108,7 +108,7 @@
             <div class="item--link">
         {/if}
             {block name="frontend_checkout_ajax_cart_articlename_quantity"}
-                <span class="item--quantity">{$basketItem.quantity}x</span>
+                <span class="item--quantity">{$basketItem.quantity}{s name="AjaxCartQuantityTimes"}{/s}</span>
             {/block}
             {block name="frontend_checkout_ajax_cart_articlename_name"}
                 <span class="item--name">


### PR DESCRIPTION
### 1. Why is this change necessary?
There should be no text present in the template at all. All of it should be moved into snippets. Also it would be semantically correct to use the times sign instead of a normal `x`.

### 2. What does this change do, exactly?
Extract the `x` from the quantity indicator in the ajax cart into snippets and replaces it by the `&times;` sign.

### 3. Describe each step to reproduce the issue or behaviour.
Open the ajax cart while at least one product is in your cart.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.