### PR TITLE
Move upperParams assignment lower to contain the productBoxLayout parameter

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.infinite-scrolling.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.infinite-scrolling.js
@@ -163,13 +163,13 @@
             };
 
             me.params = parseQueryString(window.location.href);
-            me.upperParams = $.extend({}, me.params);
             me.historyParams = $.extend({}, me.params);
 
             if (me.opts.productBoxLayout) {
                 me.params.productBoxLayout = me.opts.productBoxLayout || null;
             }
 
+            me.upperParams = $.extend({}, me.params);
             me.urlBasicMode = false;
 
             // if no seo url is provided, use the url basic push mode


### PR DESCRIPTION
### 1. Why is this change necessary?
When using a custom product box layout in an infinite listing it does not load the products by layout option.

### 2. What does this change do, exactly?
It copies the upperParams after assigning the productBoxLayout property. It is important not to move the historyParams as this will result in the productBoxLayout option being part of the URL.

### 3. Describe each step to reproduce the issue or behaviour.
1. Set attribute `data-productBoxLayout` to a different product box layout on a element with the `swInfiniteScrolling` jquery plugin registered on it
2. Load that listing on a page > 1
3. Click on "load previous"
4. See products in box basic
5. 😤 :anger: 

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Quickfix
```js
$.overridePlugin('swInfiniteScrolling', {
    init: function() {
        var me = this;
        me.superclass.init.apply(this, arguments);
        
        if (me.opts.productBoxLayout) {
            me.upperParams.productBoxLayout = me.opts.productBoxLayout || null;
        }
    }
});
```