### PR TITLE
add curl_exec and curl_multi_exec to install requirements

### DIFF
--- a/engine/Shopware/Components/Check/Data/System.xml
+++ b/engine/Shopware/Components/Check/Data/System.xml
@@ -84,6 +84,12 @@
         <name>allow_url_fopen</name><group>config</group><required>1</required>
     </requirement>
     <requirement>
+        <name>curl_exec</name><group>config</group><required>1</required>
+    </requirement>
+    <requirement>
+        <name>curl_multi_exec</name><group>config</group><required>1</required>
+    </requirement>
+    <requirement>
         <name>file_uploads</name><group>config</group><required>1</required>
     </requirement>
     <requirement>


### PR DESCRIPTION
### 1. Why is this change necessary?
The PHP methods `curl_exec` and `curl_multi_exec` may be disabled in the server configuration for security reasons. They are needed e.g. for the plugin manager to connect to the store and for guzzle to make multiple requests in parallel mode.

### 2. What does this change do, exactly?
Add  `curl_exec` and `curl_multi_exec` to this list of required functions in the install routine.

### 3. Describe each step to reproduce the issue or behaviour.
1. Disable  `curl_exec` and open the plugin manager. It will throw an error that it cannot connect to the shopware store.
2. 😢 

### 4. Please link to the relevant issues (if any).
This PR is especially for @mnaczenski 😉 

### 5. Which documentation changes (if any) need to be made because of this PR?
/

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.