### PR TITLE
Split SQL Query to avoid BNL Join in RiskManagement

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -1892,26 +1892,35 @@ class sAdmin
             if (!empty($value[0]) && isset($value[1])) {
                 $number = (int) str_ireplace('attr', '', $value[0]);
 
-                $sql = "
-                    SELECT s_articles_attributes.id
-                    FROM s_order_basket, s_articles_attributes, s_articles_details
-                    WHERE s_order_basket.sessionID = ?
-                    AND s_order_basket.modus = 0
-                    AND (
-                        s_order_basket.ordernumber = s_articles_details.ordernumber
-                        OR (s_order_basket.articleID = s_articles_details.articleID AND s_articles_details.kind = 1)
-                    )
-                    AND s_articles_details.id = s_articles_attributes.articledetailsID
-                    AND s_articles_attributes.attr{$number} = ?
-                    LIMIT 1
-                ";
+                $sql_productOrdernumber = $this->connection->createQueryBuilder()
+                   ->select(['s_articles_attributes.id'])
+                   ->from('s_order_basket, s_articles_attributes, s_articles_details')
+                   ->where('s_order_basket.sessionID = :sessionID')
+                   ->andWhere('s_order_basket.modus = 0')
+                   ->andWhere('s_order_basket.ordernumber = s_articles_details.ordernumber')
+                   ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
+                   ->andWhere('s_articles_attributes.attr' . $number . ' = :attrValue')
+                   ->setParameters([
+                       'attrValue' => $value[1],
+                       'sessionID' => $this->session->offsetGet('sessionId'),
+                   ])
+                   ->execute()->fetch(\PDO::FETCH_ASSOC);
 
-                $checkArticle = $this->db->fetchOne(
-                    $sql,
-                    [$this->session->offsetGet('sessionId'), $value[1]]
-                );
+                $sql_productId = $this->connection->createQueryBuilder()
+                  ->select(['s_articles_attributes.id'])
+                  ->from('s_order_basket, s_articles_attributes, s_articles_details')
+                  ->where('s_order_basket.sessionID = :sessionID')
+                  ->andWhere('s_order_basket.modus = 0')
+                  ->andWhere('s_order_basket.articleID = s_articles_details.articleID AND s_articles_details.kind = 1')
+                  ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
+                  ->andWhere('s_articles_attributes.attr' . $number . ' = :attrValue')
+                  ->setParameters([
+                      'attrValue' => $value[1],
+                      'sessionID' => $this->session->offsetGet('sessionId'),
+                  ])
+                  ->execute()->fetch(\PDO::FETCH_ASSOC);
 
-                return (bool) $checkArticle;
+                return (bool) $sql_productOrdernumber || (bool) $sql_productId;
             }
 
             return false;
@@ -1934,29 +1943,35 @@ class sAdmin
             if (!empty($value[0]) && isset($value[1])) {
                 $number = (int) str_ireplace('attr', '', $value[0]);
 
-                $sql = "
-                SELECT s_articles_attributes.id
-                FROM s_order_basket, s_articles_attributes, s_articles_details
-                WHERE
-                s_order_basket.sessionID=?
-                AND s_order_basket.modus=0
-                AND (
-                s_order_basket.ordernumber = s_articles_details.ordernumber
-                OR (s_order_basket.articleID = s_articles_details.articleID AND s_articles_details.kind = 1)
-                )
-                AND s_articles_details.id = s_articles_attributes.articledetailsID
-                AND s_articles_attributes.attr{$number}!= ?
-                LIMIT 1
-                ";
-                $checkArticle = $this->db->fetchOne(
-                    $sql,
-                    [
-                        $this->session->offsetGet('sessionId'),
-                        $value[1],
-                    ]
-                );
+                $sql_productOrdernumber = $this->connection->createQueryBuilder()
+                   ->select(['s_articles_attributes.id'])
+                   ->from('s_order_basket, s_articles_attributes, s_articles_details')
+                   ->where('s_order_basket.sessionID = :sessionID')
+                   ->andWhere('s_order_basket.modus = 0')
+                   ->andWhere('s_order_basket.ordernumber = s_articles_details.ordernumber')
+                   ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
+                   ->andWhere('s_articles_attributes.attr' . $number . ' != :attrValue')
+                   ->setParameters([
+                       'attrValue' => $value[1],
+                       'sessionID' => $this->session->offsetGet('sessionId'),
+                   ])
+                   ->execute()->fetch(\PDO::FETCH_ASSOC);
 
-                return (bool) $checkArticle;
+                $sql_productId = $this->connection->createQueryBuilder()
+                  ->select(['s_articles_attributes.id'])
+                  ->from('s_order_basket, s_articles_attributes, s_articles_details')
+                  ->where('s_order_basket.sessionID = :sessionID')
+                  ->andWhere('s_order_basket.modus = 0')
+                  ->andWhere('s_order_basket.articleID = s_articles_details.articleID AND s_articles_details.kind = 1')
+                  ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
+                  ->andWhere('s_articles_attributes.attr' . $number . ' != :attrValue')
+                  ->setParameters([
+                      'attrValue' => $value[1],
+                      'sessionID' => $this->session->offsetGet('sessionId'),
+                  ])
+                  ->execute()->fetch(\PDO::FETCH_ASSOC);
+
+                return (bool) $sql_productOrdernumber || (bool) $sql_productId;
             }
 
             return false;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
It fixes an important Risk Management (RM) performance issue. When using the attribute filter in RM the query will use the Join buffer (Block nested loop) which will take significatly more time in the checkout. Because it will be used on every product in the basket the problem will get bigger the bigger the basket is. Splitting the query in two seperate queries will decrease the time by factor 4-5! 

### 2. What does this change do, exactly?
It splits the one query in two and check the values programmaticly in PHP instead of using a join buffer in MYSQL.

### 3. Describe each step to reproduce the issue or behaviour.
Use the attribute filter in risk management, have at least a few products in the basket and +10.000 products/variants. In our setup (60.000 products / 15 products in the basket) it took almost 400-500ms per query and the basket loaded in 15-20 seconds.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.