### PR TITLE
Orderapi optional state

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -39,6 +39,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
 * Changed variant search to toggle join prices with `hideNoInStock` configuration
 * Changed Double-Opt-In setting for comments/ratings on products and blog articles to be off by default
 * Changed field `remoteaddr` in table `s_statistics_pool` to contain a hash instead of the real IP of a visitor
+* Changed order api to allow creating orders without stateId
 
 ## 5.4.5
 

--- a/engine/Shopware/Components/Api/Resource/Order.php
+++ b/engine/Shopware/Components/Api/Resource/Order.php
@@ -691,10 +691,6 @@ class Order extends Resource
             throw new ApiException\ParameterMissingException('billing.countryId');
         }
 
-        if (!array_key_exists('stateId', $billing)) {
-            throw new ApiException\ParameterMissingException('billing.stateId');
-        }
-
         $country = $this->getContainer()->get('models')->find(CountryModel::class, $billing['countryId']);
         if (!$country) {
             throw new ApiException\NotFoundException(sprintf(
@@ -703,12 +699,17 @@ class Order extends Resource
             ));
         }
 
-        $state = $this->getContainer()->get('models')->find(State::class, $billing['stateId']);
-        if (!$state) {
-            throw new ApiException\NotFoundException(sprintf(
-                'Shipping State by id %s not found',
-                $billing['stateId']
-            ));
+        if (array_key_exists('stateId', $billing)) {
+            $state = $this->getContainer()->get('models')->find(State::class, $billing['stateId']);
+            if (!$state) {
+                throw new ApiException\NotFoundException(sprintf(
+                    'Billing State by id %s not found',
+                    $billing['stateId']
+                ));
+            }
+        }
+        else if ($country->getForceStateInRegistration()) {
+            throw new ApiException\ParameterMissingException('billing.stateId');
         }
 
         $billingAddress = new Billing();
@@ -730,10 +731,6 @@ class Order extends Resource
             throw new ApiException\ParameterMissingException('shipping.countryId');
         }
 
-        if (!array_key_exists('stateId', $shipping)) {
-            throw new ApiException\ParameterMissingException('shipping.stateId');
-        }
-
         $country = $this->getContainer()->get('models')->find(CountryModel::class, $shipping['countryId']);
         if (!$country) {
             throw new ApiException\NotFoundException(sprintf(
@@ -742,12 +739,17 @@ class Order extends Resource
             ));
         }
 
-        $state = $this->getContainer()->get('models')->find(State::class, $shipping['stateId']);
-        if (!$state) {
-            throw new ApiException\NotFoundException(sprintf(
-                'Shipping State by id %s not found',
-                $shipping['stateId']
-            ));
+        if (array_key_exists('stateId', $shipping)) {
+            $state = $this->getContainer()->get('models')->find(State::class, $shipping['stateId']);
+            if (!$state) {
+                throw new ApiException\NotFoundException(sprintf(
+                    'Shipping State by id %s not found',
+                    $shipping['stateId']
+                ));
+            }
+        }
+        else if ($country->getForceStateInRegistration()) {
+            throw new ApiException\ParameterMissingException('shipping.stateId');
         }
 
         $shippingAddress = new Shipping();

--- a/engine/Shopware/Components/Api/Resource/Order.php
+++ b/engine/Shopware/Components/Api/Resource/Order.php
@@ -699,7 +699,7 @@ class Order extends Resource
             ));
         }
 
-        if (array_key_exists('stateId', $billing)) {
+        if (array_key_exists('stateId', $billing) && !empty($billing['stateId'])) {
             $state = $this->getContainer()->get('models')->find(State::class, $billing['stateId']);
             if (!$state) {
                 throw new ApiException\NotFoundException(sprintf(
@@ -739,7 +739,7 @@ class Order extends Resource
             ));
         }
 
-        if (array_key_exists('stateId', $shipping)) {
+        if (array_key_exists('stateId', $shipping) && !empty($shipping['stateId'])) {
             $state = $this->getContainer()->get('models')->find(State::class, $shipping['stateId']);
             if (!$state) {
                 throw new ApiException\NotFoundException(sprintf(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently the order api does not allow order creation without providing a valid stateId. These limitation should only apply if the country is configured to force registration with stateId.

### 2. What does this change do, exactly?
The order resource is modified to align with the country configuration and ensures a stateId is only needed for countries forcing registration with stateId. If an invalid stateId is provided a NotFoundException is raised in any case.

### 3. Describe each step to reproduce the issue or behaviour.
Run the current tests on a demo data set with orders placed via frontend checkout in a country not forcing state to be set.

### 4. Please link to the relevant issues (if any).
[https://issues.shopware.com/issues/SW-22401](https://issues.shopware.com/issues/SW-22401)
[https://issues.shopware.com/issues/SW-22180](https://issues.shopware.com/issues/SW-22180)
[https://issues.shopware.com/issues/SW-20045](https://issues.shopware.com/issues/SW-20045)

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.