### PR TITLE
Fix sorting of emotion elements

### DIFF
--- a/engine/Shopware/Bundle/EmotionBundle/Service/Gateway/EmotionElementGateway.php
+++ b/engine/Shopware/Bundle/EmotionBundle/Service/Gateway/EmotionElementGateway.php
@@ -124,6 +124,8 @@ class EmotionElementGateway
         $builder->addOrderBy('emotionElementViewport.start_row', 'ASC')
                 ->addOrderBy('emotionElementViewport.start_col', 'ASC');
 
+        $builder->groupBy('emotionElementViewport.elementID');
+
         return $builder;
     }
 

--- a/engine/Shopware/Bundle/EmotionBundle/Service/Gateway/EmotionElementGateway.php
+++ b/engine/Shopware/Bundle/EmotionBundle/Service/Gateway/EmotionElementGateway.php
@@ -115,13 +115,14 @@ class EmotionElementGateway
                 ->addSelect($this->fieldHelper->getEmotionElementLibraryFields());
 
         $builder->from('s_emotion_element', 'emotionElement')
-                ->innerJoin('emotionElement', 's_library_component', 'emotionLibraryComponent', 'emotionElement.componentID = emotionLibraryComponent.id');
+                ->innerJoin('emotionElement', 's_library_component', 'emotionLibraryComponent', 'emotionElement.componentID = emotionLibraryComponent.id')
+                ->innerJoin('emotionElement', 's_emotion_element_viewports', 'emotionElementViewport', 'emotionElement.id = emotionElementViewport.elementID');
 
         $builder->where('emotionElement.emotionID IN (:emotionIds)')
                 ->setParameter('emotionIds', $emotionIds, Connection::PARAM_INT_ARRAY);
 
-        $builder->addOrderBy('emotionElement.start_row', 'ASC')
-                ->addOrderBy('emotionElement.start_col', 'ASC');
+        $builder->addOrderBy('emotionElementViewport.start_row', 'ASC')
+                ->addOrderBy('emotionElementViewport.start_col', 'ASC');
 
         return $builder;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

The EmotionElementGateway sorts by the deprecated columns `s_emotion_element.start_row` and `s_emotion_element.start_col`. These columns are always filled with `1` and causes elements to be returned in the order in which they have been created in the database.
The user doesn't see this because the elements are sorted the right way in the frontend later.

### 2. What does this change do, exactly?

Use `s_emotion_element_viewports.start_row` and `s_emotion_element_viewports.start_col` for sorting instead.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a new emotion shopping world
2. Place some text elements there with an increasing number
3. Flip the order of the elements
4. Open the XHR request that loads this emotion shopping world in the frontend (e.g. http://localhost/widgets/emotion/index/emotionId/183/controllerName/index)
5. Open the source code of this request and see that the elements arent returned in the order you placed them in the backend. They will be shown in the order of how you created the elements initially.

### 4. Please link to the relevant issues (if any).

:heavy_minus_sign: 

### 5. Which documentation changes (if any) need to be made because of this PR?

:heavy_minus_sign: 

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.