### PR TITLE
Enable search for address-list in backend view

### DIFF
--- a/themes/Backend/ExtJs/backend/customer/view/address/list.js
+++ b/themes/Backend/ExtJs/backend/customer/view/address/list.js
@@ -159,7 +159,6 @@ Ext.define('Shopware.apps.Customer.view.address.List', {
 
         return {
             columns: columns,
-            searchField: true,
             detailWindow: 'Shopware.apps.Customer.view.address.detail.Window'
         };
     },

--- a/themes/Backend/ExtJs/backend/customer/view/address/list.js
+++ b/themes/Backend/ExtJs/backend/customer/view/address/list.js
@@ -159,7 +159,7 @@ Ext.define('Shopware.apps.Customer.view.address.List', {
 
         return {
             columns: columns,
-            searchField: false,
+            searchField: true,
             detailWindow: 'Shopware.apps.Customer.view.address.detail.Window'
         };
     },


### PR DESCRIPTION
### 1. Why is this change necessary?
Having users with a lot of addresses makes it hard to find the right address in the backend-view for the addresses

### 2. What does this change do, exactly?
It enables the extjs search function for the address-list in the user-view in the backend

### 3. Describe each step to reproduce the issue or behaviour.
Add more than 20 addresses to a user account and try to find the right address in the backend view

### 4. Please link to the relevant issues (if any).
`null`

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.