### PR TITLE
verify code style on travis build

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -18,7 +18,7 @@
         </parallel>
     </target>
 
-    <target name="build-continuous" depends="unit-shopware-continuous"/>
+    <target name="build-continuous" depends="check-code-style, unit-shopware-continuous"/>
     <target name="build-unit" depends="build-composer-install, build-cache-dir, build-config, build-database, build-snippets-deploy, build-theme-initialize,build-create-admin-account, build-install-lock-file, build-disable-firstrunwizard, install-git-hooks" />
     <target name="test-unit" depends="unit-shopware"/>
 
@@ -109,6 +109,17 @@
             <arg value="composer.phar" />
             <arg value="update" />
             <arg value="--no-interaction" />
+        </exec>
+    </target>
+
+    <target name="check-code-style" depends="build-composer-install">
+        <exec executable="${script.php}" failonerror="true">
+            <arg value="vendor/bin/php-cs-fixer" />
+            <arg value="fix" />
+            <arg value="--dry-run" />
+            <arg value="--stop-on-violation" />
+            <arg value="--verbose" />
+            <arg value="--show-progress=dots" />
         </exec>
     </target>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
related to this pr: https://github.com/shopware/shopware/pull/1754 the fixer is run during build-unit to enforce the code style.

### 2. What does this change do, exactly?
adds the execution of the code style fixer to the ant build file

### 3. Describe each step to reproduce the issue or behaviour.
after ant configure, run ant build-unit. The step check-code-style will be triggered and should fail until the pr: https://github.com/shopware/shopware/pull/1754 is merged.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.