### PR TITLE
No product self reference in product streams

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -6,14 +6,6 @@ This changelog references changes done in Shopware 5.5 patch versions.
 
 [View all changes from v5.5.1...v5.5.2](https://github.com/shopware/shopware/compare/v5.5.1...v5.5.2)
 
-### Changes
-
-* Changed thumbnail variable on detail page for href-attribute from `sArticle.image.src.1` to `sArticle.image.source`
-* Changed failed login behaviour by only increasing the failedlogin-count of active customer accounts, not guest accounts
-* Changed product saving to handle invalid changetime dates
-* Changed document template `themes/Frontend/Bare/documents/index.tpl` to also render a `department` if it is part of the address
-* Changed `controllerAction` and `controllerName` Smarty functions to sanitize action and controller names
-
 ### Additions
 
 * Added the following events for newsletter un/subscription
@@ -24,6 +16,17 @@ This changelog references changes done in Shopware 5.5 patch versions.
         * `Shopware_Modules_Admin_Newsletter_Unsubscribe`
         * `Shopware_Modules_Admin_sUpdateNewsletter_Subscribe`
 * Added possibility to edit index.max_result_window for ES via `config.php`
+* Added new product stream condition `SkipProductIdCondition`
+* Added new product stream condition handler `SkipProductIdConditionHandler`
+
+### Changes
+
+* Changed thumbnail variable on detail page for href-attribute from `sArticle.image.src.1` to `sArticle.image.source`
+* Changed failed login behaviour by only increasing the failedlogin-count of active customer accounts, not guest accounts
+* Changed product saving to handle invalid changetime dates
+* Changed document template `themes/Frontend/Bare/documents/index.tpl` to also render a `department` if it is part of the address
+* Changed `controllerAction` and `controllerName` Smarty functions to sanitize action and controller names
+* Changed product stream result on detail pages. The currently displayed article is no longer part of the stream.
 
 ## 5.5.1
 

--- a/engine/Shopware/Bundle/SearchBundle/Condition/SkipProductIdCondition.php
+++ b/engine/Shopware/Bundle/SearchBundle/Condition/SkipProductIdCondition.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\SearchBundle\Condition;
+
+use Shopware\Bundle\SearchBundle\ConditionInterface;
+
+/**
+ * @category  Shopware
+ *
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+class SkipProductIdCondition implements ConditionInterface, \JsonSerializable
+{
+    /**
+     * @var int[]
+     */
+    protected $productIds;
+
+    /**
+     * @param int[] $productIds
+     */
+    public function __construct(array $productIds)
+    {
+        $this->productIds = $productIds;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'skip_productids';
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getProductIds()
+    {
+        return $this->productIds;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return get_object_vars($this);
+    }
+}

--- a/engine/Shopware/Bundle/SearchBundleDBAL/ConditionHandler/SkipProductIdConditionHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/ConditionHandler/SkipProductIdConditionHandler.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\SearchBundleDBAL\ConditionHandler;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Bundle\SearchBundle\Condition\SkipProductIdCondition;
+use Shopware\Bundle\SearchBundle\ConditionInterface;
+use Shopware\Bundle\SearchBundleDBAL\ConditionHandlerInterface;
+use Shopware\Bundle\SearchBundleDBAL\QueryBuilder;
+use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
+
+/**
+ * @category  Shopware
+ *
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+class SkipProductIdConditionHandler implements ConditionHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsCondition(ConditionInterface $condition)
+    {
+        return $condition instanceof SkipProductIdCondition;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateCondition(
+        ConditionInterface $condition,
+        QueryBuilder $query,
+        ShopContextInterface $context
+    ) {
+        $key = ':productIds' . md5(json_encode($condition));
+
+        $query->andWhere('variant.articleId NOT IN (' . $key . ')');
+
+        /* @var SkipProductIdCondition $condition */
+        $query->setParameter(
+            $key,
+            $condition->getProductIds(),
+            Connection::PARAM_INT_ARRAY
+        );
+    }
+}

--- a/engine/Shopware/Bundle/SearchBundleDBAL/services.xml
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/services.xml
@@ -180,6 +180,10 @@
             <tag name="condition_handler_dbal"/>
         </service>
 
+        <service id="shopware_searchdbal.skip_productid_condition_handler_dbal" class="Shopware\Bundle\SearchBundleDBAL\ConditionHandler\SkipProductIdConditionHandler">
+            <tag name="condition_handler_dbal"/>
+        </service>
+
         <service id="shopware_searchdbal.product_attribute_condition_handler_dbal" class="Shopware\Bundle\SearchBundleDBAL\ConditionHandler\ProductAttributeConditionHandler">
             <tag name="condition_handler_dbal"/>
         </service>

