### PR TITLE
Allow empty stateId in Order API

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Order.php
+++ b/engine/Shopware/Components/Api/Resource/Order.php
@@ -691,9 +691,18 @@ class Order extends Resource
             throw new ApiException\ParameterMissingException('billing.countryId');
         }
 
-        if (!array_key_exists('stateId', $billing)) {
-            throw new ApiException\ParameterMissingException('billing.stateId');
-        }
+	    if (empty($billing['stateId'])) {
+		    $billing['stateId'] = 0;
+	    }
+	    else {
+		    $state = $this->getContainer()->get('models')->find(State::class, $billing['stateId']);
+		    if (!$state) {
+			    throw new ApiException\NotFoundException(sprintf(
+				    'Shipping State by id %s not found',
+				    $billing['stateId']
+			    ));
+		    }
+	    }
 
         $country = $this->getContainer()->get('models')->find(CountryModel::class, $billing['countryId']);
         if (!$country) {
@@ -703,13 +712,6 @@ class Order extends Resource
             ));
         }
 
-        $state = $this->getContainer()->get('models')->find(State::class, $billing['stateId']);
-        if (!$state) {
-            throw new ApiException\NotFoundException(sprintf(
-                'Shipping State by id %s not found',
-                $billing['stateId']
-            ));
-        }
 
         $billingAddress = new Billing();
         $billingAddress->fromArray($billing);
@@ -730,9 +732,18 @@ class Order extends Resource
             throw new ApiException\ParameterMissingException('shipping.countryId');
         }
 
-        if (!array_key_exists('stateId', $shipping)) {
-            throw new ApiException\ParameterMissingException('shipping.stateId');
-        }
+	    if (empty($shipping['stateId'])) {
+		    $shipping['stateId'] = 0;
+	    }
+	    else {
+		    $state = $this->getContainer()->get('models')->find(State::class, $shipping['stateId']);
+		    if (!$state) {
+			    throw new ApiException\NotFoundException(sprintf(
+				    'Shipping State by id %s not found',
+				    $shipping['stateId']
+			    ));
+		    }
+	    }
 
         $country = $this->getContainer()->get('models')->find(CountryModel::class, $shipping['countryId']);
         if (!$country) {
@@ -742,13 +753,6 @@ class Order extends Resource
             ));
         }
 
-        $state = $this->getContainer()->get('models')->find(State::class, $shipping['stateId']);
-        if (!$state) {
-            throw new ApiException\NotFoundException(sprintf(
-                'Shipping State by id %s not found',
-                $shipping['stateId']
-            ));
-        }
 
         $shippingAddress = new Shipping();
         $shippingAddress->fromArray($shipping);

--- a/tests/Functional/Components/Api/OrderTest.php
+++ b/tests/Functional/Components/Api/OrderTest.php
@@ -337,6 +337,34 @@ class OrderTest extends TestCase
         $this->resource->create($order);
     }
 
+	public function testCreateOrderOnEmptyStateIdInBillingAddress()
+	{
+		// Get existing order
+		$this->resource->setResultMode(Resource::HYDRATE_ARRAY);
+		$order = $this->resource->getOne($this->order['id']);
+
+		$order = $this->filterOrderId($order);
+		unset($order['billing']['stateId']);
+
+		$newOrder = $this->resource->create($order);
+
+		$this->assertEquals($newOrder->getBilling()->getState(), null);
+	}
+
+	public function testCreateOrderOnEmptyStateIdInShippingAddress()
+	{
+		// Get existing order
+		$this->resource->setResultMode(Resource::HYDRATE_ARRAY);
+		$order = $this->resource->getOne($this->order['id']);
+
+		$order = $this->filterOrderId($order);
+		unset($order['shipping']['stateId']);
+
+		$newOrder = $this->resource->create($order);
+
+		$this->assertEquals($newOrder->getShipping()->getState(), null);
+	}
+
     /**
      * @expectedException \Shopware\Components\Api\Exception\NotFoundException
      */


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The stateId is necessary on create of an order. This should not be requiered. Also see the ISSUE SW-21511 I also fixed the typo that states that shipping state is missing instead of billing state

The user can register without a stateId/state, why should the API disallow it.

### 2. What does this change do, exactly?
It checks if the stateId is empty - if so it sets it to 0. If it is not empty it follows the check if the state actually exists and still throws an error

### 3. Describe each step to reproduce the issue or behaviour.
Create order with empty stateId fails

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-21511

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.