### PR TITLE
Plugin commands clear caches using normalized cache clearing workflow

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/InstallerService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/InstallerService.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Bundle\PluginInstallerBundle\Service;
 
+use Shopware\Components\CacheManager;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Components\Plugin\ConfigReader;
 use Shopware\Components\Plugin\ConfigWriter;
@@ -341,7 +342,21 @@ class InstallerService
         }
 
         if (array_key_exists('invalidateCache', $result)) {
-            $context->scheduleClearCache($result['invalidateCache']);
+            foreach ($result['invalidateCache'] as $cacheTag) {
+                if ($cacheTag === 'frontend') {
+                    $cacheTags[] = CacheManager::CACHE_TAG_CONFIG;
+                    $cacheTags[] = CacheManager::CACHE_TAG_TEMPLATE;
+                    $cacheTags[] = CacheManager::CACHE_TAG_THEME;
+                    $cacheTags[] = CacheManager::CACHE_TAG_HTTP;
+                } elseif ($cacheTag === 'backend') {
+                    $cacheTags[] = CacheManager::CACHE_TAG_CONFIG;
+                    $cacheTags[] = CacheManager::CACHE_TAG_TEMPLATE;
+                } else {
+                    $cacheTags[] = $cacheTag;
+                }
+            }
+
+            $context->scheduleClearCache($cacheTags);
         }
 
         if (array_key_exists('message', $result)) {

--- a/engine/Shopware/Commands/PluginActivateCommand.php
+++ b/engine/Shopware/Commands/PluginActivateCommand.php
@@ -25,11 +25,8 @@
 namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
-use Shopware\Components\CacheManager;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -37,13 +34,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
-class PluginActivateCommand extends ShopwareCommand
+class PluginActivateCommand extends PluginCommand
 {
     /**
      * {@inheritdoc}
      */
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName('sw:plugin:activate')
             ->setDescription('Activates a plugin.')
@@ -51,12 +50,6 @@ class PluginActivateCommand extends ShopwareCommand
                 'plugin',
                 InputArgument::REQUIRED,
                 'Name of the plugin to be activated.'
-            )
-            ->addOption(
-                'clear-cache',
-                'cc',
-                InputOption::VALUE_NONE,
-                'Clear any caches that are requested by update routines'
             )
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> activates a plugin.
@@ -96,13 +89,6 @@ EOF
         $activationContext = $pluginManager->activatePlugin($plugin);
         $output->writeln(sprintf('Plugin %s has been activated.', $pluginName));
 
-        if (!empty($input->getOption('clear-cache'))) {
-            /** @var CacheManager $cacheManager */
-            $cacheManager = $this->container->get('shopware.cache_manager');
-            $cacheTags = $activationContext->getScheduled();
-            if ($cacheManager->clearByTags($cacheTags)) {
-                $output->writeln(sprintf('Caches cleared (%s).', join(', ', $cacheTags)));
-            }
-        }
+        $this->clearCachesIfRequested($input, $output, $activationContext);
     }
 }

--- a/engine/Shopware/Commands/PluginActivateCommand.php
+++ b/engine/Shopware/Commands/PluginActivateCommand.php
@@ -53,10 +53,10 @@ class PluginActivateCommand extends ShopwareCommand
                 'Name of the plugin to be activated.'
             )
             ->addOption(
-                'ignore-cache',
-                null,
+                'clear-cache',
+                'cc',
                 InputOption::VALUE_NONE,
-                'Do not clear any caches that are requested by update routines'
+                'Clear any caches that are requested by update routines'
             )
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> activates a plugin.
@@ -96,7 +96,7 @@ EOF
         $activationContext = $pluginManager->activatePlugin($plugin);
         $output->writeln(sprintf('Plugin %s has been activated.', $pluginName));
 
