### PR TITLE
consider active flag of shop-pages for sitemap-generation

### DIFF
--- a/engine/Shopware/Bundle/SitemapBundle/Provider/StaticUrlProvider.php
+++ b/engine/Shopware/Bundle/SitemapBundle/Provider/StaticUrlProvider.php
@@ -135,6 +135,9 @@ class StaticUrlProvider implements UrlProviderInterface
             $builder = $this->connection->createQueryBuilder();
             $current = $builder->from('s_cms_static', 'sites')
                 ->select('*')
+                ->where(
+                    $builder->expr()->eq('sites.active', ':active')      //like = true
+                )
                 ->andWhere(
                     $builder->expr()->orX(
                         $builder->expr()->eq('sites.grouping', ':g1'),       // = gBottom
@@ -149,6 +152,7 @@ class StaticUrlProvider implements UrlProviderInterface
                         $builder->expr()->isNull('sites.shop_ids')
                     )
                 )
+                ->setParameter('active', true)
                 ->setParameter('g1', $key)
                 ->setParameter('g2', $key . '|%')
                 ->setParameter('g3', '%|' . $key)

--- a/engine/Shopware/Components/SitemapXMLRepository.php
+++ b/engine/Shopware/Components/SitemapXMLRepository.php
@@ -325,6 +325,8 @@ class SitemapXMLRepository
             $current = $siteRepository->getSitesByNodeNameQueryBuilder($key, $shopId)
                 ->resetDQLPart('from')
                 ->from('Shopware\Models\Site\Site', 'sites', 'sites.id')
+                ->andwhere('sites.active = :active')
+                ->setParameter('active', true)
                 ->getQuery()
                 ->getArrayResult();
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently inacitive shop-pages will appear in the sitemap, that's bad for SEO and the user experience.

### 2. What does this change do, exactly?
consider the activte flag while fetching the shop-pages

### 3. Describe each step to reproduce the issue or behaviour.
add a content-group to your shop and deativate one of the shop pages
 -> check the sitemap.xml

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.