### PR TITLE
Added support for multilingual product name sorting

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/SortingHandler/ProductNameSortingHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SortingHandler/ProductNameSortingHandler.php
@@ -37,25 +37,21 @@ use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
  */
 class ProductNameSortingHandler implements SortingHandlerInterface
 {
-    const TRANSLATION_IDENTIFIER = 's:10:"txtArtikel";s:';
+    const TRANSLATIONS_TABLE = 's_articles_translations';
 
     const TRANSLATION = 'productTranslationName';
 
-    const TRANSLATION_OBJECT_DATA = self::TRANSLATION . '.objectdata';
+    const TRANSLATION_NAME = self::TRANSLATION . '.name';
 
-    const TRANSLATION_OBJECT_KEY = self::TRANSLATION . '.objectkey';
+    const TRANSLATION_PRODUCT_ID = self::TRANSLATION . '.articleID';
 
-    const TRANSLATION_OBJECT_LANGUAGE = self::TRANSLATION . '.objectlanguage';
-
-    const TRANSLATION_OBJECT_TYPE = self::TRANSLATION . '.objecttype';
+    const TRANSLATION_LANGUAGE = self::TRANSLATION . '.languageID';
 
     const PRODUCT = 'product';
 
     const PRODUCT_ID = self::PRODUCT . '.id';
 
     const PRODUCT_NAME = self::PRODUCT . '.name';
-
-    const S_CORE_TRANSLATIONS = 's_core_translations';
 
     /**
      * {@inheritdoc}
@@ -76,39 +72,21 @@ class ProductNameSortingHandler implements SortingHandlerInterface
         /* @var ProductNameSorting $sorting */
         $query->leftJoin(
             self::PRODUCT,
-            self::S_CORE_TRANSLATIONS,
+            self::TRANSLATIONS_TABLE,
             self::TRANSLATION,
             $query->expr()->andX(
-                $query->expr()->eq(self::TRANSLATION_OBJECT_TYPE, $query->expr()->literal('article')),
-                $query->expr()->eq(self::TRANSLATION_OBJECT_KEY, self::PRODUCT_ID),
-                $query->expr()->eq(self::TRANSLATION_OBJECT_LANGUAGE, $context->getShop()->getId()),
-                $query->expr()->like(self::TRANSLATION_OBJECT_DATA, $query->expr()->literal('%' . self::TRANSLATION_IDENTIFIER . '%'))
+                $query->expr()->eq(self::TRANSLATION_PRODUCT_ID, self::PRODUCT_ID),
+                $query->expr()->eq(self::TRANSLATION_LANGUAGE, $context->getShop()->getId()),
+                $query->expr()->isNotNull(self::TRANSLATION_NAME),
+                $query->expr()->neq(self::TRANSLATION_NAME, $query->expr()->literal(''))
             )
         );
 
         $query->addOrderBy(
             self::exprIf(
-                $query->expr()->isNull(self::TRANSLATION_OBJECT_DATA),
+                $query->expr()->isNull(self::TRANSLATION_NAME),
                 self::PRODUCT_NAME,
-                self::exprSubstringIndex(
-                    self::exprSubstring(
-                        self::TRANSLATION_OBJECT_DATA,
-                        self::exprAdd(
-                            self::exprLocate(
-                                $query->expr()->literal(':'),
-                                self::TRANSLATION_OBJECT_DATA,
-                                self::exprAdd(
-                                    self::exprLocate($query->expr()->literal(self::TRANSLATION_IDENTIFIER),
-                                    self::TRANSLATION_OBJECT_DATA),
-                                    strlen(self::TRANSLATION_IDENTIFIER)
-                                )
-                            ),
-                            '2'
-                        )
-                    ),
-                    $query->expr()->literal('"'),
-                    1
-                )
+                self::TRANSLATION_NAME
             ),
             $sorting->getDirection()
         );
@@ -123,52 +101,5 @@ class ProductNameSortingHandler implements SortingHandlerInterface
     protected static function exprIf($condition, $expression1, $expression2)
     {
         return " if (($condition),($expression1),($expression2)) ";
-    }
-
-    /**
-     * @param string $haystack
-     * @param string $needle
-     * @param int    $count
-     * @return string
-     */
-    protected static function exprSubstringIndex($haystack, $needle, $count)
-    {
-        return " substring_index(($haystack),($needle),($count)) ";
-    }
-
-    /**
-     * @param string          $target
-     * @param int|string      $start
-     * @param int|string|null $count
-     * @return string
-     */
-    protected static function exprSubstring($target, $start, $length = null)
-    {
-        $length = empty($length) ? '' : ",($length)";
-
-        return " substring(($target),($start)$length) ";
-    }
-
-    /**
-     * @param string          $needle
-     * @param string          $haystack
-     * @param int|string|null $position
-     * @return string
-     */
-    protected static function exprLocate($needle, $haystack, $position = null)
-    {
-        $position = empty($position) ? '' : ",($position)";
-
-        return " locate(($needle),($haystack)$position) ";
-    }
-
-    /**
-     * @param string $expression1
-     * @param string $expression2
-     * @return string
-     */
-    protected static function exprAdd($expression1, $expression2)
-    {
-        return " (($expression1)+($expression2)) ";
     }
 }