--- a/engine/Shopware/Bundle/SearchBundleES/ConditionHandler/SkipProductIdConditionHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/ConditionHandler/SkipProductIdConditionHandler.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\SearchBundleES\ConditionHandler;
+
+use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
+use ONGR\ElasticsearchDSL\Query\TermsQuery;
+use ONGR\ElasticsearchDSL\Search;
+use Shopware\Bundle\SearchBundle\Condition\SkipProductIdCondition;
+use Shopware\Bundle\SearchBundle\Criteria;
+use Shopware\Bundle\SearchBundle\CriteriaPartInterface;
+use Shopware\Bundle\SearchBundleES\PartialConditionHandlerInterface;
+use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
+
+/**
+ * @category  Shopware
+ *
+ * @copyright Copyright (c) shopware AG (http://www.shopware.com)
+ */
+class SkipProductIdConditionHandler implements PartialConditionHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(CriteriaPartInterface $criteriaPart)
+    {
+        return $criteriaPart instanceof SkipProductIdCondition;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleFilter(
+        CriteriaPartInterface $criteriaPart,
+        Criteria $criteria,
+        Search $search,
+        ShopContextInterface $context
+    ) {
+        /* @var SkipProductIdCondition $criteriaPart */
+        $search->addFilter(
+            new TermsQuery('id', $criteriaPart->getProductIds()),
+            BoolQuery::MUST_NOT
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handlePostFilter(
+        CriteriaPartInterface $criteriaPart,
+        Criteria $criteria,
+        Search $search,
+        ShopContextInterface $context
+    ) {
+        /* @var SkipProductIdCondition $criteriaPart */
+        $search->addPostFilter(
+            new TermsQuery('id', $criteriaPart->getProductIds()),
+            BoolQuery::MUST_NOT
+        );
+    }
+}

--- a/engine/Shopware/Bundle/SearchBundleES/services.xml
+++ b/engine/Shopware/Bundle/SearchBundleES/services.xml
@@ -44,6 +44,10 @@
             <tag name="shopware_search_es.search_handler" />
         </service>
 
+        <service id="shopware_search_es.skip_productid_condition_handler" class="Shopware\Bundle\SearchBundleES\ConditionHandler\SkipProductIdConditionHandler" >
+            <tag name="shopware_search_es.search_handler" />
+        </service>
+
         <service id="shopware_search_es.customer_group_condition_handler" class="Shopware\Bundle\SearchBundleES\ConditionHandler\CustomerGroupConditionHandler" >
             <tag name="shopware_search_es.search_handler" />
         </service>

--- a/engine/Shopware/Controllers/Widgets/Emotion.php
+++ b/engine/Shopware/Controllers/Widgets/Emotion.php
@@ -23,6 +23,7 @@
  */
 use Shopware\Bundle\EmotionBundle\Struct\Element;
 use Shopware\Bundle\EmotionBundle\Struct\Emotion;
+use Shopware\Bundle\SearchBundle\Condition\SkipProductIdCondition;
 use Shopware\Bundle\SearchBundle\ProductSearchResult;
 use Shopware\Bundle\SearchBundle\Sorting\PopularitySorting;
 use Shopware\Bundle\SearchBundle\Sorting\PriceSorting;
@@ -163,7 +164,9 @@ class Shopware_Controllers_Widgets_Emotion extends Enlight_Controller_Action
             $limit = 0;
         }
 
-        $values = $this->getProductStream($streamId, $offset, $limit);
+        $articleId = $this->Request()->getParam('articleId');
+
+        $values = $this->getProductStream($streamId, $offset, $limit, $articleId);
 
         $this->View()->assign('articles', $values['values']);
         $this->View()->assign('productBoxLayout', $this->Request()->getParam('productBoxLayout', 'emotion'));
@@ -249,7 +252,7 @@ class Shopware_Controllers_Widgets_Emotion extends Enlight_Controller_Action
         return ['values' => $data, 'pages' => $pages];
     }
 
