### PR TITLE
Login is not possible if php and mysql have different timezones

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -848,7 +848,7 @@ class sAdmin
         $sql = '
             SELECT * FROM s_user
             WHERE password = ? AND email = ? AND id = ?
-            AND UNIX_TIMESTAMP(lastlogin) >= (UNIX_TIMESTAMP(now())-?)
+            AND UNIX_TIMESTAMP(lastlogin) >= (UNIX_TIMESTAMP(?)-?)
         ';
 
         $timeOut = $this->config->get('sUSERTIMEOUT');
@@ -860,6 +860,7 @@ class sAdmin
                 $userPassword,
                 $userMail,
                 $userId,
+                new Zend_Date(),
                 $timeOut,
             ]
         );


### PR DESCRIPTION
### 1. Why is this change necessary?
Following situation: The login timeout is set to 2 hours, php and mysql have different timezones set. 
Shopware's login procedure does the following: After the password is verified, the lastlogin time is updated inside the `loginUser` method of `sAdmin` ([source](https://github.com/shopware/shopware/blob/5.5/engine/Shopware/Core/sAdmin.php#L3185)) using the php's timezone (`new Zend_Date()`). At the end of this method `sCheckUser` is called. Inside `sCheckUser` it will be checked if a timeout occured (e.g. user was inactive for X hours). This is done by comparing the value of `lastlogin`, which was just updated in the `loginUser`-method, but this time using the MySQL server's timezone (`NOW()`, [source](https://github.com/shopware/shopware/blob/5.5/engine/Shopware/Core/sAdmin.php#L851)). If these times differ by >= 2hours the user is unable to login.

Shopware is overriding the default timezone with "Europe/Berlin" as said in issue [SW-14889](https://issues.shopware.com/issues/SW-14889). While this is bad, as it is likely to trigger this error, it can't be the solution to just remove the default value. This might solve this issue in many cases. But still:
**This is inconsistent**. We should always use the same time provider. If we don't do that we run into the problem having the constraint, that php and mysql have to be in the same timezone in order to properly run Shopware. This should not be the case.


### 2. What does this change do, exactly?
Use php as date provider to check if the user ran into a timeout. (currently php and mysql is used which can cause trouble)

### 3. Describe each step to reproduce the issue or behaviour.
Set MySql's timezone to at least GMT+4. Do not explicitly set the timezone inside Shopware's config.php. Try to login: It's not working.

### 4. Please link to the relevant issues (if any).
[SW-14889](https://issues.shopware.com/issues/SW-14889), should also be fixed, but it's not the main issue here.

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

I run the tests and tested the change by logging in.