### PR TITLE
make all font-style accessible

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/datepicker.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/datepicker.less
@@ -278,7 +278,7 @@ The datepicker is based on the jQuery Plugin [flatpickr](https://github.com/chml
     .unitize(top, 10);
     font-size: 135%;
     line-height: inherit;
-    font-weight: @font-light-weight;
+    font-weight: @font-base-weight;
     color: inherit;
     position: absolute;
     width: 75%;
@@ -320,7 +320,7 @@ The datepicker is based on the jQuery Plugin [flatpickr](https://github.com/chml
     display: inline;
     font-size: inherit;
     font-family: inherit;
-    font-weight: @font-light-weight;
+    font-weight: @font-base-weight;
     line-height: inherit;
     height: initial;
     border: 0;

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/fonts.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/fonts.less
@@ -1,5 +1,18 @@
 @OpenSansPath: "./fonts";
 
+/* BEGIN Light */
+@font-face {
+    font-family: 'Open Sans';
+    src: local('Open Sans Light'),
+    local('OpenSans-Light'),
+    url('@{OpenSansPath}/Light/OpenSans-Light.woff2?@{shopware-revision}') format('woff2'),
+    url('@{OpenSansPath}/Light/OpenSans-Light.woff?@{shopware-revision}') format('woff'),
+    url('@{OpenSansPath}/Light/OpenSans-Light.ttf?@{shopware-revision}') format('truetype');
+    font-weight: 300;
+    font-style: normal;
+}
+/* END Light */
+
 /* BEGIN Regular */
 @font-face {
     font-family: 'Open Sans';
@@ -38,3 +51,16 @@
     font-style: normal;
 }
 /* END Bold */
+
+/* BEGIN Extrabold */
+@font-face {
+    font-family: 'Open Sans';
+    src: local('Open Sans ExtraBold'),
+    local('OpenSans-ExtraBold'),
+    url('@{OpenSansPath}/ExtraBold/OpenSans-ExtraBold.woff2?@{shopware-revision}') format('woff2'),
+    url('@{OpenSansPath}/ExtraBold/OpenSans-ExtraBold.woff?@{shopware-revision}') format('woff'),
+    url('@{OpenSansPath}/ExtraBold/OpenSans-ExtraBold.ttf?@{shopware-revision}') format('truetype');
+    font-weight: 800;
+    font-style: normal;
+}
+/* END Extrabold */


### PR DESCRIPTION
### 1. Why is this change necessary?
1. Not all fonts styles are accessible
2. @font-light-weight is used for flatpickr, but displayed as regular, cause light-style isn't available

### 2. What does this change do, exactly?
this change makes all font styles accessible for easier templating and changed font-style of flatpickr.
It won't create more traffic due to loading all fonts. cause font-file will just be loaded, if it's used in template

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.