### PR TITLE
Clean up and unify exception message generation

### DIFF
--- a/engine/Shopware/Application.php
+++ b/engine/Shopware/Application.php
@@ -96,7 +96,7 @@ class Shopware extends Enlight_Application
 
         if (!$this->container->has($name)) {
             throw new Enlight_Exception(
-                'Method "' . get_class($this) . '::' . $name . '" not found failure',
+                sprintf('Method "%s::%s" not found failure', get_class($this), $name),
                 Enlight_Exception::METHOD_NOT_FOUND
             );
         }

--- a/engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/Attributes.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/Attributes.php
@@ -71,11 +71,17 @@ class Shopware_Controllers_Backend_Attributes extends Shopware_Controllers_Backe
 
     public function resetDataAction()
     {
-        $table = $this->Request()->getParam('tableName');
-        $column = $this->Request()->getParam('columnName');
+        $tableParamName = 'tableName';
+        $columnParamName = 'columnName';
+        $table = $this->Request()->getParam($tableParamName);
+        $column = $this->Request()->getParam($columnParamName);
 
-        if (!$table || !$column) {
-            throw new Exception('Required parameter not found');
+        if (!$table) {
+            throw new Exception(sprintf('Required parameter "%s" not found', $tableParamName));
+        }
+
+        if (!$column) {
+            throw new Exception(sprintf('Required parameter "%s" not found', $columnParamName));
         }
 
         /** @var SchemaOperator $schemaOperator */

--- a/engine/Shopware/Bundle/AttributeBundle/Service/DataPersister.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Service/DataPersister.php
@@ -81,7 +81,7 @@ class DataPersister
             throw new \Exception(sprintf('Table %s is no attribute table', $table));
         }
         if (!$foreignKey) {
-            throw new \Exception(sprintf('No foreign key provided'));
+            throw new \Exception('No foreign key provided');
         }
         $data = $this->filter($table, $data);
 
@@ -113,7 +113,7 @@ class DataPersister
             throw new \Exception(sprintf('Table %s is no attribute table', $table));
         }
         if (!$sourceForeignKey) {
-            throw new \Exception(sprintf('No foreign key provided'));
+            throw new \Exception('No foreign key provided');
         }
         $data = $this->dataLoader->load($table, $sourceForeignKey);
 
@@ -139,7 +139,7 @@ class DataPersister
             throw new \Exception(sprintf('Table %s is no attribute table', $table));
         }
         if (!$sourceForeignKey) {
-            throw new \Exception(sprintf('No foreign key provided'));
+            throw new \Exception('No foreign key provided');
         }
 
         $translations = $this->dataLoader->loadTranslations($table, $sourceForeignKey);

