### PR TITLE
get laststock flag from detail

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -934,7 +934,7 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
                 a.id as articleID,
                 ob.quantity,
                 IF(ad.instock < 0, 0, ad.instock) as instock,
-                a.laststock,
+                ad.laststock,
                 ad.ordernumber as ordernumber
             FROM s_articles a
             LEFT JOIN s_articles_details ad


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
While retrieving the "laststock"-flag from "s_articles" table, the wrong text-snippet is displayed in the ajax-cart on adding a variant without the "laststock"-flag

### 2. What does this change do, exactly?
Retrieving the "laststock"-flag from the "s_article_details" table

### 3. Describe each step to reproduce the issue or behaviour.
- setup an article with 2 variants (A and B)
- unset the "laststock"-flag for the main variant "A" and set the "laststock"-flag for the second variant "B"
- ensure the stock for both is 0
- start from the frontend detail page of this article and chose the variant "B"
- add variant "B" to the cart
- wait for the ajax-cart displayed with the wrong text-snippet

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.