### PR TITLE
[BUGFIX][SW-21316] Closing already opened overlay when opening modal …

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-add.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-add.js
@@ -78,6 +78,8 @@
                     // Check if error thrown
                     if (data.indexOf('data-max-reached="true"') !== -1) {
                         $.loadingIndicator.close(function () {
+                            $.overlay.close();
+
                             $.modal.open(data, {
                                 sizing: 'content'
                             });


### PR DESCRIPTION
…box for max reached items in compare

I tried to do the following:
```
$.loadingIndicator.close(function () {
	$.modal.open(data, {
		overlay: false,
		sizing: 'content'
	});
});
```
but wasn't working. So I decided to close the overlay.

### 1. Why is this change necessary?
Fixes issues SW-21316: closing already opened overlay

### 2. What does this change do, exactly?
It closes the already opened overlay before opening a modal with a new overlay to prevent duplicate overlays

### 3. Describe each step to reproduce the issue or behaviour.
Add 5 items to the compare list. After this you add a 6th. A modal will be opened with the message "you have reached max count". When adding items to the compare, a loading circle shows up and will open a overlay, too. But with closing the loadingIndicator, the overlay will not be removed and a second one will be opened with the modal.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-21316

### 5. Which documentation changes (if any) need to be made because of this PR?
None

