### PR TITLE
 fixed short page query param in pagination

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -171,6 +171,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 * Changed visibility of `Shopware\Bundle\PluginInstallerBundle\Service\SubscriptionService::getPluginInformationFromApi()` to public
 * Changed Double-Opt-In behaviour to redirect back into the checkout, if user registered from there
 * Changed console.command tag CompilerPass to support lazy commands.
+* Changed fixed page query parameter in `themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl` with it's dynamic alias.
 
 ### Removals
 

--- a/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
+++ b/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
@@ -9,7 +9,7 @@
     {* Pagination - Frist page *}
     {block name="frontend_listing_actions_paging_first"}
         {if $sPage > 1}
-            <a href="{$baseUrl}?p=1" title="{"{s name='ListingLinkFirst'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">
+            <a href="{$baseUrl}?{$shortParameters.sPage}=1" title="{"{s name='ListingLinkFirst'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">
                 <i class="icon--arrow-left"></i>
                 <i class="icon--arrow-left"></i>
             </a>
@@ -19,7 +19,7 @@
     {* Pagination - Previous page *}
     {block name='frontend_listing_actions_paging_previous'}
         {if $sPage > 1}
-            <a href="{$baseUrl}?p={$sPage-1}" title="{"{s name='ListingLinkPrevious'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">
+            <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage-1}" title="{"{s name='ListingLinkPrevious'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">
                 <i class="icon--arrow-left"></i>
             </a>
         {/if}
@@ -35,7 +35,7 @@
     {* Pagination - Next page *}
     {block name='frontend_listing_actions_paging_next'}
         {if $sPage < $pages}
-            <a href="{$baseUrl}?p={$sPage+1}" title="{"{s name='ListingLinkNext'}{/s}"|escape}" class="paging--link paging--next" data-action-link="true">
+            <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage+1}" title="{"{s name='ListingLinkNext'}{/s}"|escape}" class="paging--link paging--next" data-action-link="true">
                 <i class="icon--arrow-right"></i>
             </a>
         {/if}
@@ -44,7 +44,7 @@
     {* Pagination - Last page *}
     {block name="frontend_listing_actions_paging_last"}
         {if $sPage < $pages}
-            <a href="{$baseUrl}?p={$pages}" title="{"{s name='ListingLinkLast'}{/s}"|escape}" class="paging--link paging--next" data-action-link="true">
+            <a href="{$baseUrl}?{$shortParameters.sPage}={$pages}" title="{"{s name='ListingLinkLast'}{/s}"|escape}" class="paging--link paging--next" data-action-link="true">
                 <i class="icon--arrow-right"></i>
                 <i class="icon--arrow-right"></i>
             </a>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

The listing pagination is broken, if one uses another short paramter than `p` for `sPage`.

### 2. What does this change do, exactly?

The listing pagination templates uses the fixed short query parameter `p` for the sPage thinggy. That's fine until one changes the short parameter in the backend settings. Now the customized short parameter will be used.

### 3. Describe each step to reproduce the issue or behaviour.

1. Log into backend
2. Go to Einstellungen->Grundeinstellungen->SEO/Router-Einstellungen->Query-Aliase
3. Change value for sPage to something different than `p` or `sPage`, e.g. `page`
4. Save & flush caches
5. Go to listing and try to change to page 2
6. Listing will show page 1

### 4. Please link to the relevant issues (if any).

PT-9511

### 5. Which documentation changes (if any) need to be made because of this PR?

No aware of one.
### 6. Checklist


- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.