### PR TITLE
adding modalboxes to emotions

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
@@ -431,6 +431,7 @@
 
             StateManager.updatePlugin('*[data-product-slider="true"]', 'swProductSlider');
             StateManager.updatePlugin('*[data-image-slider="true"]', 'swImageSlider');
+            StateManager.updatePlugin('*[data-modalbox="true"]', 'swModalbox');
 
             window.picturefill();
 


### PR DESCRIPTION


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
adds possibility to open modal boxen from emotions

### 2. What does this change do, exactly?
see #1

### 3. Describe each step to reproduce the issue or behaviour.
add default modal code into emotions and try to click the link.. it will open in the same window instead of opening the modal box

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.