### PR TITLE
Replaced static font-family value for icons with proper variable.

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/fields.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/fields.less
@@ -197,7 +197,7 @@ Creates a styled combobox selection for the basic select element.
         font-size: 5px;
         border-left: 1px solid @border-color;
         text-align: center;
-        font-family: 'shopware';
+        font-family: @sw-icon-fontname;
         pointer-events: none;
 
         &:hover {


### PR DESCRIPTION
### 1. Why is this change necessary?
To apply your own value of `@sw-icon-fontname` from your theme based on Responsive.

### 2. What does this change do, exactly?
Replace the static font-family value with the proper LESS variable.

### 3. Describe each step to reproduce the issue or behaviour.
None.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] I have read the contribution requirements and fulfil them.