### PR TITLE
Have plugin configuration inheritance in both directions (read/write)

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Plugins.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Plugins.php
@@ -40,7 +40,7 @@ class Plugins
     ) {
         $pluginManager = new \Enlight_Plugin_PluginManager($application);
 
-        $configReader = $container->get(\Shopware\Components\Plugin\CachedConfigReader::class);
+        $configReader = $container->get('shopware.plugin.configuration.cached_reader');
 
         foreach (['Core', 'Frontend', 'Backend'] as $namespace) {
             $namespace = new \Shopware_Components_Plugin_Namespace(

--- a/engine/Shopware/Components/DependencyInjection/Bridge/Plugins.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Plugins.php
@@ -25,6 +25,7 @@
 namespace Shopware\Components\DependencyInjection\Bridge;
 
 use Shopware\Components\DependencyInjection\Container;
+use Shopware\Components\Plugin\Configuration\CachedReader;
 
 class Plugins
 {
@@ -40,7 +41,8 @@ class Plugins
     ) {
         $pluginManager = new \Enlight_Plugin_PluginManager($application);
 
-        $configReader = $container->get('shopware.plugin.configuration.cached_reader');
+        /** @var CachedReader $configReader */
+        $configReader = $container->get(CachedReader::class);
 
         foreach (['Core', 'Frontend', 'Backend'] as $namespace) {
             $namespace = new \Shopware_Components_Plugin_Namespace(

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -515,11 +515,33 @@
         </service>
 
         <service id="shopware.plugin.configuration.writer" class="Shopware\Components\Plugin\Configuration\Writer">
-            <argument type="service" id="models" />
+            <argument type="service" id="shopware.plugin.configuration.language_shop_layer" />
         </service>
 
         <service id="shopware.plugin.configuration.reader" class="Shopware\Components\Plugin\Configuration\Reader">
-            <argument type="service" id="dbal_connection" />
+            <argument type="service" id="shopware.plugin.configuration.language_shop_layer"/>
+        </service>
+
+        <service id="shopware.plugin.configuration.default_layer" class="Shopware\Components\Plugin\Configuration\Layers\DefaultLayer">
+            <argument type="service" id="dbal_connection"/>
+        </service>
+
+        <service id="shopware.plugin.configuration.default_shop_layer" class="Shopware\Components\Plugin\Configuration\Layers\DefaultShopLayer">
+            <argument type="service" id="dbal_connection"/>
+            <argument type="service" id="models"/>
+            <argument type="service" id="shopware.plugin.configuration.default_layer"/>
+        </service>
+
+        <service id="shopware.plugin.configuration.sub_shop_layer" class="Shopware\Components\Plugin\Configuration\Layers\SubShopLayer">
+            <argument type="service" id="dbal_connection"/>
+            <argument type="service" id="models"/>
+            <argument type="service" id="shopware.plugin.configuration.default_shop_layer"/>
+        </service>
+
+        <service id="shopware.plugin.configuration.language_shop_layer" class="Shopware\Components\Plugin\Configuration\Layers\LanguageShopLayer">
+            <argument type="service" id="dbal_connection"/>
+            <argument type="service" id="models"/>
+            <argument type="service" id="shopware.plugin.configuration.sub_shop_layer"/>
         </service>
 
         <service id="shopware_product_stream.criteria_factory" class="Shopware\Components\ProductStream\CriteriaFactory">

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -522,11 +522,9 @@
             <argument type="service" id="Shopware\Components\Plugin\Configuration\Layers\LanguageShopLayer"/>
         </service>
 
-        <service id="shopware.plugin.configuration.cached_reader_cache" class="Symfony\Component\Cache\Simple\ArrayCache" shared="false"/>
-
         <service id="Shopware\Components\Plugin\Configuration\CachedReader">
             <argument type="service" id="Shopware\Components\Plugin\Configuration\Layers\LanguageShopLayer"/>
-            <argument type="service" id="shopware.plugin.configuration.cached_reader_cache"/>
+            <argument type="service" id="Zend_Cache_Core"/>
         </service>
 
         <service id="Shopware\Components\Plugin\Configuration\Layers\DefaultLayer">

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -522,6 +522,13 @@
             <argument type="service" id="shopware.plugin.configuration.language_shop_layer"/>
         </service>
 
+        <service id="shopware.plugin.configuration.cached_reader_cache" class="Symfony\Component\Cache\Simple\ArrayCache" shared="false"/>
+
+        <service id="shopware.plugin.configuration.cached_reader" class="Shopware\Components\Plugin\Configuration\CachedReader">
+            <argument type="service" id="shopware.plugin.configuration.language_shop_layer"/>
+            <argument type="service" id="shopware.plugin.configuration.cached_reader_cache"/>
+        </service>
+
         <service id="shopware.plugin.configuration.default_layer" class="Shopware\Components\Plugin\Configuration\Layers\DefaultLayer">
             <argument type="service" id="dbal_connection"/>
         </service>

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -502,7 +502,7 @@
         </service>
 
         <service id="shopware.plugin.config_writer" class="Shopware\Components\Plugin\ConfigWriter">
-            <argument type="service" id="shopware.plugin.configuration.writer" />
+            <argument type="service" id="Shopware\Components\Plugin\Configuration\WriterInterface" />
         </service>
 
         <service id="shopware.plugin.cached_config_reader" class="Shopware\Components\Plugin\CachedConfigReader">
@@ -511,44 +511,44 @@
         </service>
 
         <service id="shopware.plugin.config_reader" class="Shopware\Components\Plugin\DBALConfigReader">
-            <argument type="service" id="shopware.plugin.configuration.reader" />
+            <argument type="service" id="Shopware\Components\Plugin\Configuration\ReaderInterface" />
         </service>
 
-        <service id="shopware.plugin.configuration.writer" class="Shopware\Components\Plugin\Configuration\Writer">
-            <argument type="service" id="shopware.plugin.configuration.language_shop_layer" />
+        <service id="Shopware\Components\Plugin\Configuration\WriterInterface" class="Shopware\Components\Plugin\Configuration\Writer">
+            <argument type="service" id="Shopware\Components\Plugin\Configuration\Layers\LanguageShopLayer" />
         </service>
 
-        <service id="shopware.plugin.configuration.reader" class="Shopware\Components\Plugin\Configuration\Reader">
-            <argument type="service" id="shopware.plugin.configuration.language_shop_layer"/>
+        <service id="Shopware\Components\Plugin\Configuration\ReaderInterface" class="Shopware\Components\Plugin\Configuration\Reader">
+            <argument type="service" id="Shopware\Components\Plugin\Configuration\Layers\LanguageShopLayer"/>
         </service>
 
         <service id="shopware.plugin.configuration.cached_reader_cache" class="Symfony\Component\Cache\Simple\ArrayCache" shared="false"/>
 
-        <service id="shopware.plugin.configuration.cached_reader" class="Shopware\Components\Plugin\Configuration\CachedReader">
-            <argument type="service" id="shopware.plugin.configuration.language_shop_layer"/>
+        <service id="Shopware\Components\Plugin\Configuration\CachedReader">
+            <argument type="service" id="Shopware\Components\Plugin\Configuration\Layers\LanguageShopLayer"/>
             <argument type="service" id="shopware.plugin.configuration.cached_reader_cache"/>
         </service>
 
-        <service id="shopware.plugin.configuration.default_layer" class="Shopware\Components\Plugin\Configuration\Layers\DefaultLayer">
+        <service id="Shopware\Components\Plugin\Configuration\Layers\DefaultLayer">
             <argument type="service" id="dbal_connection"/>
         </service>
 
-        <service id="shopware.plugin.configuration.default_shop_layer" class="Shopware\Components\Plugin\Configuration\Layers\DefaultShopLayer">
+        <service id="Shopware\Components\Plugin\Configuration\Layers\DefaultShopLayer">
             <argument type="service" id="dbal_connection"/>
             <argument type="service" id="models"/>
-            <argument type="service" id="shopware.plugin.configuration.default_layer"/>
+            <argument type="service" id="Shopware\Components\Plugin\Configuration\Layers\DefaultLayer"/>
         </service>
 
-        <service id="shopware.plugin.configuration.sub_shop_layer" class="Shopware\Components\Plugin\Configuration\Layers\SubShopLayer">
+        <service id="Shopware\Components\Plugin\Configuration\Layers\SubShopLayer">
             <argument type="service" id="dbal_connection"/>
             <argument type="service" id="models"/>
-            <argument type="service" id="shopware.plugin.configuration.default_shop_layer"/>
+            <argument type="service" id="Shopware\Components\Plugin\Configuration\Layers\DefaultShopLayer"/>
         </service>
 
-        <service id="shopware.plugin.configuration.language_shop_layer" class="Shopware\Components\Plugin\Configuration\Layers\LanguageShopLayer">
+        <service id="Shopware\Components\Plugin\Configuration\Layers\LanguageShopLayer">
             <argument type="service" id="dbal_connection"/>
             <argument type="service" id="models"/>
-            <argument type="service" id="shopware.plugin.configuration.sub_shop_layer"/>
+            <argument type="service" id="Shopware\Components\Plugin\Configuration\Layers\SubShopLayer"/>
         </service>
 
         <service id="shopware_product_stream.criteria_factory" class="Shopware\Components\ProductStream\CriteriaFactory">

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -502,7 +502,7 @@
         </service>
 
         <service id="shopware.plugin.config_writer" class="Shopware\Components\Plugin\ConfigWriter">
-            <argument type="service" id="Shopware\Components\Model\ModelManager" />
+            <argument type="service" id="shopware.plugin.configuration.writer" />
         </service>
 
         <service id="shopware.plugin.cached_config_reader" class="Shopware\Components\Plugin\CachedConfigReader">
@@ -511,7 +511,15 @@
         </service>
 
         <service id="shopware.plugin.config_reader" class="Shopware\Components\Plugin\DBALConfigReader">
-            <argument type="service" id="Doctrine\DBAL\Connection" />
+            <argument type="service" id="shopware.plugin.configuration.reader" />
+        </service>
+
+        <service id="shopware.plugin.configuration.writer" class="Shopware\Components\Plugin\Configuration\Writer">
+            <argument type="service" id="models" />
+        </service>
+
+        <service id="shopware.plugin.configuration.reader" class="Shopware\Components\Plugin\Configuration\Reader">
+            <argument type="service" id="dbal_connection" />
         </service>
 
         <service id="shopware_product_stream.criteria_factory" class="Shopware\Components\ProductStream\CriteriaFactory">

--- a/engine/Shopware/Components/Plugin/CachedConfigReader.php
+++ b/engine/Shopware/Components/Plugin/CachedConfigReader.php
@@ -28,6 +28,9 @@ use Shopware\Components\CacheManager;
 use Shopware\Models\Shop\Shop;
 use Zend_Cache_Core as Cache;
 
+/**
+ * @deprecated Use `shopware.plugin.configuration.reader` instead
+ */
 class CachedConfigReader implements ConfigReader
 {
     /**

--- a/engine/Shopware/Components/Plugin/CachedConfigReader.php
+++ b/engine/Shopware/Components/Plugin/CachedConfigReader.php
@@ -29,7 +29,7 @@ use Shopware\Models\Shop\Shop;
 use Zend_Cache_Core as Cache;
 
 /**
- * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.cached_reader` instead
+ * @deprecated since 5.6 and removed in 5.8. Use `Shopware\Components\Plugin\Configuration\CachedReader` instead
  */
 class CachedConfigReader implements ConfigReader
 {

--- a/engine/Shopware/Components/Plugin/CachedConfigReader.php
+++ b/engine/Shopware/Components/Plugin/CachedConfigReader.php
@@ -29,7 +29,7 @@ use Shopware\Models\Shop\Shop;
 use Zend_Cache_Core as Cache;
 
 /**
- * @deprecated Use `shopware.plugin.configuration.reader` instead
+ * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.cached_reader` instead
  */
 class CachedConfigReader implements ConfigReader
 {

--- a/engine/Shopware/Components/Plugin/ConfigReader.php
+++ b/engine/Shopware/Components/Plugin/ConfigReader.php
@@ -27,7 +27,7 @@ namespace Shopware\Components\Plugin;
 use Shopware\Models\Shop\Shop;
 
 /**
- * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.reader` instead
+ * @deprecated since 5.6 and removed in 5.8. Use `Shopware\Components\Plugin\Configuration\ReaderInterface` instead
  */
 interface ConfigReader
 {
@@ -36,7 +36,7 @@ interface ConfigReader
      *
      * @return array
      *
-     * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.reader`::getByPluginName instead
+     * @deprecated since 5.6 and removed in 5.8. Use `Shopware\Components\Plugin\Configuration\ReaderInterface`::getByPluginName instead
      */
     public function getByPluginName($pluginName, Shop $shop = null);
 }

--- a/engine/Shopware/Components/Plugin/ConfigReader.php
+++ b/engine/Shopware/Components/Plugin/ConfigReader.php
@@ -27,7 +27,7 @@ namespace Shopware\Components\Plugin;
 use Shopware\Models\Shop\Shop;
 
 /**
- * @deprecated Use `shopware.plugin.configuration.reader` instead
+ * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.reader` instead
  */
 interface ConfigReader
 {
@@ -36,7 +36,7 @@ interface ConfigReader
      *
      * @return array
      *
-     * @deprecated Use `shopware.plugin.configuration.reader`::getByPluginName instead
+     * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.reader`::getByPluginName instead
      */
     public function getByPluginName($pluginName, Shop $shop = null);
 }

--- a/engine/Shopware/Components/Plugin/ConfigWriter.php
+++ b/engine/Shopware/Components/Plugin/ConfigWriter.php
@@ -25,99 +25,50 @@
 namespace Shopware\Components\Plugin;
 
 use Shopware\Components\Model\ModelManager;
-use Shopware\Models\Config\Element;
-use Shopware\Models\Config\Form;
-use Shopware\Models\Config\Value;
+use Shopware\Components\Plugin\Configuration\WriterInterface;
 use Shopware\Models\Plugin\Plugin;
 use Shopware\Models\Shop\Shop;
 
+/**
+ * @deprecated Use `shopware.plugin.configuration.writer` instead
+ */
 class ConfigWriter
 {
     /**
-     * @var ModelManager
+     * @var WriterInterface
      */
-    private $em;
+    private $writer;
 
-    /**
-     * @var \Doctrine\ORM\EntityRepository
-     */
-    private $elementRepository;
-
-    /**
-     * @var \Doctrine\ORM\EntityRepository
-     */
-    private $formRepository;
-
-    /**
-     * @var \Doctrine\ORM\EntityRepository
-     */
-    private $valueRepository;
-
-    public function __construct(ModelManager $em)
+    public function __construct(WriterInterface $writer)
     {
-        $this->em = $em;
-
-        $this->elementRepository = $this->em->getRepository(Element::class);
-        $this->formRepository = $this->em->getRepository(Form::class);
-        $this->valueRepository = $this->em->getRepository(Value::class);
+        $this->writer = $writer;
     }
 
     /**
-     * @param array $elements
+     * @param Plugin $plugin
+     * @param array  $elements
+     * @param Shop   $shop
+     *
+     * @deprecated Use `shopware.plugin.configuration.writer`::setByPluginName instead
      */
     public function savePluginConfig(Plugin $plugin, $elements, Shop $shop)
     {
-        foreach ($elements as $name => $value) {
-            $this->saveConfigElement($plugin, $name, $value, $shop);
-        }
+        $this->writer->setByPluginName($plugin->getName(), $elements, $shop->getId());
     }
 
     /**
      * @param string $name
      *
      * @throws \Exception
+     *
+     * @deprecated Use `shopware.plugin.configuration.writer`::setByPluginName instead
      */
     public function saveConfigElement(Plugin $plugin, $name, $value, Shop $shop)
     {
-        /** @var Form $form */
-        $form = $this->formRepository->findOneBy(['pluginId' => $plugin->getId()]);
-
-        /** @var Element|null $element */
-        $element = $this->elementRepository->findOneBy(['form' => $form, 'name' => $name]);
-        if (!$element) {
-            throw new \Exception(sprintf('Config element "%s" not found.', $name));
-        }
-
-        if ($element->getScope() == 0 && $shop->getId() !== 1) {
-            throw new \InvalidArgumentException(sprintf("Element '%s' is not writeable for shop %s", $element->getName(), $shop->getId()));
-        }
-
-        $defaultValue = $element->getValue();
-
-        /** @var Value|null $valueModel */
-        $valueModel = $this->valueRepository->findOneBy(['shop' => $shop, 'element' => $element]);
-
-        if (!$valueModel) {
-            if ($value == $defaultValue || $value === null) {
-                return;
-            }
-
-            $valueModel = new Value();
-            $valueModel->setElement($element);
-            $valueModel->setShop($shop);
-            $valueModel->setValue($value);
-
-            $this->em->persist($valueModel);
-            $this->em->flush($valueModel);
-
-            return;
-        }
-
-        if ($value == $defaultValue || $value === null) {
-            $this->em->remove($valueModel);
-        } else {
-            $valueModel->setValue($value);
-        }
-        $this->em->flush($valueModel);
+        $this->writer->setByPluginName(
+            $plugin->getName(),
+            [$name => $value],
+            $shop->getId()
+        );
     }
 }

--- a/engine/Shopware/Components/Plugin/ConfigWriter.php
+++ b/engine/Shopware/Components/Plugin/ConfigWriter.php
@@ -24,13 +24,12 @@
 
 namespace Shopware\Components\Plugin;
 
-use Shopware\Components\Model\ModelManager;
 use Shopware\Components\Plugin\Configuration\WriterInterface;
 use Shopware\Models\Plugin\Plugin;
 use Shopware\Models\Shop\Shop;
 
 /**
- * @deprecated Use `shopware.plugin.configuration.writer` instead
+ * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.writer` instead
  */
 class ConfigWriter
 {
@@ -45,11 +44,9 @@ class ConfigWriter
     }
 
     /**
-     * @param Plugin $plugin
-     * @param array  $elements
-     * @param Shop   $shop
+     * @param array $elements
      *
-     * @deprecated Use `shopware.plugin.configuration.writer`::setByPluginName instead
+     * @deprecated Use since 5.6 and removed in 5.8. `shopware.plugin.configuration.writer`::setByPluginName instead
      */
     public function savePluginConfig(Plugin $plugin, $elements, Shop $shop)
     {
@@ -61,7 +58,7 @@ class ConfigWriter
      *
      * @throws \Exception
      *
-     * @deprecated Use `shopware.plugin.configuration.writer`::setByPluginName instead
+     * @deprecated Use since 5.6 and removed in 5.8. `shopware.plugin.configuration.writer`::setByPluginName instead
      */
     public function saveConfigElement(Plugin $plugin, $name, $value, Shop $shop)
     {

--- a/engine/Shopware/Components/Plugin/ConfigWriter.php
+++ b/engine/Shopware/Components/Plugin/ConfigWriter.php
@@ -29,7 +29,7 @@ use Shopware\Models\Plugin\Plugin;
 use Shopware\Models\Shop\Shop;
 
 /**
- * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.writer` instead
+ * @deprecated since 5.6 and removed in 5.8. Use `Shopware\Components\Plugin\Configuration\WriterInterface` instead
  */
 class ConfigWriter
 {
@@ -46,7 +46,7 @@ class ConfigWriter
     /**
      * @param array $elements
      *
-     * @deprecated Use since 5.6 and removed in 5.8. `shopware.plugin.configuration.writer`::setByPluginName instead
+     * @deprecated Use since 5.6 and removed in 5.8. `Shopware\Components\Plugin\Configuration\WriterInterface`::setByPluginName instead
      */
     public function savePluginConfig(Plugin $plugin, $elements, Shop $shop)
     {
@@ -58,7 +58,7 @@ class ConfigWriter
      *
      * @throws \Exception
      *
-     * @deprecated Use since 5.6 and removed in 5.8. `shopware.plugin.configuration.writer`::setByPluginName instead
+     * @deprecated Use since 5.6 and removed in 5.8. `Shopware\Components\Plugin\Configuration\WriterInterface`::setByPluginName instead
      */
     public function saveConfigElement(Plugin $plugin, $name, $value, Shop $shop)
     {

--- a/engine/Shopware/Components/Plugin/Configuration/CachedReader.php
+++ b/engine/Shopware/Components/Plugin/Configuration/CachedReader.php
@@ -47,8 +47,12 @@ class CachedReader implements ReaderInterface
     {
         $cacheKey = $this->buildCacheKey($pluginName, $shopId);
 
-        if ($this->cache->test($cacheKey)) {
-            return $this->cache->load($cacheKey, true);
+        if ($this->cache->test($cacheKey) !== false) {
+            $cacheResult = $this->cache->load($cacheKey, true);
+
+            if (is_array($cacheResult)) {
+                return $cacheResult;
+            }
         }
 
         $readValues = $this->layer->readValues($pluginName, $shopId);

--- a/engine/Shopware/Components/Plugin/Configuration/CachedReader.php
+++ b/engine/Shopware/Components/Plugin/Configuration/CachedReader.php
@@ -51,7 +51,7 @@ class CachedReader implements ReaderInterface
             return $this->cache->load($cacheKey, true);
         }
 
-        $readValues = $this->layer->readValues($shopId, $pluginName);
+        $readValues = $this->layer->readValues($pluginName, $shopId);
 
         try {
             $this->cache->save(

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
@@ -63,7 +63,7 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
         return $this->parent;
     }
 
-    public function readValues(?int $shopId, string $pluginName): array
+    public function readValues(string $pluginName, ?int $shopId): array
     {
         $builder = $this->getConnection()->createQueryBuilder();
 
@@ -98,13 +98,13 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
             ->fetchAll(\PDO::FETCH_KEY_PAIR)
         ;
 
-        return $this->mergeValues($this->getParent()->readValues($shopId, $pluginName), $this->unserializeArray($values));
+        return $this->mergeValues($this->getParent()->readValues($pluginName, $shopId), $this->unserializeArray($values));
     }
 
-    public function writeValues(?int $shopId, string $pluginName, array $data): void
+    public function writeValues(string $pluginName, ?int $shopId, array $data): void
     {
         if (!$this->isLayerResponsibleForShopId($shopId)) {
-            $this->getParent()->writeValues($shopId, $pluginName, $data);
+            $this->getParent()->writeValues($pluginName, $shopId, $data);
 
             return;
         }
@@ -124,7 +124,7 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
             throw new WriterException(sprintf('Plugin formular by plugin id "%u" not found.', $plugin->getId()));
         }
 
-        $parentValues = $this->getParent()->readValues($shopId, $pluginName);
+        $parentValues = $this->getParent()->readValues($pluginName, $shopId);
 
         foreach ($data as $key => $value) {
             $this->writeValue(

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
@@ -107,7 +107,7 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
             ->fetchAll(\PDO::FETCH_KEY_PAIR)
         ;
 
-        // TODO use a serialization helepr
+        // TODO use a serialization helper
         return $this->mergeValues($this->getParent()->readValues($shopId, $pluginName), $this->unserializeArray($values));
     }
 

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin\Configuration\Layers;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\ORM\OptimisticLockException;
+use InvalidArgumentException;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Components\Plugin\Configuration\WriterException;
+use Shopware\Models\Config\Element;
+use Shopware\Models\Config\Form;
+use Shopware\Models\Config\Value;
+use Shopware\Models\Plugin\Plugin;
+
+abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    /** @var ConfigurationLayerInterface */
+    private $parent;
+
+    /** @var ModelManager */
+    private $modelManager;
+
+    public function __construct(Connection $connection, ModelManager $modelManager, ConfigurationLayerInterface $parent)
+    {
+        $this->connection = $connection;
+        $this->modelManager = $modelManager;
+        $this->parent = $parent;
+    }
+
+    /**
+     * @return Connection
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
+     * @return ConfigurationLayerInterface
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function readValues($shopId, $pluginName)
+    {
+        $builder = $this->getConnection()->createQueryBuilder();
+
+        $builder->from('s_core_config_values', 'coreConfigValues')
+            ->innerJoin(
+                'coreConfigValues',
+                's_core_config_elements',
+                'coreConfigElements',
+                'coreConfigValues.element_id = coreConfigElements.id'
+            )
+            ->innerJoin(
+                'coreConfigElements',
+                's_core_config_forms',
+                'coreConfigForms',
+                'coreConfigElements.form_id = coreConfigForms.id'
+            )
+            ->innerJoin(
+                'coreConfigForms',
+                's_core_plugins',
+                'corePlugins',
+                'coreConfigForms.plugin_id = corePlugins.id'
+            )
+        ;
+
+        $builder = $this->configureQuery($builder, $shopId, $pluginName);
+
+        $values = $builder->select([
+                'coreConfigElements.name',
+                'coreConfigValues.value',
+            ])
+            ->execute()
+            ->fetchAll(\PDO::FETCH_KEY_PAIR)
+        ;
+
+        // TODO use a serialization helepr
+        return $this->mergeValues($this->getParent()->readValues($shopId, $pluginName), $this->unserializeArray($values));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writeValues($shopId, $pluginName, array $data)
+    {
+        if (!$this->isLayerResponsibleForShopId($shopId)) {
+            return $this->getParent()->writeValues($shopId, $pluginName, $data);
+        }
+
+        $pluginRepository = $this->modelManager->getRepository(Plugin::class);
+        $formRepository = $this->modelManager->getRepository(Form::class);
+
+        /** @var Plugin $plugin */
+        $plugin = $pluginRepository->findOneBy(['name' => $pluginName]);
+        if (is_null($plugin)) {
+            throw new WriterException(sprintf('Plugin by name "%s" not found.', $pluginName));
+        }
+
+        /** @var $form Form */
+        $form = $formRepository->findOneBy(['pluginId' => $plugin->getId()]);
+        if (is_null($form)) {
+            throw new WriterException(sprintf('Plugin formular by plugin id "%i" not found.', $plugin->getId()));
+        }
+
+        $parentValues = $this->getParent()->readValues($shopId, $pluginName);
+
+        foreach ($data as $key => $value) {
+            $this->writeValue(
+                $shopId,
+                $form,
+                $key,
+                $value,
+                array_key_exists($key, $parentValues) ? $parentValues[$key] : null
+            );
+        }
+    }
+
+    /**
+     * @param int|null $shopId
+     * @param Form     $form
+     * @param string   $name
+     * @param mixed    $value
+     * @param mixed    $parentValue
+     *
+     * @throws WriterException
+     */
+    public function writeValue($shopId, $form, $name, $value, $parentValue)
+    {
+        $elementRepository = $this->modelManager->getRepository(Element::class);
+        $valueRepository = $this->modelManager->getRepository(Value::class);
+
+        /** @var $element Element */
+        $element = $elementRepository->findOneBy(['form' => $form, 'name' => $name]);
+        if (!$element) {
+            throw new WriterException(sprintf('Config element "%s" not found.', $name));
+        }
+
+        if ($element->getScope() == 0 && $shopId !== 1) {
+            $message = sprintf("Element '%s' is not writeable for shop %i", $element->getName(), $shopId);
+            $baseException = new InvalidArgumentException($message);
+            throw new WriterException('Element is not valid', 0, $baseException);
+        }
+
+        /** @var Value $valueModel */
+        $valueModel = $valueRepository->findOneBy(['shopId' => $shopId, 'element' => $element]);
+
+        if (!$valueModel) {
+            if ($value === $parentValue || $value === null) {
+                return;
+            }
+
+            $valueModel = new Value();
+            $valueModel->setElement($element);
+            $valueModel->setShopId($shopId);
+            // serialize done by Doctrine
+            $valueModel->setValue($value);
+
+            $this->modelManager->persist($valueModel);
+            try {
+                $this->modelManager->flush($valueModel);
+            } catch (OptimisticLockException $e) {
+                throw new WriterException('Failed writing to database', 0, $e);
+            }
+
+            return;
+        }
+
+        if ($value === $parentValue || $value === null) {
+            $this->modelManager->remove($valueModel);
+        } else {
+            // serialize done by Doctrine
+            $valueModel->setValue($value);
+        }
+
+        try {
+            $this->modelManager->flush($valueModel);
+        } catch (OptimisticLockException $e) {
+            throw new WriterException('Failed writing to database', 0, $e);
+        }
+    }
+
+    /**
+     * @param array $values
+     *
+     * @return array
+     */
+    public static function unserializeArray(array $values)
+    {
+        $result = [];
+
+        foreach ($values as $key => $value) {
+            $result[$key] = empty($value) ? null : @unserialize($value);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array $old
+     * @param array $new
+     *
+     * @return array
+     */
+    protected function mergeValues(array $old, array $new)
+    {
+        foreach ($new as $key => $value) {
+            if (!array_key_exists($key, $old) || !is_null($value)) {
+                $old[$key] = $value;
+            }
+        }
+
+        return $old;
+    }
+
+    /**
+     * @param QueryBuilder $builder
+     * @param int|null     $shopId
+     * @param string       $pluginName
+     *
+     * @return QueryBuilder
+     */
+    abstract protected function configureQuery(QueryBuilder $builder, $shopId, $pluginName);
+
+    /**
+     * @param int|null $shopId
+     *
+     * @return bool
+     */
+    abstract protected function isLayerResponsibleForShopId($shopId);
+}

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
@@ -98,7 +98,6 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
             ->fetchAll(\PDO::FETCH_KEY_PAIR)
         ;
 
-        // TODO use a serialization helper
         return $this->mergeValues($this->getParent()->readValues($shopId, $pluginName), $this->unserializeArray($values));
     }
 

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
@@ -114,13 +114,13 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
 
         /** @var Plugin|null $plugin */
         $plugin = $pluginRepository->findOneBy(['name' => $pluginName]);
-        if (is_null($plugin)) {
+        if ($plugin === null) {
             throw new WriterException(sprintf('Plugin by name "%s" not found.', $pluginName));
         }
 
         /** @var Form|null $form */
         $form = $formRepository->findOneBy(['pluginId' => $plugin->getId()]);
-        if (is_null($form)) {
+        if ($form === null) {
             throw new WriterException(sprintf('Plugin formular by plugin id "%u" not found.', $plugin->getId()));
         }
 
@@ -147,7 +147,7 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
 
         /** @var Element|null $element */
         $element = $elementRepository->findOneBy(['form' => $form, 'name' => $name]);
-        if (is_null($element)) {
+        if ($element === null) {
             throw new WriterException(sprintf('Config element "%s" not found.', $name));
         }
 
@@ -160,7 +160,7 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
         /** @var Value|null $valueModel */
         $valueModel = $valueRepository->findOneBy(['shopId' => $shopId, 'element' => $element]);
 
-        if (is_null($valueModel)) {
+        if ($valueModel === null) {
             if ($value === $parentValue || $value === null) {
                 return;
             }
@@ -209,7 +209,7 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
     protected function mergeValues(array $old, array $new): array
     {
         foreach ($new as $key => $value) {
-            if (!array_key_exists($key, $old) || !is_null($value)) {
+            if (!array_key_exists($key, $old) || $value !== null) {
                 $old[$key] = $value;
             }
         }

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShopConfigurationLayer.php
@@ -53,11 +53,6 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
         $this->parent = $parent;
     }
 
-    public function getConnection(): Connection
-    {
-        return $this->connection;
-    }
-
     public function getParent(): ConfigurationLayerInterface
     {
         return $this->parent;
@@ -204,6 +199,11 @@ abstract class AbstractShopConfigurationLayer implements ConfigurationLayerInter
         }
 
         return $result;
+    }
+
+    protected function getConnection(): Connection
+    {
+        return $this->connection;
     }
 
     protected function mergeValues(array $old, array $new): array

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/ConfigurationLayerInterface.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/ConfigurationLayerInterface.php
@@ -22,25 +22,30 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Components\Plugin\Configuration;
+namespace Shopware\Components\Plugin\Configuration\Layers;
 
-use Shopware\Components\Plugin\Configuration\Layers\ConfigurationLayerInterface;
+use Shopware\Components\Plugin\Configuration\WriterException;
 
-class Writer implements WriterInterface
+interface ConfigurationLayerInterface
 {
-    /** @var ConfigurationLayerInterface */
-    private $lastLayer;
-
-    public function __construct(ConfigurationLayerInterface $lastLayer)
-    {
-        $this->lastLayer = $lastLayer;
-    }
+    /**
+     * Read the values attached to this layer by shop and plugin name
+     *
+     * @param int|null $shopId
+     * @param string   $pluginName
+     *
+     * @return array
+     */
+    public function readValues($shopId, $pluginName);
 
     /**
-     * {@inheritdoc}
+     * Write the values attached to this layer by shop and plugin name
+     *
+     * @param int|null $shopId
+     * @param string   $pluginName
+     * @param array    $data
+     *
+     * @throws WriterException
      */
-    public function setByPluginName($pluginName, array $elements, $shopId = 1)
-    {
-        return $this->lastLayer->writeValues($shopId, $pluginName, $elements);
-    }
+    public function writeValues($shopId, $pluginName, array $data);
 }

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/ConfigurationLayerInterface.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/ConfigurationLayerInterface.php
@@ -30,22 +30,13 @@ interface ConfigurationLayerInterface
 {
     /**
      * Read the values attached to this layer by shop and plugin name
-     *
-     * @param int|null $shopId
-     * @param string   $pluginName
-     *
-     * @return array
      */
-    public function readValues($shopId, $pluginName);
+    public function readValues(?int $shopId, string $pluginName): array;
 
     /**
      * Write the values attached to this layer by shop and plugin name
      *
-     * @param int|null $shopId
-     * @param string   $pluginName
-     * @param array    $data
-     *
      * @throws WriterException
      */
-    public function writeValues($shopId, $pluginName, array $data);
+    public function writeValues(?int $shopId, string $pluginName, array $data): void;
 }

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/ConfigurationLayerInterface.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/ConfigurationLayerInterface.php
@@ -31,12 +31,12 @@ interface ConfigurationLayerInterface
     /**
      * Read the values attached to this layer by shop and plugin name
      */
-    public function readValues(?int $shopId, string $pluginName): array;
+    public function readValues(string $pluginName, ?int $shopId): array;
 
     /**
      * Write the values attached to this layer by shop and plugin name
      *
      * @throws WriterException
      */
-    public function writeValues(?int $shopId, string $pluginName, array $data): void;
+    public function writeValues(string $pluginName, ?int $shopId, array $data): void;
 }

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
@@ -69,7 +69,7 @@ class DefaultLayer implements ConfigurationLayerInterface
             ->fetchAll(\PDO::FETCH_KEY_PAIR)
         ;
 
-        // TODO use a serialization helepr
+        // TODO use a serialization helper
         return AbstractShopConfigurationLayer::unserializeArray($values);
     }
 

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin\Configuration\Layers;
+
+use Doctrine\DBAL\Connection;
+use LogicException;
+use Shopware\Components\Plugin\Configuration\WriterException;
+
+class DefaultLayer implements ConfigurationLayerInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function readValues($shopId, $pluginName)
+    {
+        $pluginNameKey = 'pluginName' . crc32($pluginName);
+        $builder = $this->connection->createQueryBuilder();
+
+        $values = $builder->from('s_core_config_elements', 'coreConfigElements')
+            ->innerJoin(
+                'coreConfigElements',
+                's_core_config_forms',
+                'coreConfigForms',
+                'coreConfigElements.form_id = coreConfigForms.id'
+            )
+            ->innerJoin(
+                'coreConfigForms',
+                's_core_plugins',
+                'corePlugins',
+                'coreConfigForms.plugin_id = corePlugins.id'
+            )
+            ->andWhere($builder->expr()->eq('corePlugins.name', ':' . $pluginNameKey))
+            ->setParameter($pluginNameKey, $pluginName)
+            ->select([
+                'coreConfigElements.name',
+                'coreConfigElements.value',
+            ])
+            ->execute()
+            ->fetchAll(\PDO::FETCH_KEY_PAIR)
+        ;
+
+        // TODO use a serialization helepr
+        return AbstractShopConfigurationLayer::unserializeArray($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writeValues($shopId, $pluginName, array $data)
+    {
+        $baseException = new LogicException('Cannot change values on default layer');
+        throw new WriterException($baseException);
+    }
+}

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
@@ -66,7 +66,6 @@ class DefaultLayer implements ConfigurationLayerInterface
             ->fetchAll(\PDO::FETCH_KEY_PAIR)
         ;
 
-        // TODO use a serialization helper
         return AbstractShopConfigurationLayer::unserializeArray($values);
     }
 

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
@@ -38,7 +38,7 @@ class DefaultLayer implements ConfigurationLayerInterface
         $this->connection = $connection;
     }
 
-    public function readValues(?int $shopId, string $pluginName): array
+    public function readValues(string $pluginName, ?int $shopId): array
     {
         $pluginNameKey = 'pluginName' . crc32($pluginName);
         $builder = $this->connection->createQueryBuilder();
@@ -69,7 +69,7 @@ class DefaultLayer implements ConfigurationLayerInterface
         return AbstractShopConfigurationLayer::unserializeArray($values);
     }
 
-    public function writeValues(?int $shopId, string $pluginName, array $data): void
+    public function writeValues(string $pluginName, ?int $shopId, array $data): void
     {
         $baseException = new LogicException('Cannot change values on default layer');
         throw new WriterException($baseException);

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
@@ -38,10 +38,7 @@ class DefaultLayer implements ConfigurationLayerInterface
         $this->connection = $connection;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function readValues($shopId, $pluginName)
+    public function readValues(?int $shopId, string $pluginName): array
     {
         $pluginNameKey = 'pluginName' . crc32($pluginName);
         $builder = $this->connection->createQueryBuilder();
@@ -73,10 +70,7 @@ class DefaultLayer implements ConfigurationLayerInterface
         return AbstractShopConfigurationLayer::unserializeArray($values);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function writeValues($shopId, $pluginName, array $data)
+    public function writeValues(?int $shopId, string $pluginName, array $data): void
     {
         $baseException = new LogicException('Cannot change values on default layer');
         throw new WriterException($baseException);

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultShopLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultShopLayer.php
@@ -28,9 +28,9 @@ use Doctrine\DBAL\Query\QueryBuilder;
 
 class DefaultShopLayer extends AbstractShopConfigurationLayer
 {
-    public function readValues(?int $shopId, string $pluginName): array
+    public function readValues(string $pluginName, ?int $shopId): array
     {
-        return parent::readValues(1, $pluginName);
+        return parent::readValues($pluginName, 1);
     }
 
     protected function configureQuery(QueryBuilder $builder, ?int $shopId, string $pluginName): QueryBuilder

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultShopLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultShopLayer.php
@@ -28,20 +28,14 @@ use Doctrine\DBAL\Query\QueryBuilder;
 
 class DefaultShopLayer extends AbstractShopConfigurationLayer
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function readValues($shopId, $pluginName)
+    public function readValues(?int $shopId, string $pluginName): array
     {
         return parent::readValues(1, $pluginName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function configureQuery(QueryBuilder $builder, $shopId, $pluginName)
+    protected function configureQuery(QueryBuilder $builder, ?int $shopId, string $pluginName): QueryBuilder
     {
-        $shopIdKey = 'shopId' . crc32($shopId);
+        $shopIdKey = 'shopId' . crc32(strval($shopId) ?? '');
         $pluginNameKey = 'pluginName' . crc32($pluginName);
 
         return $builder
@@ -52,10 +46,7 @@ class DefaultShopLayer extends AbstractShopConfigurationLayer
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function isLayerResponsibleForShopId($shopId)
+    protected function isLayerResponsibleForShopId(?int $shopId): bool
     {
         return $shopId === 1 || is_null($shopId);
     }

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/LanguageShopLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/LanguageShopLayer.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin\Configuration\Layers;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+
+class LanguageShopLayer extends AbstractShopConfigurationLayer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function readValues($shopId, $pluginName)
+    {
+        return is_null($shopId) ? [] : parent::readValues($shopId, $pluginName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureQuery(QueryBuilder $builder, $shopId, $pluginName)
+    {
+        $shopIdKey = 'shopId' . crc32($shopId);
+        $pluginNameKey = 'pluginName' . crc32($pluginName);
+
+        return $builder
+            ->andWhere($builder->expr()->eq('corePlugins.name', ':' . $pluginNameKey))
+            ->andWhere($builder->expr()->eq('coreConfigValues.shop_id', ':' . $shopIdKey))
+            ->setParameter($pluginNameKey, $pluginName)
+            ->setParameter($shopIdKey, $shopId)
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function isLayerResponsibleForShopId($shopId)
+    {
+        $queryBuilder = $this->getConnection()->createQueryBuilder();
+
+        return $queryBuilder->from('s_core_shops')
+            ->select('1')
+            ->andWhere($queryBuilder->expr()->eq('id', ':id'))
+            ->andWhere($queryBuilder->expr()->isNotNull('main_id'))
+            ->setParameter('id', $shopId)
+            ->execute()->fetchColumn() !== false
+        ;
+    }
+}

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/LanguageShopLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/LanguageShopLayer.php
@@ -28,13 +28,13 @@ use Doctrine\DBAL\Query\QueryBuilder;
 
 class LanguageShopLayer extends AbstractShopConfigurationLayer
 {
-    public function readValues(?int $shopId, string $pluginName): array
+    public function readValues(string $pluginName, ?int $shopId): array
     {
         if (is_null($shopId)) {
-            return $this->getParent()->readValues($shopId, $pluginName);
+            return $this->getParent()->readValues($pluginName, $shopId);
         }
 
-        return parent::readValues($shopId, $pluginName);
+        return parent::readValues($pluginName, $shopId);
     }
 
     protected function configureQuery(QueryBuilder $builder, ?int $shopId, string $pluginName): QueryBuilder

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/LanguageShopLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/LanguageShopLayer.php
@@ -28,20 +28,18 @@ use Doctrine\DBAL\Query\QueryBuilder;
 
 class LanguageShopLayer extends AbstractShopConfigurationLayer
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function readValues($shopId, $pluginName)
+    public function readValues(?int $shopId, string $pluginName): array
     {
-        return is_null($shopId) ? [] : parent::readValues($shopId, $pluginName);
+        if (is_null($shopId)) {
+            return $this->getParent()->readValues($shopId, $pluginName);
+        }
+
+        return parent::readValues($shopId, $pluginName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function configureQuery(QueryBuilder $builder, $shopId, $pluginName)
+    protected function configureQuery(QueryBuilder $builder, ?int $shopId, string $pluginName): QueryBuilder
     {
-        $shopIdKey = 'shopId' . crc32($shopId);
+        $shopIdKey = 'shopId' . crc32(strval($shopId ?? ''));
         $pluginNameKey = 'pluginName' . crc32($pluginName);
 
         return $builder
@@ -52,10 +50,7 @@ class LanguageShopLayer extends AbstractShopConfigurationLayer
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function isLayerResponsibleForShopId($shopId)
+    protected function isLayerResponsibleForShopId(?int $shopId): bool
     {
         $queryBuilder = $this->getConnection()->createQueryBuilder();
 

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/SubShopLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/SubShopLayer.php
@@ -28,20 +28,18 @@ use Doctrine\DBAL\Query\QueryBuilder;
 
 class SubShopLayer extends AbstractShopConfigurationLayer
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function readValues($shopId, $pluginName)
+    public function readValues(?int $shopId, string $pluginName): array
     {
-        return is_null($shopId) ? [] : parent::readValues($shopId, $pluginName);
+        if (is_null($shopId)) {
+            return $this->getParent()->readValues($shopId, $pluginName);
+        }
+
+        return parent::readValues($shopId, $pluginName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function configureQuery(QueryBuilder $builder, $shopId, $pluginName)
+    protected function configureQuery(QueryBuilder $builder, ?int $shopId, string $pluginName): QueryBuilder
     {
-        $shopIdKey = 'shopId' . crc32($shopId);
+        $shopIdKey = 'shopId' . crc32(strval($shopId ?? ''));
         $pluginNameKey = 'pluginName' . crc32($pluginName);
 
         return $builder
@@ -58,10 +56,7 @@ class SubShopLayer extends AbstractShopConfigurationLayer
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function isLayerResponsibleForShopId($shopId)
+    protected function isLayerResponsibleForShopId(?int $shopId): bool
     {
         $queryBuilder = $this->getConnection()->createQueryBuilder();
 

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/SubShopLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/SubShopLayer.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin\Configuration\Layers;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+
+class SubShopLayer extends AbstractShopConfigurationLayer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function readValues($shopId, $pluginName)
+    {
+        return is_null($shopId) ? [] : parent::readValues($shopId, $pluginName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureQuery(QueryBuilder $builder, $shopId, $pluginName)
+    {
+        $shopIdKey = 'shopId' . crc32($shopId);
+        $pluginNameKey = 'pluginName' . crc32($pluginName);
+
+        return $builder
+            ->innerJoin(
+                'coreConfigValues',
+                's_core_shops',
+                'coreShops',
+                'coreConfigValues.shop_id = coreShops.main_id'
+            )
+            ->andWhere($builder->expr()->eq('corePlugins.name', ':' . $pluginNameKey))
+            ->andWhere($builder->expr()->eq('coreShops.id', ':' . $shopIdKey))
+            ->setParameter($pluginNameKey, $pluginName)
+            ->setParameter($shopIdKey, $shopId)
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function isLayerResponsibleForShopId($shopId)
+    {
+        $queryBuilder = $this->getConnection()->createQueryBuilder();
+
+        return $queryBuilder->from('s_core_shops')
+                ->select('1')
+                ->andWhere($queryBuilder->expr()->eq('id', ':id'))
+                ->andWhere($queryBuilder->expr()->isNull('main_id'))
+                ->setParameter('id', $shopId)
+                ->execute()->fetchColumn() !== false
+        ;
+    }
+}

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/SubShopLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/SubShopLayer.php
@@ -28,13 +28,13 @@ use Doctrine\DBAL\Query\QueryBuilder;
 
 class SubShopLayer extends AbstractShopConfigurationLayer
 {
-    public function readValues(?int $shopId, string $pluginName): array
+    public function readValues(string $pluginName, ?int $shopId): array
     {
         if (is_null($shopId)) {
-            return $this->getParent()->readValues($shopId, $pluginName);
+            return $this->getParent()->readValues($pluginName, $shopId);
         }
 
-        return parent::readValues($shopId, $pluginName);
+        return parent::readValues($pluginName, $shopId);
     }
 
     protected function configureQuery(QueryBuilder $builder, ?int $shopId, string $pluginName): QueryBuilder

--- a/engine/Shopware/Components/Plugin/Configuration/Reader.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Reader.php
@@ -38,6 +38,6 @@ class Reader implements ReaderInterface
 
     public function getByPluginName(string $pluginName, ?int $shopId = null): array
     {
-        return $this->layer->readValues($shopId, $pluginName);
+        return $this->layer->readValues($pluginName, $shopId);
     }
 }

--- a/engine/Shopware/Components/Plugin/Configuration/Reader.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Reader.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin\Configuration;
+
+use Doctrine\DBAL\Connection;
+
+class Reader implements ReaderInterface
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getByPluginName($pluginName, $shopId = null)
+    {
+        $mainShop = $this->connection->createQueryBuilder()
+            ->from('s_core_shops', 'shop')
+            ->select(['shop.main_id'])
+            ->where('shop.id = :shopId')
+            ->setParameter('shopId', $shopId ?: 1)
+            ->execute()
+            ->fetchColumn() ?: 1;
+
+        $sql = <<<'SQL'
+SELECT
+  ce.name,
+  COALESCE(currentShop.value, parentShop.value, fallbackShop.value, ce.value) as value
+
+FROM s_core_plugins p
+
+INNER JOIN s_core_config_forms cf
+  ON cf.plugin_id = p.id
+
+INNER JOIN s_core_config_elements ce
+  ON ce.form_id = cf.id
+
+LEFT JOIN s_core_config_values currentShop
+  ON currentShop.element_id = ce.id
+  AND currentShop.shop_id = :currentShopId
+
+LEFT JOIN s_core_config_values parentShop
+  ON parentShop.element_id = ce.id
+  AND parentShop.shop_id = :parentShopId
+
+LEFT JOIN s_core_config_values fallbackShop
+  ON fallbackShop.element_id = ce.id
+  AND fallbackShop.shop_id = :fallbackShopId
+
+WHERE p.name=:pluginName
+SQL;
+
+        $stmt = $this->connection->prepare($sql);
+        $stmt->execute([
+            'fallbackShopId' => 1, //Shop parent id
+            'parentShopId' => $mainShop,
+            'currentShopId' => $shopId,
+            'pluginName' => $pluginName,
+        ]);
+
+        $config = $stmt->fetchAll(\PDO::FETCH_KEY_PAIR);
+
+        foreach ($config as $key => $value) {
+            $config[$key] = !empty($value) ? @unserialize($value) : null;
+        }
+
+        return $config;
+    }
+}

--- a/engine/Shopware/Components/Plugin/Configuration/ReaderInterface.php
+++ b/engine/Shopware/Components/Plugin/Configuration/ReaderInterface.php
@@ -26,11 +26,5 @@ namespace Shopware\Components\Plugin\Configuration;
 
 interface ReaderInterface
 {
-    /**
-     * @param string   $pluginName
-     * @param int|null $shop
-     *
-     * @return array
-     */
-    public function getByPluginName($pluginName, $shopId = null);
+    public function getByPluginName(string $pluginName, ?int $shopId = null): array;
 }

--- a/engine/Shopware/Components/Plugin/Configuration/ReaderInterface.php
+++ b/engine/Shopware/Components/Plugin/Configuration/ReaderInterface.php
@@ -22,21 +22,15 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Components\Plugin;
+namespace Shopware\Components\Plugin\Configuration;
 
-use Shopware\Models\Shop\Shop;
-
-/**
- * @deprecated Use `shopware.plugin.configuration.reader` instead
- */
-interface ConfigReader
+interface ReaderInterface
 {
     /**
-     * @param string $pluginName
+     * @param string   $pluginName
+     * @param int|null $shop
      *
      * @return array
-     *
-     * @deprecated Use `shopware.plugin.configuration.reader`::getByPluginName instead
      */
-    public function getByPluginName($pluginName, Shop $shop = null);
+    public function getByPluginName($pluginName, $shopId = null);
 }

--- a/engine/Shopware/Components/Plugin/Configuration/Writer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Writer.php
@@ -41,6 +41,6 @@ class Writer implements WriterInterface
      */
     public function setByPluginName($pluginName, array $elements, $shopId = 1)
     {
-        $this->lastLayer->writeValues($shopId, $pluginName, $elements);
+        $this->lastLayer->writeValues($pluginName, $shopId, $elements);
     }
 }

--- a/engine/Shopware/Components/Plugin/Configuration/Writer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Writer.php
@@ -39,7 +39,7 @@ class Writer implements WriterInterface
     /**
      * {@inheritdoc}
      */
-    public function setByPluginName($pluginName, array $elements, $shopId = 1)
+    public function setByPluginName(string $pluginName, array $elements, $shopId = 1)
     {
         $this->lastLayer->writeValues($pluginName, $shopId, $elements);
     }

--- a/engine/Shopware/Components/Plugin/Configuration/Writer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Writer.php
@@ -41,6 +41,6 @@ class Writer implements WriterInterface
      */
     public function setByPluginName($pluginName, array $elements, $shopId = 1)
     {
-        return $this->lastLayer->writeValues($shopId, $pluginName, $elements);
+        $this->lastLayer->writeValues($shopId, $pluginName, $elements);
     }
 }

--- a/engine/Shopware/Components/Plugin/Configuration/Writer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Writer.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Plugin\Configuration;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\OptimisticLockException;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Models\Config\Element;
+use Shopware\Models\Config\Form;
+use Shopware\Models\Config\Value;
+use Shopware\Models\Plugin\Plugin;
+
+class Writer implements WriterInterface
+{
+    /**
+     * @var ModelManager
+     */
+    private $modelManager;
+
+    /**
+     * @var EntityRepository
+     */
+    private $elementRepository;
+
+    /**
+     * @var EntityRepository
+     */
+    private $formRepository;
+
+    /**
+     * @var EntityRepository
+     */
+    private $valueRepository;
+
+    /**
+     * @var EntityRepository
+     */
+    private $pluginRepository;
+
+    public function __construct(ModelManager $modelManager)
+    {
+        $this->modelManager = $modelManager;
+
+        $this->elementRepository = $this->modelManager->getRepository(Element::class);
+        $this->formRepository = $this->modelManager->getRepository(Form::class);
+        $this->valueRepository = $this->modelManager->getRepository(Value::class);
+        $this->pluginRepository = $this->modelManager->getRepository(Plugin::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setByPluginName($pluginName, array $elements, $shopId = 1)
+    {
+        $plugin = $this->pluginRepository->findOneBy([
+            'name' => $pluginName,
+        ]);
+
+        foreach ($elements as $name => $value) {
+            $this->saveConfigElement($plugin->getId(), $name, $value, $shopId);
+        }
+    }
+
+    /**
+     * @param int    $pluginId
+     * @param string $name
+     * @param mixed  $value
+     * @param int    $shopId
+     *
+     * @throws WriterException
+     */
+    protected function saveConfigElement($pluginId, $name, $value, $shopId)
+    {
+        /** @var $form Form */
+        $form = $this->formRepository->findOneBy(['pluginId' => $pluginId]);
+
+        /** @var $element Element */
+        $element = $this->elementRepository->findOneBy(['form' => $form, 'name' => $name]);
+        if (!$element) {
+            throw new WriterException(sprintf('Config element "%s" not found.', $name));
+        }
+
+        if ($element->getScope() == 0 && $shopId !== 1) {
+            throw new WriterException('Element is not valid', 0, new \InvalidArgumentException(sprintf("Element '%s' is not writeable for shop %s", $element->getName(), $shopId)));
+        }
+
+        $defaultValue = $element->getValue();
+
+        /** @var Value $valueModel */
+        $valueModel = $this->valueRepository->findOneBy(['shopId' => $shopId, 'element' => $element]);
+
+        if (!$valueModel) {
+            if ($value == $defaultValue || $value === null) {
+                return;
+            }
+
+            $valueModel = new Value();
+            $valueModel->setElement($element);
+            $valueModel->setShopId($shopId);
+            // serialize done by Doctrine
+            $valueModel->setValue($value);
+
+            $this->modelManager->persist($valueModel);
+            try {
+                $this->modelManager->flush($valueModel);
+            } catch (OptimisticLockException $e) {
+                throw new WriterException('Failed writing to database', 0, $e);
+            }
+
+            return;
+        }
+
+        if ($value == $defaultValue || $value === null) {
+            $this->modelManager->remove($valueModel);
+        } else {
+            // serialize done by Doctrine
+            $valueModel->setValue($value);
+        }
+
+        try {
+            $this->modelManager->flush($valueModel);
+        } catch (OptimisticLockException $e) {
+            throw new WriterException('Failed writing to database', 0, $e);
+        }
+    }
+}

--- a/engine/Shopware/Components/Plugin/Configuration/WriterException.php
+++ b/engine/Shopware/Components/Plugin/Configuration/WriterException.php
@@ -22,21 +22,10 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Components\Plugin;
+namespace Shopware\Components\Plugin\Configuration;
 
-use Shopware\Models\Shop\Shop;
+use Exception;
 
-/**
- * @deprecated Use `shopware.plugin.configuration.reader` instead
- */
-interface ConfigReader
+class WriterException extends Exception
 {
-    /**
-     * @param string $pluginName
-     *
-     * @return array
-     *
-     * @deprecated Use `shopware.plugin.configuration.reader`::getByPluginName instead
-     */
-    public function getByPluginName($pluginName, Shop $shop = null);
 }

--- a/engine/Shopware/Components/Plugin/Configuration/WriterInterface.php
+++ b/engine/Shopware/Components/Plugin/Configuration/WriterInterface.php
@@ -28,7 +28,6 @@ interface WriterInterface
 {
     /**
      * @param string $pluginName
-     * @param array  $elements
      * @param int    $shopId
      *
      * @throws WriterException

--- a/engine/Shopware/Components/Plugin/Configuration/WriterInterface.php
+++ b/engine/Shopware/Components/Plugin/Configuration/WriterInterface.php
@@ -22,21 +22,16 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Components\Plugin;
+namespace Shopware\Components\Plugin\Configuration;
 
-use Shopware\Models\Shop\Shop;
-
-/**
- * @deprecated Use `shopware.plugin.configuration.reader` instead
- */
-interface ConfigReader
+interface WriterInterface
 {
     /**
      * @param string $pluginName
+     * @param array  $elements
+     * @param int    $shopId
      *
-     * @return array
-     *
-     * @deprecated Use `shopware.plugin.configuration.reader`::getByPluginName instead
+     * @throws WriterException
      */
-    public function getByPluginName($pluginName, Shop $shop = null);
+    public function setByPluginName($pluginName, array $elements, $shopId = 1);
 }

--- a/engine/Shopware/Components/Plugin/Configuration/WriterInterface.php
+++ b/engine/Shopware/Components/Plugin/Configuration/WriterInterface.php
@@ -27,10 +27,7 @@ namespace Shopware\Components\Plugin\Configuration;
 interface WriterInterface
 {
     /**
-     * @param string $pluginName
-     * @param int    $shopId
-     *
      * @throws WriterException
      */
-    public function setByPluginName($pluginName, array $elements, $shopId = 1);
+    public function setByPluginName(string $pluginName, array $elements, $shopId = 1);
 }

--- a/engine/Shopware/Components/Plugin/DBALConfigReader.php
+++ b/engine/Shopware/Components/Plugin/DBALConfigReader.php
@@ -28,7 +28,7 @@ use Shopware\Components\Plugin\Configuration\ReaderInterface;
 use Shopware\Models\Shop\Shop;
 
 /**
- * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.reader` instead
+ * @deprecated since 5.6 and removed in 5.8. Use `Shopware\Components\Plugin\Configuration\ReaderInterface` instead
  */
 class DBALConfigReader implements ConfigReader
 {
@@ -47,7 +47,7 @@ class DBALConfigReader implements ConfigReader
      *
      * @return array
      *
-     * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.reader`::getByPluginName instead
+     * @deprecated since 5.6 and removed in 5.8. Use `Shopware\Components\Plugin\Configuration\ReaderInterface`::getByPluginName instead
      */
     public function getByPluginName($pluginName, Shop $shop = null)
     {

--- a/engine/Shopware/Components/Plugin/DBALConfigReader.php
+++ b/engine/Shopware/Components/Plugin/DBALConfigReader.php
@@ -24,12 +24,11 @@
 
 namespace Shopware\Components\Plugin;
 
-use Doctrine\DBAL\Connection;
 use Shopware\Components\Plugin\Configuration\ReaderInterface;
 use Shopware\Models\Shop\Shop;
 
 /**
- * @deprecated Use `shopware.plugin.configuration.reader` instead
+ * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.reader` instead
  */
 class DBALConfigReader implements ConfigReader
 {
@@ -48,7 +47,7 @@ class DBALConfigReader implements ConfigReader
      *
      * @return array
      *
-     * @deprecated Use `shopware.plugin.configuration.reader`::getByPluginName instead
+     * @deprecated since 5.6 and removed in 5.8. Use `shopware.plugin.configuration.reader`::getByPluginName instead
      */
     public function getByPluginName($pluginName, Shop $shop = null)
     {

--- a/engine/Shopware/Components/Plugin/Namespace.php
+++ b/engine/Shopware/Components/Plugin/Namespace.php
@@ -24,7 +24,7 @@
 
 use Doctrine\DBAL\Connection;
 use Shopware\Components\Model\ModelManager;
-use Shopware\Components\Plugin\ConfigReader;
+use Shopware\Components\Plugin\Configuration\ReaderInterface as ConfigurationReader;
 use Shopware\Models\Plugin\Plugin;
 use Shopware\Models\Shop\Shop;
 
@@ -34,7 +34,7 @@ use Shopware\Models\Shop\Shop;
 class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Config
 {
     /**
-     * @var Shop
+     * @var Shop|null
      */
     protected $shop;
 
@@ -44,7 +44,7 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
     private $pluginDirectories;
 
     /**
-     * @var ConfigReader
+     * @var ConfigurationReader
      */
     private $configReader;
 
@@ -52,7 +52,7 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
      * @param string              $name
      * @param Enlight_Config|null $storage
      */
-    public function __construct($name, $storage, array $pluginDirectories, ConfigReader $configReader)
+    public function __construct($name, $storage, array $pluginDirectories, ConfigurationReader $configReader)
     {
         $this->pluginDirectories = $pluginDirectories;
         $this->configReader = $configReader;
@@ -65,7 +65,6 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
      * plugin has no config, the config is automatically set to an empty array.
      *
      * @param string $name
-     * @param Shop   $shop
      *
      * @return Enlight_Config
      */
@@ -75,7 +74,7 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
             $shop = $this->shop;
         }
 
-        $config = $this->configReader->getByPluginName($name, $shop);
+        $config = $this->configReader->getByPluginName($name, $shop ? $shop->getId() : null);
 
         return new Enlight_Config($config, true);
     }

--- a/engine/Shopware/Models/Config/Value.php
+++ b/engine/Shopware/Models/Config/Value.php
@@ -122,8 +122,6 @@ class Value extends ModelEntity
     }
 
     /**
-     * Get shop
-     *
      * @return int
      */
     public function getShopId()
@@ -146,8 +144,6 @@ class Value extends ModelEntity
     }
 
     /**
-     * Set value
-     *
      * @return Value
      */
     public function setValue($value)

--- a/engine/Shopware/Models/Config/Value.php
+++ b/engine/Shopware/Models/Config/Value.php
@@ -122,7 +122,31 @@ class Value extends ModelEntity
     }
 
     /**
-     * @param string $value
+     * Get shop
+     *
+     * @return int
+     */
+    public function getShopId()
+    {
+        return $this->shopId;
+    }
+
+    /**
+     * Set shop id
+     *
+     * @param int $shopId
+     *
+     * @return Value
+     */
+    public function setShopId($shopId)
+    {
+        $this->shopId = $shopId;
+
+        return $this;
+    }
+
+    /**
+     * Set value
      *
      * @return Value
      */

--- a/tests/Functional/Components/Plugin/ConfigReaderTest.php
+++ b/tests/Functional/Components/Plugin/ConfigReaderTest.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Functional\Components\Plugin;
+
+use DateTime;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Components\Plugin\DBALConfigReader;
+use Shopware\Models\Shop\Shop;
+
+class ConfigReaderTest extends TestCase
+{
+    const PLUGIN_NAME = 'swConfigReaderPluginTest';
+
+    const NUMBER_CONFIGURATION_NAME = 'numberConfiguration';
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var ModelManager
+     */
+    private $modelManager;
+
+    /**
+     * @var DBALConfigReader
+     */
+    private $configReader;
+
+    /**
+     * @var int
+     */
+    private $configElementId;
+
+    /**
+     * @var Shop
+     */
+    private $installationShop;
+
+    /**
+     * @var Shop
+     */
+    private $subShop;
+
+    /**
+     * @var Shop
+     */
+    private $languageShop;
+
+    public function setUp()
+    {
+        $this->connection = Shopware()->Container()->get('dbal_connection');
+        $this->connection->beginTransaction();
+        $this->modelManager = Shopware()->Container()->get('models');
+
+        // setup plugin
+        $this->connection->insert('s_core_plugins', [
+            'namespace' => 'Core',
+            'name' => self::PLUGIN_NAME,
+            'label' => 'This is a config reader test plugin',
+            'source' => 'php unit',
+            'active' => 0,
+            'added' => new DateTime(),
+            'version' => '1.0.0',
+            'capability_update' => 0,
+            'capability_install' => 0,
+            'capability_enable' => 1,
+            'capability_secure_uninstall' => 1,
+        ]);
+        $pluginId = $this->connection->lastInsertId();
+
+        // setup plugin configuration
+        $parentFormId = $this->connection
+            ->executeQuery('SELECT id FROM s_core_config_forms WHERE `name` = ?', ['Core'])
+            ->fetchColumn();
+
+        $this->connection->insert('s_core_config_forms', [
+            'name' => self::PLUGIN_NAME,
+            'label' => 'This is a config reader test plugin',
+            'position' => 0,
+            'plugin_id' => $pluginId,
+            'parent_id' => $parentFormId,
+        ]);
+        $formId = $this->connection->lastInsertId();
+
+        $this->connection->insert('s_core_config_elements', [
+            'form_id' => $formId,
+            'name' => self::NUMBER_CONFIGURATION_NAME,
+            'value' => serialize(1),
+            'type' => 'number',
+            'required' => 0,
+            'position' => 0,
+            'scope' => 1,
+        ]);
+        $this->configElementId = $this->connection->lastInsertId();
+
+        // setup shops
+        // assume shop by id 1 exists
+        $this->installationShop = $this->modelManager->find(Shop::class, 1);
+
+        $this->connection->insert('s_core_shops', [
+            'name' => 'Sub Shop',
+            'position' => 0,
+            'hosts' => '',
+            'secure' => 1,
+            'customer_scope' => 0,
+            '`default`' => 0,
+            'active' => 1,
+        ]);
+        $this->subShop = $this->modelManager->find(Shop::class, $this->connection->lastInsertId());
+
+        $this->connection->insert('s_core_shops', [
+            'name' => 'Sub Shop',
+            'position' => 0,
+            'hosts' => '',
+            'secure' => 1,
+            'customer_scope' => 0,
+            '`default`' => 0,
+            'active' => 1,
+            'main_id' => $this->subShop->getId(),
+        ]);
+        $this->languageShop = $this->modelManager->find(Shop::class, $this->connection->lastInsertId());
+
+        $this->configReader = new DBALConfigReader($this->connection);
+    }
+
+    public function tearDown()
+    {
+        $this->connection->rollBack();
+        $this->connection = null;
+        $this->configReader = null;
+    }
+
+    public function testReadElementDefault()
+    {
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME),
+            [self::NUMBER_CONFIGURATION_NAME => 1]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
+            [self::NUMBER_CONFIGURATION_NAME => 1]
+        );
+    }
+
+    public function testReadValueForInstallation()
+    {
+        $this->connection->insert('s_core_config_values', [
+            'element_id' => $this->configElementId,
+            'value' => serialize(2),
+            'shop_id' => $this->installationShop->getId(),
+        ]);
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+    }
+
+    public function testReadValueForSubShop()
+    {
+        $this->connection->insert('s_core_config_values', [
+            'element_id' => $this->configElementId,
+            'value' => serialize(2),
+            'shop_id' => $this->installationShop->getId(),
+        ]);
+
+        $this->connection->insert('s_core_config_values', [
+            'element_id' => $this->configElementId,
+            'value' => serialize(3),
+            'shop_id' => $this->subShop->getId(),
+        ]);
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
+            [self::NUMBER_CONFIGURATION_NAME => 3]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
+            [self::NUMBER_CONFIGURATION_NAME => 3]
+        );
+    }
+
+    public function testReadValueForLanguageShop()
+    {
+        $this->connection->insert('s_core_config_values', [
+            'element_id' => $this->configElementId,
+            'value' => serialize(2),
+            'shop_id' => $this->installationShop->getId(),
+        ]);
+
+        $this->connection->insert('s_core_config_values', [
+            'element_id' => $this->configElementId,
+            'value' => serialize(3),
+            'shop_id' => $this->subShop->getId(),
+        ]);
+
+        $this->connection->insert('s_core_config_values', [
+            'element_id' => $this->configElementId,
+            'value' => serialize(4),
+            'shop_id' => $this->languageShop->getId(),
+        ]);
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
+            [self::NUMBER_CONFIGURATION_NAME => 3]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
+            [self::NUMBER_CONFIGURATION_NAME => 4]
+        );
+    }
+}

--- a/tests/Functional/Components/Plugin/ConfigReaderTest.php
+++ b/tests/Functional/Components/Plugin/ConfigReaderTest.php
@@ -147,7 +147,7 @@ class ConfigReaderTest extends TestCase
         ]);
         $this->languageShopId = $this->connection->lastInsertId();
 
-        $this->configReader = Shopware()->Container()->get('shopware.plugin.configuration.reader');
+        $this->configReader = Shopware()->Container()->get(ReaderInterface::class);
     }
 
     public function tearDown()

--- a/tests/Functional/Components/Plugin/ConfigReaderTest.php
+++ b/tests/Functional/Components/Plugin/ConfigReaderTest.php
@@ -90,6 +90,8 @@ class ConfigReaderTest extends TestCase
             'capability_install' => 0,
             'capability_enable' => 1,
             'capability_secure_uninstall' => 1,
+        ], [
+            'added' => 'datetime',
         ]);
         $pluginId = $this->connection->lastInsertId();
 
@@ -157,12 +159,12 @@ class ConfigReaderTest extends TestCase
 
     public function testReadElementDefault()
     {
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => 1]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShopId),
             [self::NUMBER_CONFIGURATION_NAME => 1]
         );
@@ -176,22 +178,22 @@ class ConfigReaderTest extends TestCase
             'shop_id' => $this->installationShopId,
         ]);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShopId),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShopId),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShopId),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
@@ -211,22 +213,22 @@ class ConfigReaderTest extends TestCase
             'shop_id' => $this->subShopId,
         ]);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShopId),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShopId),
             [self::NUMBER_CONFIGURATION_NAME => 3]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShopId),
             [self::NUMBER_CONFIGURATION_NAME => 3]
         );
@@ -252,22 +254,22 @@ class ConfigReaderTest extends TestCase
             'shop_id' => $this->languageShopId,
         ]);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShopId),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShopId),
             [self::NUMBER_CONFIGURATION_NAME => 3]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShopId),
             [self::NUMBER_CONFIGURATION_NAME => 4]
         );

--- a/tests/Functional/Components/Plugin/ConfigWriterTest.php
+++ b/tests/Functional/Components/Plugin/ConfigWriterTest.php
@@ -158,8 +158,8 @@ class ConfigWriterTest extends TestCase
         ]);
         $this->languageShopId = $this->connection->lastInsertId();
 
-        $this->configWriter = Shopware()->Container()->get('shopware.plugin.configuration.writer');
-        $this->configReader = Shopware()->Container()->get('shopware.plugin.configuration.reader');
+        $this->configWriter = Shopware()->Container()->get(WriterInterface::class);
+        $this->configReader = Shopware()->Container()->get(ReaderInterface::class);
     }
 
     public function tearDown()

--- a/tests/Functional/Components/Plugin/ConfigWriterTest.php
+++ b/tests/Functional/Components/Plugin/ConfigWriterTest.php
@@ -100,6 +100,8 @@ class ConfigWriterTest extends TestCase
             'capability_install' => 0,
             'capability_enable' => 1,
             'capability_secure_uninstall' => 1,
+        ], [
+            'added' => 'datetime',
         ]);
         /** @var Plugin $plugin */
         $plugin = $this->modelManager->find(Plugin::class, $this->connection->lastInsertId());
@@ -175,12 +177,12 @@ class ConfigWriterTest extends TestCase
             $this->installationShopId
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShopId),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
@@ -194,17 +196,17 @@ class ConfigWriterTest extends TestCase
             $this->subShopId
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShopId),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShopId),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
@@ -218,22 +220,22 @@ class ConfigWriterTest extends TestCase
             $this->languageShopId
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShopId),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShopId),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShopId),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
@@ -253,22 +255,22 @@ class ConfigWriterTest extends TestCase
             $this->subShopId
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
-            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+            [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShopId),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShopId),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShopId),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
@@ -288,22 +290,22 @@ class ConfigWriterTest extends TestCase
             $this->languageShopId
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShopId),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShopId),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShopId),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );

