### PR TITLE
Ask password with a hidden input in sw:admin:create

### DIFF
--- a/engine/Shopware/Commands/AdminCreateCommand.php
+++ b/engine/Shopware/Commands/AdminCreateCommand.php
@@ -92,7 +92,7 @@ class AdminCreateCommand extends ShopwareCommand
         $this->fillOption('username', 'Username', $input, $output);
         $this->fillOption('name', 'Fullname', $input, $output);
         $this->fillOption('locale', 'Locale', $input, $output);
-        $this->fillOption('password', 'Password', $input, $output);
+        $this->fillOption('password', 'Password', $input, $output, true);
     }
 
     /**
@@ -123,14 +123,15 @@ class AdminCreateCommand extends ShopwareCommand
      * @param string          $label
      * @param InputInterface  $input
      * @param OutputInterface $output
+     * @param bool            $hidden
      */
-    private function fillOption($field, $label, InputInterface $input, OutputInterface $output)
+    private function fillOption($field, $label, InputInterface $input, OutputInterface $output, $hidden = false)
     {
         $io = new SymfonyStyle($input, $output);
 
         $input->setOption(
             $field,
-            $io->ask($label, $input->getOption($field))
+            $hidden ? $io->askHidden($label) : $io->ask($label, $input->getOption($field))
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
There is currently no way to create an administration account without a visible password.

### 2. What does this change do, exactly?
In the interactive way the command asks for missing information. Now if the missing information is the password there is a input used that does not print what you type and therefore a way to enter a password without being visible to others seeing the output of the terminal.

### 3. Describe each step to reproduce the issue or behaviour.

1. Execute `sw:admin:create`
2. Fill in all the questions being asked
3. Wonder why you see the password while you type it

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.