### PR TITLE
Make 'Shopware\Bundle\PluginInstallerBundle\Service\SubscriptionService::getPluginInformationFromApi()' public

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -167,6 +167,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
        | --variantswitch       | -d    | Warm up variant switch of configurators  |
        | --productwithnumber   | -x    | Warm up products with number parameter   |
        | --productwithcategory | -y    | Warm up producss with category parameter |        
+* Changed visibility of `Shopware\Bundle\PluginInstallerBundle\Service\SubscriptionService::getPluginInformationFromApi()` to public
 
 ### Removals
 

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/SubscriptionService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/SubscriptionService.php
@@ -143,11 +143,9 @@ class SubscriptionService
         }
 
         try {
-            $secret = $this->getShopSecret();
-
             $response->setCookie('lastCheckSubscriptionDate', date('dmY'), time() + 60 * 60 * 24);
 
-            return $this->getPluginInformationFromApi($secret);
+            return $this->getPluginInformationFromApi();
         } catch (ShopSecretException $e) {
             $this->resetShopSecret();
 
@@ -159,12 +157,17 @@ class SubscriptionService
     }
 
     /**
-     * @param string $secret
+     * Requests the plugin information from the store API and returns the parsed result.
      *
      * @return PluginInformationResultStruct|false
      */
-    private function getPluginInformationFromApi($secret)
+    public function getPluginInformationFromApi()
     {
+        $secret = $this->getShopSecret();
+        if (empty($secret)) {
+            return false;
+        }
+
         $domain = $this->getDomain();
         $params = [
             'domain' => $domain,
@@ -179,10 +182,6 @@ class SubscriptionService
             $params,
             $header
         );
-
-        if (empty($secret)) {
-            return false;
-        }
 
         $isShopUpgraded = $data['general']['isUpgraded'];
         $pluginInformationStructs = array_map(


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently information about plugin subscriptions can only be retrieved by calling `Shopware\Bundle\PluginInstallerBundle\Service\SubscriptionService::getPluginInformation()`, which only allows to fetch new information from the Showpare store API every 24 hours (based on a browser cookie). Hence it is currently not possible to arbitrarily get the latest subscription data.

### 2. What does this change do, exactly?

This PR changes the visibility of `Shopware\Bundle\PluginInstallerBundle\Service\SubscriptionService::getPluginInformationFromApi()` from `private` to `public`. Furthermore it removes its only parameter `$secret` and instead directly loads the required value as needed.

### 3. Describe each step to reproduce the issue or behaviour.

**Note:** The shop needs to be logged into your Shopware store account.

Call `Shopware()->Container()->get('shopware_plugininstaller.subscription_service')->getPluginInformationFromApi()` from anywhere inside Shopware to always retrieve the latest subscription data.

### 4. Please link to the relevant issues (if any).

n/a

### 5. Which documentation changes (if any) need to be made because of this PR?

n/a

### 6. Checklist

- [ ] ~I have written tests and verified that they fail without my change~ (cannot be tested without a valid store account)
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.