### PR TITLE
fix smarty flink function, if its a composer project

### DIFF
--- a/engine/Library/Enlight/Template/Plugins/function.flink.php
+++ b/engine/Library/Enlight/Template/Plugins/function.flink.php
@@ -60,8 +60,9 @@ function smarty_function_flink($params, $template)
         }
 
         //Cleanup vendor paths if is composer project
-        if (strpos($file, 'vendor/shopware/shopware') !== false) {
-            $file = substr($file, strlen($docPath . 'vendor/shopware/shopware'));
+        $vendorPath = 'vendor' . DIRECTORY_SEPARATOR . 'shopware' . DIRECTORY_SEPARATOR . 'shopware';
+        if (strpos($file, $vendorPath) !== false) {
+            $file = str_replace($vendorPath, '', $file);
         }
 
         // Some cleanup code

--- a/engine/Library/Enlight/Template/Plugins/function.flink.php
+++ b/engine/Library/Enlight/Template/Plugins/function.flink.php
@@ -59,6 +59,11 @@ function smarty_function_flink($params, $template)
             }
         }
 
+        //Cleanup vendor paths if is composer project
+        if (strpos($file, 'vendor/shopware/shopware') !== false) {
+            $file = substr($file, strlen($docPath . 'vendor/shopware/shopware'));
+        }
+
         // Some cleanup code
         if (strpos($file, $docPath) === 0) {
             $file = substr($file, strlen($docPath));


### PR DESCRIPTION
### 1. Why is this change necessary?
If you use shopware composer project, the smarty flink function generates the wrong file include paths. Some of the JS Libraries linked from vendor paths. Usually vendor paths not accessable from outside, so if you try to use tinymce in shopware backend, you get forbidden errors.

the main header of the shopware backend
`themes/Backend/ExtJs/backend/base/header.tpl`
![bildschirmfoto 2018-09-20 um 21 05 00](https://user-images.githubusercontent.com/907458/45841056-f447a180-bd18-11e8-9fd8-48ef96ff7475.png)

without this fix, you get this kind of js library includes in html source code
![bildschirmfoto 2018-09-20 um 21 11 31](https://user-images.githubusercontent.com/907458/45841340-d0d12680-bd19-11e8-9bd8-a585acca7b09.png)

but in a composer project the libraries symlinked into that folder 
`/engine/Library`

so the real include path is
`/engine/Library/ExtJs/ext-all.js`

### 2. What does this change do, exactly?
It removes the vendor paths from the file paths.

### 3. Describe each step to reproduce the issue or behaviour.

- create an shopware composer project
- navigate to the shopware backend
- look at the HTML source code
- the javascript files (tiny_mce.js,ext-all.js,codemirror.js) will be include from vendor paths

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.