### PR TITLE
Fix smarty flink function when rendered in cli context

### DIFF
--- a/engine/Library/Enlight/Template/Plugins/function.flink.php
+++ b/engine/Library/Enlight/Template/Plugins/function.flink.php
@@ -61,7 +61,7 @@ function smarty_function_flink($params, $template)
 
         // Some cleanup code
         if (strpos($file, $docPath) === 0) {
-            $file = substr($file, strlen($docPath));
+            $file = '/' . substr($file, strlen($docPath));
         }
 
         // Make sure we have the right separator for the web context
@@ -82,8 +82,14 @@ function smarty_function_flink($params, $template)
         $file = $request->getBasePath() . '/';
     }
 
-    if ($request !== null && !empty($params['fullPath']) && strpos($file, '/') === 0) {
-        $file = $request->getScheme() . '://' . $request->getHttpHost() . $file;
+    if (!empty($params['fullPath']) && strpos($file, '/') === 0) {
+        if ($request === null) {
+            $baseUrl = Shopware()->Container()->get('router')->assemble();
+        } else {
+            $baseUrl = $request->getScheme() . '://' . $request->getHttpHost();
+        }
+
+        $file = $baseUrl . $file;
     }
 
     return $file;


### PR DESCRIPTION
### 1. Why is this change necessary?
When a template is rendered a cli environment there is no request object. Since the request is essentially null, the `flink` function will not render a base url even is `fullPath` is set to `true`. To initialize a shop context in a cli environment, one may call `\Shopware\Models\Shop\Shop::registerResources()` which will set a context to the router. That would be sufficient to let the router know about the base url and include it in generated urls. However that does not help at all when the `flink` function simply prepends the scheme and http host of the current request to the rendered url. The request is still null at this point, remember? So I suppose to use the router's `assemble` method to generate the base url of the given context.

### 2. What does this change do, exactly?
When the smarty function `flink` is called with `fullPath` and the request is null, the base url is retrieved from the router's `assemble` method instead of *not at all*.

### 3. Describe each step to reproduce the issue or behaviour.
1. Make a simple template that uses `{link file="..." fullPath}`.
2. Call the router's `setContext` method to initialize it with a certain shop.
3. For comparison call the router's `assemble` method.
4. Execute the script in a cli environment.
5. See that `fullPath` has no effect. *Also a leading slash is missing.*
6. See that `assemble` as succeeded in rendering the base url.

### 4. Please link to the relevant issues (if any).
None. (yet)

### 5. Which documentation changes (if any) need to be made because of this PR?
Maybe some, maybe none...

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.