### PR TITLE
fixed auto-scroll for emotion attributes

### DIFF
--- a/themes/Backend/ExtJs/backend/emotion/view/detail/window.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/detail/window.js
@@ -270,7 +270,7 @@ Ext.define('Shopware.apps.Emotion.view.detail.Window', {
             },
             style: 'background: rgb(240, 242, 244)',
             title: '{s namespace="backend/attributes/main" name="attribute_form_title"}{/s}',
-            translationForm: me.mainForm
+            translationForm: me.mainForm,
             autoScroll: true
         });
     }

--- a/themes/Backend/ExtJs/backend/emotion/view/detail/window.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/detail/window.js
@@ -271,6 +271,7 @@ Ext.define('Shopware.apps.Emotion.view.detail.Window', {
             style: 'background: rgb(240, 242, 244)',
             title: '{s namespace="backend/attributes/main" name="attribute_form_title"}{/s}',
             translationForm: me.mainForm
+            autoScroll: true
         });
     }
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
If the emotion component has a lot of attributes, the backend window doesn't have a scrollbar.

### 2. What does this change do, exactly?
Adds autoScroll to ExtJS.

### 3. Describe each step to reproduce the issue or behaviour.
Add emotion attributes.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.