### PR TITLE
Removed an unneeded leftJoin

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLicenceService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLicenceService.php
@@ -260,8 +260,7 @@ class PluginLicenceService
         $builder = $connection->createQueryBuilder();
 
         $builder->select(['license.module, license.label, license.expiration, license.license'])
-            ->from('s_core_licenses', 'license')
-            ->leftJoin('license', 's_core_plugins', 'plugin', 'plugin.name = license.module');
+            ->from('s_core_licenses', 'license');
 
         $builderExecute = $builder->execute();
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The leftJoin became obsolete as of commit 2a519912b5963a32a26fee0ef98e876ca1208721.



### 2. What does this change do, exactly?
It removes the left-joining. 


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/commit/2a519912b5963a32a26fee0ef98e876ca1208721

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.