### PR TITLE
prevent display of "price starting from" because of price differences…

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ListProductGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ListProductGateway.php
@@ -187,7 +187,7 @@ class ListProductGateway implements Gateway\ListProductGatewayInterface
         if ($this->config->get('calculateCheapestPriceWithMinPurchase')) {
             $query->addSelect('COUNT(DISTINCT ROUND(prices.price * priceVariant.minpurchase, 2)) as priceCount');
         } else {
-            $query->addSelect('COUNT(DISTINCT prices.price) as priceCount');
+            $query->addSelect('COUNT(DISTINCT ROUND(prices.price, 2)) as priceCount');
         }
 
         $query->from('s_articles_prices', 'prices')


### PR DESCRIPTION
… less than 0.01

### 1. Why is this change necessary?
Without this change the product price will show the "price starting from" (="ab ...") text even if the price difference between variants is lower than 0.01 and therefore not visible to the customer. 


### 2. What does this change do, exactly?
The price will be rounded in the SQL query that is responsible for counting the number of different prices.

### 3. Describe each step to reproduce the issue or behaviour.
Create a product with two variants and set the prices in s_articles_prices for instance to 10.0001, 10.0002

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [+] I have written tests and verified that they fail without my change
- [+] I have squashed any insignificant commits
- [+] This change has comments for package types, values, functions, and non-obvious lines of code
- [+] I have read the contribution requirements and fulfil them.