### PR TITLE
Add regex validation to registration

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -101,6 +101,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
         - `DynamicCacheTimeService`
     * Added `invalidation_date_provider` tag to the DIC
 * Added parameter mode to Log module, to directly open the systemlogs tab
+* Added a config option to set a regular expression to validate passwords during registration
 
 ### Changes
 

--- a/_sql/migrations/1434-add-password-regex.php
+++ b/_sql/migrations/1434-add-password-regex.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+class Migrations_Migration1434 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+SET @parent = (SELECT id FROM s_core_config_forms WHERE label = 'Anmeldung / Registrierung' LIMIT 1);
+        
+INSERT IGNORE INTO `s_core_config_elements`
+(`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`, `options`)
+VALUES
+(@parent, 'passwordRegex', 's:0:"";', 'Regulärer Ausdruck zur Passwortvalidierung', 'Diese Option ermöglicht es Passwörter während der Registrierung durch einen regulären Ausdruck zu beschränken.', 'text', 0, 0, 1, NULL);
+EOD;
+
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+        SET @elementId = (SELECT id FROM `s_core_config_elements` WHERE `name` = 'passwordRegex' LIMIT 1);
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+        INSERT IGNORE INTO `s_core_config_element_translations` (`element_id`, `locale_id`, `label`, `description`)
+        VALUES (@elementId, 2, 'Regular expression to validate passwords', 'This option validates passwords against the given regular expression during registration.');
+EOD;
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Bundle/AccountBundle/Constraint/PasswordValidator.php
+++ b/engine/Shopware/Bundle/AccountBundle/Constraint/PasswordValidator.php
@@ -47,6 +47,12 @@ class PasswordValidator extends ConstraintValidator
         'default' => '',
     ];
 
+    const SNIPPET_PASSWORD_REGEX = [
+        'namespace' => 'frontend',
+        'name' => 'RegisterPasswordRegexNotMatched',
+        'default' => '',
+    ];
+
     /**
      * @var Shopware_Components_Snippet_Manager
      */
@@ -90,6 +96,14 @@ class PasswordValidator extends ConstraintValidator
 
         if (empty($password) || ($minLength && strlen($password) < $minLength)) {
             $this->addError($this->getSnippet(self::SNIPPET_PASSWORD_LENGTH));
+        }
+
+        $passwordRegex = $this->config->get('passwordRegex');
+
+        if ($passwordRegex !== '' && !empty($password) && !preg_match($passwordRegex, $password)) {
+            $regexNotMatchedError = new FormError($this->getSnippet(self::SNIPPET_PASSWORD_REGEX));
+            $regexNotMatchedError->setOrigin($form->get('password'));
+            $form->addError($regexNotMatchedError);
         }
 
         if ($form->has('passwordConfirmation') && $form->get('passwordConfirmation')->getData() !== $password) {

--- a/snippets/frontend.ini
+++ b/snippets/frontend.ini
@@ -13,6 +13,7 @@ RegisterAjaxEmailNotValid = "Please enter a valid email address"
 RegisterPasswordLength = "Your password should contain at least {config name=\"MinPassword\"} characters"
 RegisterPasswordNotEqual = "The passwords do not match."
 sMailConfirmation = "Thank you! When you register for the first time, you will now receive a confirmation e-mail."
+RegisterPasswordRegexNotMatched = "Your password should contain at least one uppercase letter, one lowercase letter, a number and a special character."
 [de_DE]
 AccountLoginTitle = "Login"
 AccountPasswordNotEqual = "Die Passwörter stimmen nicht überein."
@@ -28,3 +29,4 @@ RegisterPasswordLength = "Bitte w&auml;hlen Sie ein Passwort, welches aus mindes
 RegisterPasswordNotEqual = "Die Passw&ouml;rter stimmen nicht &uuml;berein."
 sMailConfirmation = "Vielen Dank. Bei einer erstmaligen Anmeldung erhalten Sie nun eine Bestätigungs-E-Mail."
 AccountCurrentPassword = "Das aktuelle Passwort stimmt nicht!"
+RegisterPasswordRegexNotMatched = "Bitte w&auml;hlen Sie ein Passwort mit mindestens einem Großbuchstaben, einem Kleinbuchstaben, einer Zahl und einem Sonderzeichen."

--- a/snippets/frontend/register/personal_fieldset.ini
+++ b/snippets/frontend/register/personal_fieldset.ini
@@ -1,6 +1,7 @@
 [en_GB]
 RegisterInfoPassword = "Your password must contain at least"
 RegisterInfoPassword2 = "The password is case sensitive."
+RegisterInfoPasswordRegex = "Your password has to contain at least one uppercase letter, one lowercase letter, a number and a special character."
 RegisterInfoPasswordCharacters = "characters."
 RegisterLabelMail = "Your email address*:"
 RegisterLabelMr = "Mr"
@@ -29,6 +30,7 @@ RegisterPlaceholderBirthday = "Date of birth"
 [de_DE]
 RegisterInfoPassword = "Ihr Passwort muss mindestens"
 RegisterInfoPassword2 = "Berücksichtigen Sie Groß- und Kleinschreibung."
+RegisterInfoPasswordRegex = "Ihr Passwort muss mindestens einen Großbuchstaben, einen Kleinbuchstaben, eine Zahl und ein Sonderzeichen enthalten."
 RegisterInfoPasswordCharacters = "Zeichen umfassen."
 RegisterLabelMail = "Ihre E-Mail-Adresse*:"
 RegisterLabelMr = "Herr"

--- a/themes/Frontend/Bare/frontend/register/personal_fieldset.tpl
+++ b/themes/Frontend/Bare/frontend/register/personal_fieldset.tpl
@@ -206,7 +206,9 @@
                         {* Password description *}
                         {block name='frontend_register_personal_fieldset_password_description'}
                             <div class="register--password-description">
-                                {s name='RegisterInfoPassword'}{/s} {config name=MinPassword} {s name='RegisterInfoPasswordCharacters'}{/s}<br />{s name='RegisterInfoPassword2'}{/s}
+                                {s name='RegisterInfoPassword'}{/s} {config name=MinPassword} {s name='RegisterInfoPasswordCharacters'}{/s}
+                                {if {config name=passwordRegex}}<br />{s name='RegisterInfoPasswordRegex'}{/s}{/if}
+                                <br />{s name='RegisterInfoPassword2'}{/s}
                             </div>
                         {/block}
                     </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
To force customers to use certain characters in their password.

### 2. What does this change do, exactly?
It adds a new config option to define a regular expression. If it is set passwords will be validated against the regular expression

### 3. Describe each step to reproduce the issue or behaviour.
Set the new config option in the basic settings at "Registration / login" to
`/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9]).+/`.
Now you will have to provide a password with at least one uppercase letter, one lowercase letter, a number and a special character.
Otherwise you will not be able to register and get an error message.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.