### PR TITLE
Always set given config value in config writer

### DIFF
--- a/engine/Shopware/Components/Plugin/ConfigWriter.php
+++ b/engine/Shopware/Components/Plugin/ConfigWriter.php
@@ -106,7 +106,7 @@ class ConfigWriter
         $valueModel = $this->valueRepository->findOneBy(['shop' => $shop, 'element' => $element]);
 
         if (!$valueModel) {
-            if ($value == $defaultValue || $value === null) {
+            if ($value === null) {
                 return;
             }
 
@@ -121,7 +121,7 @@ class ConfigWriter
             return;
         }
 
-        if ($value == $defaultValue || $value === null) {
+        if ($value === null) {
             $this->em->remove($valueModel);
         } else {
             $valueModel->setValue($value);


### PR DESCRIPTION
### 1. Why is this change necessary?
Imagine a boolean config element which defaults to falsey and is changable for every sub-/language shop. The loading hierarchy of the config reader is *requested shop*, *parent shop* (if given), *shop with id = 1*, *element default*.

This change allows to set the config value for the requested shop to the default value without always falling back to shop with id 1 setted value.

### 2. What does this change do, exactly?
Always write a given value except it is null to match the coalasce in the reader.

### 3. Describe each step to reproduce the issue or behaviour.
Have the following shop tree.
```
|--* 1 Pan cake mixes
|--+ 2 Flux compensators
   |--* 3 Flux compensatoren (NL)
```

Have plugin (maybe for [Regulation (EU) 1169/2011](https://eur-lex.europa.eu/legal-content/DE/TXT/?uri=CELEX:32011R1169) better known as LMIV in :de:). This plugin has configuration element which allows being changed for every sub-/language shop (scope = 1) and a default value of null. For example the setting for being enabled.
One sets the enabled configuration value to true for the pancake shop (id: 1). Therefore it is enabled everywhere. Afterwards you disable it for the flux compensators shop (id: 2). This is denied by the config writer as the false value is loosely equals to the null default value. Therefore it skips the writing of the value. The reader now falls back to shop with id 1 and reads the value true.

### 4. Which documentation changes (if any) need to be made because of this PR?
Maybe some comments in the documentation about the config reader/writer have to be changed.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.