### PR TITLE
Added missing blocks around template includes.

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/content.tpl
+++ b/themes/Frontend/Bare/frontend/detail/content.tpl
@@ -19,7 +19,9 @@
         {/block}
 
         {* Product header *}
-        {include file="frontend/detail/content/header.tpl"}
+        {block name="frontend_detail_index_header_container"}
+            {include file="frontend/detail/content/header.tpl"}
+        {/block}
 
         <div class="product--detail-upper block-group">
             {* Product image *}
@@ -31,12 +33,16 @@
                     data-maxZoom="{$theme.lightboxZoomFactor}"
                     data-thumbnails=".image--thumbnails"
                     {/if}>
-                    {include file="frontend/detail/image.tpl"}
+                    {block name="frontend_detail_index_image"}
+                        {include file="frontend/detail/image.tpl"}
+                    {/block}
                 </div>
             {/block}
 
             {* "Buy now" box container *}
-            {include file="frontend/detail/content/buy_container.tpl"}
+            {block name="frontend_detail_index_buy_box_container"}
+                {include file="frontend/detail/content/buy_container.tpl"}
+            {/block}
         </div>
 
         {* Product bundle hook point *}
@@ -58,10 +64,14 @@
             <div class="tab-menu--cross-selling"{if $sArticle.relatedProductStreams} data-scrollable="true"{/if}>
 
                 {* Tab navigation *}
-                {include file="frontend/detail/content/tab_navigation.tpl"}
+                {block name="frontend_detail_index_tabs_navigation_container"}
+                    {include file="frontend/detail/content/tab_navigation.tpl"}
+                {/block}
 
                 {* Tab content container *}
-                {include file="frontend/detail/content/tab_container.tpl"}
+                {block name="frontend_detail_index_tab_container"}
+                    {include file="frontend/detail/content/tab_container.tpl"}
+                {/block}
             </div>
         {/block}
     </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
To have the possibility to move the included template files to another position or just hide them and empty the `{block}`.

### 2. What does this change do, exactly?
Set a `{block}` around each template include.

### 3. Describe each step to reproduce the issue or behaviour.
Look at template includes in file `themes/Frontend/Bare/frontend/detail/content.tpl`

### 4. Please link to the relevant issues (if any).
N/A

### 5. Which documentation changes (if any) need to be made because of this PR?
N/A

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.