--- a/tests/Functional/Components/Plugin/ConfigWriterTest.php
+++ b/tests/Functional/Components/Plugin/ConfigWriterTest.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Functional\Components\Plugin;
+
+use DateTime;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Components\Plugin\ConfigWriter;
+use Shopware\Components\Plugin\DBALConfigReader;
+use Shopware\Models\Plugin\Plugin;
+use Shopware\Models\Shop\Shop;
+
+class ConfigWriterTest extends TestCase
+{
+    const PLUGIN_NAME = 'swConfigWriterPluginTest';
+
+    const NUMBER_CONFIGURATION_NAME = 'numberConfiguration';
+
+    const ELEMENT_DEFAULT_VALUE = 1;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var ModelManager
+     */
+    private $modelManager;
+
+    /**
+     * @var Plugin
+     */
+    private $plugin;
+
+    /**
+     * @var int
+     */
+    private $configElementId;
+
+    /**
+     * @var Shop
+     */
+    private $installationShop;
+
+    /**
+     * @var Shop
+     */
+    private $subShop;
+
+    /**
+     * @var Shop
+     */
+    private $languageShop;
+
+    /**
+     * @var ConfigWriter
+     */
+    private $configWriter;
+
+    /**
+     * @var DBALConfigReader
+     */
+    private $configReader;
+
+    public function setUp()
+    {
+        $this->connection = Shopware()->Container()->get('dbal_connection');
+        $this->connection->beginTransaction();
+        $this->modelManager = Shopware()->Container()->get('models');
+
+        // setup plugin
+        $this->connection->insert('s_core_plugins', [
+            'namespace' => 'Core',
+            'name' => self::PLUGIN_NAME,
+            'label' => 'This is a config reader test plugin',
+            'source' => 'php unit',
+            'active' => 0,
+            'added' => new DateTime(),
+            'version' => '1.0.0',
+            'capability_update' => 0,
+            'capability_install' => 0,
+            'capability_enable' => 1,
+            'capability_secure_uninstall' => 1,
+        ]);
+        $this->plugin = $this->modelManager->find(Plugin::class, $this->connection->lastInsertId());
+
+        // setup plugin configuration
+        $parentFormId = $this->connection
+            ->executeQuery('SELECT id FROM s_core_config_forms WHERE `name` = ?', ['Core'])
+            ->fetchColumn();
+
+        $this->connection->insert('s_core_config_forms', [
+            'name' => self::PLUGIN_NAME,
+            'label' => 'This is a config reader test plugin',
+            'position' => 0,
+            'plugin_id' => $this->plugin->getId(),
+            'parent_id' => $parentFormId,
+        ]);
+        $formId = $this->connection->lastInsertId();
+
+        $this->connection->insert('s_core_config_elements', [
+            'form_id' => $formId,
+            'name' => self::NUMBER_CONFIGURATION_NAME,
+            'value' => serialize(self::ELEMENT_DEFAULT_VALUE),
+            'type' => 'number',
+            'required' => 0,
+            'position' => 0,
+            'scope' => 1,
+        ]);
+        $this->configElementId = $this->connection->lastInsertId();
+
+        // setup shops
+        // assume shop by id 1 exists
+        $this->installationShop = $this->modelManager->find(Shop::class, 1);
+
+        $this->connection->insert('s_core_shops', [
+            'name' => 'Sub Shop',
+            'position' => 0,
+            'hosts' => '',
+            'secure' => 1,
+            'customer_scope' => 0,
+            '`default`' => 0,
+            'active' => 1,
+        ]);
+        $this->subShop = $this->modelManager->find(Shop::class, $this->connection->lastInsertId());
+
+        $this->connection->insert('s_core_shops', [
+            'name' => 'Sub Shop',
+            'position' => 0,
+            'hosts' => '',
+            'secure' => 1,
+            'customer_scope' => 0,
+            '`default`' => 0,
+            'active' => 1,
+            'main_id' => $this->subShop->getId(),
+        ]);
+        $this->languageShop = $this->modelManager->find(Shop::class, $this->connection->lastInsertId());
+
+        $this->configWriter = new ConfigWriter($this->modelManager);
+        $this->configReader = new DBALConfigReader($this->connection);
+    }
+
+    public function tearDown()
+    {
+        $this->connection->rollBack();
+        $this->connection = null;
+        $this->configReader = null;
+    }
+
+    public function testWriteValueForInstallation()
+    {
+        $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, 2, $this->installationShop);
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+    }
+
+    public function testWriteValueForSubShop()
+    {
+        $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, 2, $this->subShop);
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+    }
+
+    public function testWriteValueForLanguageShop()
+    {
+        $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, 2, $this->languageShop);
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+    }
+
+    public function testWriteDefaultValueForSubShop()
+    {
+        $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, 2, $this->installationShop);
+        $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, self::ELEMENT_DEFAULT_VALUE, $this->subShop);
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+    }
+
+    public function testWriteDefaultValueForLanguageShop()
+    {
+        $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, 2, $this->subShop);
+        $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, self::ELEMENT_DEFAULT_VALUE, $this->languageShop);
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
+            [self::NUMBER_CONFIGURATION_NAME => 2]
+        );
+
+        $this->assertArraySubset(
+            $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
+            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+        );
+    }
+}

