### PR TITLE
[ADD] Add new event Shopware_Modules_Admin_GetDispatchBasketCalculati…

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -2511,12 +2511,20 @@ class sAdmin
             $addSelect[] = $premiumShippingBasketSelect;
         }
 
-        $calculations = $this->connection->createQueryBuilder()
+        $calculationQueryBuilder = $this->connection->createQueryBuilder()
             ->select(['id', 'calculation_sql'])
             ->from('s_premium_dispatch')
             ->where('active = 1')
-            ->andWhere('calculation = 3')
-            ->execute()->fetchAll(\PDO::FETCH_KEY_PAIR);
+            ->andWhere('calculation = 3');
+
+        $this->eventManager->notify(
+            'Shopware_Modules_Admin_GetDispatchBasketCalculation_QueryBuilder',
+            [
+                'queryBuilder' => $calculationQueryBuilder
+            ]
+        );
+
+        $calculations = $calculationQueryBuilder->execute()->fetchAll(\PDO::FETCH_KEY_PAIR);
 
         if (!empty($calculations)) {
             foreach ($calculations as $dispatchID => $calculation) {


### PR DESCRIPTION
### 1. Why is this change necessary?
When you have got a lot of dispatch methods (>1000), e.g. for each zipcode then the calculation in sGetDispatchBasket costs a lot of performace. With this commit you have got a filter event, to reduce the calculation

### 2. What does this change do, exactly?
Adds a new Event Shopware_Modules_Admin_GetDispatchBasketCalculation_QueryBuilder to filter the calculation query

### 3. Describe each step to reproduce the issue or behaviour.
Insert more than 1000 dispatch methods with calculation method 3 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.