### PR TITLE
Add not-writable path to exception message

### DIFF
--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Download.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Download.php
@@ -94,7 +94,7 @@ class Download
     public function downloadFile($sourceUri, $destinationUri, $totalSize, $hash)
     {
         if (($destination = fopen($destinationUri, 'a+')) === false) {
-            throw new \Exception('Destination is invalid.');
+            throw new \Exception(sprintf('Destination "%s" is invalid.', $destinationUri));
         }
 
         if (filesize($destinationUri) > 0) {


### PR DESCRIPTION
### 1. Why is this change necessary?
To give better feedback what exact destination is invalid.

### 2. What does this change do, exactly?
It adds the path that is not writable to an exception message.

### 3. Describe each step to reproduce the issue or behaviour.
Remove the directory files/downloads and try to download the SwagDemoData plugin via plugin manager

### 4. Please link to the relevant issues (if any).

:heavy_minus_sign: 

### 5. Which documentation changes (if any) need to be made because of this PR?

:heavy_minus_sign: 

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.