--- a/tests/Functional/Components/Plugin/LegacyConfigReaderTest.php
+++ b/tests/Functional/Components/Plugin/LegacyConfigReaderTest.php
@@ -28,6 +28,7 @@ use DateTime;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Components\Model\ModelManager;
+use Shopware\Components\Plugin\Configuration\ReaderInterface;
 use Shopware\Components\Plugin\DBALConfigReader;
 use Shopware\Models\Shop\Shop;
 
@@ -148,7 +149,7 @@ class LegacyConfigReaderTest extends TestCase
         ]);
         $this->languageShop = $this->modelManager->find(Shop::class, $this->connection->lastInsertId());
 
-        $this->configReader = new DBALConfigReader(Shopware()->Container()->get('shopware.plugin.configuration.reader'));
+        $this->configReader = new DBALConfigReader(Shopware()->Container()->get(ReaderInterface::class));
     }
 
     public function tearDown()

--- a/tests/Functional/Components/Plugin/LegacyConfigReaderTest.php
+++ b/tests/Functional/Components/Plugin/LegacyConfigReaderTest.php
@@ -91,6 +91,8 @@ class LegacyConfigReaderTest extends TestCase
             'capability_install' => 0,
             'capability_enable' => 1,
             'capability_secure_uninstall' => 1,
