### PR TITLE
Fix Opt-In Link for newsletter registrations

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Newsletter.php
+++ b/engine/Shopware/Controllers/Frontend/Newsletter.php
@@ -87,7 +87,7 @@ class Shopware_Controllers_Frontend_Newsletter extends Enlight_Controller_Action
                     $hash = \Shopware\Components\Random::getAlphanumericString(32);
                     $data = serialize(Shopware()->System()->_POST->toArray());
 
-                    $link = $this->Front()->Router()->assemble(['sViewport' => 'newsletter', 'action' => 'confirm', 'sConfirmation' => $hash]);
+                    $link = $this->Front()->Router()->assemble(['sViewport' => 'newsletter', 'action' => 'index', 'sConfirmation' => $hash]);
 
                     $this->sendMail(Shopware()->System()->_POST['newsletter'], 'sOPTINNEWSLETTER', $link);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently the opt-in links are broken in 5.5, because the confirm-action is removed (deprecation)

### 2. What does this change do, exactly?
Change the link to the index-action.

### 3. Describe each step to reproduce the issue or behaviour.
Activate opt-in for newsletters, try to verify your registration with the link from the mail
-> It won't work

/newsletter/confirm/sConfirmation/5Pmg3PPbfrkBXJYC2Fh4fnO9DfSlSqxG

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22424

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.