### PR TITLE
Fetches usergroup id from sSYSTEM not ShopContext

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1414,7 +1414,7 @@ class sBasket
         list($queryAdditionalInfo, $quantity) = $this->getAdditionalInfoForUpdateArticle($id, $quantity);
         $queryNewPrice = $this->getPriceForUpdateArticle($id, $quantity, $queryAdditionalInfo);
 
-        $customerGroupId = $this->contextService->getShopContext()->getCurrentCustomerGroup()->getId();
+        $customerGroupId = $this->sSYSTEM->sUSERGROUPDATA['id'];
         if (in_array($customerGroupId, $queryAdditionalInfo['blocked_customer_groups'])) {
             // if blocked for current customer group, delete article from basket
             $this->sDeleteArticle($id);


### PR DESCRIPTION
ShopContext Variable is not updated during Login Process. sSYSTEM contains the correct usergroup of the user during login process.
See Issue https://issues.shopware.com/issues/SW-22229

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
ShopContext Variable is not updated during login process if known but not logged in customer puts articles into the basket and logs-in afterwards.

### 2. What does this change do, exactly?
Fetches usergroup from sSYSTEM as in other locations in this class and not from ShopContext.

### 3. Describe each step to reproduce the issue or behaviour.
Issue occurs together with plugin https://store.shopware.com/atsd00790/warenkorb-von-registrierten-benutzern-speichern.html if not "public available" articles are stored in the basket and the user performs a new login.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22229

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have read the contribution requirements and fulfil them.