--- a/engine/Shopware/Bundle/BenchmarkBundle/BenchmarkCollector.php
+++ b/engine/Shopware/Bundle/BenchmarkBundle/BenchmarkCollector.php
@@ -90,12 +90,13 @@ class BenchmarkCollector implements BenchmarkCollectorInterface
      */
     private function moveShopData(array $providerData)
     {
-        if (!array_key_exists('shop', $providerData)) {
-            throw new \Exception('Necessary data with name \'shop\' not provided.');
+        $shopDataArrayKey = 'shop';
+        if (!array_key_exists($shopDataArrayKey, $providerData)) {
+            throw new \Exception(sprintf('Necessary data with name \'%s\' not provided.', $shopDataArrayKey));
         }
 
-        $providerData = $providerData['shop'] + $providerData;
-        unset($providerData['shop']);
+        $providerData = $providerData[$shopDataArrayKey] + $providerData;
+        unset($providerData[$shopDataArrayKey]);
 
         return $providerData;
     }

--- a/engine/Shopware/Bundle/BenchmarkBundle/BusinessIntelligenceClient.php
+++ b/engine/Shopware/Bundle/BenchmarkBundle/BusinessIntelligenceClient.php
@@ -132,10 +132,11 @@ class BusinessIntelligenceClient implements BusinessIntelligenceClientInterface
      */
     private function verifyResponseSignature(Response $response)
     {
-        $signature = $response->getHeader('x-shopware-signature');
+        $signatureHeaderName = 'x-shopware-signature';
+        $signature = $response->getHeader($signatureHeaderName);
 
         if (empty($signature)) {
-            throw new \RuntimeException('Signature not found in x-shopware-signature header');
+            throw new \RuntimeException(sprintf('Signature not found in %s header', $signatureHeaderName));
         }
 
         if (!$this->benchmarkEncryption->isSignatureSupported()) {

--- a/engine/Shopware/Bundle/BenchmarkBundle/Hydrator/StatisticsResponseHydrator.php
+++ b/engine/Shopware/Bundle/BenchmarkBundle/Hydrator/StatisticsResponseHydrator.php
@@ -38,8 +38,17 @@ class StatisticsResponseHydrator implements HydratorInterface
      */
     public function hydrate(array $data)
     {
-        if ($data['message'] !== 'Success') {
-            throw new StatisticsHydratingException(sprintf('Expected field "message" to be "success", was "%s"', $data['message']));
+        $messageDataArrayKey = 'message';
+        $messageDataSuccessValue = 'Success';
+        if ($data[$messageDataArrayKey] !== $messageDataSuccessValue) {
+            throw new StatisticsHydratingException(
+                sprintf(
+                    'Expected field "%s" to be "%s", was "%s"',
+                    $messageDataArrayKey,
+                    $messageDataSuccessValue,
+                    $data[$messageDataArrayKey]
+                )
+            );
         }
 
         if (empty($data['responseToken'])) {

--- a/engine/Shopware/Bundle/ESIndexingBundle/Commands/SwitchAliasCommand.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Commands/SwitchAliasCommand.php
@@ -72,7 +72,7 @@ class SwitchAliasCommand extends ShopwareCommand
 
         $exist = $client->indices()->exists(['index' => $indexName]);
         if (!$exist) {
-            throw new \RuntimeException(sprintf('Index %s not exist', $indexName));
+            throw new \RuntimeException(sprintf('Index %s does not exist', $indexName));
         }
 
         $actions = [

--- a/engine/Shopware/Bundle/MediaBundle/MediaService.php
+++ b/engine/Shopware/Bundle/MediaBundle/MediaService.php
@@ -75,7 +75,7 @@ class MediaService implements MediaServiceInterface
         $this->config = $config;
 
         if (!isset($config['mediaUrl'])) {
-            throw new \Exception(sprintf("Please provide a 'mediaUrl' in your %s adapter.", $config['type']));
+            throw new \Exception(sprintf('Please provide a "mediaUrl" in your %s adapter.', $config['type']));
         }
 
         $mediaUrl = $config['mediaUrl'] ?: $this->createFallbackMediaUrl();

--- a/engine/Shopware/Bundle/MediaBundle/MediaServiceFactory.php
+++ b/engine/Shopware/Bundle/MediaBundle/MediaServiceFactory.php
@@ -75,7 +75,7 @@ class MediaServiceFactory
     public function factory($backendName)
     {
         if (!isset($this->cdnConfig['adapters'][$backendName])) {
-            throw new \Exception("Configuration '" . $backendName . "' not found");
+            throw new \Exception(sprintf('Configuration "%s" not found', $backendName));
         }
 
         // Filesystem
@@ -109,7 +109,7 @@ class MediaServiceFactory
         $adapter = $adapters->first();
 
         if (!$adapter) {
-            throw new \Exception("CDN Adapter '" . $config['type'] . "' not found.");
+            throw new \Exception(sprintf('CDN Adapter "%s" not found.', $config['type']));
         }
 
         return $adapter;

--- a/engine/Shopware/Bundle/MediaBundle/Strategy/StrategyFactory.php
+++ b/engine/Shopware/Bundle/MediaBundle/Strategy/StrategyFactory.php
@@ -46,7 +46,7 @@ class StrategyFactory
             case 'plain':
                 return new PlainStrategy();
             default:
-                throw new \Exception(sprintf("Unsupported strategy '%s'.", $strategy));
+                throw new \Exception(sprintf('Unsupported strategy "%s".', $strategy));
         }
     }
 }

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/InstallerService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/InstallerService.php
@@ -135,7 +135,7 @@ class InstallerService
         $plugin = $this->pluginRepository->findOneBy(['name' => $pluginName, 'capabilityEnable' => 1]);
 
         if ($plugin === null) {
-            throw new \Exception(sprintf('Unknown plugin: %s.', $pluginName));
+            throw new \Exception(sprintf('Unknown plugin "%s".', $pluginName));
         }
 
         return $plugin;
@@ -241,7 +241,7 @@ class InstallerService
         }
 
         if (!$plugin->getInstalled()) {
-            throw new \Exception('Plugin has to be installed first.');
+            throw new \Exception(sprintf('Plugin "%s" has to be installed first.', $plugin->getName()));
         }
 
         if (!$plugin->isLegacyPlugin()) {

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/LegacyPluginExtractor.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/LegacyPluginExtractor.php
@@ -37,9 +37,7 @@ class LegacyPluginExtractor
     public function extract($archive, $destination)
     {
         if (!is_writable($destination)) {
-            throw new \Exception(
-                'Destination directory is not writable'
-            );
+            throw new \Exception(sprintf('Destination directory "%s" is not writable', $destination));
         }
 
         $this->validatePluginZip($archive);
@@ -141,9 +139,7 @@ class LegacyPluginExtractor
     private function assertNoDirectoryTraversal($filename)
     {
         if (strpos($filename, '../') !== false) {
-            throw new \RuntimeException(
-                sprintf('Directory Traversal detected')
-            );
+            throw new \RuntimeException('Directory Traversal detected');
         }
     }
 }

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/LegacyPluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/LegacyPluginInstaller.php
@@ -193,7 +193,7 @@ class LegacyPluginInstaller
         $result = is_bool($result) ? ['success' => $result] : $result;
 
         if ($result['success'] == false) {
-            throw new \Exception('Not allowed to enable plugin.');
+            throw new \Exception(sprintf('Not allowed to enable plugin %s.', $plugin->getName()));
         }
 
         $plugin->setActive(true);
@@ -211,7 +211,7 @@ class LegacyPluginInstaller
         $result = is_bool($result) ? ['success' => $result] : $result;
 
         if ($result['success'] == false) {
-            throw new \Exception('Not allowed to disable plugin.');
+            throw new \Exception(sprintf('Not allowed to disable plugin %s.', $plugin->getName()));
         }
 
         $plugin->setActive(false);
@@ -247,10 +247,12 @@ class LegacyPluginInstaller
                     $name = $dir->getFilename();
 
                     if ($this->validateIonCube($file)) {
-                        throw new \Exception(sprintf(
-                            'Plugin %s is encrypted but ioncube Loader extension is not installed',
-                            $name
-                        ));
+                        throw new \Exception(
+                            sprintf(
+                                'Plugin %s is encrypted but the ionCube Loader extension is not installed',
+                                $name
+                            )
+                        );
                     }
 
                     $plugin = $collection->get($name);

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginExtractor.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginExtractor.php
@@ -67,9 +67,7 @@ class PluginExtractor
         $destination = $this->pluginDir;
 
         if (!is_writable($destination)) {
-            throw new \Exception(
-                'Destination directory is not writable'
-            );
+            throw new \Exception(sprintf('Destination directory "%s" is not writable', $destination));
         }
 
         $prefix = $this->getPluginPrefix($archive);
@@ -164,9 +162,7 @@ class PluginExtractor
     private function assertNoDirectoryTraversal($filename)
     {
         if (strpos($filename, '../') !== false) {
-            throw new \RuntimeException(
-                sprintf('Directory Traversal detected')
-            );
+            throw new \RuntimeException('Directory Traversal detected');
         }
     }
 

--- a/engine/Shopware/Bundle/PluginInstallerBundle/StoreClient.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/StoreClient.php
@@ -521,10 +521,11 @@ class StoreClient
      */
     private function verifyResponseSignature(Response $response)
     {
-        $signature = $response->getHeader('x-shopware-signature');
+        $signatureHeaderName = 'x-shopware-signature';
+        $signature = $response->getHeader($signatureHeaderName);
 
         if (empty($signature)) {
-            throw new \RuntimeException('Signature not found in x-shopware-signature header');
+            throw new \RuntimeException(sprintf('Signature not found in %s header', $signatureHeaderName));
         }
 
         if (!$this->openSSLVerifier->isSystemSupported()) {

--- a/engine/Shopware/Bundle/SearchBundleDBAL/ConditionHandler/DynamicConditionParserTrait.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/ConditionHandler/DynamicConditionParserTrait.php
@@ -51,8 +51,7 @@ trait DynamicConditionParserTrait
         $field = trim($field);
 
         if (empty($field)) {
-            $msg = 'Condition class requires a defined attribute field!';
-            throw new \InvalidArgumentException($msg, 1);
+            throw new \InvalidArgumentException('Condition class requires a defined attribute field!', 1);
         }
 
         /**
@@ -63,7 +62,7 @@ trait DynamicConditionParserTrait
             ->listTableColumns($table);
 
         if (empty($columns)) {
-            throw new \RuntimeException("Could not retrieve columns from '$table'");
+            throw new \RuntimeException(sprintf('Could not retrieve columns from "%s".', $table));
         }
 
         $names = array_map(function (\Doctrine\DBAL\Schema\Column $column) {
@@ -71,7 +70,7 @@ trait DynamicConditionParserTrait
         }, $columns);
 
         if (!array_key_exists(strtolower($field), $names)) {
-            throw new \InvalidArgumentException("Invalid column name specified '$field'", 1);
+            throw new \InvalidArgumentException(sprintf('Invalid column name "%s" specified.', $field), 1);
         }
 
         $validOperators = [

--- a/engine/Shopware/Bundle/SearchBundleDBAL/SearchBundleDBALSubscriber.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SearchBundleDBALSubscriber.php
@@ -124,7 +124,7 @@ class SearchBundleDBALSubscriber implements SubscriberInterface
     private function validateHandlers(array $handlers)
     {
         if (empty($handlers)) {
-            throw new \RuntimeException('No handlers provided in \Shopware\Bundle\SearchBundleDBAL\SearchBundleDBALSubscriber');
+            throw new \RuntimeException(sprintf('No handlers provided in %s', __CLASS__));
         }
 
         foreach ($handlers as $handler) {

--- a/engine/Shopware/Bundle/SearchBundleES/ProductNumberSearch.php
+++ b/engine/Shopware/Bundle/SearchBundleES/ProductNumberSearch.php
@@ -242,12 +242,12 @@ class ProductNumberSearch implements ProductNumberSearchInterface
 
             //trigger error when new interface isn't implemented
             if (!$handler instanceof PartialConditionHandlerInterface) {
-                trigger_error(sprintf("Condition handler %s doesn't support new filter mode. Class has to implement \\Shopware\\Bundle\\SearchBundleES\\PartialConditionHandlerInterface.", get_class($handler)), E_USER_DEPRECATED);
+                trigger_error(sprintf("Condition handler %s doesn't support new filter mode. Class has to implement %s.", get_class($handler), PartialConditionHandlerInterface::class), E_USER_DEPRECATED);
             }
 
             //filter mode active and handler doesn't supports the filter mode?
             if ($criteria->generatePartialFacets() && !$handler instanceof PartialConditionHandlerInterface) {
-                throw new \Exception(sprintf("New filter mode activated, handler class %s doesn't support this mode", get_class($handler)));
+                throw new \Exception(sprintf('New filter mode activated, handler class %s doesn\'t support this mode', get_class($handler)));
             }
 
             //filter mode active and handler supports new filter mode?

--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/ProductNumberService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/ProductNumberService.php
@@ -76,7 +76,7 @@ class ProductNumberService implements ProductNumberServiceInterface
         $number = $statement->fetch(\PDO::FETCH_COLUMN);
 
         if (!$number) {
-            throw new \RuntimeException('No valid product number found');
+            throw new \RuntimeException(sprintf('No valid product number found by id %d', $productId));
         }
 
         return $number;
@@ -89,11 +89,11 @@ class ProductNumberService implements ProductNumberServiceInterface
     {
         $productId = $this->getProductIdByNumber($number);
         if (!$productId) {
-            throw new \RuntimeException('No valid product id found');
+            throw new \RuntimeException(sprintf('No valid product id found by product number "%s"', $number));
         }
 
         if (!$this->isProductAvailableInShop($productId, $context->getShop())) {
-            throw new \RuntimeException('Product not available in current shop');
+            throw new \RuntimeException(sprintf('Product with number "%s" is not available in current shop', $number));
         }
 
         $selected = null;
@@ -111,7 +111,7 @@ class ProductNumberService implements ProductNumberServiceInterface
 
         $selected = $this->findFallbackById($productId);
         if (!$selected) {
-            throw new \RuntimeException('No active product variant found');
+            throw new \RuntimeException(sprintf('No active product variant found by product with number "%s"', $number));
         }
 
         return $selected;

--- a/engine/Shopware/Commands/AdminCreateCommand.php
+++ b/engine/Shopware/Commands/AdminCreateCommand.php
@@ -165,10 +165,7 @@ class AdminCreateCommand extends ShopwareCommand
             return $locales[$locale];
         }
 
-        throw new \RuntimeException(sprintf(
-            'Backend Locale not supported (%s)',
-            $locale
-        ));
+        throw new \RuntimeException(sprintf('Backend Locale "%s" not supported', $locale));
     }
 
     /**
@@ -235,7 +232,7 @@ class AdminCreateCommand extends ShopwareCommand
 
         $option = $input->getOption('locale');
         if (empty($option)) {
-            throw new \InvalidArgumentException('Locle is required');
+            throw new \InvalidArgumentException('Locale is required');
         }
 
         $option = $input->getOption('password');

--- a/engine/Shopware/Commands/CacheClearCommand.php
+++ b/engine/Shopware/Commands/CacheClearCommand.php
@@ -56,7 +56,7 @@ class CacheClearCommand extends ShopwareCommand
         $filesystem = $this->getContainer()->get('file_system');
 
         if (!is_writable($realCacheDir)) {
-            throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $realCacheDir));
+            throw new \RuntimeException(sprintf('Unable to write in directory "%s"', $realCacheDir));
         }
 
         if ($filesystem->exists($oldCacheDir)) {

--- a/engine/Shopware/Commands/CronRunCommand.php
+++ b/engine/Shopware/Commands/CronRunCommand.php
@@ -162,13 +162,14 @@ EOF
 
         if (strpos($action, 'Shopware_') !== 0) {
             $action = str_replace(' ', '', ucwords(str_replace('_', ' ', $action)));
-            $job = $manager->getJobByAction('Shopware_CronJob_' . $action);
+            $action = 'Shopware_CronJob_' . $action;
+            $job = $manager->getJobByAction($action);
         }
 
         if ($job != null) {
             return $job;
         }
 
-        throw new \RuntimeException('Cron not found by given action name.');
+        throw new \RuntimeException(sprintf('Cron not found by action name "%s".', $action));
     }
 }

--- a/engine/Shopware/Commands/GenerateProductFeedCommand.php
+++ b/engine/Shopware/Commands/GenerateProductFeedCommand.php
@@ -76,10 +76,10 @@ class GenerateProductFeedCommand extends ShopwareCommand
 
         if (!is_dir($this->cacheDir)) {
             if (@mkdir($this->cacheDir, 0777, true) === false) {
-                throw new \RuntimeException(sprintf("Unable to create the %s directory (%s)\n", 'Productexport', $this->cacheDir));
+                throw new \RuntimeException(sprintf("Unable to create directory '%s'\n", $this->cacheDir));
             }
         } elseif (!is_writable($this->cacheDir)) {
-            throw new \RuntimeException(sprintf("Unable to write in the %s directory (%s)\n", 'Productexport', $this->cacheDir));
+            throw new \RuntimeException(sprintf("Unable to write in directory '%s'\n", $this->cacheDir));
         }
 
         $feedId = (int) $input->getOption('feed-id');

--- a/engine/Shopware/Commands/ThumbnailGenerateCommand.php
+++ b/engine/Shopware/Commands/ThumbnailGenerateCommand.php
@@ -199,7 +199,7 @@ class ThumbnailGenerateCommand extends ShopwareCommand
     private function createMediaThumbnails(Media $media)
     {
         if (!$this->imageExists($media)) {
-            throw new \Exception('Base image file does not exist: ' . $media->getPath());
+            throw new \Exception(sprintf('Base image file "%s" does not exist', $media->getPath()));
         }
 
         $thumbnails = $media->getThumbnailFilePaths();

--- a/engine/Shopware/Components/Acl.php
+++ b/engine/Shopware/Components/Acl.php
@@ -153,7 +153,7 @@ class Shopware_Components_Acl extends Zend_Acl
     {
         // Check if resource already exists
         if ($this->hasResourceInDatabase($resourceName)) {
-            throw new Enlight_Exception("Resource $resourceName already exists");
+            throw new Enlight_Exception(sprintf('Resource "%s" already exists', $resourceName));
         }
 
         $resource = new Resource();

--- a/engine/Shopware/Components/Api/Resource/Address.php
+++ b/engine/Shopware/Components/Api/Resource/Address.php
@@ -81,7 +81,7 @@ class Address extends Resource
         $address = $query->getOneOrNullResult($this->getResultMode());
 
         if (!$address) {
-            throw new ApiException\NotFoundException("Address by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Address by id %d not found', $id));
         }
 
         return $address;
@@ -130,7 +130,7 @@ class Address extends Resource
 
         $customer = $this->getContainer()->get('models')->find(CustomerModel::class, $customerId);
         if (!$customer) {
-            throw new ApiException\NotFoundException("Customer by id $customerId not found");
+            throw new ApiException\NotFoundException(sprintf('Customer by id %s not found', $customerId));
         }
 
         $this->setupContext($customer->getShop()->getId());
@@ -179,7 +179,7 @@ class Address extends Resource
         $address = $this->getRepository()->findOneBy(['id' => $id]);
 
         if (!$address) {
-            throw new ApiException\NotFoundException("Address by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Address by id %d not found', $id));
         }
 
         $this->setupContext($address->getCustomer()->getShop()->getId());
@@ -220,7 +220,7 @@ class Address extends Resource
         $address = $this->getRepository()->findOneBy(['id' => $id]);
 
         if (!$address) {
-            throw new ApiException\NotFoundException("Address by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Address by id %d not found', $id));
         }
 
         $this->addressService->delete($address);

--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -94,7 +94,7 @@ class Article extends Resource implements BatchInterface
         $articleDetail = $this->getDetailRepository()->findOneBy(['number' => $number]);
 
         if (!$articleDetail) {
-            throw new ApiException\NotFoundException("Article by number {$number} not found");
+            throw new ApiException\NotFoundException(sprintf('Article by number %s not found', $number));
         }
 
         return $articleDetail
@@ -166,7 +166,7 @@ class Article extends Resource implements BatchInterface
         $article = $builder->getQuery()->getOneOrNullResult($this->getResultMode());
 
         if (!$article) {
-            throw new ApiException\NotFoundException("Article by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Article by id %d not found', $id));
         }
 
         if ($this->getResultMode() == self::HYDRATE_ARRAY) {
@@ -421,7 +421,7 @@ class Article extends Resource implements BatchInterface
         $article = $builder->getQuery()->getOneOrNullResult(self::HYDRATE_OBJECT);
 
         if (!$article) {
-            throw new ApiException\NotFoundException("Article by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Article by id %d not found', $id));
         }
 
         $translations = [];
@@ -483,7 +483,7 @@ class Article extends Resource implements BatchInterface
         $article = $this->getRepository()->find($id);
 
         if (!$article) {
-            throw new ApiException\NotFoundException("Article by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Article by id %d not found', $id));
         }
 
         // Delete associated data
@@ -1424,8 +1424,9 @@ class Article extends Resource implements BatchInterface
                     $category = $this->getResource('Category')->findCategoryByPath($categoryData['path'], true);
 
                     if (!$category) {
-                        throw new ApiException\CustomValidationException(sprintf('Could not find or create category by path: %s.',
-                            $categoryData['path']));
+                        throw new ApiException\CustomValidationException(
+                            sprintf('Could not find or create category by path: %s.', $categoryData['path'])
+                        );
                     }
 
                     if (isset($categoryIds[$category->getId()])) {
@@ -1530,7 +1531,7 @@ class Article extends Resource implements BatchInterface
 
             if (!$existing) {
                 throw new ApiException\CustomValidationException(
-                    sprintf("Seo category isn't assigned as normal article category. Only assigned categories can be used as seo category")
+                    sprintf('Seo category isn\'t assigned as normal article category. Only assigned categories can be used as seo category')
                 );
             }
 
@@ -1730,7 +1731,7 @@ class Article extends Resource implements BatchInterface
         }
 
         if (!$propertyGroup instanceof \Shopware\Models\Property\Group) {
-            throw new ApiException\CustomValidationException(sprintf('There is no propertyGroup specified'));
+            throw new ApiException\CustomValidationException('There is no propertyGroup specified');
         }
 
         $models = [];
@@ -1796,14 +1797,14 @@ class Article extends Resource implements BatchInterface
                             $option = $relation->getOption();
                         }
                     } else {
-                        throw new ApiException\CustomValidationException('A property option need to be given for each property value');
+                        throw new ApiException\CustomValidationException('A property option needs to be given for each property value');
                     }
                     $option->fromArray($valueData['option']);
                     if ($option->isFilterable() === null) {
                         $option->setFilterable(false);
                     }
                 } else {
-                    throw new ApiException\CustomValidationException('A property option need to be given for each property value');
+                    throw new ApiException\CustomValidationException('A property option needs to be given for each property value');
                 }
                 // create the value
                 // If there is a filter value with matching name and option, load this value, else create a new one
@@ -1939,7 +1940,7 @@ class Article extends Resource implements BatchInterface
                 if (!$available) {
                     $property = $option['id'] ? $option['id'] : $option['name'];
                     throw new ApiException\CustomValidationException(
-                        sprintf('Passed option %s do not exist in the configurator set of the article', $property)
+                        sprintf('Passed option %s does not exist in the configurator set of the article', $property)
                     );
                 }
 
@@ -2386,7 +2387,9 @@ class Article extends Resource implements BatchInterface
                 try { //persist the model into the model manager
                     $this->getManager()->persist($media);
                 } catch (\Doctrine\ORM\ORMException $e) {
-                    throw new ApiException\CustomValidationException(sprintf('Some error occured while loading your image'));
+                    throw new ApiException\CustomValidationException(
+                        sprintf('Some error occured while loading your image from link "%s"', $downloadData['link'])
+                    );
                 }
 
                 $download->setFile($media->getPath());

--- a/engine/Shopware/Components/Api/Resource/Cache.php
+++ b/engine/Shopware/Components/Api/Resource/Cache.php
@@ -253,7 +253,7 @@ class Cache extends Resource implements ContainerAwareInterface, BatchInterface
                 $this->cacheManager->clearOpCache();
                 break;
             default:
-                throw new ApiException\NotFoundException("Cache {$cache} is not a valid cache id.");
+                throw new ApiException\NotFoundException(sprintf('Cache "%s" is not a valid cache id.', $cache));
         }
 
         if (!empty($capabilities['tags'])) {
@@ -296,7 +296,7 @@ class Cache extends Resource implements ContainerAwareInterface, BatchInterface
                 $cacheInfo = $this->cacheManager->getOpCacheCacheInfo();
                 break;
             default:
-                throw new ApiException\NotFoundException("Cache {$cache} is not a valid cache id.");
+                throw new ApiException\NotFoundException(sprintf('Cache "%s" is not a valid cache id.', $cache));
         }
 
         $cacheInfo['id'] = $cache;

--- a/engine/Shopware/Components/Api/Resource/Category.php
+++ b/engine/Shopware/Components/Api/Resource/Category.php
@@ -80,7 +80,7 @@ class Category extends Resource
         $category = $query->getOneOrNullResult($this->getResultMode());
 
         if (!$category) {
-            throw new ApiException\NotFoundException("Category by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Category by id %d not found', $id));
         }
 
         if ($this->getResultMode() === Resource::HYDRATE_ARRAY) {
@@ -203,7 +203,7 @@ class Category extends Resource
         $category = $this->getRepository()->find($id);
 
         if (!$category) {
-            throw new ApiException\NotFoundException("Category by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Category by id %d not found', $id));
         }
 
         $params = $this->prepareCategoryData($params);
@@ -244,7 +244,7 @@ class Category extends Resource
         $category = $this->getRepository()->find($id);
 
         if (!$category) {
-            throw new ApiException\NotFoundException("Category by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Category by id %d not found', $id));
         }
 
         $this->getManager()->remove($category);

--- a/engine/Shopware/Components/Api/Resource/Country.php
+++ b/engine/Shopware/Components/Api/Resource/Country.php
@@ -72,7 +72,7 @@ class Country extends Resource
         /** @var $country \Shopware\Models\Country\Country */
         $country = $builder->getQuery()->getOneOrNullResult($this->getResultMode());
         if (!$country) {
-            throw new ApiException\NotFoundException("Country by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Country by id %d not found', $id));
         }
 
         return $country;
@@ -167,7 +167,7 @@ class Country extends Resource
         /** @var $country \Shopware\Models\Country\Country */
         $country = $this->getRepository()->find($id);
         if (!$country) {
-            throw new ApiException\NotFoundException("Country by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Country by id %d not found', $id));
         }
 
         $params = $this->prepareCountryData($params, $country);
@@ -204,7 +204,7 @@ class Country extends Resource
         /** @var $country \Shopware\Models\Country\Country */
         $country = $this->getRepository()->find($id);
         if (!$country) {
-            throw new ApiException\NotFoundException("Country by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Country by id %d not found', $id));
         }
 
         $this->getManager()->remove($country);
@@ -238,7 +238,7 @@ class Country extends Resource
                 }
             } else {
                 if (isset($params[$param]) && empty($params[$param])) {
-                    throw new ApiException\CustomValidationException("Param $param may not be empty");
+                    throw new ApiException\CustomValidationException(sprintf('Param "%s" may not be empty', $param));
                 }
             }
         }
@@ -250,7 +250,7 @@ class Country extends Resource
                 if ($area) {
                     $params['area'] = $area;
                 } else {
-                    throw new ApiException\NotFoundException("Area by id {$areaId} not found");
+                    throw new ApiException\NotFoundException(sprintf('Area by id %d not found', $areaId));
                 }
             } else {
                 $params['area'] = null;
@@ -286,7 +286,7 @@ class Country extends Resource
             /** @var \Shopware\Models\Country\State $stateModel */
             $stateModel = $this->getManager()->find('Shopware\Models\Country\State', $state['id']);
             if (!$stateModel) {
-                throw new ApiException\NotFoundException("State by id {$state['id']} not found");
+                throw new ApiException\NotFoundException(sprintf('State by id %d not found', (int) $state['id']));
             }
 
             // Update state

--- a/engine/Shopware/Components/Api/Resource/Customer.php
+++ b/engine/Shopware/Components/Api/Resource/Customer.php
@@ -78,7 +78,7 @@ class Customer extends Resource
         $id = $builder->getQuery()->getOneOrNullResult();
 
         if (!$id) {
-            throw new ApiException\NotFoundException("Customer by number {$number} not found");
+            throw new ApiException\NotFoundException(sprintf('Customer by number %s not found', $number));
         }
 
         return $id['id'];
@@ -147,7 +147,7 @@ class Customer extends Resource
         $customer = $builder->getQuery()->getOneOrNullResult($this->getResultMode());
 
         if (!$customer) {
-            throw new ApiException\NotFoundException("Customer by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Customer by id %d not found', $id));
         }
 
         return $customer;
@@ -258,7 +258,7 @@ class Customer extends Resource
         $customer = $this->getRepository()->find($id);
 
         if (!$customer) {
-            throw new ApiException\NotFoundException("Customer with id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Customer by id %d not found', $id));
         }
 
         $this->setupContext($customer->getShop()->getId());
@@ -320,7 +320,7 @@ class Customer extends Resource
         $customer = $this->getRepository()->find($id);
 
         if (!$customer) {
-            throw new ApiException\NotFoundException("Customer by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Customer by id %d not found', $id));
         }
 
         $this->getManager()->remove($customer);

--- a/engine/Shopware/Components/Api/Resource/CustomerGroup.php
+++ b/engine/Shopware/Components/Api/Resource/CustomerGroup.php
@@ -72,7 +72,7 @@ class CustomerGroup extends Resource
         $result = $query->getOneOrNullResult($this->getResultMode());
 
         if (!$result) {
-            throw new ApiException\NotFoundException("CustomerGroup by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('CustomerGroup by id %d not found', $id));
         }
 
         return $result;
@@ -170,7 +170,7 @@ class CustomerGroup extends Resource
         $result = $this->getRepository()->find($id);
 
         if (!$result) {
-            throw new ApiException\NotFoundException("CustomerGroup by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('CustomerGroup by id %d not found', $id));
         }
 
         $params = $this->prepareCustomerGroupData($params, $result);
@@ -212,7 +212,7 @@ class CustomerGroup extends Resource
         $result = $this->getRepository()->find($id);
 
         if (!$result) {
-            throw new ApiException\NotFoundException("CustomerGroup by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('CustomerGroup by id %d not found', $id));
         }
 
         $this->getManager()->remove($result);

--- a/engine/Shopware/Components/Api/Resource/CustomerStream.php
+++ b/engine/Shopware/Components/Api/Resource/CustomerStream.php
@@ -230,7 +230,7 @@ class CustomerStream extends Resource
         $stream = $this->getManager()->find(CustomerStreamEntity::class, $id);
 
         if (!$stream) {
-            throw new NotFoundException("Customer Stream with id $id not found");
+            throw new NotFoundException(sprintf('Customer Stream by id %d not found', $id));
         }
 
         $data = $this->prepareData($data);

--- a/engine/Shopware/Components/Api/Resource/Manufacturer.php
+++ b/engine/Shopware/Components/Api/Resource/Manufacturer.php
@@ -68,7 +68,7 @@ class Manufacturer extends Resource
         $manufacturer = $query->getOneOrNullResult($this->getResultMode());
 
         if (!$manufacturer) {
-            throw new ApiException\NotFoundException("Manufacturer by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Manufacturer by id %d not found', $id));
         }
 
         return $manufacturer;
@@ -157,7 +157,7 @@ class Manufacturer extends Resource
         $manufacturer = $this->getRepository()->findOneBy(['id' => $id]);
 
         if (!$manufacturer) {
-            throw new ApiException\NotFoundException("Manufacturer by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Manufacturer by id %d not found', $id));
         }
 
         $params = $this->prepareManufacturerData($params);
@@ -194,7 +194,7 @@ class Manufacturer extends Resource
         $manufacturer = $this->getRepository()->findOneBy(['id' => $id]);
 
         if (!$manufacturer) {
-            throw new ApiException\NotFoundException("Manufacturer by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Manufacturer by id %d not found', $id));
         }
 
         $this->getManager()->remove($manufacturer);

--- a/engine/Shopware/Components/Api/Resource/Media.php
+++ b/engine/Shopware/Components/Api/Resource/Media.php
@@ -74,7 +74,7 @@ class Media extends Resource
         $media = $query->getOneOrNullResult($this->getResultMode());
 
         if (!$media) {
-            throw new ApiException\NotFoundException("Media by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Media by id %d not found', $id));
         }
 
         $mediaService = Shopware()->Container()->get('shopware_media.media_service');
@@ -214,7 +214,7 @@ class Media extends Resource
         $media = $this->getRepository()->find($id);
 
         if (!$media) {
-            throw new ApiException\NotFoundException("Media by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Media by id %d not found', $id));
         }
 
         $this->getManager()->remove($media);
@@ -312,13 +312,14 @@ class Media extends Resource
             case 'https':
             case 'file':
                 $filename = $this->getUniqueFileName($destPath, $baseFilename);
+                $destFilePath = sprintf('%s/%s', $destPath, $filename);
 
-                if (!$put_handle = fopen("$destPath/$filename", 'wb+')) {
-                    throw new \Exception("Could not open $destPath/$filename for writing");
+                if (!$put_handle = fopen($destFilePath, 'wb+')) {
+                    throw new \Exception(sprintf('Could not open %s for writing', $destFilePath));
                 }
 
                 if (!$get_handle = fopen($url, 'rb')) {
-                    throw new \Exception("Could not open $url for reading");
+                    throw new \Exception(sprintf('Could not open %s for reading', $url));
                 }
                 while (!feof($get_handle)) {
                     fwrite($put_handle, fgets($get_handle, 4096));
@@ -326,10 +327,10 @@ class Media extends Resource
                 fclose($get_handle);
                 fclose($put_handle);
 
-                return "$destPath/$filename";
+                return $destFilePath;
         }
         throw new \InvalidArgumentException(
-            sprintf("Unsupported schema '%s'.", $urlArray['scheme'])
+            sprintf('Unsupported schema "%s".', $urlArray['scheme'])
         );
     }
 
@@ -392,17 +393,17 @@ class Media extends Resource
     protected function uploadBase64File($url, $destinationPath, $baseFilename)
     {
         if (!$get_handle = fopen($url, 'r')) {
-            throw new \Exception("Could not open $url for reading");
+            throw new \Exception(sprintf('Could not open %s for reading', $url));
         }
 
         $meta = stream_get_meta_data($get_handle);
         if (!strpos($meta['mediatype'], 'image/') === false) {
-            throw new ApiException\CustomValidationException('No valid media type passed for the article image : ' . $url);
+            throw new ApiException\CustomValidationException(sprintf('No valid media type passed for the article image: %s', $url));
         }
 
         $extension = str_replace('image/', '', $meta['mediatype']);
-        $filename = $this->getUniqueFileName($destinationPath, $baseFilename);
-        $filename .= '.' . $extension;
+        $filename = $this->getUniqueFileName($destinationPath, $baseFilename) . '.' . $extension;
+        $destinationFilePath = sprintf('%s/%s', $destinationPath, $filename);
 
         if (!$put_handle = fopen("$destinationPath/$filename", 'wb+')) {
             throw new \Exception("Could not open $destinationPath/$filename for writing");
@@ -413,7 +414,7 @@ class Media extends Resource
         fclose($get_handle);
         fclose($put_handle);
 
-        return "$destinationPath/$filename";
+        return $destinationFilePath;
     }
 
     /**

--- a/engine/Shopware/Components/Api/Resource/Order.php
+++ b/engine/Shopware/Components/Api/Resource/Order.php
@@ -77,7 +77,7 @@ class Order extends Resource
         $orderModel = $this->getRepository()->findOneBy(['number' => $number]);
 
         if (!$orderModel) {
-            throw new ApiException\NotFoundException("Order by number {$number} not found");
+            throw new ApiException\NotFoundException(sprintf('Order by number %s not found', $number));
         }
 
         return $orderModel->getId();
@@ -120,7 +120,7 @@ class Order extends Resource
         $order = $builder->getQuery()->getOneOrNullResult($this->getResultMode());
 
         if (!$order) {
-            throw new ApiException\NotFoundException("Order by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Order by id %d not found', $id));
         }
 
         if (is_array($order)) {
@@ -277,7 +277,7 @@ class Order extends Resource
         $order = $this->getRepository()->find($id);
 
         if (!$order) {
-            throw new ApiException\NotFoundException("Order by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Order by id %d not found', $id));
         }
 
         $params = $this->prepareOrderData($params);
@@ -413,10 +413,9 @@ class Order extends Resource
             $params['partner'] = $this->getContainer()->get('models')->find(Partner::class, $params['partnerId']);
 
             if (empty($params['partner'])) {
-                throw new ApiException\NotFoundException(sprintf(
-                    'Partner by id %s not found',
-                    $params['partnerId']
-                ));
+                throw new ApiException\NotFoundException(
+                    sprintf('Partner by id %s not found', $params['partnerId'])
+                );
             }
 
             unset($params['partnerId']);

--- a/engine/Shopware/Components/Api/Resource/PropertyGroup.php
+++ b/engine/Shopware/Components/Api/Resource/PropertyGroup.php
@@ -66,7 +66,7 @@ class PropertyGroup extends Resource
         $property = $query->getOneOrNullResult($this->getResultMode());
 
         if (!$property) {
-            throw new ApiException\NotFoundException("Property group by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('PropertyGroup by id %d not found', $id));
         }
 
         return $property;
@@ -149,7 +149,7 @@ class PropertyGroup extends Resource
         $propertyGroup = $this->getRepository()->find($id);
 
         if (!$propertyGroup) {
-            throw new ApiException\NotFoundException("Property group by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('PropertyGroup by id %d not found', $id));
         }
 
         $params = $this->preparePropertyData($params, $propertyGroup);
@@ -185,7 +185,7 @@ class PropertyGroup extends Resource
         $propertyGroup = $this->getRepository()->find($id);
 
         if (!$propertyGroup) {
-            throw new ApiException\NotFoundException("PropertyGroup by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('PropertyGroup by id %d not found', $id));
         }
 
         $this->getManager()->remove($propertyGroup);

--- a/engine/Shopware/Components/Api/Resource/User.php
+++ b/engine/Shopware/Components/Api/Resource/User.php
@@ -268,20 +268,20 @@ class User extends Resource
         }
 
         if (!$this->getAcl()->has($resource)) {
-            $message = sprintf('No resource "%s" found', $resource);
-            throw new ApiException\PrivilegeException($message);
+            throw new ApiException\PrivilegeException(sprintf('No resource "%s" found', $resource));
         }
 
         $role = $this->getRole();
 
         if (!$this->getAcl()->isAllowed($role, $resource, $privilege)) {
-            $message = sprintf(
-                'Role "%s" is not allowed to "%s" on resource "%s"',
-                is_string($role) ? $role : $role->getRoleId(),
-                $privilege,
-                is_string($resource) ? $resource : $resource->getResourceId()
+            throw new ApiException\PrivilegeException(
+                sprintf(
+                    'Role "%s" is not allowed to "%s" on resource "%s"',
+                    is_string($role) ? $role : $role->getRoleId(),
+                    $privilege,
+                    is_string($resource) ? $resource : $resource->getResourceId()
+                )
             );
-            throw new ApiException\PrivilegeException($message);
         }
     }
 

--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -98,7 +98,7 @@ class Variant extends Resource implements BatchInterface
         $variant = $builder->getQuery()->getOneOrNullResult($this->getResultMode());
 
         if (!$variant) {
-            throw new ApiException\NotFoundException("Variant by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Variant by id %d not found', $id));
         }
 
         if ($this->getResultMode() === self::HYDRATE_ARRAY) {
@@ -178,7 +178,7 @@ class Variant extends Resource implements BatchInterface
         $articleDetail = $this->getRepository()->findOneBy(['number' => $number]);
 
         if (!$articleDetail) {
-            throw new ApiException\NotFoundException("Variant by number {$number} not found");
+            throw new ApiException\NotFoundException(sprintf('Variant by number %s not found', $number));
         }
 
         return $articleDetail->getId();
@@ -219,7 +219,7 @@ class Variant extends Resource implements BatchInterface
         $articleDetail = $this->getRepository()->find($id);
 
         if (!$articleDetail) {
-            throw new ApiException\NotFoundException("Variant by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Variant by id %d not found', $id));
         }
 
         if ($articleDetail->getKind() === 1) {
@@ -273,7 +273,7 @@ class Variant extends Resource implements BatchInterface
         $variant = $this->getRepository()->find($id);
 
         if (!$variant) {
-            throw new ApiException\NotFoundException("Variant by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Variant by id %d not found', $id));
         }
 
         $variant = $this->internalUpdate($id, $params, $variant->getArticle());
@@ -312,7 +312,7 @@ class Variant extends Resource implements BatchInterface
         $article = $this->getManager()->find('Shopware\Models\Article\Article', $articleId);
 
         if (!$article) {
-            throw new ApiException\NotFoundException("Article by id $articleId not found");
+            throw new ApiException\NotFoundException(sprintf('Article by id %d not found', $articleId));
         }
 
         $variant = $this->internalCreate($params, $article);
@@ -354,7 +354,7 @@ class Variant extends Resource implements BatchInterface
         $variant = $this->getRepository()->find($id);
 
         if (!$variant) {
-            throw new ApiException\NotFoundException("Variant by id $id not found");
+            throw new ApiException\NotFoundException(sprintf('Variant by id %d not found', $id));
         }
 
         $variant->setArticle($article);

--- a/engine/Shopware/Components/CategoryHandling/CategoryDuplicator.php
+++ b/engine/Shopware/Components/CategoryHandling/CategoryDuplicator.php
@@ -78,7 +78,7 @@ class CategoryDuplicator
         $originalCategory = $originalCategoryStmt->fetch(\PDO::FETCH_ASSOC);
 
         if (empty($originalCategory)) {
-            throw new \RuntimeException('Category ' . $originalCategoryId . ' not found');
+            throw new \RuntimeException(sprintf('Category "%s" not found', $originalCategoryId));
         }
 
         $newPosStmt = $this->connection

--- a/engine/Shopware/Components/ConfigLoader.php
+++ b/engine/Shopware/Components/ConfigLoader.php
@@ -99,14 +99,14 @@ class ConfigLoader
         $suffix = strtolower(pathinfo($file, PATHINFO_EXTENSION));
 
         if (!in_array($suffix, ['php', 'inc'])) {
-            throw new \Exception('Invalid configuration file provided; unknown config type');
+            throw new \Exception(sprintf('Invalid configuration file provided; unknown config type "%s"', $suffix));
         }
 
         $config = include $file;
 
         if (!is_array($config)) {
             throw new \Exception(
-                'Invalid configuration file provided; PHP file does not return array value'
+                'Invalid configuration file provided; PHP file does not return an array value'
             );
         }
 

--- a/engine/Shopware/Components/CsvIterator.php
+++ b/engine/Shopware/Components/CsvIterator.php
@@ -94,7 +94,7 @@ class Shopware_Components_CsvIterator extends Enlight_Class implements Iterator
     public function __construct($filename, $delimiter = self::DEFAULT_DELIMITER, $header = null)
     {
         if (($this->_handler = fopen($filename, 'r')) === false) {
-            throw new Exception("The file '$filename' cannot be opened");
+            throw new Exception(sprintf('The file "%s" cannot be opened', $filename));
         }
 
         $this->_newline = $this->getNewLineType();

--- a/engine/Shopware/Components/DependencyInjection/Bridge/Db.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Db.php
@@ -75,7 +75,7 @@ class Db
                 $message
             );
 
-            throw new \RuntimeException('Could not connect to database. Message from SQL Server: ' . $message, $e->getCode());
+            throw new \RuntimeException(sprintf('Could not connect to database. Message from SQL Server: %s', $message), $e->getCode());
         }
 
         return $conn;

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -203,7 +203,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
             }
 
             if (empty($document->_subshop['id'])) {
-                throw new Enlight_Exception("Could not load template path for order $orderID");
+                throw new Enlight_Exception(sprintf('Could not load template path for order "%s"', $orderID));
             }
             if (!empty($config['_allowMultipleDocuments'])) {
                 $document->_allowMultipleDocuments = $config['_allowMultipleDocuments'];

--- a/engine/Shopware/Components/Emotion/EmotionExporter.php
+++ b/engine/Shopware/Components/Emotion/EmotionExporter.php
@@ -113,7 +113,7 @@ class EmotionExporter implements EmotionExporterInterface
         $filename = $this->rootDirectory . '/files/downloads/' . $name . time() . '.zip';
 
         if ($zip->open($filename, \ZipArchive::CREATE) !== true) {
-            throw new \Exception('Could not create zip file!');
+            throw new \Exception(sprintf('Could not create zip file in %s!', $filename));
         }
 
         $emotionData = $this->transformer->transform($emotionId, true);
@@ -148,7 +148,7 @@ class EmotionExporter implements EmotionExporterInterface
         $zip->addFromString('emotion.json', json_encode($exportData));
 
         if (!$zip->close()) {
-            throw new \Exception('Could not close zip file!');
+            throw new \Exception(sprintf('Could not close zip file in %s!', $filename));
         }
 
         $this->presetResource->delete($preset->getId());

--- a/engine/Shopware/Components/Emotion/EmotionImporter.php
+++ b/engine/Shopware/Components/Emotion/EmotionImporter.php
@@ -117,15 +117,15 @@ class EmotionImporter implements EmotionImporterInterface
         $zip = new \ZipArchive();
 
         if ($zip->open($filePath) !== true) {
-            throw new EmotionImportException('Could not open zip file!');
+            throw new EmotionImportException(sprintf('Could not open zip file in %s!', $filePath));
         }
 
         if ($zip->locateName('emotion.json') === false) {
-            throw new EmotionImportException('Missing emotion data file!');
+            throw new EmotionImportException(sprintf('Missing emotion.json in %s!', $filePath));
         }
 
         if ($zip->extractTo($extractPath) !== true) {
-            throw new EmotionImportException('Could not extract zip file!');
+            throw new EmotionImportException(sprintf('Could not extract zip file %s to $s!', $filePath, $extractPath));
         }
 
         $zip->close();
@@ -173,7 +173,9 @@ class EmotionImporter implements EmotionImporterInterface
         }
 
         if ($missingPlugins) {
-            throw new EmotionImportException('The following plugins are required to use this shopping world: <br>' . implode('<br>', $missingPlugins));
+            throw new EmotionImportException(
+                sprintf('The following plugins are required to use this shopping world: <br>%s', implode('<br>', $missingPlugins))
+            );
         }
     }
 

--- a/engine/Shopware/Components/Emotion/Preset/PresetDataSynchronizer.php
+++ b/engine/Shopware/Components/Emotion/Preset/PresetDataSynchronizer.php
@@ -82,7 +82,7 @@ class PresetDataSynchronizer implements PresetDataSynchronizerInterface
         $presetData = json_decode($preset->getPresetData(), true);
 
         if (!$presetData || !is_array($presetData) || !array_key_exists('elements', $presetData)) {
-            throw new PresetAssetImportException('The preset data of the ' . $preset->getName() . ' preset seems to be invalid.');
+            throw new PresetAssetImportException(sprintf('The preset data of the %s preset seems to be invalid.', $preset->getName()));
         }
 
         // continue if no sync data present or we just have an assets key which is empty

--- a/engine/Shopware/Components/HttpCache/Store.php
+++ b/engine/Shopware/Components/HttpCache/Store.php
@@ -203,7 +203,7 @@ class Store extends BaseStore
             $content[$cacheKey] = $headerKey;
 
             if (!false === $this->save($key, json_encode($content))) {
-                throw new \RuntimeException("Could not write cacheKey $key");
+                throw new \RuntimeException(sprintf('Could not write cacheKey "%s"', $key));
             }
         }
 

--- a/engine/Shopware/Components/License/Service/LocalLicenseUnpackService.php
+++ b/engine/Shopware/Components/License/Service/LocalLicenseUnpackService.php
@@ -58,7 +58,7 @@ class LocalLicenseUnpackService implements LicenseUnpackServiceInterface
         }
 
         if ($info['host'] != $host) {
-            throw new LicenseHostException(new LicenseInformation($info), 'License key is not valid for domain ' . $request->host);
+            throw new LicenseHostException(new LicenseInformation($info), sprintf('License key is not valid for domain %s', $request->host));
         }
 
         $info['edition'] = $info['product'];

--- a/engine/Shopware/Components/Migrations/Manager.php
+++ b/engine/Shopware/Components/Migrations/Manager.php
@@ -201,7 +201,7 @@ class Manager
             }
 
             if (!($migrationClass instanceof AbstractMigration)) {
-                throw new \Exception("$migrationClassName is not instanceof AbstractMigration");
+                throw new \Exception(sprintf('%s is not instanceof AbstractMigration', $migrationClassName));
             }
 
             if ($migrationClass->getVersion() != $result['0']) {

--- a/engine/Shopware/Components/Model/CategoryDenormalization.php
+++ b/engine/Shopware/Components/Model/CategoryDenormalization.php
@@ -609,12 +609,12 @@ class CategoryDenormalization
     {
         $count = (int) $count;
         if ($count <= 0) {
-            throw new \Exception("LIMIT argument count=$count is not valid");
+            throw new \Exception(sprintf('LIMIT argument count=%s is not valid', $count));
         }
 
         $offset = (int) $offset;
         if ($offset < 0) {
-            throw new \Exception("LIMIT argument offset=$offset is not valid");
+            throw new \Exception(sprintf('LIMIT argument offset=%s is not valid', $offset));
         }
 
         $sql .= " LIMIT $count";

--- a/engine/Shopware/Components/Model/Configuration.php
+++ b/engine/Shopware/Components/Model/Configuration.php
@@ -301,7 +301,7 @@ class Configuration extends BaseConfiguration
         }
 
         if (!class_exists($provider)) {
-            throw new \Exception('Doctrine cache provider "' . $provider . "' not found failure.");
+            throw new \Exception(sprintf('Doctrine cache provider "%s" not found failure.', $provider));
         }
 
         return new $provider();

--- a/engine/Shopware/Components/Model/Generator.php
+++ b/engine/Shopware/Components/Model/Generator.php
@@ -329,7 +329,9 @@ class %className% extends ModelEntity
         $file = $this->getPath() . $className . '.php';
 
         if (file_exists($file) && !is_writable($file)) {
-            throw new \Exception('File: ' . $file . " isn't writable, please check the file permissions for this model!", 501);
+            throw new \Exception(
+                sprintf('File: "%s" isn\'t writable, please check the file permissions for this model!', $file), 501
+            );
         }
 
         $result = file_put_contents($file, $sourceCode);

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Backup.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Backup.php
@@ -110,7 +110,7 @@ class Backup
             }
 
             if (!is_dir($this->backupPath)) {
-                throw new \RuntimeException("Could not find nor create '{$this->backupPath}'");
+                throw new \RuntimeException(sprintf('Could not find nor create "%s"', $this->backupPath));
             }
         }
     }
@@ -217,7 +217,7 @@ class Backup
         $backup = $entityManager->find(\Shopware\Models\MultiEdit\Backup::class, $id);
 
         if (!$backup) {
-            throw new \RuntimeException("Backup by id {$id} not found");
+            throw new \RuntimeException(sprintf('Backup by id %d not found', $id));
         }
 
         $path = $backup->getPath();
@@ -228,7 +228,7 @@ class Backup
             $zip->open($path);
             $success = $zip->extractTo($dir);
             if (!$success) {
-                throw new \RuntimeException("Could not extract {$path} to {$dir}");
+                throw new \RuntimeException(sprintf('Could not extract %s to %s', $path, $dir));
             }
             $zip->close();
         }
@@ -295,7 +295,7 @@ class Backup
         $backup = $entityManager->find(\Shopware\Models\MultiEdit\Backup::class, $id);
 
         if (!$backup) {
-            throw new \RuntimeException("Backup by id {$id} not found");
+            throw new \RuntimeException(sprintf('Backup by id %d not found', $id));
         }
 
         $dir = dirname($backup->getPath());
@@ -450,7 +450,7 @@ class Backup
         $prefix = $this->affectedTables[$table]['prefix'];
 
         if (!$prefix) {
-            throw new \RuntimeException("Empty prefix for {$table}");
+            throw new \RuntimeException(sprintf('Empty prefix for %s', $table));
         }
 
         return $prefix;
@@ -470,7 +470,7 @@ class Backup
         $columns = $this->affectedTables[$table]['columns'];
 
         if (!$columns) {
-            throw new \RuntimeException("Empty column for {$table}");
+            throw new \RuntimeException(sprintf('Empty column for %s', $table));
         }
 
         return $columns;
@@ -644,7 +644,7 @@ class Backup
         $zip = new \ZipArchive();
 
         if ($zip->open($zipPath, \ZipArchive::CREATE) !== true) {
-            throw new \RuntimeException("Could not open {$zipPath}, please check the permissions. ");
+            throw new \RuntimeException(sprintf('Could not open %s, please check the permissions.', $zipPath));
         }
 
         $files = $this->getDirectoryList($this->outputPath);

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/BatchProcess.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/BatchProcess.php
@@ -153,7 +153,7 @@ class BatchProcess
                     $attributes[$attribute] = ['set'];
                     break;
                 default:
-                    throw new \RuntimeException("Column with type {$type} was not configured, yet");
+                    throw new \RuntimeException(sprintf('Column with type %s was not configured, yet', $type));
             }
             // Technically we're able to process DQL here. This should not be enabled by default and is quite limited
             if (false) {
@@ -296,7 +296,7 @@ class BatchProcess
         $queue = $entityManager->find('\Shopware\Models\MultiEdit\Queue', $queueId);
 
         if (!$queue) {
-            throw new \RuntimeException("Queue with ID {$queueId} not found");
+            throw new \RuntimeException(sprintf('Queue with ID %s not found', $queueId));
         }
 
         $operations = json_decode($queue->getOperations(), true);
@@ -314,7 +314,7 @@ class BatchProcess
             }
         } catch (\Exception $e) {
             $connection->rollBack();
-            throw new \RuntimeException("Error updating details: {$e->getMessage()}", 0, $e);
+            throw new \RuntimeException(sprintf('Error updating details: %s', $e->getMessage()), 0, $e);
         }
         $remaining = $queue->getArticleDetails()->count();
 

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
@@ -937,7 +937,7 @@ class DqlHelper
                 );
         }
 
-        throw new \RuntimeException("Foreign table {$foreignPrefix} not defined, yet. Please report this error.");
+        throw new \RuntimeException(sprintf('Foreign table %s not defined, yet. Please report this error.', $foreignPrefix));
     }
 
     /**

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Grammar.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Grammar.php
@@ -132,7 +132,7 @@ class Grammar
                     )) {
                         $attributes[$formattedColumn] = $event->getReturn();
                     } else {
-                        throw new \RuntimeException("Column with type {$type} was not configured, yet");
+                        throw new \RuntimeException(sprintf('Column with type %s was not configured, yet', $type));
                     }
             }
         }

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Queue.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Queue.php
@@ -153,7 +153,7 @@ class Queue
             $newBackup = false;
             $queue = $entityManager->find('\Shopware\Models\MultiEdit\Queue', $queueId);
             if (!$queue) {
-                throw new \RuntimeException("Queue with id {$queueId} not found");
+                throw new \RuntimeException(sprintf('Queue with ID %s not found', $queueId));
             }
         } else {
             $newBackup = true;

--- a/engine/Shopware/Components/OpenSSLEncryption.php
+++ b/engine/Shopware/Components/OpenSSLEncryption.php
@@ -81,7 +81,7 @@ class OpenSSLEncryption
             $errors = [];
             while ($errors[] = openssl_error_string());
             $errorString = implode("\n", $errors);
-            throw new \Exception('Got openssl error' . $errorString);
+            throw new \Exception(sprintf('Got openssl error %s', $errorString));
         }
 
         $result = [

--- a/engine/Shopware/Components/OpenSSLVerifier.php
+++ b/engine/Shopware/Components/OpenSSLVerifier.php
@@ -44,10 +44,7 @@ class OpenSSLVerifier
     public function __construct($publicKey)
     {
         if (!is_readable($publicKey)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Public keyfile (%s) not readable',
-                $publicKey
-            ));
+            throw new \InvalidArgumentException(sprintf('Public keyfile "%s" not readable', $publicKey));
         }
 
         $this->publicKeyPath = $publicKey;

--- a/engine/Shopware/Components/Password/Manager.php
+++ b/engine/Shopware/Components/Password/Manager.php
@@ -61,7 +61,7 @@ class Manager
         $name = strtolower(trim($encoder->getName()));
 
         if (isset($this->encoder[$name])) {
-            throw new \Exception("Encoder by name {$name} already registered");
+            throw new \Exception(sprintf('Encoder by name %s already registered', $name));
         }
 
         $this->encoder[$name] = $encoder;
@@ -79,13 +79,13 @@ class Manager
         $name = strtolower(trim($name));
 
         if (!isset($this->encoder[$name])) {
-            throw new \Exception("Encoder by name {$name} not found");
+            throw new \Exception(sprintf('Encoder by name %s not found', $name));
         }
 
         $encoder = $this->encoder[$name];
 
         if (method_exists($encoder, 'isCompatible') && !$encoder->isCompatible()) {
-            throw new \Exception("Encoder by name {$name} is not compatible with your system");
+            throw new \Exception(sprintf('Encoder by name %s is not compatible with your system', $name));
         }
 
         return $encoder;

--- a/engine/Shopware/Components/Plugin/Bootstrap.php
+++ b/engine/Shopware/Components/Plugin/Bootstrap.php
@@ -520,7 +520,7 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
         $path = $this->Path() . 'Controllers/' . ucfirst($module) . '/' . ucfirst($controller) . '.php';
 
         if (!file_exists($path)) {
-            throw new Enlight_Exception('Controller "' . $controller . '" can\'t load failure');
+            throw new Enlight_Exception(sprintf('Controller "%s" can\'t load failure', $controller));
         }
 
         //register plugin model directory

--- a/engine/Shopware/Components/Random.php
+++ b/engine/Shopware/Components/Random.php
@@ -82,9 +82,7 @@ abstract class Random
     public static function getInteger($min, $max)
     {
         if ($min > $max) {
-            throw new \DomainException(
-                'The min parameter must be lower than max parameter'
-            );
+            throw new \DomainException('The min parameter must be lower than max parameter');
         }
 
         return random_int($min, $max);

--- a/engine/Shopware/Components/ReflectionHelper.php
+++ b/engine/Shopware/Components/ReflectionHelper.php
@@ -72,7 +72,7 @@ class ReflectionHelper
 
             if (!isset($arguments[$paramName])) {
                 if (!$constructorParam->isOptional()) {
-                    throw new \RuntimeException(sprintf("Required constructor Parameter Missing: '$%s'.", $paramName));
+                    throw new \RuntimeException(sprintf('Required constructor parameter missing: "$%s".', $paramName));
                 }
                 $newParams[] = $constructorParam->getDefaultValue();
 
@@ -104,7 +104,7 @@ class ReflectionHelper
          * Trying to execute a class outside of the Shopware DocumentRoot
          */
         if ($fileDir !== $docPath) {
-            throw new \InvalidArgumentException('Class out of scope', 1);
+            throw new \InvalidArgumentException(sprintf('Class "%s" out of scope', $class->getFileName()), 1);
         }
         if (empty($directories)) {
             return;
@@ -129,7 +129,7 @@ class ReflectionHelper
         }
 
         if ($error) {
-            throw new \InvalidArgumentException('Class out of scope', 2);
+            throw new \InvalidArgumentException(sprintf('Class "%s" out of scope', $class->getFileName()), 2);
         }
     }
 }

--- a/engine/Shopware/Components/Snippet/SnippetValidator.php
+++ b/engine/Shopware/Components/Snippet/SnippetValidator.php
@@ -54,7 +54,7 @@ class SnippetValidator
     public function validate($snippetsDir)
     {
         if (!file_exists($snippetsDir)) {
-            throw new \RuntimeException('Could not find ' . $snippetsDir . ' folder for snippet validation');
+            throw new \RuntimeException(sprintf('Could not find %s folder for snippet validation', $snippetsDir));
         }
 
         $dirIterator = new \RecursiveDirectoryIterator($snippetsDir, \RecursiveDirectoryIterator::SKIP_DOTS);

--- a/engine/Shopware/Components/StringCompiler.php
+++ b/engine/Shopware/Components/StringCompiler.php
@@ -171,7 +171,7 @@ class Shopware_Components_StringCompiler
 
             if (stripos($errorMessage, 'Syntax Error in template') === 0) {
                 // Strip away filepath which is a md5sum
-                $errorMessage = 'Syntax Error ' . substr($errorMessage, 69);
+                $errorMessage = sprintf('Syntax Error %s', substr($errorMessage, 69));
             }
 
             throw new \Enlight_Exception($errorMessage, 0, $e);

--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -184,7 +184,7 @@ class Shopware_Components_TemplateMail
                 ['name' => $modelName]
             );
             if (!$mailModel) {
-                throw new \Enlight_Exception("Mail-Template with name '{$modelName}' could not be found.");
+                throw new \Enlight_Exception(sprintf('Mail-Template with name "%s" could not be found.', $modelName));
             }
         }
 

--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -437,7 +437,7 @@ class Compiler
 
         foreach ($collection as $temp) {
             if (!is_array($temp)) {
-                throw new \Exception("The passed plugin less config isn't an array!");
+                throw new \Exception('The passed plugin less config isn\'t an array!');
             }
             $config = array_merge($config, $temp);
         }

--- a/engine/Shopware/Components/Theme/Generator.php
+++ b/engine/Shopware/Components/Theme/Generator.php
@@ -205,12 +205,12 @@ EOD;
     {
         if (!is_writable($this->pathResolver->getFrontendThemeDirectory())) {
             throw new \Exception(
-                "Theme directory isn't writable"
+                sprintf('Theme directory %s isn\'t writable', $this->pathResolver->getFrontendThemeDirectory())
             );
         }
         if (!isset($data['template']) || empty($data['template'])) {
             throw new \Exception(
-                "Passed data array contains no valid theme name under the array key 'template'."
+                'Passed data array contains no valid theme name under the array key "template".'
             );
         }
 

--- a/engine/Shopware/Components/Theme/JavascriptCollector.php
+++ b/engine/Shopware/Components/Theme/JavascriptCollector.php
@@ -155,7 +155,7 @@ class JavascriptCollector
         foreach ($collection as $file) {
             if (!file_exists($file)) {
                 throw new \Exception(
-                    sprintf("Some plugin tries to compress a javascript file, but the file %s doesn't exist", $file)
+                    sprintf('Some plugin tries to compress a javascript file, but the file %s doesn\'t exist', $file)
                 );
             }
         }

--- a/engine/Shopware/Components/Theme/Util.php
+++ b/engine/Shopware/Components/Theme/Util.php
@@ -103,7 +103,7 @@ class Util
         if (!file_exists($file)) {
             throw new \Exception(sprintf(
                 'Theme directory %s contains no Theme.php',
-                $template->getTemplate()
+                $directory
             ));
         }
 
@@ -132,7 +132,7 @@ class Util
         if (!file_exists($file)) {
             throw new \Exception(sprintf(
                 'Theme directory %s contains no Theme.php',
-                $directory->getFilename()
+                $directory->getPathname()
             ));
         }
 

--- a/engine/Shopware/Components/Thumbnail/Generator/Basic.php
+++ b/engine/Shopware/Components/Thumbnail/Generator/Basic.php
@@ -76,7 +76,7 @@ class Basic implements GeneratorInterface
     public function createThumbnail($imagePath, $destination, $maxWidth, $maxHeight, $keepProportions = false, $quality = 90)
     {
         if (!$this->mediaService->has($imagePath)) {
-            throw new \Exception('File not found: ' . $imagePath);
+            throw new \Exception(sprintf('File not found: %s', $imagePath));
         }
 
         $content = $this->mediaService->read($imagePath);

--- a/engine/Shopware/Components/Thumbnail/Manager.php
+++ b/engine/Shopware/Components/Thumbnail/Manager.php
@@ -97,8 +97,10 @@ class Manager
      */
     public function createMediaThumbnail(Media $media, $thumbnailSizes = [], $keepProportions = false)
     {
+        $imagePath = $media->getPath();
+
         if ($media->getType() !== $media::TYPE_IMAGE) {
-            throw new \Exception('File is not an image.');
+            throw new \Exception('File %s is not an image.', $imagePath);
         }
 
         if (empty($thumbnailSizes)) {
@@ -118,8 +120,6 @@ class Manager
         }
 
         $thumbnailSizes = $this->uniformThumbnailSizes($thumbnailSizes);
-
-        $imagePath = $media->getPath();
 
         $parameters = [
             'path' => $imagePath,

--- a/engine/Shopware/Controllers/Api/GenerateArticleImages.php
+++ b/engine/Shopware/Controllers/Api/GenerateArticleImages.php
@@ -59,7 +59,7 @@ class Shopware_Controllers_Api_GenerateArticleImages extends Shopware_Controller
         $article = $this->resource->getRepository()->find($id);
 
         if (!$article) {
-            throw new ApiException\NotFoundException("Article with id \"$id\" was not found");
+            throw new ApiException\NotFoundException(sprintf('Article by id %d not found', $id));
         }
 
         $this->resource->generateImages($article, (bool) $this->Request()->getParam('force', 0));

--- a/engine/Shopware/Controllers/Backend/ArticleList.php
+++ b/engine/Shopware/Controllers/Backend/ArticleList.php
@@ -471,12 +471,12 @@ class Shopware_Controllers_Backend_ArticleList extends Shopware_Controllers_Back
         $offset = $this->Request()->getParam('offset', 0);
         $filterArray = json_decode($filterArray, true);
         if ($filterArray == false) {
-            throw new RuntimeException("Could not decode '{$this->Request()->getParam('filterArray')}'");
+            throw new RuntimeException(sprintf('Could not decode "%s"', $this->Request()->getParam('filterArray')));
         }
 
         $operations = json_decode($operations, true);
         if ($operations == false) {
-            throw new RuntimeException("Could not decode '{$this->Request()->getParam('operations')}'");
+            throw new RuntimeException(sprintf('Could not decode "%s"', $this->Request()->getParam('operations')));
         }
 
         /** @var \Shopware\Components\MultiEdit\Resource\ResourceInterface $resource */

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1686,7 +1686,7 @@ SQL;
                 );
 
                 if (!$update || !$updatedPrice) {
-                    throw new Enlight_Exception('Basket Update ##01 Could not update quantity' . $sql);
+                    throw new Enlight_Exception(sprintf('Basket Update ##01 Could not update quantity%s', $sql));
                 }
             }
         }
@@ -1893,7 +1893,7 @@ SQL;
         $result = $this->db->query($sql, $params);
 
         if (!$result) {
-            throw new Enlight_Exception('BASKET-INSERT #02 SQL-Error' . $sql);
+            throw new Enlight_Exception(sprintf('BASKET-INSERT #02 SQL-Error%s', $sql));
         }
         $insertId = $this->db->lastInsertId();
 

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -448,7 +448,7 @@ class sOrder
             $affectedRows = $this->db->insert('s_order', $data);
             $orderID = $this->db->lastInsertId();
         } catch (Exception $e) {
-            throw new Enlight_Exception('##sOrder-sTemporaryOrder-#01:' . $e->getMessage(), 0, $e);
+            throw new Enlight_Exception(sprintf('##sOrder-sTemporaryOrder-#01:%s', $e->getMessage()), 0, $e);
         }
         if (!$affectedRows || !$orderID) {
             throw new Enlight_Exception('##sOrder-sTemporaryOrder-#01: No rows affected or no order id saved', 0);
@@ -504,7 +504,7 @@ class sOrder
                 $this->db->insert('s_order_details', $data);
                 $orderDetailId = $this->db->lastInsertId();
             } catch (Exception $e) {
-                throw new Enlight_Exception('##sOrder-sTemporaryOrder-Position-#02:' . $e->getMessage(), 0, $e);
+                throw new Enlight_Exception(sprintf('##sOrder-sTemporaryOrder-Position-#02:%s', $e->getMessage()), 0, $e);
             }
 
             // Create order detail attributes
@@ -617,11 +617,11 @@ class sOrder
             $this->db->commit();
         } catch (Exception $e) {
             $this->db->rollBack();
-            throw new Enlight_Exception("Shopware Order Fatal-Error {$_SERVER['HTTP_HOST']} :" . $e->getMessage(), 0, $e);
+            throw new Enlight_Exception(sprintf('Shopware Order Fatal-Error %s :%s', $_SERVER['HTTP_HOST'], $e->getMessage()), 0, $e);
         }
 
         if (!$affectedRows || !$orderID) {
-            throw new Enlight_Exception("Shopware Order Fatal-Error {$_SERVER['HTTP_HOST']} : No rows affected or no order id created.", 0);
+            throw new Enlight_Exception(sprintf('Shopware Order Fatal-Error %s : No rows affected or no order id created.', $_SERVER['HTTP_HOST']), 0);
         }
 
         try {
@@ -718,7 +718,7 @@ class sOrder
                 $this->db->executeUpdate($sql);
                 $orderdetailsID = $this->db->lastInsertId();
             } catch (Exception $e) {
-                throw new Enlight_Exception("Shopware Order Fatal-Error {$_SERVER['HTTP_HOST']} :" . $e->getMessage(), 0, $e);
+                throw new Enlight_Exception(sprintf('Shopware Order Fatal-Error %s :%s', $_SERVER['HTTP_HOST'], $e->getMessage()), 0, $e);
             }
 
             $this->sBasketData['content'][$key]['orderDetailId'] = $orderdetailsID;

--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -243,7 +243,7 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
         if (property_exists($this, $var_name)) {
             return $this->$var_name;
         }
-        throw new Enlight_Exception("Property $var_name does not exists");
+        throw new Enlight_Exception(sprintf('Property %s does not exists', $var_name));
     }
 
     /**
@@ -261,7 +261,7 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
             ', [$this->_id]), ArrayObject::ARRAY_AS_PROPS);
 
         if (empty($this->_order['id'])) {
-            throw new Enlight_Exception('Order with id ' . $this->_id . ' not found!');
+            throw new Enlight_Exception(sprintf('Order with id %d not found!', $this->_id));
         }
 
         // Load order attributes

--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Steps/UnpackStep.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Steps/UnpackStep.php
@@ -74,7 +74,7 @@ class UnpackStep
             $source->seek($offset);
         } catch (\Exception $e) {
             @unlink($this->source);
-            throw new \Exception('Could not open update package:<br>' . $e->getMessage(), 0, $e);
+            throw new \Exception(sprintf('Could not open update package:<br>%s', $e->getMessage()), 0, $e);
         }
 
         /** @var ZipEntry $entry */

--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
@@ -317,9 +317,10 @@ class Shopware_Controllers_Backend_SwagUpdate extends Shopware_Controllers_Backe
 
         $payload = json_encode($payload);
         $projectDir = $this->container->getParameter('shopware.app.rootdir');
+        $updateFilePath = $projectDir . 'files/update/update.json';
 
-        if (!file_put_contents($projectDir . 'files/update/update.json', $payload)) {
-            throw new \Exception('Could not write update.json');
+        if (!file_put_contents($updateFilePath, $payload)) {
+            throw new \Exception(sprintf('Could not write file %s', $updateFilePath));
         }
 
         $this->redirect($base . '/recovery/update/index.php');

--- a/tests/Functional/Bundle/SearchBundle/SearchBundleDBALSubscriberTest.php
+++ b/tests/Functional/Bundle/SearchBundle/SearchBundleDBALSubscriberTest.php
@@ -61,7 +61,7 @@ class SearchBundleDBALSubscriberTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage No handlers provided in \Shopware\Bundle\SearchBundleDBAL\SearchBundleDBALSubscriber
+     * @expectedExceptionMessage No handlers provided in Shopware\Bundle\SearchBundleDBAL\SearchBundleDBALSubscriber
      */
     public function testEmptyArray()
     {

--- a/tests/Functional/Components/Thumbnail/ManagerTest.php
+++ b/tests/Functional/Components/Thumbnail/ManagerTest.php
@@ -151,7 +151,7 @@ class Shopware_Tests_Components_Thumbnail_ManagerTest extends \PHPUnit\Framework
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage File is not an image
+     * @expectedExceptionMessageRegExp /File .* is not an image/
      */
     public function testGenerationWithEmptyMedia()
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

To provide a cleaner way of exception message generation.

### 2. What does this change do, exactly?

- Clean up exception messages
- Replace string concatenation with sprintf in exception messages
- Use single quoted strings wherever possible

### 3. Describe each step to reproduce the issue or behaviour.

➖ 

### 4. Please link to the relevant issues (if any).

It may be related to #1814

### 5. Which documentation changes (if any) need to be made because of this PR?

➖ 

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.