### PR TITLE
Used interface instead of class for CustomerServiceInterface

### DIFF
--- a/engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/CustomerProvider.php
+++ b/engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/CustomerProvider.php
@@ -24,12 +24,12 @@
 
 namespace Shopware\Bundle\CustomerSearchBundleDBAL\Indexing;
 
-use Shopware\Bundle\StoreFrontBundle\Service\Core\CustomerService;
+use Shopware\Bundle\StoreFrontBundle\Service\CustomerServiceInterface;
 
 class CustomerProvider implements CustomerProviderInterface
 {
     /**
-     * @var CustomerService
+     * @var CustomerServiceInterface
      */
     private $customerService;
 
@@ -39,11 +39,11 @@ class CustomerProvider implements CustomerProviderInterface
     private $customerOrderGateway;
 
     /**
-     * @param CustomerService      $customerService
-     * @param CustomerOrderGateway $customerOrderGateway
+     * @param CustomerServiceInterface $customerService
+     * @param CustomerOrderGateway     $customerOrderGateway
      */
     public function __construct(
-        CustomerService $customerService,
+        CustomerServiceInterface $customerService,
         CustomerOrderGateway $customerOrderGateway
     ) {
         $this->customerService = $customerService;

--- a/engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/SearchIndexer.php
+++ b/engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/SearchIndexer.php
@@ -34,15 +34,15 @@ class SearchIndexer implements SearchIndexerInterface
     private $connection;
 
     /**
-     * @var CustomerProvider
+     * @var CustomerProviderInterface
      */
     private $provider;
 
     /**
-     * @param Connection       $connection
-     * @param CustomerProvider $provider
+     * @param Connection                $connection
+     * @param CustomerProviderInterface $provider
      */
-    public function __construct(Connection $connection, CustomerProvider $provider)
+    public function __construct(Connection $connection, CustomerProviderInterface $provider)
     {
         $this->connection = $connection;
         $this->provider = $provider;


### PR DESCRIPTION
### 1. Why is this change necessary?
Used interface instead of class to enable decoration via DI. The class hint is flawed as this will throw an exception if an other interface implementation is given.

### 2. What does this change do, exactly?
Change type hints/constructor signature.

### 3. Describe each step to reproduce the issue or behaviour.
Use a different interface implementation (e.g. a decorator) as constructor parameter.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.