+        ], [
+            'added' => 'datetime',
         ]);
         $pluginId = $this->connection->lastInsertId();
 
@@ -158,12 +160,12 @@ class LegacyConfigReaderTest extends TestCase
 
     public function testReadElementDefault()
     {
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => 1]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
             [self::NUMBER_CONFIGURATION_NAME => 1]
         );
@@ -177,22 +179,22 @@ class LegacyConfigReaderTest extends TestCase
             'shop_id' => $this->installationShop->getId(),
         ]);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
@@ -212,22 +214,22 @@ class LegacyConfigReaderTest extends TestCase
             'shop_id' => $this->subShop->getId(),
         ]);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
             [self::NUMBER_CONFIGURATION_NAME => 3]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
             [self::NUMBER_CONFIGURATION_NAME => 3]
         );
@@ -253,22 +255,22 @@ class LegacyConfigReaderTest extends TestCase
             'shop_id' => $this->languageShop->getId(),
         ]);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
             [self::NUMBER_CONFIGURATION_NAME => 3]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
             [self::NUMBER_CONFIGURATION_NAME => 4]
         );

--- a/tests/Functional/Components/Plugin/LegacyConfigWriterTest.php
+++ b/tests/Functional/Components/Plugin/LegacyConfigWriterTest.php
@@ -28,6 +28,8 @@ use DateTime;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Components\Model\ModelManager;
+use Shopware\Components\Plugin\Configuration\ReaderInterface;
+use Shopware\Components\Plugin\Configuration\WriterInterface;
 use Shopware\Components\Plugin\ConfigWriter;
 use Shopware\Components\Plugin\DBALConfigReader;
 use Shopware\Models\Plugin\Plugin;
