### PR TITLE
Fix DOI URL generation from non-frontend contexts

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -593,6 +593,7 @@ class sAdmin
                         'sViewport' => 'newsletter',
                         'action' => 'index',
                         'sConfirmation' => $hash,
+                        'module' => 'frontend',
                     ]
                 );
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When calling `\sAdmin::sUpdateNewsletter(true, ...)` from a non-frontend context (e.g. from an API controller) while the `optinnewsletter` configuration setting is enabled, the generated e-mail will have an invalid confirmation link which looks like this:

```
/shopware/api/newsletter/index/sConfirmation/JFQWqhJWkqvifzBo79AbLBf2fEqaTn0A
```

After this change, the link will be generated correctly and look like this:

```
http://janniks-mbp/shopware/newsletter/index/sConfirmation/6p7oN0thUPzV6jlw5DznfcMC00BTQasR
```

### 2. What does this change do, exactly?

It explicitly specifies the `frontend` module when assembling DOI confirmation URLs.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable `optinnewsletter`.
1. Have a plugin which adds an API resource that calls `\sAdmin::sUpdateNewsletter(true, ...)` to add a new newsletter subscriber.
1. Trigger that call.
1. Observe that the confirmation link is broken.

### 4. Please link to the relevant issues (if any).

None that I know of.

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

> - [ ] I have written tests and verified that they fail without my change

I'd appreciate pointers on how to test this behavior within Shopware's test suite.

- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.