### PR TITLE
fixed unescaped post param

### DIFF
--- a/themes/Frontend/Bare/frontend/newsletter/index.tpl
+++ b/themes/Frontend/Bare/frontend/newsletter/index.tpl
@@ -98,7 +98,7 @@
                             {* Email *}
                             {block name="frontend_newsletter_form_input_email"}
                                 <div class="newsletter--email">
-                                    <input name="newsletter" type="email" placeholder="{s name="sNewsletterPlaceholderMail"}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}" required="required" aria-required="true" value="{if $_POST.newsletter}{$_POST.newsletter}{elseif $_GET.sNewsletter}{$_GET.sNewsletter|escape}{/if}" class="input--field is--required{if $sStatus.sErrorFlag.newsletter} has--error{/if}"/>
+                                    <input name="newsletter" type="email" placeholder="{s name="sNewsletterPlaceholderMail"}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}" required="required" aria-required="true" value="{if $_POST.newsletter}{$_POST.newsletter|escape}{elseif $_GET.sNewsletter}{$_GET.sNewsletter|escape}{/if}" class="input--field is--required{if $sStatus.sErrorFlag.newsletter} has--error{/if}"/>
                                 </div>
                             {/block}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
unexcaped post param is used as value in a template form. All other params are escaped, so this one should be escaped too?
@flynorc found it in the conexco bootstrap theme. We compared the template file with the one in your bare theme and found the same behaviour.


### 2. What does this change do, exactly?
escapes that param

### 3. Describe each step to reproduce the issue or behaviour.
look into the template file

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.