### PR TITLE
added block for custom order status

### DIFF
--- a/themes/Frontend/Bare/frontend/account/order_item.tpl
+++ b/themes/Frontend/Bare/frontend/account/order_item.tpl
@@ -90,6 +90,8 @@
                             {s name="OrderItemInfoShipped"}{/s}
                         {elseif $offerPosition.status==8}
                             {s name="OrderItemInfoClarificationNeeded"}{/s}
+                        {else}
+                            {block name="frontend_account_order_item_status_value_custom"}{/block}
                         {/if}
                     </div>
                 {/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
If a plugin adds new order status.

### 2. What does this change do, exactly?
Adds a block to hook into.

### 3. Describe each step to reproduce the issue or behaviour.
Create a new order status and open the orders within the account.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.