### PR TITLE
Extracts ESD download logic into new bundle

### DIFF
--- a/engine/Shopware/Bundle/EsdBundle/Service/Core/DownloadService.php
+++ b/engine/Shopware/Bundle/EsdBundle/Service/Core/DownloadService.php
@@ -43,7 +43,7 @@ class DownloadService implements DownloadInterface
      */
     public function getAbsoluteFilePath($file)
     {
-        return $this->shopwareRootDirectory . $this->getRelativeFilePath($this);
+        return $this->shopwareRootDirectory . $this->getRelativeFilePath($file);
     }
 
     /**

--- a/engine/Shopware/Bundle/EsdBundle/Service/Core/DownloadService.php
+++ b/engine/Shopware/Bundle/EsdBundle/Service/Core/DownloadService.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Shopware\Bundle\EsdBundle\Service\Core;
+
+use Enlight_Controller_Front;
+use Shopware\Bundle\EsdBundle\Service\DownloadInterface;
+use Shopware_Components_Config;
+
+class DownloadService implements DownloadInterface
+{
+    /**
+     * @var string
+     */
+    private $shopwareRootDirectory;
+
+    /**
+     * @var Shopware_Components_Config
+     */
+    private $config;
+
+    /**
+     * @var Enlight_Controller_Front
+     */
+    private $front;
+
+    /**
+     * @param Enlight_Controller_Front $front
+     */
+    public function __construct(
+        $shopwareRootDirectory,
+        Shopware_Components_Config $config,
+        Enlight_Controller_Front $front
+    ) {
+        $this->shopwareRootDirectory = $shopwareRootDirectory;
+        $this->config = $config;
+        $this->front = $front;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAbsoluteFilePath($file)
+    {
+        return $this->shopwareRootDirectory . $this->getRelativeFilePath($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRelativeFilePath($file)
+    {
+        return 'files/' . $this->config->get('sESDKEY') . '/' . $file;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function existsFile($file)
+    {
+        return file_exists($this->getAbsoluteFilePath($file));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendFile($file)
+    {
+        $relativeFilePath = $this->getRelativeFilePath($file);
+        $absoluteFilePath = $this->getAbsoluteFilePath($file);
+        $fileName = basename($absoluteFilePath);
+
+        switch ($this->config->get('esdDownloadStrategy')) {
+            case 0:
+                $url = $this->front->Request()->getBasePath() . '/' . $relativeFilePath;
+                $this->front->Response()->setRedirect($url);
+                break;
+            case 1:
+                @set_time_limit(0);
+                $this->front->Response()
+                    ->setHeader('Content-Type', 'application/octet-stream')
+                    ->setHeader('Content-Disposition', 'attachment; filename="' . $fileName . '"')
+                    ->setHeader('Content-Length', filesize($absoluteFilePath));
+
+                $this->front->Plugins()->ViewRenderer()->setNoRender();
+
+                readfile($absoluteFilePath);
+                break;
+            case 2:
+                // Apache2 + X-Sendfile
+                $this->front->Response()
+                    ->setHeader('Content-Type', 'application/octet-stream')
+                    ->setHeader('Content-Disposition', 'attachment; filename="' . $fileName . '"')
+                    ->setHeader('X-Sendfile', $absoluteFilePath);
+
+                $this->front->Plugins()->ViewRenderer()->setNoRender();
+
+                break;
+            case 3:
+                // Nginx + X-Accel
+                $this->front->Response()
+                    ->setHeader('Content-Type', 'application/octet-stream')
+                    ->setHeader('Content-Disposition', 'attachment; filename="' . $fileName . '"')
+                    ->setHeader('X-Accel-Redirect', '/' . $relativeFilePath);
+
+                $this->front->Plugins()->ViewRenderer()->setNoRender();
+
+                break;
+        }
+    }
+}

--- a/engine/Shopware/Bundle/EsdBundle/Service/Core/DownloadService.php
+++ b/engine/Shopware/Bundle/EsdBundle/Service/Core/DownloadService.php
@@ -24,6 +24,8 @@ class DownloadService implements DownloadInterface
     private $front;
 
     /**
+     * @param $shopwareRootDirectory
+     * @param Shopware_Components_Config $config
      * @param Enlight_Controller_Front $front
      */
     public function __construct(

--- a/engine/Shopware/Bundle/EsdBundle/Service/DownloadInterface.php
+++ b/engine/Shopware/Bundle/EsdBundle/Service/DownloadInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Shopware\Bundle\EsdBundle\Service;
+
+interface DownloadInterface
+{
+    /**
+     * @param string $file
+     * @return string
+     */
+    public function getAbsoluteFilePath($file);
+
+    /**
+     * @param string $file
+     * @return string
+     */
+    public function getRelativeFilePath($file);
+
+    /**
+     * @param string $file
+     * @return bool
+     */
+    public function existsFile($file);
+
+    /**
+     * @param string $file
+     */
+    public function sendFile($file);
+}

--- a/engine/Shopware/Bundle/EsdBundle/services.xml
+++ b/engine/Shopware/Bundle/EsdBundle/services.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="shopware_esd.download_service" class="Shopware\Bundle\EsdBundle\Service\Core\DownloadService">
+            <argument type="string">%shopware.app.rootdir%</argument>
+            <argument type="service" id="config" />
+            <argument type="service" id="front" />
+        </service>
+
+    </services>
+</container>

--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -395,7 +395,7 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
         /** @var \Shopware\Bundle\EsdBundle\Service\DownloadInterface $downloadService */
         $downloadService = $this->container->get('shopware_esd.download_service');
 
-        if ($downloadService->existsFile($download['file'])) {
+        if (!$downloadService->existsFile($download['file'])) {
             $this->View()->sErrorCode = 2;
 
             return $this->forward('downloads');

--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -392,52 +392,16 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
             return $this->forward('downloads');
         }
 
-        $file = 'files/' . Shopware()->Config()->get('sESDKEY') . '/' . $download['file'];
+        /** @var \Shopware\Bundle\EsdBundle\Service\DownloadInterface $downloadService */
+        $downloadService = $this->container->get('shopware_esd.download_service');
 
-        $filePath = $this->container->getParameter('shopware.app.rootdir') . $file;
-
-        if (!file_exists($filePath)) {
+        if ($downloadService->existsFile($download['file'])) {
             $this->View()->sErrorCode = 2;
 
             return $this->forward('downloads');
         }
 
-        switch (Shopware()->Config()->get('esdDownloadStrategy')) {
-            case 0:
-                $this->redirect($this->Request()->getBasePath() . '/' . $file);
-                break;
-            case 1:
-                @set_time_limit(0);
-                $this->Response()
-                    ->setHeader('Content-Type', 'application/octet-stream')
-                    ->setHeader('Content-Disposition', 'attachment; filename="' . $download['file'] . '"')
-                    ->setHeader('Content-Length', filesize($filePath));
-
-                $this->Front()->Plugins()->ViewRenderer()->setNoRender();
-
-                readfile($filePath);
-                break;
-            case 2:
-                // Apache2 + X-Sendfile
-                $this->Response()
-                    ->setHeader('Content-Type', 'application/octet-stream')
-                    ->setHeader('Content-Disposition', 'attachment; filename="' . $download['file'] . '"')
-                    ->setHeader('X-Sendfile', $filePath);
-
-                $this->Front()->Plugins()->ViewRenderer()->setNoRender();
-
-                break;
-            case 3:
-                // Nginx + X-Accel
-                $this->Response()
-                    ->setHeader('Content-Type', 'application/octet-stream')
-                    ->setHeader('Content-Disposition', 'attachment; filename="' . $download['file'] . '"')
-                    ->setHeader('X-Accel-Redirect', '/' . $file);
-
-                $this->Front()->Plugins()->ViewRenderer()->setNoRender();
-
-                break;
-        }
+        $downloadService->sendFile($download['file']);
     }
 
     /**

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -670,6 +670,7 @@ class Kernel implements HttpKernelInterface
         $loader->load('StoreFrontBundle/services.xml');
         $loader->load('PluginInstallerBundle/services.xml');
         $loader->load('ESIndexingBundle/services.xml');
+        $loader->load('EsdBundle/services.xml');
         $loader->load('MediaBundle/services.xml');
         $loader->load('FormBundle/services.xml');
         $loader->load('AccountBundle/services.xml');


### PR DESCRIPTION
### 1. Why is this change necessary?
To have nicer code and be able to access esd-related functions from everywhere.

### 2. What does this change do, exactly?
It moves some esd-related business logic from a controller into a dedicated bundle.

### 3. Describe each step to reproduce the issue or behaviour.
Log into an account and download a purchased esd product.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.