### PR TITLE
Replaces type-hints for VariantHelper by VariantHelperInterface

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductProvider.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductProvider.php
@@ -27,7 +27,7 @@ namespace Shopware\Bundle\ESIndexingBundle\Product;
 use Doctrine\DBAL\Connection;
 use Shopware\Bundle\ESIndexingBundle\IdentifierSelector;
 use Shopware\Bundle\ESIndexingBundle\Struct\Product;
-use Shopware\Bundle\SearchBundleDBAL\VariantHelper;
+use Shopware\Bundle\SearchBundleDBAL\VariantHelperInterface;
 use Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\FieldHelper;
 use Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\Hydrator\PropertyHydrator;
 use Shopware\Bundle\StoreFrontBundle\Gateway\ListProductGatewayInterface;
@@ -98,7 +98,7 @@ class ProductProvider implements ProductProviderInterface
     private $configuratorService;
 
     /**
-     * @var VariantHelper
+     * @var VariantHelperInterface
      */
     private $variantHelper;
 
@@ -123,7 +123,7 @@ class ProductProvider implements ProductProviderInterface
         FieldHelper $fieldHelper,
         PropertyHydrator $propertyHydrator,
         ConfiguratorServiceInterface $configuratorService,
-        VariantHelper $variantHelper,
+        VariantHelperInterface $variantHelper,
         ProductConfigurationLoader $configurationLoader,
         ProductListingVariationLoader $visibilityLoader
     ) {

--- a/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductQueryFactory.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductQueryFactory.php
@@ -26,7 +26,7 @@ namespace Shopware\Bundle\ESIndexingBundle\Product;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Bundle\ESIndexingBundle\LastIdQuery;
-use Shopware\Bundle\SearchBundleDBAL\VariantHelper;
+use Shopware\Bundle\SearchBundleDBAL\VariantHelperInterface;
 
 /**
  * Class ProductQueryFactory
@@ -40,10 +40,10 @@ class ProductQueryFactory implements ProductQueryFactoryInterface
     private $variantHelper;
 
     /**
-     * @param Connection    $connection
-     * @param VariantHelper $variantHelper
+     * @param Connection             $connection
+     * @param VariantHelperInterface $variantHelper
      */
-    public function __construct(Connection $connection, VariantHelper $variantHelper)
+    public function __construct(Connection $connection, VariantHelperInterface $variantHelper)
     {
         $this->connection = $connection;
         $this->variantHelper = $variantHelper;

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ConfiguratorGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ConfiguratorGateway.php
@@ -26,7 +26,6 @@ namespace Shopware\Bundle\StoreFrontBundle\Gateway\DBAL;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use Shopware\Bundle\SearchBundleDBAL\VariantHelper;
 use Shopware\Bundle\StoreFrontBundle\Gateway;
 use Shopware\Bundle\StoreFrontBundle\Struct;
 
@@ -72,7 +71,6 @@ class ConfiguratorGateway implements Gateway\ConfiguratorGatewayInterface
      * @param FieldHelper                                                     $fieldHelper
      * @param Hydrator\ConfiguratorHydrator                                   $configuratorHydrator
      * @param \Shopware\Bundle\StoreFrontBundle\Gateway\MediaGatewayInterface $mediaGateway
-     * @param VariantHelper                                                   $variantHelper
      */
     public function __construct(
         Connection $connection,


### PR DESCRIPTION
### 1. Why is this change necessary?
For good flexibility when using symfony di container and because an interface makes no sense if nobody uses it.

### 2. What does this change do, exactly?
Replaces type-hints for VariantHelper by VariantHelperInterface.

### 3. Describe each step to reproduce the issue or behaviour.
None.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.