### PR TITLE
Create own function to push state.

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -151,19 +151,28 @@
                     $.publish('plugin/swAjaxVariant/onRequestData', [me, response, values, stateObj.location]);
 
                     if (pushState && me.hasHistorySupport) {
-                        var location = stateObj.location + '?number=' + ordernumber;
-
-                        if (stateObj.params.hasOwnProperty('c')) {
-                            location += '&c=' + stateObj.params.c;
-                        }
-
-                        window.history.pushState(stateObj.state, stateObj.title, location);
+                        me.pushState(stateObj);
                     }
                 },
                 complete: function () {
                     $.loadingIndicator.close();
                 }
             });
+        },
+        
+        /**
+         * Push state to browser history.
+         */
+        pushState: function(stateObj) {
+            var me = this;
+            
+            var location = stateObj.location + '?number=' + ordernumber;
+
+            if (stateObj.params.hasOwnProperty('c')) {
+                location += '&c=' + stateObj.params.c;
+            }
+
+            window.history.pushState(stateObj.state, stateObj.title, location);
         },
 
         /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -164,8 +164,6 @@
          * Push state to browser history.
          */
         pushState: function(stateObj) {
-            var me = this;
-            
             var location = stateObj.location + '?number=' + ordernumber;
 
             if (stateObj.params.hasOwnProperty('c')) {


### PR DESCRIPTION
### 1. Why is this change necessary?
This is useful if someone wants to change the new pushState function.
In my case i would like to override the new function to replace window.history.pushState(stateObj.state, stateObj.title, location); with window.history.replaceState(stateObj.state, stateObj.title, location);

### 2. What does this change do, exactly?
This seperates a function part to a seperate function.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.