### PR TITLE
Changed repository method params to be allowed to be emtpy

### DIFF
--- a/engine/Shopware/Models/Form/Repository.php
+++ b/engine/Shopware/Models/Form/Repository.php
@@ -51,22 +51,23 @@ class Repository extends ModelRepository
      * Helper function to create the query builder for the "getListQuery" function.
      * This function can be hooked to modify the query builder of the query object.
      *
-     * @param null|array $filter
+     * @param null $filter
      * @param null $orderBy
      *
      * @return \Doctrine\ORM\QueryBuilder
      */
-    public function getListQueryBuilder($filter = [], $orderBy = null)
+    public function getListQueryBuilder($filter = null, $orderBy = null)
     {
         $builder = $this->getEntityManager()->createQueryBuilder();
         $builder->select(['form', 'attribute'])
             ->from($this->getEntityName(), 'form')
             ->leftJoin('form.attribute', 'attribute');
         
-        $this->addFilter($builder, $filter);
-
-        if($orderBy !== null)
-        {
+        if($filter !== null) {
+            $this->addFilter($builder, $filter);
+        }
+        
+        if($orderBy !== null) {
             $this->addOrderBy($builder, $orderBy);
         }
 

--- a/engine/Shopware/Models/Form/Repository.php
+++ b/engine/Shopware/Models/Form/Repository.php
@@ -51,20 +51,24 @@ class Repository extends ModelRepository
      * Helper function to create the query builder for the "getListQuery" function.
      * This function can be hooked to modify the query builder of the query object.
      *
-     * @param null $filter
+     * @param null|array $filter
      * @param null $orderBy
      *
      * @return \Doctrine\ORM\QueryBuilder
      */
-    public function getListQueryBuilder($filter = null, $orderBy = null)
+    public function getListQueryBuilder($filter = [], $orderBy = null)
     {
         $builder = $this->getEntityManager()->createQueryBuilder();
         $builder->select(['form', 'attribute'])
             ->from($this->getEntityName(), 'form')
             ->leftJoin('form.attribute', 'attribute');
-
+        
         $this->addFilter($builder, $filter);
-        $this->addOrderBy($builder, $orderBy);
+
+        if($orderBy !== null)
+        {
+            $this->addOrderBy($builder, $orderBy);
+        }
 
         return $builder;
     }

--- a/engine/Shopware/Models/Form/Repository.php
+++ b/engine/Shopware/Models/Form/Repository.php
@@ -63,11 +63,11 @@ class Repository extends ModelRepository
             ->from($this->getEntityName(), 'form')
             ->leftJoin('form.attribute', 'attribute');
         
-        if($filter !== null) {
+        if ($filter !== null) {
             $this->addFilter($builder, $filter);
         }
         
-        if($orderBy !== null) {
+        if ($orderBy !== null) {
             $this->addOrderBy($builder, $orderBy);
         }
 


### PR DESCRIPTION
getListQueryBuilder can't be called without optional params because of false type of the filter param which should be array

### 1. Why is this change necessary?
Method can be called without parms to get all results

### 2. What does this change do, exactly?
Changed default value of optional param 

### 3. Describe each step to reproduce the issue or behaviour.
call getListQueryBuilder() without params

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.