-        if (empty($input->getOption('ignore-cache'))) {
+        if (!empty($input->getOption('clear-cache'))) {
             /** @var CacheManager $cacheManager */
             $cacheManager = $this->container->get('shopware.cache_manager');
             $cacheTags = $activationContext->getScheduled();

--- a/engine/Shopware/Commands/PluginCommand.php
+++ b/engine/Shopware/Commands/PluginCommand.php
@@ -56,6 +56,11 @@ abstract class PluginCommand extends ShopwareCommand
     {
         if (!empty($input->getOption('clear-cache'))) {
             $this->clearCaches($output, ...$contexts);
+        } elseif (!empty($this->getScheduledCaches(...$contexts))) {
+            $output->writeln([
+                'Consider sw:cache:clear to refresh the installation to keep up to the current changes.',
+                'Try the --clear-cache option if you run into this more often.',
+            ]);
         }
     }
 

--- a/engine/Shopware/Commands/PluginCommand.php
+++ b/engine/Shopware/Commands/PluginCommand.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Shopware\Components\CacheManager;
+use Shopware\Components\Plugin\Context\InstallContext;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class PluginCommand extends ShopwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->addOption(
+            'clear-cache',
+            'c',
+            InputOption::VALUE_NONE,
+            'Clear any neccessary caches'
+        );
+    }
+
+    /**
+     * @param InputInterface   $input
+     * @param OutputInterface  $output
+     * @param InstallContext[] ...$contexts
+     */
+    protected function clearCachesIfRequested(InputInterface $input, OutputInterface $output, ...$contexts)
+    {
+        if (!empty($input->getOption('clear-cache'))) {
+            $this->clearCaches($output, ...$contexts);
+        }
+    }
+
+    /**
+     * @param OutputInterface  $output
+     * @param InstallContext[] ...$contexts
+     */
+    protected function clearCaches(OutputInterface $output, ...$contexts)
+    {
+        /** @var CacheManager $cacheManager */
+        $cacheManager = $this->container->get('shopware.cache_manager');
+        $cacheTags = $this->getScheduledCaches(...$contexts);
+        if ($cacheManager->clearByTags($cacheTags)) {
+            $output->writeln(sprintf('Caches cleared (%s).', join(', ', $cacheTags)));
+        }
+    }
+
+    /**
+     * @param InstallContext[] ...$contexts
+     *
+     * @return string[]
+     */
+    protected function getScheduledCaches(...$contexts)
+    {
+        $tags = [];
+
+        foreach ($contexts as $context) {
+            if (!$context instanceof InstallContext || !array_key_exists('cache', $context->getScheduled())) {
+                continue;
+            }
+
+            $tags = array_merge($tags, $context->getScheduled()['cache']);
+        }
+
+        return array_unique($tags);
+    }
+}

--- a/engine/Shopware/Commands/PluginDeactivateCommand.php
+++ b/engine/Shopware/Commands/PluginDeactivateCommand.php
@@ -25,11 +25,8 @@
 namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
-use Shopware\Components\CacheManager;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -37,13 +34,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
-class PluginDeactivateCommand extends ShopwareCommand
+class PluginDeactivateCommand extends PluginCommand
 {
     /**
      * {@inheritdoc}
      */
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName('sw:plugin:deactivate')
             ->setDescription('Deactivates a plugin.')
@@ -51,12 +50,6 @@ class PluginDeactivateCommand extends ShopwareCommand
                 'plugin',
                 InputArgument::REQUIRED,
                 'Name of the plugin to be deactivated.'
-            )
-            ->addOption(
-                'clear-cache',
-                'cc',
-                InputOption::VALUE_NONE,
-                'Clear any caches that are requested by deactivate routines'
             )
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> deactivates a plugin.
@@ -90,13 +83,6 @@ EOF
         $deactivationContext = $pluginManager->deactivatePlugin($plugin);
         $output->writeln(sprintf('Plugin %s has been deactivated', $pluginName));
 
-        if (!empty($input->getOption('clear-cache'))) {
-            /** @var CacheManager $cacheManager */
-            $cacheManager = $this->container->get('shopware.cache_manager');
-            $cacheTags = $deactivationContext->getScheduled();
-            if ($cacheManager->clearByTags($cacheTags)) {
-                $output->writeln(sprintf('Caches cleared (%s).', join(', ', $cacheTags)));
-            }
-        }
+        $this->clearCachesIfRequested($input, $output, $deactivationContext);
     }
 }

