### PR TITLE
 Remove Composer platform fake 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,10 +115,7 @@
     },
     "config": {
         "autoloader-suffix": "Shopware",
-        "optimize-autoloader": true,
-        "platform": {
-            "php": "5.6.4"
-        }
+        "optimize-autoloader": true
     },
     "scripts": {
         "cs-check": "php-cs-fixer fix --dry-run -v",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

In order to install libraries requiring PHP >= 7.0, platform fake is an obstacle.
Furthermore, it's a lie and we should rely on "require" and real running version.

### 2. What does this change do, exactly?

Removes specific PHP version faking.

### 3. Describe each step to reproduce the issue or behaviour.

Add for example frosh/shopware-profiler (`php composer.phar require --dev frosh/shopware-profiler`).

It results into this error:

```
  Problem 1
    - This package requires php ^7.0 but your PHP version (5.6.4) does not satisfy that requirement.

```

### 4. Please link to the relevant issues (if any).

None.

### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.