### PR TITLE
Add filter event for product price conversion.

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -101,6 +101,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
         - `DynamicCacheTimeService`
     * Added `invalidation_date_provider` tag to the DIC
 * Added parameter mode to Log module, to directly open the systemlogs tab
+* Added filter event `Legacy_Struct_Converter_Convert_Product_Price` to LegacyStructConverter
 
 ### Changes
 

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -392,7 +392,9 @@ class LegacyStructConverter
             $data = array_merge($data, $this->convertUnitStruct($price->getUnit()));
         }
 
-        return $data;
+        return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Product_Price', $data, [
+            'price' => $price,
+        ]);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`convertProductPriceStruct` is the only conversion method without a filter event. This prevents a clean extension of this conversion and should be fixed.

### 2. What does this change do, exactly?
It adds a filter event in a similar manner as in all other conversion methods.

### 3. Describe each step to reproduce the issue or behaviour.
- Try to extend the product price conversion
- Fail to do so because there is no filter event

### 4. Please link to the relevant issues (if any).
There is no issue yet.

### 5. Which documentation changes (if any) need to be made because of this PR?
Change in UPGRADE-5.5.md is included. I'm not aware of any other necessary changes.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.