### PR TITLE
Fix order state change and mail window when opened via quick search

### DIFF
--- a/themes/Backend/ExtJs/backend/order/controller/attachment.js
+++ b/themes/Backend/ExtJs/backend/order/controller/attachment.js
@@ -184,9 +184,14 @@ Ext.define('Shopware.apps.Order.controller.Attachment', {
     callStoreReload: function(attachmentGrid, addAsAttachment, listStore) {
         var me = this;
 
-        listStore.reload({
-            callback: Ext.bind(me.applyNewDocument, me, [attachmentGrid, addAsAttachment])
-        });
+        try {
+            listStore.reload({
+                callback: Ext.bind(me.applyNewDocument, me, [attachmentGrid, addAsAttachment])
+            });
+        } catch(e) {
+            // In this case the order overview/list might not be opened. E.g. user opened the the order via quick search in topbar.
+            // Do nothing intentionally.
+        }
     },
 
     /**

--- a/themes/Backend/ExtJs/backend/order/controller/detail.js
+++ b/themes/Backend/ExtJs/backend/order/controller/detail.js
@@ -741,7 +741,13 @@ Ext.define('Shopware.apps.Order.controller.Detail', {
                     }
                 }
                 // reload the order list
-                me.getOrderList().store.load();
+                try {
+                    me.getOrderList().getStore().load();
+                } catch(e) {
+                    // In this case the order overview/list might not be opened. E.g. user opened the the order via quick search in topbar.
+                    // Do nothing intentionally.
+                }
+
             }
         });
     },
@@ -763,7 +769,7 @@ Ext.define('Shopware.apps.Order.controller.Detail', {
                         record.get('id')
                     ],
                     record: record,
-                    listStore: me.getOrderList().getStore(),
+                    listStore: me.getOrderList() ? me.getOrderList().getStore() : null,
                     documentTypeStore: documentTypeStore,
                     mail: mail
                 }).show();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

The order state change and the mail window depends on the order list. Both try to update/reload the order list, when state is changed or a document is added. This dependency throws an error, if the order isn't oped via the order list window, but from the quick search bar in the blue top bar. When one opens an order via quick search there is simply no order list window available.

### 2. What does this change do, exactly?

This change introduces a try/catch block, when accessing the order list object. It will simply not reloaded, if it's not available.

### 3. Describe each step to reproduce the issue or behaviour.

Working example:

1. Open in backend "Kunden -> Bestellungen"
2. Edit an order
3. Change order or payment state, to a state with an email associated. E.g. "Bestellstatus: In Bearbeitung" (not sure if this is really standard or our customization ;)
4. Save order
5. Growl notification: Succesfull 
5. Mail window opens

Not working example:

1. Look for existing order number in quick search
2. Pick order to open
3. Change order or payment state, to a state with an email associated. E.g. "Bestellstatus: In Bearbeitung" (not sure if this is really standard or our customization ;)
4. Save order
5. Growl notification: Succesfull 
5. Mail window does NOT open. There is an error on JavaScript console.

### 4. Please link to the relevant issues (if any).

Don't know.

### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.