### PR TITLE
Prevent smarty variable-leak

### DIFF
--- a/themes/Frontend/Bare/widgets/emotion/components/component_banner_slider.tpl
+++ b/themes/Frontend/Bare/widgets/emotion/components/component_banner_slider.tpl
@@ -32,10 +32,11 @@
                                         <div class="banner-slider--banner">
 
                                             {block name="frontend_widgets_banner_slider_banner_picture"}
+                                                {$srcSet = ''}
+                                                {$itemSize = ''}
+                                                
                                                 {if $banner.thumbnails}
                                                     {$baseSource = $banner.thumbnails[0].source}
-                                                    {$srcSet = ''}
-                                                    {$itemSize = ''}
 
                                                     {foreach $element.viewports as $viewport}
                                                         {$cols = ($viewport.endCol - $viewport.startCol) + 1}


### PR DESCRIPTION
The Emotion Banner-Slider has a mechanism which uses a given images' thumbnails when available. If there is none available (not generated / folder doesn't generate thumbanils), the element won't get a `srcset` and `sizes` attribute.

The problem arises, when the first image, given to the banner-slider has thumbnails, but the second image has not. Due to the way smarty variable-scoping works, the variables `$srcSet` and `$itemSet` will get re-used, because they are not overridden outside of the `{if $banner.thumbnails}`.

### 1. Why is this change necessary?
In order to prevent this leak, we have to reset these both variables for every image.

### 2. What does this change do, exactly?
Reset the variables `$srcSet` and `$itemSet` for every media-element given to the banner-slider.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add a Banner-Slider to a Shoppingworld
2. Add an Image to the banner-slider which has thumbnails
3. Add a second Image to the banner-slider which has no thumbnails (e.g. by creating a new sub-album of the "Einkaufswelten"-Album, which has no thumbnails configured)

The Frontend should now properly display the first image in the banner-slider. The second one however will be a copy of the first one, because the `$srcSet` variable leaked from the last `{foreach}`-run.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.