### PR TITLE
Add dummy listStore to "Showpare.apps.Order.view.detail.Window" if none exists

### DIFF
--- a/themes/Backend/ExtJs/backend/order/controller/attachment.js
+++ b/themes/Backend/ExtJs/backend/order/controller/attachment.js
@@ -184,9 +184,12 @@ Ext.define('Shopware.apps.Order.controller.Attachment', {
     callStoreReload: function(attachmentGrid, addAsAttachment, listStore) {
         var me = this;
 
-        listStore.reload({
-            callback: Ext.bind(me.applyNewDocument, me, [attachmentGrid, addAsAttachment])
-        });
+        // if no listStore is available no need to reload & update ui
+        if (listStore) {
+            listStore.reload({
+                callback: Ext.bind(me.applyNewDocument, me, [attachmentGrid, addAsAttachment])
+            });
+        }
     },
 
     /**

--- a/themes/Backend/ExtJs/backend/order/controller/document.js
+++ b/themes/Backend/ExtJs/backend/order/controller/document.js
@@ -67,19 +67,20 @@ Ext.define('Shopware.apps.Order.controller.Document', {
     openMail: function(record) {
         var me = this,
             order = me.getDocumentWindow().record,
-            documentTypeStore = Ext.create('Shopware.apps.Order.store.DocType');
+            documentTypeStore = Ext.create('Shopware.apps.Order.store.DocType'),
+            listingStore = me.getListing() ? me.getListing().listStore : null;
 
         // The window depends on a completely loaded documentTypeStore. So we load it here and open the window
         // after successful loading.
         documentTypeStore.load({
             scope: me,
             callback: function() {
-                this.getView('mail.Window').create({
+                me.getView('mail.Window').create({
                     record: order,
                     order: order,
                     preSelectedAttachment: record,
                     documentTypeStore: documentTypeStore,
-                    listStore: this.getListing().listStore
+                    listStore: listingStore
                 }).show();
             }
         });

--- a/themes/Backend/ExtJs/backend/order/controller/main.js
+++ b/themes/Backend/ExtJs/backend/order/controller/main.js
@@ -182,7 +182,8 @@ Ext.define('Shopware.apps.Order.controller.Main', {
                         countriesStore: me.countriesStore,
                         paymentsStore: me.paymentsStore,
                         dispatchesStore: me.dispatchesStore,
-                        documentTypesStore: me.documentTypesStore
+                        documentTypesStore: me.documentTypesStore,
+                        listStore: me.subApplication.getStore('Order')
                     });
                 }
             }


### PR DESCRIPTION
### 1. Why is this change necessary?
If you open an order by searching for it or by clicking on order history in a customer in backend, you can't send documents via mail.

### 2. What does this change do, exactly?
Adds listStore to _Showpare.apps.Order.view.detail.Window_ by extending its controller.

### 3. Describe each step to reproduce the issue or behaviour.

1. In backend: Open a customer account with at least 1 order
2. Go to orders and open one
3. Try sending a document via mail
-> JS error

Same goes for orders that are opened via search.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.