### PR TITLE
manual adding of article to order: additional text not taken into position name

### DIFF
--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -1081,7 +1081,7 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
         $tmpVariant = [];
 
         // Checks if an additional text is available
-        foreach ($data as $variantData) {
+        foreach ($data as &$variantData) {
             if (!empty($variantData['additionalText'])) {
                 $variantData['name'] = $variantData['name'] . ' ' . $variantData['additionalText'];
             } else {


### PR DESCRIPTION
if all articles have an additionaltext, the array $variantIds is empty and the changed name was never returned.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

When adding a position to an existing order in backend, the additional text of variant was not taken if all articles have an additional text.


### 2. What does this change do, exactly?

It makes sure that the already overwritten data array (with added texts) is really returned.


### 3. Describe each step to reproduce the issue or behaviour.

Set the additional text for ALL your articles.
Place an order.
In backend, add a position to your order.
The additional text of the article is not taken in the position (e.g. not in the pdf documents).


### 4. Please link to the relevant issues (if any).

none found.


### 5. Which documentation changes (if any) need to be made because of this PR?

none.


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.