@@ -162,8 +164,8 @@ class LegacyConfigWriterTest extends TestCase
         ]);
         $this->languageShop = $this->modelManager->find(Shop::class, $this->connection->lastInsertId());
 
-        $this->configWriter = new ConfigWriter(Shopware()->Container()->get('shopware.plugin.configuration.writer'));
-        $this->configReader = new DBALConfigReader(Shopware()->Container()->get('shopware.plugin.configuration.reader'));
+        $this->configWriter = new ConfigWriter(Shopware()->Container()->get(WriterInterface::class));
+        $this->configReader = new DBALConfigReader(Shopware()->Container()->get(ReaderInterface::class));
     }
 
     public function tearDown()

--- a/tests/Functional/Components/Plugin/LegacyConfigWriterTest.php
+++ b/tests/Functional/Components/Plugin/LegacyConfigWriterTest.php
@@ -105,6 +105,8 @@ class LegacyConfigWriterTest extends TestCase
             'capability_install' => 0,
             'capability_enable' => 1,
             'capability_secure_uninstall' => 1,
+        ], [
+            'added' => 'datetime',
         ]);
         $this->plugin = $this->modelManager->find(Plugin::class, $this->connection->lastInsertId());
 
@@ -175,12 +177,12 @@ class LegacyConfigWriterTest extends TestCase
     {
         $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, 2, $this->installationShop);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
