### PR TITLE
Update Forms.php

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Forms.php
+++ b/engine/Shopware/Controllers/Frontend/Forms.php
@@ -240,6 +240,7 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
         ];
 
         return array_merge($formData, [
+            'attribute' => Shopware()->Container()->get('shopware_attribute.data_loader')->load('s_cms_support_attributes', $formId),
             'sErrors' => $this->_errors,
             'sElements' => $this->_elements,
             'sFields' => $fields,


### PR DESCRIPTION
make the custom form attributes available to the frontend template

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
A user should be able to use the freetext fields they configure in the backend, in the frontend

### 2. What does this change do, exactly?
Makes freetext fields for Forms available in the frontend template

### 3. Describe each step to reproduce the issue or behaviour.
1) add a freetext field to Forms (s_cms_support_attributes)
2) try to find the freetext field in the template variables, it's not there

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.