### PR TITLE
Added block to change product box image link attributes

### DIFF
--- a/themes/Frontend/Bare/frontend/listing/product-box/product-image.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/product-image.tpl
@@ -2,7 +2,7 @@
 <a href="{$sArticle.linkDetails}"
    title="{$sArticle.articleName|escape}"
    class="product--image"
-    {block name="frontend_listing_box_article_image/attributes"}
+    {block name="frontend_listing_box_article_image_attributes"}
         {if $target}target="{$target}"{/if}
     {/block}
    >

--- a/themes/Frontend/Bare/frontend/listing/product-box/product-image.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/product-image.tpl
@@ -2,9 +2,7 @@
 <a href="{$sArticle.linkDetails}"
    title="{$sArticle.articleName|escape}"
    class="product--image"
-    {block name="frontend_listing_box_article_image_attributes"}
-        {if $target}target="{$target}"{/if}
-    {/block}
+    {block name="frontend_listing_box_article_image_attributes"}{/block}
    >
     {block name='frontend_listing_box_article_image_element'}
         <span class="image--element">

--- a/themes/Frontend/Bare/frontend/listing/product-box/product-image.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/product-image.tpl
@@ -1,7 +1,11 @@
 {* Product image - uses the picture element for responsive retina images. *}
 <a href="{$sArticle.linkDetails}"
    title="{$sArticle.articleName|escape}"
-   class="product--image">
+   class="product--image"
+    {block name="frontend_listing_box_article_image/attributes"}
+        {if $target}target="{$target}"{/if}
+    {/block}
+   >
     {block name='frontend_listing_box_article_image_element'}
         <span class="image--element">
             {block name='frontend_listing_box_article_image_media'}


### PR DESCRIPTION
### 1. Why is this change necessary?
The product-image.tpl generates a embracing a-tag. This a-tag is not modifiable yet.

### 2. What does this change do, exactly?
* adds an optional variable to change the target
* adds a block to add even more attributes
* uses `/attributes` naming to support the [FroshProfiler](https://github.com/FriendsOfShopware/FroshProfiler)s block annotator

### 3. Describe each step to reproduce the issue or behaviour.
1. Try to change the target to _blank
2. Copy whole file and overwrite it completely with the old content for changing one line without using the power of ~~grayskull~~ inheritance
3. :man_facepalming: 
4. no profit
5. (╯ರ ~ ರ）╯︵ ┻━┻

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.