### PR TITLE
change docID column type from integer to varchar

### DIFF
--- a/_sql/migrations/1231-change-docid-column-type.php
+++ b/_sql/migrations/1231-change-docid-column-type.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+class Migrations_Migration1231 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('ALTER TABLE `s_order_documents` MODIFY `docID` VARCHAR(30) COLLATE utf8_unicode_ci NOT NULL;');
+    }
+}

--- a/engine/Shopware/Models/Order/Document/Document.php
+++ b/engine/Shopware/Models/Order/Document/Document.php
@@ -96,9 +96,9 @@ class Document extends ModelEntity
     private $amount;
 
     /**
-     * @var int
+     * @var string
      *
-     * @ORM\Column(name="docID", type="integer", nullable=false)
+     * @ORM\Column(name="docID", type="string", nullable=false)
      */
     private $documentId;
 
@@ -234,7 +234,7 @@ class Document extends ModelEntity
     /**
      * Set documentId
      *
-     * @param int $documentId
+     * @param string $documentId
      *
      * @return Document
      */
@@ -248,7 +248,7 @@ class Document extends ModelEntity
     /**
      * Get documentId
      *
-     * @return int
+     * @return string
      */
     public function getDocumentId()
     {

--- a/themes/Backend/ExtJs/backend/order/model/receipt.js
+++ b/themes/Backend/ExtJs/backend/order/model/receipt.js
@@ -60,7 +60,7 @@ Ext.define('Shopware.apps.Order.model.Receipt', {
         { name: 'customerId', type:'int' },
         { name: 'orderId', type:'int' },
         { name: 'amount', type:'float' },
-        { name: 'documentId', type:'int' },
+        { name: 'documentId', type:'string' },
         { name: 'hash', type:'string' },
         { name: 'typeName', type:'string' },
         { name: 'active', type:'boolean', defaultValue: false }


### PR DESCRIPTION
### 1. Why is this change necessary?
The change is needed to provide compatibility for customized number ranges and the resulting document ids. Other identifiers, like the column `ordernumber` in table `s_order` or the column `customernumber` in the table `s_user`, has already the right datatype for the requirement.

### 2. What does this change do, exactly?
It makes the column `docID` compatible for letters. So a docID like 'INV_12345' is possible. The resulting filename will be 'INV_12345.pdf'.

### 3. Describe each step to reproduce the issue or behaviour.
Create a Document-ID (bid) with letters in. This leads to a "0" value for the column `docID` in the table `s_order_documents`.

### 4. Please link to the relevant issues (if any).
#1656 mistakenly closed by myself

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.