### PR TITLE
Fixes undefined offset error in migration

### DIFF
--- a/_sql/migrations/705-rename-category-template-column.php
+++ b/_sql/migrations/705-rename-category-template-column.php
@@ -36,6 +36,10 @@ class Migrations_Migration705 extends Shopware\Components\Migrations\AbstractMig
             $templates = unserialize($serializedValue);
 
             foreach (explode(";", $templates) as $template) {
+                if (strpos($template, ":") === false) {
+                    continue;
+                }
+                
                 list($file, $name) = explode(":", $template);
 
                 if (in_array($file, $templateBlacklist) || empty($name)) {


### PR DESCRIPTION
### 1. Why is this change necessary?
When the config option `categorytemplates` has a trailing semicolon the `list()`-function throws an error when processing an empty string.

### 2. What does this change do, exactly?
Checks if the `$template` contains a colon  and only progresses if it does.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have the following value in `s_core_config_values` for the entry `categorytemplates`: `s:31:"article_listing_1col.tpl:Liste;";`
2. Apply this migration.
3. Run into undefined offset error.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.