### PR TITLE
Support all numbers

### DIFF
--- a/engine/Shopware/Models/Article/Detail.php
+++ b/engine/Shopware/Models/Article/Detail.php
@@ -142,7 +142,6 @@ class Detail extends ModelEntity
     /**
      * @var string
      * @Assert\NotBlank
-     * @Assert\Regex("/^[a-zA-Z0-9-_.]+$/")
      *
      * @ORM\Column(name="ordernumber", type="string", nullable=false, unique = true)
      */

--- a/themes/Backend/ExtJs/backend/article/view/detail/base.js
+++ b/themes/Backend/ExtJs/backend/article/view/detail/base.js
@@ -79,8 +79,7 @@ Ext.define('Shopware.apps.Article.view.detail.Base', {
         priceGroup: '{s name=detail/base/price_group_select}Select price group{/s}',
         purchasePrice: '{s name=detail/base/purchase_price}Purchase price{/s}',
         numberValidation: '{s name=detail/base/number_validation}The inserted article number already exists!{/s}',
-        mainDetailAdditionalText: '{s name=detail/base/main_detail_additional_text}Varianten-Zusatztext{/s}',
-        regexNumberValidation: '{s name=detail/base/regex_number_validation}The inserted article number contains illegal characters!{/s}'
+        mainDetailAdditionalText: '{s name=detail/base/main_detail_additional_text}Varianten-Zusatztext{/s}'
     },
 
     /**
@@ -180,8 +179,6 @@ Ext.define('Shopware.apps.Article.view.detail.Base', {
             name: 'mainDetail[number]',
             dataIndex: 'mainDetail[number]',
             fieldLabel: me.snippets.number,
-            regex: /^[a-zA-Z0-9-_.]+$/,
-            regexText: me.snippets.regexNumberValidation,
             allowBlank: false,
             enableKeyEvents:true,
             checkChangeBuffer:700,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Support ordernumbers like "000/001/002"

### 2. What does this change do, exactly?

Remove the regex check

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?

no

### 6. Checklist

- [x ] I have written tests and verified that they fail without my change
- [x ] I have squashed any insignificant commits
- [x ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.