### PR TITLE
Fix missing space in currency transformation

### DIFF
--- a/engine/Library/Zend/Currency.php
+++ b/engine/Library/Zend/Currency.php
@@ -190,7 +190,7 @@ class Zend_Currency
 
         if ($options['position'] !== self::STANDARD) {
             $value = str_replace('¤', '', $value);
-            $space = '';
+            $space = ' ';
             if (iconv_strpos($value, ' ') !== false) {
                 $value = str_replace(' ', '', $value);
                 $space = ' ';


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When using "." as a decimal separator, the currency modifier of smarty won't add a space to the price.
This leads to prices like "5.55CHF" and not "5.55 CHF"

### 2. What does this change do, exactly?
the variable "$space" will contain a space after this change...

### 3. Describe each step to reproduce the issue or behaviour.
1. Change the localisation of the shop to one that uses a "." as decimal separator (like en_GB)
2. Add a new currency like "CHF" with a symbol position "right"
-> The frontend will show "5.55CHF" without a space

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.