### PR TITLE
do not set basketdiscount if it's 0

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -4003,52 +4003,56 @@ SQL;
             [$this->sSYSTEM->sUSERGROUPDATA['id'], $amount]
         );
 
-        if (!empty($basket_discount)) {
-            $percent = $basket_discount;
-            $basket_discount = round($basket_discount / 100 * ($amount * $currencyFactor), 2);
+        if (empty($basket_discount)) {
+            return;
+        }
 
-            if($basket_discount) {
-                if (empty($this->sSYSTEM->sUSERGROUPDATA['tax']) && !empty($this->sSYSTEM->sUSERGROUPDATA['id'])) {
-                    $basket_discount_net = $basket_discount;
-                } else {
-                    $basket_discount_net = round($basket_discount / (100 + $discount_tax) * 100, 2);
-                }
-                $tax_rate = $discount_tax;
-                $basket_discount_net = $basket_discount_net * -1;
-                $basket_discount = $basket_discount * -1;
+        $percent = $basket_discount;
+        $basket_discount = round($basket_discount / 100 * ($amount * $currencyFactor), 2);
 
-                if ($this->config->get('proportionalTaxCalculation') && !$this->session->get('taxFree')) {
-                    $this->basketHelper->addProportionalDiscount(
-                        new DiscountContext(
-                            $this->session->get('sessionId'),
-                            BasketHelperInterface::DISCOUNT_ABSOLUTE,
-                            $basket_discount,
-                            '-' . $percent . ' % ' . $discount_basket_name,
-                            $discount_basket_ordernumber,
-                            3,
-                            $this->sSYSTEM->sCurrency['factor'],
-                            !$this->sSYSTEM->sUSERGROUPDATA['tax'] && $this->sSYSTEM->sUSERGROUPDATA['id']
-                        )
-                    );
-                } else {
-                    $this->db->insert(
-                        's_order_basket',
-                        [
-                            'sessionID' => $this->session->offsetGet('sessionId'),
-                            'articlename' => '- ' . $percent . ' % ' . $discount_basket_name,
-                            'articleID' => 0,
-                            'ordernumber' => $discount_basket_ordernumber,
-                            'quantity' => 1,
-                            'price' => $basket_discount,
-                            'netprice' => $basket_discount_net,
-                            'tax_rate' => $tax_rate,
-                            'datum' => new Zend_Date(),
-                            'modus' => 3,
-                            'currencyFactor' => $currencyFactor,
-                        ]
-                    );
-                }
-            }
+        if (!$basket_discount) {
+            return;
+        }
+
+        if (empty($this->sSYSTEM->sUSERGROUPDATA['tax']) && !empty($this->sSYSTEM->sUSERGROUPDATA['id'])) {
+            $basket_discount_net = $basket_discount;
+        } else {
+            $basket_discount_net = round($basket_discount / (100 + $discount_tax) * 100, 2);
+        }
+        $tax_rate = $discount_tax;
+        $basket_discount_net = $basket_discount_net * -1;
+        $basket_discount = $basket_discount * -1;
+
+        if ($this->config->get('proportionalTaxCalculation') && !$this->session->get('taxFree')) {
+            $this->basketHelper->addProportionalDiscount(
+                new DiscountContext(
+                    $this->session->get('sessionId'),
+                    BasketHelperInterface::DISCOUNT_ABSOLUTE,
+                    $basket_discount,
+                    '-' . $percent . ' % ' . $discount_basket_name,
+                    $discount_basket_ordernumber,
+                    3,
+                    $this->sSYSTEM->sCurrency['factor'],
+                    !$this->sSYSTEM->sUSERGROUPDATA['tax'] && $this->sSYSTEM->sUSERGROUPDATA['id']
+                )
+            );
+        } else {
+            $this->db->insert(
+                's_order_basket',
+                [
+                    'sessionID' => $this->session->offsetGet('sessionId'),
+                    'articlename' => '- ' . $percent . ' % ' . $discount_basket_name,
+                    'articleID' => 0,
+                    'ordernumber' => $discount_basket_ordernumber,
+                    'quantity' => 1,
+                    'price' => $basket_discount,
+                    'netprice' => $basket_discount_net,
+                    'tax_rate' => $tax_rate,
+                    'datum' => new Zend_Date(),
+                    'modus' => 3,
+                    'currencyFactor' => $currencyFactor,
+                ]
+            );
         }
     }
 

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -3972,7 +3972,6 @@ SQL;
             }
             $surcharge += $result['value'];
             if (!empty($result['factor'])) {
-                //die($result["factor"].">".$from);
                 $surcharge += $result['factor'] / 100 * $from;
             }
         }
@@ -4008,45 +4007,47 @@ SQL;
             $percent = $basket_discount;
             $basket_discount = round($basket_discount / 100 * ($amount * $currencyFactor), 2);
 
