### PR TITLE
Added endpoint config option to AwsS3v3Factory

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -2,6 +2,14 @@
 
 This changelog references changes done in Shopware 5.5 patch versions.
 
+## 5.5.2
+
+[View all changes from v5.5.1...v5.5.2](https://github.com/shopware/shopware/compare/v5.5.0...v5.5.1)
+
+### Additions
+
+* Added `endpoint` option to `AwsS3v3Factory` to set the S3 endpoint specifically (e.g. non-AWS S3)
+
 ## 5.5.1
 
 [View all changes from v5.5.0...v5.5.1](https://github.com/shopware/shopware/compare/v5.5.0...v5.5.1)

--- a/engine/Shopware/Bundle/MediaBundle/Adapters/AwsS3v3Factory.php
+++ b/engine/Shopware/Bundle/MediaBundle/Adapters/AwsS3v3Factory.php
@@ -62,7 +62,7 @@ class AwsS3v3Factory implements AdapterFactoryInterface
         $options = new OptionsResolver();
 
         $options->setRequired(['credentials', 'bucket', 'region']);
-        $options->setDefined(['version', 'root', 'type', 'mediaUrl', 'url']);
+        $options->setDefined(['version', 'root', 'type', 'mediaUrl', 'url', 'endpoint']);
 
         $options->setAllowedTypes('credentials', 'array');
         $options->setAllowedTypes('region', 'string');
@@ -71,6 +71,7 @@ class AwsS3v3Factory implements AdapterFactoryInterface
 
         $options->setDefault('version', 'latest');
         $options->setDefault('root', '');
+        $options->setDefault('endpoint', null);
 
         $config = $options->resolve($definition);
         $config['credentials'] = $this->resolveCredentialsOptions($config['credentials']);

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -99,6 +99,7 @@ return array_replace_recursive([
 
                 'bucket' => '',
                 'region' => '',
+                'endpoint' => null,
                 'credentials' => [
                     'key' => '',
                     'secret' => '',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

The change is neccessary to use the S3 adapter with non-AWS S3 endpoints or custom S3-URLs with CNAMEs. Like the old shopwareLabs/SwagMediaS3 module.

### 2. What does this change do, exactly?

It adds a new option `endpoint` to `AwsS3v3Factory` and defaults the value to `null`.

### 3. Describe each step to reproduce the issue or behaviour.

Set the cdn adapter to `s3` and `mediaUrl` to an non-standard AWS-S3 url, then try to load the media files from the specified custom URL. It will still connect to a standard AWS-S3 url because of the missing `endpoint` option.

### 4. Please link to the relevant issues (if any).

\-

### 5. Which documentation changes (if any) need to be made because of this PR?

\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.