### PR TITLE
Allow 0 as ID in state of Order API

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Order.php
+++ b/engine/Shopware/Components/Api/Resource/Order.php
@@ -703,12 +703,14 @@ class Order extends Resource
             ));
         }
 
-        $state = $this->getContainer()->get('models')->find(State::class, $billing['stateId']);
-        if (!$state) {
-            throw new ApiException\NotFoundException(sprintf(
-                'Shipping State by id %s not found',
-                $billing['stateId']
-            ));
+        if($billing['stateId'] != 0){
+            $state = $this->getContainer()->get('models')->find(State::class, $billing['stateId']);
+            if (!$state) {
+                throw new ApiException\NotFoundException(sprintf(
+                    'Billing State by id %s not found',
+                    $billing['stateId']
+                ));
+            }
         }
 
         $billingAddress = new Billing();
@@ -742,12 +744,14 @@ class Order extends Resource
             ));
         }
 
-        $state = $this->getContainer()->get('models')->find(State::class, $shipping['stateId']);
-        if (!$state) {
-            throw new ApiException\NotFoundException(sprintf(
-                'Shipping State by id %s not found',
-                $shipping['stateId']
-            ));
+        if($shipping['stateId'] != 0) {
+            $state = $this->getContainer()->get('models')->find(State::class, $shipping['stateId']);
+            if (!$state) {
+                throw new ApiException\NotFoundException(sprintf(
+                    'Shipping State by id %s not found',
+                    $shipping['stateId']
+                ));
+            }
         }
 
         $shippingAddress = new Shipping();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The stateId is necessary on create of an order. This should not be requiered. Also see the ISSUE SW-21511 I also fixed the typo that states that shipping state is missing instead of billing state

The user can register without a stateId/state, why should the API disallow it.

### 2. What does this change do, exactly?
It checks if the stateId is 0 - if so it does not check if the state exists in the list

### 3. Describe each step to reproduce the issue or behaviour.
Create order with stateId 0 fails

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-21511

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.