### PR TITLE
SW-20629: Fix endless loop for cronjobs with interval of 0

### DIFF
--- a/engine/Library/Enlight/Components/Cron/Manager.php
+++ b/engine/Library/Enlight/Components/Cron/Manager.php
@@ -323,9 +323,13 @@ class Enlight_Components_Cron_Manager
         $now = $now->getTimestamp();
         $interval = $job->getInterval();
         $next = $job->getNext()->getTimestamp();
-        do {
-            $next += $interval;
-        } while ($now >= $next);
+        if ($interval > 0) {
+            do {
+                $next += $interval;
+            } while ($now >= $next);
+        } else {
+            $next = $now;
+        }
         $job->setNext($next);
         $job->setEnd($now);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It fixes an endless loop with cronjobs that have an interval of zero

### 2. What does this change do, exactly?
Check whether the interval is zero and if it is just use the current timestamp as next execution time instead of trying to calculate it.

### 3. Describe each step to reproduce the issue or behaviour.
Create a cronjob, set the interval to zero and execute the cronjobs e.g. via console:
php bin/console sw:cron:run
The command will be stuck after running through your cronjob and get stuck while calculating the next execution timestamp. After this fix it will finish correctly.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-20629

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.