--- a/engine/Shopware/Bundle/SearchBundleDBAL/SortingHandler/ProductNameSortingHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SortingHandler/ProductNameSortingHandler.php
@@ -37,22 +37,12 @@ use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
  */
 class ProductNameSortingHandler implements SortingHandlerInterface
 {
-    const TRANSLATIONS_TABLE = 's_articles_translations';
-
     const TRANSLATION = 'productTranslationName';
 
     const TRANSLATION_NAME = self::TRANSLATION . '.name';
 
-    const TRANSLATION_PRODUCT_ID = self::TRANSLATION . '.articleID';
-
-    const TRANSLATION_LANGUAGE = self::TRANSLATION . '.languageID';
-
     const PRODUCT = 'product';
-
-    const PRODUCT_ID = self::PRODUCT . '.id';
-
-    const PRODUCT_NAME = self::PRODUCT . '.name';
-
+    
     /**
      * {@inheritdoc}
      */
@@ -72,11 +62,11 @@ class ProductNameSortingHandler implements SortingHandlerInterface
         /* @var ProductNameSorting $sorting */
         $query->leftJoin(
             self::PRODUCT,
-            self::TRANSLATIONS_TABLE,
+            's_articles_translations',
             self::TRANSLATION,
             $query->expr()->andX(
-                $query->expr()->eq(self::TRANSLATION_PRODUCT_ID, self::PRODUCT_ID),
-                $query->expr()->eq(self::TRANSLATION_LANGUAGE, $context->getShop()->getId()),
+                $query->expr()->eq(self::TRANSLATION . '.articleID', self::PRODUCT . '.id'),
+                $query->expr()->eq(self::TRANSLATION . '.languageID', $context->getShop()->getId()),
                 $query->expr()->isNotNull(self::TRANSLATION_NAME),
                 $query->expr()->neq(self::TRANSLATION_NAME, $query->expr()->literal(''))
             )
@@ -85,7 +75,7 @@ class ProductNameSortingHandler implements SortingHandlerInterface
         $query->addOrderBy(
             self::exprIf(
                 $query->expr()->isNull(self::TRANSLATION_NAME),
-                self::PRODUCT_NAME,
+                self::PRODUCT . '.name',
                 self::TRANSLATION_NAME
             ),
             $sorting->getDirection()


### PR DESCRIPTION
### 1. Why is this change necessary?
Sorting products by its name is not working properly when using translations on products to serve them in two different languages. When one sort products by name in a category listing they are ordered by their untranslated name. 

### 2. What does this change do, exactly?
It joins the s_core_translations table for sorting by the suitable translation.

### 3. Describe each step to reproduce the issue or behaviour.
The common shopware installation serves a German product set with English translations. If you have an 'Igelmütze' in this shop it will be ordered wrong in an English listing as the translation says 'Hedgehog hat'. The listing displays 'Hedgehog hat' but it was sorted by 'Igelmütze'. This will be subtle as H and I are next to each other. But imagine a 'Strandtuch' product and its translation 'Beach towel'.

I recognized it in the Shopware 4 demo data in the category 'Genusswelten'/'World of Indulgence' with the product 'Wacholder Premium extra mild 32%' with its translation 'Juniper premium extra mild 32%'.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.