### PR TITLE
add “not in” product stream filter

### DIFF
--- a/themes/Backend/ExtJs/backend/product_stream/view/condition_list/field/attribute.js
+++ b/themes/Backend/ExtJs/backend/product_stream/view/condition_list/field/attribute.js
@@ -110,6 +110,7 @@ Ext.define('Shopware.apps.ProductStream.view.condition_list.field.Attribute', {
                 { name: '{s name=attribute_condition/greater_than}greater than{/s}', value: '>' },
                 { name: '{s name=attribute_condition/greater_than_equals}greater than equals{/s}', value: '>=' },
                 { name: '{s name=attribute_condition/in}in{/s}', value: 'IN' },
+                { name: '{s name=attribute_condition/not_in}not in{/s}', value: 'NOT IN' },
                 { name: '{s name=attribute_condition/starts_with}starts with{/s}', value: 'STARTS_WITH' },
                 { name: '{s name=attribute_condition/ends_with}ends with{/s}', value: 'ENDS_WITH' },
                 { name: '{s name=attribute_condition/like}like{/s}', value: 'CONTAINS' }
@@ -184,6 +185,8 @@ Ext.define('Shopware.apps.ProductStream.view.condition_list.field.Attribute', {
             }
         } else if (value.operator == 'IN') {
             value.value = value.value.split(",");
+        } else if (value.operator === 'NOT IN') {
+          value.value = value.value.split(",")
         }
 
         var result = {};


### PR DESCRIPTION
### 1. Why is this change necessary?
To filter product streams with the operator "NOT IN"

### 2. What does this change do, exactly?
Filter Attributes in the backend Product Stream overview with the operator "NOT IN".

### 3. Describe each step to reproduce the issue or behaviour.
Backend -> Article -> Product Streams -> "create Filter stream" -> add filter "attribute filter" and search for the operator "NOT IN". It's not available in the extJs part.

### 4. Please link to the relevant issues (if any).
/

### 5. Which documentation changes (if any) need to be made because of this PR?
/

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.