### PR TITLE
Added missing type hints for Order\Document\Document::$type

### DIFF
--- a/engine/Shopware/Models/Order/Document/Document.php
+++ b/engine/Shopware/Models/Order/Document/Document.php
@@ -121,7 +121,7 @@ class Document extends ModelEntity
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Document\Document")
      * @ORM\JoinColumn(name="type", referencedColumnName="id")
      *
-     * @var
+     * @var \Shopware\Models\Document\Document
      */
     private $type;
 
@@ -312,7 +312,7 @@ class Document extends ModelEntity
     }
 
     /**
-     * @return
+     * @return \Shopware\Models\Document\Document
      */
     public function getType()
     {
@@ -320,7 +320,7 @@ class Document extends ModelEntity
     }
 
     /**
-     * @param  $type
+     * @param \Shopware\Models\Document\Document $type
      */
     public function setType($type)
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
Auto completion is missing therefore there is developer experience missing.
We need more developer experience :blue_heart: 

### 2. What does this change do, exactly?
Add type hints.

### 3. Describe each step to reproduce the issue or behaviour.
Type `getType` on an instance of Models\Order\Order and :sob: because the autocompletion fails.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.