### PR TITLE
Backend search: Use DBAL-Query Builder instead of raw queries + add events

### DIFF
--- a/engine/Shopware/Controllers/Backend/Search.php
+++ b/engine/Shopware/Controllers/Backend/Search.php
@@ -126,11 +126,8 @@ class Shopware_Controllers_Backend_Search extends Shopware_Controllers_Backend_E
         $query->leftJoin('article', 's_articles_translations', 'translation', 'article.id= translation.articleID');
         $query->leftJoin('article', 's_articles_supplier', 'manufacturer', 'article.supplierID = manufacturer.id');
 
-        /** @var \Shopware\Components\Model\SearchBuilder $builder */
-        $builder = $this->container->get('shopware.model.search_builder');
-        $builder->addSearchTerm(
-            $query,
-            $search,
+        $searchTerm = $this->get('events')->filter(
+            'Shopware_Backend_Search_GetArticles_SearchTerms',
             [
                 'article.name^3',
                 'variant.ordernumber^2',
@@ -138,9 +135,21 @@ class Shopware_Controllers_Backend_Search extends Shopware_Controllers_Backend_E
                 'manufacturer.name^1',
             ]
         );
+
+        /** @var \Shopware\Components\Model\SearchBuilder $builder */
+        $builder = $this->container->get('shopware.model.search_builder');
+        $builder->addSearchTerm(
+            $query,
+            $search,
+            $searchTerm
+        );
+
         $query->addGroupBy('article.id');
         $query->setFirstResult(0);
         $query->setMaxResults(5);
+
+        // add additional table joins for conditions
+        $query = $this->get('events')->filter('Shopware_Backend_Search_GetArticles_PreFetch', $query);
 
         return $query->execute()->fetchAll(PDO::FETCH_ASSOC);
     }
@@ -166,11 +175,8 @@ class Shopware_Controllers_Backend_Search extends Shopware_Controllers_Backend_E
         $query->from('s_user', 'user');
         $query->innerJoin('user', 's_user_addresses', 'address', 'address.user_id = user.id');
 
-        /** @var \Shopware\Components\Model\SearchBuilder $builder */
-        $builder = $this->container->get('shopware.model.search_builder');
-        $builder->addSearchTerm(
-            $query,
-            $search,
+        $searchTerm = $this->get('events')->filter(
+            'Shopware_Backend_Search_GetCustomers_SearchTerms',
             [
                 'user.email^3',
                 'user.customernumber^4',
@@ -178,9 +184,21 @@ class Shopware_Controllers_Backend_Search extends Shopware_Controllers_Backend_E
                 'TRIM(CONCAT(address.firstname, \' \', address.lastname))^1',
             ]
         );
+
+        /** @var \Shopware\Components\Model\SearchBuilder $builder */
+        $builder = $this->container->get('shopware.model.search_builder');
+        $builder->addSearchTerm(
+            $query,
+            $search,
+            $searchTerm
+        );
+
         $query->addGroupBy('user.id');
         $query->setFirstResult(0);
         $query->setMaxResults(5);
+
+        // add additional table joins for conditions
+        $query = $this->get('events')->filter('Shopware_Backend_Search_GetCustomers_PreFetch', $query);
 
         return $query->execute()->fetchAll(PDO::FETCH_ASSOC);
     }
@@ -221,21 +239,30 @@ class Shopware_Controllers_Backend_Search extends Shopware_Controllers_Backend_E
 
         $query->where('`order`.id != "0"');
 
-        /** @var \Shopware\Components\Model\SearchBuilder $builder */
-        $builder = $this->container->get('shopware.model.search_builder');
-        $builder->addSearchTerm(
-            $query,
-            $search,
+        $searchTerm = $this->get('events')->filter(
+            'Shopware_Backend_Search_GetOrders_SearchTerms',
             [
                 '`order`.ordernumber^3',
                 '`order`.transactionID^1',
                 '`doc`.docID^3'
             ]
         );
+
+        /** @var \Shopware\Components\Model\SearchBuilder $builder */
+        $builder = $this->container->get('shopware.model.search_builder');
+        $builder->addSearchTerm(
+            $query,
+            $search,
+            $searchTerm
+        );
+
         $query->addGroupBy('`order`.id');
         $query->orderBy('`order`.ordertime', 'DESC');
         $query->setFirstResult(0);
         $query->setMaxResults(5);
+
+        // add additional table joins for conditions
+        $query = $this->get('events')->filter('Shopware_Backend_Search_GetOrders_PreFetch', $query);
 
         return $query->execute()->fetchAll(PDO::FETCH_ASSOC);
     }

--- a/engine/Shopware/Controllers/Backend/Search.php
+++ b/engine/Shopware/Controllers/Backend/Search.php
@@ -126,6 +126,7 @@ class Shopware_Controllers_Backend_Search extends Shopware_Controllers_Backend_E
         $query->leftJoin('article', 's_articles_translations', 'translation', 'article.id= translation.articleID');
         $query->leftJoin('article', 's_articles_supplier', 'manufacturer', 'article.supplierID = manufacturer.id');
 
