### PR TITLE
Adding check if apikey,pw,sessionId and encoder should be resetted

### DIFF
--- a/engine/Shopware/Components/Api/Resource/User.php
+++ b/engine/Shopware/Components/Api/Resource/User.php
@@ -87,13 +87,16 @@ class User extends Resource
             throw new ApiException\NotFoundException(sprintf('User by id %s not found', $id));
         }
 
-        if (is_array($user)) {
-            unset($user['apiKey'], $user['sessionId'], $user['password'], $user['encoder']);
-        } else {
-            $user->setApiKey('');
-            $user->setSessionId('');
-            $user->setPassword('');
-            $user->setEncoder('');
+        if (!$this->hasPrivilege('create', 'usermanager') &&
+            !$this->hasPrivilege('update', 'usermanager')) {
+            if (is_array($user)) {
+                unset($user['apiKey'], $user['sessionId'], $user['password'], $user['encoder']);
+            } else {
+                $user->setApiKey('');
+                $user->setSessionId('');
+                $user->setPassword('');
+                $user->setEncoder('');
+            }
         }
 
         return $user;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Getting one user by API should return API key, password, sessionId and encoder instead of always unsetting it. As implemented in the getList method a check will make sure if the user has create and update privileges.

### 2. What does this change do, exactly?
Checks if the user has create/update privileges

### 3. Describe each step to reproduce the issue or behaviour.
Getting one user never returns the API key, password, sessionId or encoder 

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.