### PR TITLE
Fix rounding differences on net orders

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2590,7 +2590,7 @@ SQL;
                 || (!$this->sSYSTEM->sUSERGROUPDATA['tax'] && $this->sSYSTEM->sUSERGROUPDATA['id'])
             ) {
                 if (empty($getArticles[$key]['modus'])) {
-                    $priceWithTax = round($netprice, 2) / 100 * (100 + $tax);
+                    $priceWithTax = round(round($netprice, 2) / 100 * (100 + $tax),2);
 
                     $getArticles[$key]['amountWithTax'] = $quantity * $priceWithTax;
                     // If basket comprised any discount, calculate brutto-value for the discount

--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -514,7 +514,7 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
 
                 if ($this->_net == true) {
                     $position['netto'] = round($position['price'], 2);
-                    $position['price'] = round($position['price'], 2) * (1 + $position['tax'] / 100);
+                    $position['price'] = round(round($position['price'], 2) * (1 + $position['tax'] / 100),2);
                 } else {
                     $position['netto'] = $position['price'] / (100 + $position['tax']) * 100;
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Shopware should always calculate the prices based on the displayed decimal places. Since we only show 2 decimal places in the basket, this miscalculation leads to rounding differences.

### 2. What does this change do, exactly?
Changes the "priceWithTax" to a price with two decimal places (only on net orders).

### 3. Describe each step to reproduce the issue or behaviour.
after the fix:
![nachher](https://user-images.githubusercontent.com/10058559/44148745-d44ed9ac-a099-11e8-98be-6f690f5d15cb.png)

before:
![vorher](https://user-images.githubusercontent.com/10058559/44148747-d465920a-a099-11e8-98de-2e4cbcb027dc.png)



for reproducing this issue, please have a look at https://issues.shopware.com/issues/SW-22338
price per unit: 7,56
tax per unit: 1,44



### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22338

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.