### PR TITLE
Allow to configure Shopware::DocPath()

### DIFF
--- a/engine/Shopware/Application.php
+++ b/engine/Shopware/Application.php
@@ -64,15 +64,18 @@ class Shopware extends Enlight_Application
 
     /**
      * @param Container $container
+     * @param string|null $docPath
      */
-    public function __construct(Container $container)
+    public function __construct(Container $container, $docPath = null)
     {
         // Initialize global Shopware function
         Shopware($this);
 
         $this->container = $container;
         $this->appPath = __DIR__ . DIRECTORY_SEPARATOR;
-        $this->docPath = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR;
+        $this->docPath = ($docPath === null) ?
+            dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR :
+            $docPath;
 
         parent::__construct();
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently Shopware determines its root directory from location of `engine/Shopware/Application.php` file.

Unfortunately this location can be nested in `vendor/shopware/shopware` which results into invalid paths in code relying on `Shopware::DocPath()`.

### 2. What does this change do, exactly?

After provided change, it's possible to easily set correct `DocPath` from `Kernel::initializeShopware()` which can be overridden (and it is in mentioned composer-project).
Then there is no need of any special proxy or adapter object to fix behavior when using Shopware as a Composer dependency.

### 3. Describe each step to reproduce the issue or behaviour.

Install Shopware's composer-project and call `Shopware()->DocPath()`. It's suppose to return project root path which is not within `vendor/shopware/shopware`.

### 4. Please link to the relevant issues (if any).

This problem is related to https://github.com/shopware/composer-project/pull/15

### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->
