### PR TITLE
fix duplicate slash shopware icon font path

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_variables/typography.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_variables/typography.less
@@ -21,7 +21,7 @@ The values can be changed with the backend theme manager.
 `@font-size-h6` - h6 element font-size *(default: 12)*<br/>
 
 **Shopware font directory**<br/>
-`@font-directory` - font-directory folder (default: "../../fonts/")
+`@font-directory` - font-directory folder (default: "../../fonts")
 
 **Open Sans font directory**<br/>
 `@OpenSansPath` - "Open Sans" font-directory folder (default: "./../fonts/open-sans-fontface")
@@ -29,7 +29,7 @@ The values can be changed with the backend theme manager.
 
 */
     // Shopware font directory
-@font-directory: "../../fonts/";
+@font-directory: "../../fonts";
 
     // Open Sans font directory
 @OpenSansPath: "../../../vendors/fonts/open-sans-fontface";


### PR DESCRIPTION
The default value in _variables/typography.less has a trailing slash, but another slash is concatenated in _components/icon-set.less.
Remove the trailing slash in _variables/typography.less For consistency with @OpenSansPath in the same file.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
"Wrong" path in compiled css file.

In some cases, when the site is served via https, the double slash in the middle of the path triggers the protocol downgrade prevention (which seems to be a bug in some older chrome versions).

### 2. What does this change do, exactly?
Remove the trailing slash in @font-directory to fix the concatenated path in _components/icon-set.less

### 3. Describe each step to reproduce the issue or behaviour.
Search for the @font-face definition in the compiled css of any Shopware installation, e.g.: https://www.shopwaredemo.de/web/cache/1531139832_619fa108cec94b2467af3d2b6daf6eec.css

### 4. Please link to the relevant issues (if any).
/

### 5. Which documentation changes (if any) need to be made because of this PR?
It may be necessary to place a note in the upgrade instructions for people that use the @font-directory in their own themes derived from the Responsive theme and depend on the trailing slash.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.