### PR TITLE
add translation for streamId in categories

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
@@ -175,7 +175,7 @@ class CategoryGateway implements Gateway\CategoryGatewayInterface
         $categories = [];
         foreach ($data as $row) {
             $id = $row['__category_id'];
-            $categories[$id] = $this->categoryHydrator->hydrate($this->translateCategoryMedia($row, $context));
+            $categories[$id] = $this->categoryHydrator->hydrate($this->translateCategoryData($row, $context));
         }
 
         return $categories;
@@ -236,14 +236,14 @@ class CategoryGateway implements Gateway\CategoryGatewayInterface
     }
 
     /**
-     * Resolves translated category media
+     * Resolves translated data for media and streamId
      *
      * @param array                       $category
      * @param Struct\ShopContextInterface $context
      *
      * @return array
      */
-    private function translateCategoryMedia(array $category, Struct\ShopContextInterface $context)
+    private function translateCategoryData(array $category, Struct\ShopContextInterface $context)
     {
         if (empty($category['__category_translation'])) {
             return $category;
@@ -253,6 +253,10 @@ class CategoryGateway implements Gateway\CategoryGatewayInterface
 
         if (!empty($translation['imagePath'])) {
             $category['mediaTranslation'] = $this->mediaService->get($translation['imagePath'], $context);
+        }
+
+        if (!empty($translation['streamId'])) {
+            $category['__stream_id'] = $translation['streamId'];
         }
 
         return $category;

--- a/engine/Shopware/Controllers/Widgets/Listing.php
+++ b/engine/Shopware/Controllers/Widgets/Listing.php
@@ -194,10 +194,15 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
         }
 
         $categoryId = (int) $this->Request()->getParam('sCategory');
-        $productStreamId = $this->findStreamIdByCategoryId($categoryId);
 
-        if ($productStreamId) {
-            $result = $this->fetchStreamListing($categoryId, $productStreamId);
+        $context = $this->container->get('shopware_storefront.context_service')->getShopContext();
+
+        $category = $this->container->get('shopware_storefront.category_gateway')->get([$categoryId], $context);
+
+        $productStream = $category->getProductStream();
+
+        if ($productStream) {
+            $result = $this->fetchStreamListing($categoryId, $productStream->getId());
             $this->setSearchResultResponse($result);
 
             return;
@@ -280,25 +285,6 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
             ->setParameter(':parentId', $categoryId);
 
         return $query->execute()->fetchAll(PDO::FETCH_COLUMN);
-    }
-
-    /**
-     * @param int $categoryId
-     *
-     * @return int|null
-     */
-    private function findStreamIdByCategoryId($categoryId)
-    {
-        $streamId = $this->get('dbal_connection')->fetchColumn(
-            'SELECT stream_id FROM s_categories WHERE id = :id',
-            ['id' => $categoryId]
-        );
-
-        if ($streamId) {
-            return (int) $streamId;
-        }
-
-        return null;
     }
 
     /**

--- a/themes/Backend/ExtJs/backend/category/view/category/tabs/settings.js
+++ b/themes/Backend/ExtJs/backend/category/view/category/tabs/settings.js
@@ -405,7 +405,8 @@ Ext.define('Shopware.apps.Category.view.category.tabs.Settings', {
 
         me.streamSelection = Ext.create('Shopware.form.field.ProductStreamSelection', {
             name: 'streamId',
-            labelWidth: 155
+            labelWidth: 155,
+            translatable: true
         });
 
         return [


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it isn't possible to use another streamId for shops. 

### 2. What does this change do, exactly?
Add possibility to "translate" productstream. 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.