### PR TITLE
fix old shopware 4 supplier urls

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/ViewportForward/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/ViewportForward/Bootstrap.php
@@ -62,7 +62,7 @@ class Shopware_Plugins_Core_ViewportForward_Bootstrap extends Shopware_Component
                 break;
             case 'cat':
             case 'supplier':
-                $request->setControllerName('listing')->setDispatched(false);
+                $request->setControllerName('listing')->setActionName('manufacturer')->setDispatched(false);
                 break;
             case 'captcha':
                 $request->setModuleName('widgets')->setControllerName('captcha')->setDispatched(false);

--- a/engine/Shopware/Plugins/Default/Core/ViewportForward/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/ViewportForward/Bootstrap.php
@@ -61,6 +61,8 @@ class Shopware_Plugins_Core_ViewportForward_Bootstrap extends Shopware_Component
                 }
                 break;
             case 'cat':
+                $request->setControllerName('listing')->setDispatched(false);
+                break;
             case 'supplier':
                 $request->setControllerName('listing')->setActionName('manufacturer')->setDispatched(false);
                 break;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently the old manufacturers urls will not work anymore, because of an exception. 

`Fatal error: Uncaught TypeError: Argument 1 passed to Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\CustomSortingGateway::getList() must be of the type array, null given, called in /var/www/html/55/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CustomSortingGateway.php on line 100 and defined in /var/www/html/55/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CustomSortingGateway.php:77 Stack trace: #0 /var/www/html/55/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CustomSortingGateway.php(100): Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\CustomSortingGateway->getList(NULL, Object(Shopware\Bundle\StoreFrontBundle\Struct\ShopContext)) #1 /var/www/html/55/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/CustomSortingService.php(59): Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\CustomSortingGateway->getSortingsOfCategories(Array, Object(Shopware\Bundle\StoreFrontBundle\Struct\ShopContext)) #2 /var/www/html/55/engine/Shopware/Controllers/Frontend/Listing.php(524): Shopware\Bundle\StoreFrontBundle\Servi in /var/www/html/55/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CustomSortingGateway.php on line 77`

### 2. What does this change do, exactly?
Adds the action name to the compatibility layer to redirect the old links correctly to the new supplier page.

### 3. Describe each step to reproduce the issue or behaviour.
Links like shopware.php?sViewport=supplier&sSupplier=5 will throw an exception.
Links like shopware.php?sViewport=cat&sCategory=33 will work as before

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22339

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.