### PR TITLE
Fix typo in AttributeHydrator

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/AttributeHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/AttributeHydrator.php
@@ -58,7 +58,7 @@ class AttributeHydrator extends Hydrator
     {
         $attribute = new Struct\Attribute();
         $translation = $this->getTranslation($data, null);
-        $translation = $this->extractFields('___attribute_', $translation);
+        $translation = $this->extractFields('__attribute_', $translation);
         unset($data['translation']);
         unset($data['translation_fallback']);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

It seems like there is a typo in the AttributeHydrator with one underscore too much.

### 2. What does this change do, exactly?

It removes one underscore form the `extractFields` method call.

### 3. Describe each step to reproduce the issue or behaviour.

- Fetch some attribute translations: `$translations = $translationService->readWithFallback($shopId, 1, 'article', $supplierId);`
- Try to hydrate them: `$attributeHydrator->hydrate($translations);`
- var_dump the result. The `__attribute_` prefix will still be there in the attributes.

### 4. Please link to the relevant issues (if any).

:heavy_minus_sign: 

### 5. Which documentation changes (if any) need to be made because of this PR?

:heavy_minus_sign: 

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.