--- a/engine/Shopware/Commands/PluginDeactivateCommand.php
+++ b/engine/Shopware/Commands/PluginDeactivateCommand.php
@@ -53,10 +53,10 @@ class PluginDeactivateCommand extends ShopwareCommand
                 'Name of the plugin to be deactivated.'
             )
             ->addOption(
-                'ignore-cache',
-                null,
+                'clear-cache',
+                'cc',
                 InputOption::VALUE_NONE,
-                'Do not clear any caches that are requested by deactivate routines'
+                'Clear any caches that are requested by deactivate routines'
             )
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> deactivates a plugin.
@@ -90,7 +90,7 @@ EOF
         $deactivationContext = $pluginManager->deactivatePlugin($plugin);
         $output->writeln(sprintf('Plugin %s has been deactivated', $pluginName));
 
-        if (empty($input->getOption('ignore-cache'))) {
+        if (!empty($input->getOption('clear-cache'))) {
             /** @var CacheManager $cacheManager */
             $cacheManager = $this->container->get('shopware.cache_manager');
             $cacheTags = $deactivationContext->getScheduled();

--- a/engine/Shopware/Commands/PluginInstallCommand.php
+++ b/engine/Shopware/Commands/PluginInstallCommand.php
@@ -59,10 +59,10 @@ class PluginInstallCommand extends ShopwareCommand
                 'Activate plugin after intallation.'
             )
             ->addOption(
-                'ignore-cache',
-                null,
+                'clear-cache',
+                'cc',
                 InputOption::VALUE_NONE,
-                'Do not clear any caches that are requested by install/activate routines'
+                'Clear any caches that are requested by install/activate routines'
             )
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> installs a plugin.
@@ -103,7 +103,7 @@ EOF
             $output->writeln(sprintf('Plugin %s has been activated successfully. Consider sw:cache:clear to enable possible behaviors that come with the plugin.', $pluginName));
         }
 