-    private function getProductStream($productStreamId, $offset = 0, $limit = 100)
+    private function getProductStream($productStreamId, $offset = 0, $limit = 100, $articleId = null)
     {
         $context = Shopware()->Container()->get('shopware_storefront.context_service')->getShopContext();
         $factory = Shopware()->Container()->get('shopware_search.store_front_criteria_factory');
@@ -258,6 +261,10 @@ class Shopware_Controllers_Widgets_Emotion extends Enlight_Controller_Action
         $criteria = $factory->createBaseCriteria([$category], $context);
         $criteria->offset($offset)
                  ->limit($limit);
+
+        if ($articleId) {
+            $criteria->addBaseCondition(new SkipProductIdCondition([$articleId]));
+        }
 
         /** @var \Shopware\Components\ProductStream\RepositoryInterface $streamRepository */
         $streamRepository = $this->get('shopware_product_stream.repository');

--- a/engine/Shopware/Controllers/Widgets/Emotion.php
+++ b/engine/Shopware/Controllers/Widgets/Emotion.php
@@ -164,9 +164,9 @@ class Shopware_Controllers_Widgets_Emotion extends Enlight_Controller_Action
             $limit = 0;
         }
 
-        $articleId = $this->Request()->getParam('articleId');
+        $skippedArticleId = $this->Request()->getParam('skippedArticleId');
 
-        $values = $this->getProductStream($streamId, $offset, $limit, $articleId);
+        $values = $this->getProductStream($streamId, $offset, $limit, $skippedArticleId);
 
         $this->View()->assign('articles', $values['values']);
         $this->View()->assign('productBoxLayout', $this->Request()->getParam('productBoxLayout', 'emotion'));
@@ -252,7 +252,7 @@ class Shopware_Controllers_Widgets_Emotion extends Enlight_Controller_Action
         return ['values' => $data, 'pages' => $pages];
     }
 
-    private function getProductStream($productStreamId, $offset = 0, $limit = 100, $articleId = null)
+    private function getProductStream($productStreamId, $offset = 0, $limit = 100, $skippedArticleId = null)
     {
         $context = Shopware()->Container()->get('shopware_storefront.context_service')->getShopContext();
         $factory = Shopware()->Container()->get('shopware_search.store_front_criteria_factory');
@@ -262,8 +262,8 @@ class Shopware_Controllers_Widgets_Emotion extends Enlight_Controller_Action
         $criteria->offset($offset)
                  ->limit($limit);
 
-        if ($articleId) {
-            $criteria->addBaseCondition(new SkipProductIdCondition([$articleId]));
+        if ($skippedArticleId) {
+            $criteria->addBaseCondition(new SkipProductIdCondition([$skippedArticleId]));
         }
 
         /** @var \Shopware\Components\ProductStream\RepositoryInterface $streamRepository */

--- a/themes/Frontend/Bare/frontend/detail/tabs/product_streams.tpl
+++ b/themes/Frontend/Bare/frontend/detail/tabs/product_streams.tpl
@@ -4,7 +4,7 @@
         {include file="frontend/_includes/product_slider.tpl"
                  sliderMode="ajax"
                  sliderInitOnEvent="onShowContent-productStreamSliderId-{$relatedProductStream.id}"
-                 sliderAjaxCtrlUrl="{url module=widgets controller=emotion action=productStreamArticleSlider streamId=$relatedProductStream.id articleId=$sArticle.articleID productBoxLayout="slider"}"
+                 sliderAjaxCtrlUrl="{url module=widgets controller=emotion action=productStreamArticleSlider streamId=$relatedProductStream.id skippedArticleId=$sArticle.articleID productBoxLayout="slider"}"
                  sliderAjaxMaxShow="40"}
     </div>
 {/block}

--- a/themes/Frontend/Bare/frontend/detail/tabs/product_streams.tpl
+++ b/themes/Frontend/Bare/frontend/detail/tabs/product_streams.tpl
@@ -4,7 +4,7 @@
         {include file="frontend/_includes/product_slider.tpl"
                  sliderMode="ajax"
                  sliderInitOnEvent="onShowContent-productStreamSliderId-{$relatedProductStream.id}"
-                 sliderAjaxCtrlUrl="{url module=widgets controller=emotion action=productStreamArticleSlider streamId=$relatedProductStream.id productBoxLayout="slider"}"
+                 sliderAjaxCtrlUrl="{url module=widgets controller=emotion action=productStreamArticleSlider streamId=$relatedProductStream.id articleId=$sArticle.articleID productBoxLayout="slider"}"
                  sliderAjaxMaxShow="40"}
     </div>
 {/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
When a customer views a product detail page it makes no sense to show this product in a linked product stream in the cross selling section.

### 2. What does this change do, exactly?
A new product stream condition + handler allows to remove articles from the product stream criteria. If a product stream gets loaded from the detail page the current article id will be automatically added as `SkipProductIdCondition` to remove the product from the stream.
The PR does not alter the behavior of product stream when loaded inside the emotion context.

### 3. Describe each step to reproduce the issue or behaviour.
* Create a product stream and add it to a product that potentially appear in the stream.
* Open the product page and look into the linked product stream. The currently open product will appear there.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-16157

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.