### PR TITLE
Make Zend Session check compatible with PHP 7.1+

### DIFF
--- a/engine/Library/Zend/Session.php
+++ b/engine/Library/Zend/Session.php
@@ -558,7 +558,8 @@ class Zend_Session extends Zend_Session_Abstract
             }
         }
 
-        $hashBitsPerChar = ini_get('session.hash_bits_per_character');
+        $hashBitsPerChar = ini_get('session.sid_bits_per_character') ?: ini_get('session.hash_bits_per_character');
+
         if (!$hashBitsPerChar) {
             $hashBitsPerChar = 5; // the default value
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
To make Shopware compatible with PHP 7.1+ configurations

### 2. What does this change do, exactly?
Check wether the code is run with PHP 7.1+, if so use `session.sid_bits_per_character` instead of `session.hash_bits_per_character` which was removed with PHP 7.1

### 3. Describe each step to reproduce the issue or behaviour.
Run shopware on PHP 7.1+ with `session.sid_bits_per_character` set to 4 or 6.
Login to backend or frontend. Shopware will throw an exception that the session has already been started.
After this fix you will be able to login correctly.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
Since Shopware is currently not fully compatible with PHP 7.1 you may want to note this somewhere.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.