### PR TITLE
Improve ES Indexing Performance

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductListingVariationLoader.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductListingVariationLoader.php
@@ -424,6 +424,7 @@ class ProductListingVariationLoader
         $subPriceQuery->from('s_articles_details', 'details');
         $subPriceQuery->leftJoin('details', '(' . $priceListingQuery . ')', 'prices', 'details.id = prices.articledetailsID');
         $subPriceQuery->leftJoin('details', '(' . $onSalePriceListingQuery . ')', 'onsalePriceList', 'details.id = onsalePriceList.articledetailsID');
+        $subPriceQuery->andWhere('details.id IN (:variants)');
 
         $query->innerJoin('availableVariant', '(' . $subPriceQuery . ')', 'prices', 'availableVariant.id = prices.articledetailsID');
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The `\Shopware\Bundle\ESIndexingBundle\Product\ProductListingVariationLoader::fetchPrices` method took over 5 seconds for 10 products on MariaDB 10.3.

### 2. What does this change do, exactly?

It helps the QueryOptimizer to reduce the rows returned by a subquery to the necessary. This speeds up the constructed query from 5s down to 20ms.

### 3. Describe each step to reproduce the issue or behaviour.

Try to index products with variants and multiple customergroups.
