### PR TITLE
redesign comment in script-async-ready.tpl

### DIFF
--- a/themes/Frontend/Bare/frontend/index/script-async-ready.tpl
+++ b/themes/Frontend/Bare/frontend/index/script-async-ready.tpl
@@ -1,6 +1,8 @@
 {literal}
 <script type="text/javascript">
-    // Wrap the replacement code into a function to call it from the outside to replace the method when necessary
+    /**
+     * Wrap the replacement code into a function to call it from the outside to replace the method when necessary
+     */
     var replaceAsyncReady = window.replaceAsyncReady = function() {
         document.asyncReady = function (callback) {
             if (typeof callback === 'function') {


### PR DESCRIPTION
### 1. Why is this change necessary?
The comment breaks javascript in different scenario. F.e. html-Compressor, Browser-Addons, too.
literal will prevent any smarty-function to remove comment.

Maybe we could delete the comment completly?

### 2. What does this change do, exactly?
it changed the comment-style.

### 3. Describe each step to reproduce the issue or behaviour.
short way to reproduce: {strip} around. The comment-line will be in one line with following stuff, so it won't be executable.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.