### PR TITLE
Update AppCache.php

### DIFF
--- a/engine/Shopware/Components/HttpCache/AppCache.php
+++ b/engine/Shopware/Components/HttpCache/AppCache.php
@@ -116,7 +116,7 @@ class AppCache extends HttpCache
         $response = parent::handle($request, $type, $catch);
 
         $response->headers->remove('cache-control');
-        $response->headers->addCacheControlDirective('no-cache');
+        $response->headers->addCacheControlDirective('no-cache, no-store');
 
         return $response;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

If you move over the page and go back by using the history back of your browser, some contents are displayed cached by your browser. For example by opening a list page, clicking on a product and then going back by hitting the history back on your browser, some widgets like basket or notes are displayed from the browser cached.

### 2. What does this change do, exactly?

The change adds a “no-store” to the response. 

### 3. Describe each step to reproduce the issue or behaviour.

Activate HTTP Cache and move shop into production mode. Open a listing page, move on a detail page, add a product to basket and then use the history back to go to the listing page.
The basket is not updated because it was loaded from the browser cache.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.