@@ -190,17 +192,17 @@ class LegacyConfigWriterTest extends TestCase
     {
         $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, 2, $this->subShop);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
@@ -210,22 +212,22 @@ class LegacyConfigWriterTest extends TestCase
     {
         $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, 2, $this->languageShop);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
@@ -236,22 +238,22 @@ class LegacyConfigWriterTest extends TestCase
         $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, 2, $this->installationShop);
         $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, self::ELEMENT_DEFAULT_VALUE, $this->subShop);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
-            [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
+            [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
@@ -262,22 +264,22 @@ class LegacyConfigWriterTest extends TestCase
         $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, 2, $this->subShop);
         $this->configWriter->saveConfigElement($this->plugin, self::NUMBER_CONFIGURATION_NAME, self::ELEMENT_DEFAULT_VALUE, $this->languageShop);
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->installationShop),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->subShop),
             [self::NUMBER_CONFIGURATION_NAME => 2]
         );
 
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $this->configReader->getByPluginName(self::PLUGIN_NAME, $this->languageShop),
             [self::NUMBER_CONFIGURATION_NAME => self::ELEMENT_DEFAULT_VALUE]
         );


### PR DESCRIPTION
### 1. Why is this change necessary?
This is a follow up to https://github.com/shopware/shopware/pull/1779. Please read the previous PR to be sure to get the main problem and followed discussion.

When using the `ConfigReader` there is an inheritance used that the shop structure has impact on the chosen value as they override each other. The `ConfigWriter` skips the inheritance that is used on reading.

I separated the squashed commits to check the major steps for their differences and use the new tests to verify the wrong behaviour.

### 2. What does this change do, exactly?
The configuration inheritance is now solved via php code and not via sql code. This adds more complexity by having new classes but also add more power to change the behaviour.

### 3. Describe each step to reproduce the issue or behaviour.
* Have a nullable boolean (default null) plugin configuration
* Use `sw:plugin:config:set` and set value for the default shop to true
* Use `sw:plugin:config:set` and set value for a sub shop to false
* Use `sw:plugin:config:get` and read value for the sub shop which is true

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/pull/1779

### 5. Which documentation changes (if any) need to be made because of this PR?
Some classes are now obsolete as they wrap other classes to maintain a similar interface structure while having backwards compatibility.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.