### PR TITLE
Make plugin loading order predictable

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
@@ -68,9 +68,8 @@ class PluginInitializer
         $classLoader = new Psr4ClassLoader();
         $classLoader->register(true);
 
-        $stmt = $this->connection->query('SELECT name, version, namespace FROM s_core_plugins WHERE active = 1 AND installation_date IS NOT NULL;');
+        $stmt = $this->connection->query('SELECT name, version, namespace FROM s_core_plugins WHERE active = 1 AND installation_date IS NOT NULL ORDER BY name ASC;');
         $this->activePlugins = $stmt->fetchAll(PDO::FETCH_UNIQUE);
-        ksort($this->activePlugins);
 
         foreach ($this->activePlugins as $pluginName => &$pluginData) {
             if (in_array($pluginData['namespace'], ['ShopwarePlugins', 'ProjectPlugins'], true)) {

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php
@@ -70,6 +70,7 @@ class PluginInitializer
 
         $stmt = $this->connection->query('SELECT name, version, namespace FROM s_core_plugins WHERE active = 1 AND installation_date IS NOT NULL;');
         $this->activePlugins = $stmt->fetchAll(PDO::FETCH_UNIQUE);
+        ksort($this->activePlugins);
 
         foreach ($this->activePlugins as $pluginName => &$pluginData) {
             if (in_array($pluginData['namespace'], ['ShopwarePlugins', 'ProjectPlugins'], true)) {
@@ -110,6 +111,7 @@ class PluginInitializer
                 $plugins[$plugin->getName()] = $plugin;
             }
         }
+        ksort($plugins);
 
         return $plugins;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

When loading the plugins, the DirectoryIterator which scans for plugins is not working
in a predictable order, because it uses the ctime of the directories as sorting order.

### 2. What does this change do, exactly?

It makes the loading order of the plugins predictable (simply alphabetically).

This is just a workaround, there should be a meaningful plugin loading order according
to their dependencies (either composer or requiredPlugins from XML).

### 3. Describe each step to reproduce the issue or behaviour.

If you try to override a symfony parameter or service of another plugin, you can't be sure
that it works consistently due to deviations of the ctime values of the plugin directories.
This can be caused by deployment, etc.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/SW-22399