-            if (empty($this->sSYSTEM->sUSERGROUPDATA['tax']) && !empty($this->sSYSTEM->sUSERGROUPDATA['id'])) {
-                $basket_discount_net = $basket_discount;
-            } else {
-                $basket_discount_net = round($basket_discount / (100 + $discount_tax) * 100, 2);
-            }
-            $tax_rate = $discount_tax;
-            $basket_discount_net = $basket_discount_net * -1;
-            $basket_discount = $basket_discount * -1;
+            if($basket_discount) {
+                if (empty($this->sSYSTEM->sUSERGROUPDATA['tax']) && !empty($this->sSYSTEM->sUSERGROUPDATA['id'])) {
+                    $basket_discount_net = $basket_discount;
+                } else {
+                    $basket_discount_net = round($basket_discount / (100 + $discount_tax) * 100, 2);
+                }
+                $tax_rate = $discount_tax;
+                $basket_discount_net = $basket_discount_net * -1;
+                $basket_discount = $basket_discount * -1;
 
-            if ($this->config->get('proportionalTaxCalculation') && !$this->session->get('taxFree')) {
-                $this->basketHelper->addProportionalDiscount(
-                    new DiscountContext(
-                        $this->session->get('sessionId'),
-                        BasketHelperInterface::DISCOUNT_ABSOLUTE,
-                        $basket_discount,
-                        '- ' . $percent . ' % ' . $discount_basket_name,
-                        $discount_basket_ordernumber,
-                        3,
-                        $this->sSYSTEM->sCurrency['factor'],
-                        !$this->sSYSTEM->sUSERGROUPDATA['tax'] && $this->sSYSTEM->sUSERGROUPDATA['id']
-                    )
-                );
-            } else {
-                $this->db->insert(
-                    's_order_basket',
-                    [
-                        'sessionID' => $this->session->offsetGet('sessionId'),
-                        'articlename' => '- ' . $percent . ' % ' . $discount_basket_name,
-                        'articleID' => 0,
-                        'ordernumber' => $discount_basket_ordernumber,
-                        'quantity' => 1,
-                        'price' => $basket_discount,
-                        'netprice' => $basket_discount_net,
-                        'tax_rate' => $tax_rate,
-                        'datum' => new Zend_Date(),
-                        'modus' => 3,
-                        'currencyFactor' => $currencyFactor,
-                    ]
-                );
+                if ($this->config->get('proportionalTaxCalculation') && !$this->session->get('taxFree')) {
+                    $this->basketHelper->addProportionalDiscount(
+                        new DiscountContext(
+                            $this->session->get('sessionId'),
+                            BasketHelperInterface::DISCOUNT_ABSOLUTE,
+                            $basket_discount,
+                            '-' . $percent . ' % ' . $discount_basket_name,
+                            $discount_basket_ordernumber,
+                            3,
+                            $this->sSYSTEM->sCurrency['factor'],
+                            !$this->sSYSTEM->sUSERGROUPDATA['tax'] && $this->sSYSTEM->sUSERGROUPDATA['id']
+                        )
+                    );
+                } else {
+                    $this->db->insert(
+                        's_order_basket',
+                        [
+                            'sessionID' => $this->session->offsetGet('sessionId'),
+                            'articlename' => '- ' . $percent . ' % ' . $discount_basket_name,
+                            'articleID' => 0,
+                            'ordernumber' => $discount_basket_ordernumber,
+                            'quantity' => 1,
+                            'price' => $basket_discount,
+                            'netprice' => $basket_discount_net,
+                            'tax_rate' => $tax_rate,
+                            'datum' => new Zend_Date(),
+                            'modus' => 3,
+                            'currencyFactor' => $currencyFactor,
+                        ]
+                    );
+                }
             }
         }
     }

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -4041,7 +4041,7 @@ SQL;
                 's_order_basket',
                 [
                     'sessionID' => $this->session->offsetGet('sessionId'),
-                    'articlename' => '- ' . $percent . ' % ' . $discount_basket_name,
+                    'articlename' => '-' . $percent . ' % ' . $discount_basket_name,
                     'articleID' => 0,
                     'ordernumber' => $discount_basket_ordernumber,
                     'quantity' => 1,

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -375,7 +375,7 @@ class sBasket
         $discount *= -1;
         $discount = round($discount, 2);
 
-        if(!$discount) {
+        if (!$discount) {
             return;
         }
         

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -375,6 +375,10 @@ class sBasket
         $discount *= -1;
         $discount = round($discount, 2);
 
+        if(!$discount) {
+            return;
+        }
+        
         $taxMode = $this->config->get('sTAXAUTOMODE');
         if (!empty($taxMode)) {
             $tax = $this->getMaxTax();


### PR DESCRIPTION
### 1. Why is this change necessary?
currently if the basketdiscount result 0 it'll be displayed as "FREE" in Basket. Which makes no sense in my eyes.
adjust naming of basket-discount in sAdmin to sBasket`s.

### 2. What does this change do, exactly?
check if $discount is set valid

### 3. Describe each step to reproduce the issue or behaviour.
define a product-price and basket discount which results <0.01€

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