-        if (empty($input->getOption('ignore-cache'))) {
+        if (!empty($input->getOption('clear-cache'))) {
             /** @var CacheManager $cacheManager */
             $cacheManager = $this->container->get('shopware.cache_manager');
             $cacheTags = array_merge(

--- a/engine/Shopware/Commands/PluginReinstallCommand.php
+++ b/engine/Shopware/Commands/PluginReinstallCommand.php
@@ -53,10 +53,10 @@ class PluginReinstallCommand extends ShopwareCommand
                 'if supplied plugin data will be removed'
             )
             ->addOption(
-                'ignore-cache',
-                null,
+                'clear-cache',
+                'cc',
                 InputOption::VALUE_NONE,
-                'Do not clear any caches that are requested by uninstall/install/activate routines'
+                'Clear any caches that are requested by uninstall/install/activate routines'
             );
     }
 
@@ -84,7 +84,7 @@ class PluginReinstallCommand extends ShopwareCommand
         $activationContext = $pluginManager->activatePlugin($plugin);
         $output->writeln(sprintf('Plugin %s has been reinstalled successfully.', $pluginName));
 
-        if (empty($input->getOption('ignore-cache'))) {
+        if (!empty($input->getOption('clear-cache'))) {
             /** @var CacheManager $cacheManager */
             $cacheManager = $this->container->get('shopware.cache_manager');
             $cacheTags = array_merge(

--- a/engine/Shopware/Commands/PluginUninstallCommand.php
+++ b/engine/Shopware/Commands/PluginUninstallCommand.php
@@ -25,8 +25,6 @@
 namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
-use Shopware\Components\CacheManager;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -37,13 +35,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
-class PluginUninstallCommand extends ShopwareCommand
+class PluginUninstallCommand extends PluginCommand
 {
     /**
      * {@inheritdoc}
      */
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName('sw:plugin:uninstall')
             ->setDescription('Uninstalls a plugin.')
@@ -57,12 +57,6 @@ class PluginUninstallCommand extends ShopwareCommand
                 'S',
                 InputOption::VALUE_NONE,
                 'Keep the saved data of the plugin. (if supported)'
-            )
-            ->addOption(
-                'clear-cache',
-                'cc',
-                InputOption::VALUE_NONE,
-                'Clear any caches that are requested by uninstall routines'
             )
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> uninstalls a plugin.
@@ -98,13 +92,6 @@ EOF
         $uninstallationContext = $pluginManager->uninstallPlugin($plugin, $removeData);
         $output->writeln(sprintf('Plugin %s has been uninstalled successfully.', $pluginName));
 
-        if (!empty($input->getOption('clear-cache'))) {
-            /** @var CacheManager $cacheManager */
-            $cacheManager = $this->container->get('shopware.cache_manager');
-            $cacheTags = $uninstallationContext->getScheduled();
-            if ($cacheManager->clearByTags($cacheTags)) {
-                $output->writeln(sprintf('Caches cleared (%s).', join(', ', $cacheTags)));
-            }
-        }
+        $this->clearCachesIfRequested($input, $output, $uninstallationContext);
     }
 }

--- a/engine/Shopware/Commands/PluginUninstallCommand.php
+++ b/engine/Shopware/Commands/PluginUninstallCommand.php
@@ -59,10 +59,10 @@ class PluginUninstallCommand extends ShopwareCommand
                 'Keep the saved data of the plugin. (if supported)'
             )
             ->addOption(
-                'ignore-cache',
-                null,
+                'clear-cache',
+                'cc',
                 InputOption::VALUE_NONE,
-                'Do not clear any caches that are requested by uninstall routines'
+                'Clear any caches that are requested by uninstall routines'
             )
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> uninstalls a plugin.
@@ -98,7 +98,7 @@ EOF
         $uninstallationContext = $pluginManager->uninstallPlugin($plugin, $removeData);
         $output->writeln(sprintf('Plugin %s has been uninstalled successfully.', $pluginName));
 
-        if (empty($input->getOption('ignore-cache'))) {
+        if (!empty($input->getOption('clear-cache'))) {
             /** @var CacheManager $cacheManager */
             $cacheManager = $this->container->get('shopware.cache_manager');
             $cacheTags = $uninstallationContext->getScheduled();

--- a/engine/Shopware/Commands/PluginUpdateCommand.php
+++ b/engine/Shopware/Commands/PluginUpdateCommand.php
@@ -59,10 +59,10 @@ class PluginUpdateCommand extends ShopwareCommand
                 'Batch update several plugins. Possible values are all, inactive, active, installed, uninstalled'
             )
             ->addOption(
-                'ignore-cache',
-                null,
+                'clear-cache',
+                'cc',
                 InputOption::VALUE_NONE,
-                'Do not clear any caches that are requested by update routines'
+                'Clear any caches that are requested by update routines'
             )
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> updates a plugin.
@@ -87,7 +87,7 @@ EOF
 
         if (!empty($pluginNames)) {
             foreach ($pluginNames as $pluginName) {
-                $this->updatePlugin($pluginManager, $pluginName, $output, !empty($input->getOption('ignore-cache')));
+                $this->updatePlugin($pluginManager, $pluginName, $output, empty($input->getOption('clear-cache')));
             }
 
             return 0;

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -466,17 +466,17 @@ class CacheManager
      *
      * @param string[] $tags
      *
-     * @return int
+     * @return string[]
      */
     public function clearByTags(array $tags)
     {
-        $count = 0;
-
-        foreach (array_unique($tags) as $tag) {
-            $count += (int) $this->clearByTag($tag);
+        foreach ($tags = array_unique($tags) as $key => $tag) {
+            if (!$this->clearByTag($tag)) {
+                unset($tags[$key]);
+            }
         }
 
-        return $count;
+        return $tags;
     }
 
     /**

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -486,7 +486,7 @@ class CacheManager
      *
      * @return bool
      */
-    public function clearByTag(array $tag)
+    public function clearByTag($tag)
     {
         switch ($tag) {
             case self::CACHE_TAG_CONFIG:

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -513,7 +513,7 @@ class CacheManager
                 return false;
         }
 
-        return false;
+        return true;
     }
 
     /**

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -34,6 +34,20 @@ use Shopware\Components\Theme\PathResolver;
  */
 class CacheManager
 {
+    const CACHE_TAG_TEMPLATE = 'template';
+
+    const CACHE_TAG_CONFIG = 'config';
+
+    const CACHE_TAG_ROUTER = 'router';
+
+    const CACHE_TAG_PROXY = 'proxy';
+
+    const CACHE_TAG_THEME = 'theme';
+
+    const CACHE_TAG_HTTP = 'http';
+
+    const CACHE_TAG_SEARCH = 'search';
+
     /**
      * @var Container
      */
@@ -445,6 +459,61 @@ class CacheManager
         for ($i = 0; $bytes >= 1024 && $i < (count($types) - 1); $bytes /= 1024, $i++);
 
         return round($bytes, 2) . ' ' . $types[$i];
+    }
+
+    /**
+     * Clear caches by list of CacheManager::CACHE_TAG_* items
+     *
+     * @param string[] $tags
+     *
+     * @return int
+     */
+    public function clearByTags(array $tags)
+    {
+        $count = 0;
+
+        foreach (array_unique($tags) as $tag) {
+            $count += (int) $this->clearByTag($tag);
+        }
+
+        return $count;
+    }
+
+    /**
+     * Clear cache by its tag of CacheManager::CACHE_TAG_*
+     *
+     * @param string $tag
+     *
+     * @return bool
+     */
+    public function clearByTag(array $tag)
+    {
+        switch ($tag) {
+            case self::CACHE_TAG_CONFIG:
+                $this->clearConfigCache();
+                break;
+            case self::CACHE_TAG_SEARCH:
+                $this->clearSearchCache();
+                break;
+            case self::CACHE_TAG_ROUTER:
+                $this->clearRewriteCache();
+                break;
+            case self::CACHE_TAG_TEMPLATE:
+                $this->clearTemplateCache();
+                break;
+            case self::CACHE_TAG_THEME:
+            case self::CACHE_TAG_HTTP:
+                $this->clearHttpCache();
+                break;
+            case self::CACHE_TAG_PROXY:
+                $this->clearProxyCache();
+                $this->clearOpCache();
+                break;
+            default:
+                return false;
+        }
+
+        return false;
     }
 
     /**

--- a/engine/Shopware/Components/Plugin/Context/InstallContext.php
+++ b/engine/Shopware/Components/Plugin/Context/InstallContext.php
@@ -24,16 +24,40 @@
 
 namespace Shopware\Components\Plugin\Context;
 
+use Shopware\Components\CacheManager;
 use Shopware\Models\Plugin\Plugin;
 
 class InstallContext implements \JsonSerializable
 {
-    const CACHE_TAG_TEMPLATE = 'template';
-    const CACHE_TAG_CONFIG = 'config';
-    const CACHE_TAG_ROUTER = 'router';
-    const CACHE_TAG_PROXY = 'proxy';
-    const CACHE_TAG_THEME = 'theme';
-    const CACHE_TAG_HTTP = 'http';
+    /**
+     * @deprecated Use Shopware\Components\CacheManager::CACHE_TAG_TEMPLATE instead.
+     */
+    const CACHE_TAG_TEMPLATE = CacheManager::CACHE_TAG_TEMPLATE;
+
+    /**
+     * @deprecated Use Shopware\Components\CacheManager::CACHE_TAG_CONFIG instead.
+     */
+    const CACHE_TAG_CONFIG = CacheManager::CACHE_TAG_CONFIG;
+
+    /**
+     * @deprecated Use Shopware\Components\CacheManager::CACHE_TAG_ROUTER instead.
+     */
+    const CACHE_TAG_ROUTER = CacheManager::CACHE_TAG_ROUTER;
+
+    /**
+     * @deprecated Use Shopware\Components\CacheManager::CACHE_TAG_PROXY instead.
+     */
+    const CACHE_TAG_PROXY = CacheManager::CACHE_TAG_PROXY;
+
+    /**
+     * @deprecated Use Shopware\Components\CacheManager::CACHE_TAG_THEME instead.
+     */
+    const CACHE_TAG_THEME = CacheManager::CACHE_TAG_THEME;
+
+    /**
+     * @deprecated Use Shopware\Components\CacheManager::CACHE_TAG_HTTP instead.
+     */
+    const CACHE_TAG_HTTP = CacheManager::CACHE_TAG_HTTP;
 
     /**
      * pre defined list to invalidate simple caches

--- a/engine/Shopware/Controllers/Backend/Cache.php
+++ b/engine/Shopware/Controllers/Backend/Cache.php
@@ -131,28 +131,25 @@ class Shopware_Controllers_Backend_Cache extends Shopware_Controllers_Backend_Ex
             }
         }
 
-        if ($cache['config'] === 'on' || $cache['backend'] === 'on' || $cache['frontend'] === 'on') {
-            $this->cacheManager->clearConfigCache();
+        $cacheTags = [];
+
+        foreach ($cache as $cacheTag => $value) {
+            if ($value === 'on') {
+                if ($cacheTag === 'frontend') {
+                    $cacheTags[] = CacheManager::CACHE_TAG_CONFIG;
+                    $cacheTags[] = CacheManager::CACHE_TAG_TEMPLATE;
+                    $cacheTags[] = CacheManager::CACHE_TAG_THEME;
+                    $cacheTags[] = CacheManager::CACHE_TAG_HTTP;
+                } elseif ($cacheTag === 'backend') {
+                    $cacheTags[] = CacheManager::CACHE_TAG_CONFIG;
+                    $cacheTags[] = CacheManager::CACHE_TAG_TEMPLATE;
+                } else {
+                    $cacheTags[] = $cacheTag;
+                }
+            }
         }
-        if ($cache['search'] === 'on') {
-            $this->cacheManager->clearSearchCache();
-        }
-        if ($cache['router'] === 'on') {
-            $this->cacheManager->clearRewriteCache();
-        }
-        if ($cache['template'] === 'on' || $cache['backend'] === 'on' || $cache['frontend'] === 'on') {
-            $this->cacheManager->clearTemplateCache();
-        }
-        if ($cache['theme'] === 'on' || $cache['frontend'] === 'on') {
-            $this->cacheManager->clearHttpCache();
-        }
-        if ($cache['http'] === 'on' || $cache['frontend'] === 'on') {
-            $this->cacheManager->clearHttpCache();
-        }
-        if ($cache['proxy'] === 'on') {
-            $this->cacheManager->clearProxyCache();
-            $this->cacheManager->clearOpCache();
-        }
+
+        $this->cacheManager->clearByTags($cacheTags);
 
         $this->View()->assign([
             'success' => true,


### PR DESCRIPTION
### 1. Why is this change necessary?
There is [a hint](https://github.com/shopware/shopware/blob/f32eba00c30de2f4098a6f5083879b63ad6e597c/engine/Shopware/Commands/PluginActivateCommand.php#L90) that I should clear the cache after installing a plugin. Why not clear it directly?

### 2. What does this change do, exactly?
The scheduled caches from the plugin installation change are passed to the backend cache controller. This is replicated in the commands to change a plugin installation state. Both workflows are using the same methods, which are now extracted into the cache service.

### 3. Describe each step to reproduce the issue or behaviour.
1. Activate a plugin that adds a feature to the storefront via command line
2. Reload page
3. See no changes
4. Facepalm because one forgot the cache clear which is done by the backend automatically
5. `sw:cache:clear`

### 4. Which documentation changes (if any) need to be made because of this PR?
`--clear-cache` is a new option for some plugin commands to enable cache clearing as this is now part of the routines. This might change scripts in the composer-project. There is a new cache tag: search.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.