+        /** @var \Shopware\Components\Model\SearchBuilder $builder */
         $builder = $this->container->get('shopware.model.search_builder');
         $builder->addSearchTerm(
             $query,
@@ -153,30 +154,35 @@ class Shopware_Controllers_Backend_Search extends Shopware_Controllers_Backend_E
      */
     public function getCustomers($search)
     {
-        $search2 = Shopware()->Db()->quote("$search%");
-        $search = Shopware()->Db()->quote("%$search%");
+        /** @var \Doctrine\DBAL\Query\QueryBuilder $query */
+        $query = $this->container->get('dbal_connection')->createQueryBuilder();
 
-        $sql = "
-            SELECT b.user_id as id,
-            IF(b.company != '', b.company, CONCAT(u.firstname, ' ', u.lastname)) as name,
-            CONCAT(street, ' ', zipcode, ' ', city) as description
-            FROM s_user_addresses b, s_user u
-            WHERE u.default_billing_address_id=b.id
-            AND
-            (
-                email LIKE $search
-                OR u.customernumber LIKE $search2
-                OR TRIM(CONCAT(b.company,' ', b.department)) LIKE $search
-                OR TRIM(CONCAT(b.firstname,' ',b.lastname)) LIKE $search
-            )
-            AND u.id = b.user_id
-            GROUP BY u.id
-            ORDER BY name ASC
-        ";
+        $query->select([
+            'user.id',
+            'IF(address.company != "", address.company, CONCAT(address.firstname, " ", address.lastname)) as name',
+            'CONCAT(address.street, " ", address.zipcode, " ", address.city) as description'
+        ]);
 
-        $sql = Shopware()->Db()->limit($sql, 5);
+        $query->from('s_user', 'user');
+        $query->innerJoin('user', 's_user_addresses', 'address', 'address.user_id = user.id');
 
-        return Shopware()->Db()->fetchAll($sql);
+        /** @var \Shopware\Components\Model\SearchBuilder $builder */
+        $builder = $this->container->get('shopware.model.search_builder');
+        $builder->addSearchTerm(
+            $query,
+            $search,
+            [
+                'user.email^3',
+                'user.customernumber^4',
+                'TRIM(CONCAT(address.company, \' \', address.department))^1',
+                'TRIM(CONCAT(address.firstname, \' \', address.lastname))^1',
+            ]
+        );
+        $query->addGroupBy('user.id');
+        $query->setFirstResult(0);
+        $query->setMaxResults(5);
+
+        return $query->execute()->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**
@@ -188,41 +194,50 @@ class Shopware_Controllers_Backend_Search extends Shopware_Controllers_Backend_E
      */
     public function getOrders($search)
     {
-        $search = Shopware()->Db()->quote("$search%");
+        /** @var \Doctrine\DBAL\Query\QueryBuilder $query */
+        $query = $this->container->get('dbal_connection')->createQueryBuilder();
 
-        $sql = "
-            SELECT
-                o.id,
-                o.ordernumber as name,
-                o.userID,
-                o.invoice_amount as totalAmount,
-                o.transactionID,
-                o.status,
-                o.cleared,
-                d.type,
-                d.docID,
-                CONCAT(
-                    IF(b.company != '', b.company, CONCAT(b.firstname, ' ', b.lastname)),
-                    ', ',
-                    p.description
-                ) as description
-            FROM s_order o
-            LEFT JOIN s_order_documents d
-            ON d.orderID=o.id AND docID != '0'
-            LEFT JOIN s_order_billingaddress b
-            ON o.id=b.orderID
-            LEFT JOIN s_core_paymentmeans p
-            ON o.paymentID = p.id
-            WHERE o.id != '0'
-            AND (o.ordernumber LIKE $search
-            OR o.transactionID LIKE $search
-            OR docID LIKE $search)
-            GROUP BY o.id
-            ORDER BY o.ordertime DESC
-        ";
-        $sql = Shopware()->Db()->limit($sql, 5);
+        $query->select([
+            '`order`.id',
+            '`order`.ordernumber as name',
+            '`order`.userID',
+            '`order`.invoice_amount as totalAmount',
+            '`order`.transactionID',
+            '`order`.status',
+            '`order`.cleared',
+            'doc.type',
+            'doc.docID',
+            'CONCAT(
+                IF(address.company != "", address.company, CONCAT(address.firstname, " ", address.lastname)),
+                ", ",
+                payment.description
+            ) as description'
+        ]);
 
-        return Shopware()->Db()->fetchAll($sql);
+        $query->from('s_order', '`order`');
+        $query->leftJoin('`order`', 's_order_documents', 'doc', '(doc.orderID = `order`.id AND doc.docID != 0)');
+        $query->leftJoin('`order`', 's_order_billingaddress', 'address', 'address.orderID = `order`.id');
+        $query->leftJoin('`order`', 's_core_paymentmeans', 'payment', 'payment.id = `order`.paymentID');
+
+        $query->where('`order`.id != "0"');
+
+        /** @var \Shopware\Components\Model\SearchBuilder $builder */
+        $builder = $this->container->get('shopware.model.search_builder');
+        $builder->addSearchTerm(
+            $query,
+            $search,
+            [
+                '`order`.ordernumber^3',
+                '`order`.transactionID^1',
+                '`doc`.docID^3'
+            ]
+        );
+        $query->addGroupBy('`order`.id');
+        $query->orderBy('`order`.ordertime', 'DESC');
+        $query->setFirstResult(0);
+        $query->setMaxResults(5);
+
+        return $query->execute()->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Backend search right now is quite hit or miss and by its design can't be used to filter by custom fields (without hooking the controller itself), like the customer number that is used in your ERP and synced between shopware and your external system. By adding events to both the fields that are used to filter each article/customer/order this is now possible.
The other commit of this PR is prerequisite to those events as orders and customers use raw queries and are therefore not accessible in a structured, OOP way required for using those events efficiently.

### 2. What does this change do, exactly?
1. commit: use dbal query instead of raw queries
2. commit: add event for searchterm manipulation and to modify the whole query builder object just before it will be executed

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
Using `shopware.model.search_builder` introduces weights to each parameter and therefore might change the order of the results. This should improve the search results as more relevant fields get preferred, but using events it is easily tweakable to your own needs if not sufficient.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.