### PR TITLE
redirect deleteArticleAction

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -535,7 +535,7 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
         if ($this->Request()->getParam('sAddAccessories')) {
             $this->forward('addAccessories');
         } else {
-            $this->forward($this->Request()->getParam('sTargetAction', 'cart'));
+            $this->redirect(['action' => $this->Request()->getParam('sTargetAction', 'cart')]);
         }
     }
 
@@ -552,7 +552,7 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
             $this->Request()->getParam('sAddAccessoriesQuantity')
         );
 
-        $this->forward($this->Request()->getParam('sTargetAction', 'cart'));
+        $this->redirect(['action' => $this->Request()->getParam('sTargetAction', 'cart')]);
     }
 
     /**
@@ -566,7 +566,7 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
         if ($this->Request()->getParam('sDelete')) {
             $this->basket->sDeleteArticle($this->Request()->getParam('sDelete'));
         }
-        $this->forward($this->Request()->getParam('sTargetAction', 'index'));
+        $this->redirect(['action' => $this->Request()->getParam('sTargetAction', 'index')]);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
the links for deleteArticle and addAccessories,  stays in browser. If the user submits this address again, there will be an error.

### 2. What does this change do, exactly?
change forward to redirect

### 3. Describe each step to reproduce the issue or behaviour.
- add an product to basket
- switch to basket
- remove article
- see address in browser

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.