### PR TITLE
Allow SVG as category image

### DIFF
--- a/themes/Backend/ExtJs/backend/category/view/category/tabs/settings.js
+++ b/themes/Backend/ExtJs/backend/category/view/category/tabs/settings.js
@@ -582,7 +582,7 @@ Ext.define('Shopware.apps.Category.view.category.tabs.Settings', {
      * @return array of strings
      */
     getAllowedExtensions : function() {
-        return [ 'gif', 'png', 'jpeg', 'jpg' ]
+        return [ 'gif', 'png', 'jpeg', 'jpg', 'svg' ]
     }
 });
 //{/block}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
To use SVG images e.g. as icons in the frontend

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.