### PR TITLE
WIP: Use correct Attribute data types in PHP

### DIFF
--- a/tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
+++ b/tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
@@ -32,7 +32,7 @@ class SchemaOperatorTest extends \PHPUnit\Framework\TestCase
             'string' => 'test123',
             'integer' => 123,
             'float' => 123,
-            'boolean' => 1,
+            'boolean' => true,
             'date' => '2010-01-01',
             'datetime' => '2010-01-01 10:00:00',
             'text' => 'test123',

--- a/tests/Functional/Components/Model/GeneratorTest.php
+++ b/tests/Functional/Components/Model/GeneratorTest.php
@@ -99,9 +99,9 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     {
         $this->addAndEvaluateInitialization(
             'boolean',
-            'integer',
-            'integer',
-            1
+            'bool',
+            'boolean',
+            true
         );
     }
 
@@ -109,9 +109,9 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     {
         $this->addAndEvaluateInitialization(
             'boolean',
-            'integer',
-            'integer',
-            0
+            'bool',
+            'boolean',
+            false
         );
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

If I specify some attribute as a boolean, I expect boolean type also in PHP (e.g. $category->getAttribute()->getMyBoolean() should really return PHP `bool`).

### 2. What does this change do, exactly?

For now, there are just tests as a proof of the problem.

Fix has to be added.

### 3. Describe each step to reproduce the issue or behaviour.

Create a new attribute with type "boolean", for instance like:

```php
        $attributes->update('s_categories_attributes', 'my_boolean', 'boolean', [
            'label' => 'Is it true?',
        ], null, false, false);
```

Then when accessing that attribute in PHP via generate Attribute class, value is integer, not bool.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.