### PR TITLE
ntr - ensure plugin load priority

### DIFF
--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -366,6 +366,12 @@ return array_replace_recursive([
             ],
         ],
     ],
+    /*
+     * @deprecated since 5.5, will be set to false with Shopware 5.6
+     */
+    'backward_compatibility' => [
+        'disable_plugin_sorting' => true,
+    ],
     'logger' => [
         'level' => $this->Environment() !== 'production' ? Logger::DEBUG : Logger::ERROR,
     ],

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -497,6 +497,10 @@ class Kernel implements HttpKernelInterface, TerminableInterface
 
         $this->plugins = $initializer->initializePlugins();
 
+        if ($this->config['backward_compatibility']['disable_plugin_sorting'] !== true) {
+            ksort($this->plugins);
+        }
+
         $this->activePlugins = $initializer->getActivePlugins();
 
         $this->pluginHash = $this->createPluginHash($this->plugins);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Because of this DirectoryIterator (https://github.com/shopware/shopware/blob/5.5/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php#L83) it is possible that 2 App Servers have a different chain how the plugins are loaded. It can cause to very hard to debug issues if the priority of the plugin loading is necessary.

With this small change it is ensured that the plugins are loaded and processed with an alphabetical sorting. 

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.