### PR TITLE
Use data attributes in jQuery `swRegister` plugin

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -2,6 +2,16 @@
 
 This changelog references changes done in Shopware 5.5 patch versions.
 
+## 5.5.1
+
+[View all changes from v5.5.0...v5.5.1](https://github.com/shopware/shopware/compare/v5.5.0...v5.5.1)
+
+### Additions
+
+* Correctly use the data attributes in the jQuery plugin `swRegister`
+
+## 5.5.0
+
 [View all changes from v5.4.6...v5.5.0](https://github.com/shopware/shopware/compare/v5.4.6...v5.5.0)
 
 ### Additions

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
@@ -216,6 +216,8 @@
                 opts = me.opts,
                 $el = me.$el;
 
+            me.applyDataAttributes();
+
             me.$personalEmail = $el.find(opts.personalEmailSelector);
             me.$personalPassword = $el.find(opts.personalPasswordSelector);
             me.$personalEmailConfirmation = $el.find(opts.personalEmailConfirmationSelector);


### PR DESCRIPTION
### 1. Why is this change necessary?
As a theme developer one should be able to modify the defaults of the jQuery plugin `swRegister`. 

### 2. What does this change do, exactly?
Use the method `applyDataAttributes()` in the `init`-function of the `swRegister` plugin.

### 3. Describe each step to reproduce the issue or behaviour.
Try to override an option of the `swRegister` plugin.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.