### PR TITLE
Snippet shops fix

### DIFF
--- a/engine/Shopware/Components/Snippet/SnippetValidator.php
+++ b/engine/Shopware/Components/Snippet/SnippetValidator.php
@@ -112,6 +112,21 @@ class SnippetValidator
             FROM `s_core_locales`'
         )->fetchAll(\PDO::FETCH_COLUMN);
 
-        return $locales;
+        $shops = $this->db->executeQuery(
+            'SELECT id
+            FROM `s_core_shops`'
+        )->fetchAll(\PDO::FETCH_COLUMN);
+        $return = [];
+
+        foreach ($locales as $locale) {
+            $return[$locale] = 1;
+            foreach ($shops as $shop) {
+                $return[$shop . '/' . $locale] = 1;
+            }
+        }
+
+        $return = array_keys($return);
+
+        return $return;
     }
 }

--- a/engine/Shopware/Models/Snippet/SnippetRepository.php
+++ b/engine/Shopware/Models/Snippet/SnippetRepository.php
@@ -31,14 +31,14 @@ use Shopware\Components\Model\ModelRepository;
  */
 class SnippetRepository extends ModelRepository
 {
-    public function getDistinctNamespacesQuery($locales = null, $limit = null, $offset = null)
+    public function getDistinctNamespacesQuery($locales = null, $shopIds = null, $limit = null, $offset = null)
     {
-        $builder = $this->getDistinctNamespacesQueryBuilder($locales, $limit, $offset);
+        $builder = $this->getDistinctNamespacesQueryBuilder($locales, $shopIds, $limit, $offset);
 
         return $builder->getQuery();
     }
 
-    public function getDistinctNamespacesQueryBuilder($locales = null, $limit = null, $offset = null)
+    public function getDistinctNamespacesQueryBuilder($locales = null, $shopIds = null, $limit = null, $offset = null)
     {
         $builder = $this->createQueryBuilder('snippet')
             ->select([
@@ -46,11 +46,32 @@ class SnippetRepository extends ModelRepository
             ]);
         if ($locales) {
             $builder
-                ->where('snippet.localeId IN (:locales)')->setParameter('locales', $locales);
+                ->andWhere('snippet.localeId IN (:locales)')->setParameter('locales', $locales);
+        }
+        if ($shopIds) {
+            $builder
+                ->andWhere('snippet.shopId = (:shopIds)')->setParameter('shopIds', $shopIds);
         }
 
         $builder->setFirstResult($offset)
-                ->setMaxResults($limit);
+            ->setMaxResults($limit);
+
+        return $builder;
+    }
+
+    public function getDistinctShopsQueryQuery($localeId)
+    {
+        $builder = $this->getDistinctShopsQueryBuilder($localeId);
+
+        return $builder->getQuery();
+    }
+
+    public function getDistinctShopsQueryBuilder($localeId)
+    {
+        $builder = $this->createQueryBuilder('snippet')
+            ->select([
+                'DISTINCT snippet.shopId as shopId',
+            ])->where('snippet.localeId = :localeId')->setParameter('localeId', $localeId);
 
         return $builder;
     }

--- a/tests/Functional/Components/Snippet/SnippetStructureTest.php
+++ b/tests/Functional/Components/Snippet/SnippetStructureTest.php
@@ -53,4 +53,35 @@ class Shopware_Tests_Components_Snippet_SnippetStructureTest extends Enlight_Com
 
         $this->assertEmpty($validationResult, "Snippet validation errors detected: \n" . implode("\n", $validationResult));
     }
+
+    /**
+     * Test case
+     */
+    public function testShopSpecificSnippetsStructure()
+    {
+        $source = Shopware()->Container()->getParameter('kernel.root_dir') . '/snippets';
+
+        $validator = Shopware()->Container()->get('shopware.snippet_validator');
+
+        // try to find snippet for special subshop
+        $snippetFakeData = Shopware()->Db()->fetchRow('select * from s_core_snippets where shopID="2" and localeID="1" limit 1');
+
+        // insert new faked snippet translation for a special subshop for locale 1 if not already found
+        if ($snippetFakeData === false) {
+            $snippetFakeData = Shopware()->Db()->fetchRow('select * from s_core_snippets where localeID="1" limit 1');
+            unset($snippetFakeData['id']);
+            $snippetFakeData['shopID'] = '2';
+            Shopware()->Db()->insert('s_core_snippets', $snippetFakeData);
+        }
+
+        // export snippets to snippet folder
+        /** @var $databaseLoader \Shopware\Components\Snippet\DatabaseHandler */
+        $databaseLoader = Shopware()->Container()->get('shopware.snippet_database_handler');
+        $databaseLoader->dumpFromDatabase('snippets', 'de_DE');
+
+        // validate snippets
+        $validationResult = $validator->validate($source);
+
+        $this->assertEmpty($validationResult, "Snippet validation errors detected: \n" . implode("\n", $validationResult));
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
I'ts possible to use special translations for each shop at shopware's backend and to the db.
When the Snippet-DB-Adapter dumps the snippets to an ini file, the only sections that will get interpreted are the locales.
That causes trouble when snippets for the same locale BUT different shops are translated differently.
When importing back, the snippets are ONLY imported for the shopID 1.
That results in massive and unacceptable data missmatches when im/ex - porting several times.

### 2. What does this change do, exactly?
Now all relevant shop-ids will be collected before exporting.
The snippets will be stored under its own ini section ({shopId}/{locale}).
The sections also will get interpreted correctly upon import.
Here you can take a look for new Ini-File Structure: 
[excample.ini.txt](https://github.com/shopware/shopware/files/2302311/excample.ini.txt)


### 3. Describe each step to reproduce the issue or behaviour.
1. Configure 2 shops with the same locale.
2. Translate a snippet for the second shop.
3. Export Snippets to an ini file
4. Import Snippets from the same file back to db
5. Both Snippets will now contain the second shop's value.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.