### PR TITLE
add product information to sARTICLEAVAILABLE template

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
@@ -330,11 +330,16 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
                 'sArticle' => $product['articleID'],
                 'number' => $product['ordernumber'],
             ]);
+            
+            $sContext = Shopware()->Container()->get('shopware_storefront.context_service')->createShopContext($notify['language']);
+            $product_information = Shopware()->Container()->get('shopware_storefront.list_product_service')->get($notify['ordernumber'], $sContext);
+            $product_information = Shopware()->Container()->get('legacy_struct_converter')->convertListProductStruct($product_information);
 
             $context = [
                 'sArticleLink' => $link,
                 'sOrdernumber' => $notify['ordernumber'],
                 'sData' => $job['data'],
+                'product' => $product_information,
             ];
 
             $mail = Shopware()->TemplateMail()->createMail('sARTICLEAVAILABLE', $context);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request. 

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
There is currently no product information available in sARTICLEAVAILABLE. In order to further personalize the email, however, often the picture, the description and further information of the product are necessary

### 2. What does this change do, exactly?
Replace the SQL-Syntax with the list_product_service

### 3. Describe each step to reproduce the issue or behaviour.
- install notification plugin and add the notification flag to a product that is not available (instock = 0 + laststock)
- execute the notification cronjob
-> Only {$sShop}, {$sShopURL}, {$sArticleLink}, {$sOrdernumber} are available

After the change the whole product-information is added to the avaiable variables

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22283
and much more

### 5. Which documentation changes (if any) need to be made because of this PR?
It would be possible to improve the email-template by default, but not necessarily

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.