### PR TITLE
Add description and translation for subshop only votes setting

### DIFF
--- a/_sql/migrations/1441-update-subshop-vote-description.php
+++ b/_sql/migrations/1441-update-subshop-vote-description.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+class Migrations_Migration1441 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+            SET @elementId = (SELECT id FROM `s_core_config_elements` WHERE `name` LIKE 'displayOnlySubShopVotes' LIMIT 1);
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+            UPDATE `s_core_config_elements` SET description = 'Legt fest, ob zu einem Artikel nur die Bewertungen aus dem entsprechenden Shop angezeigt werden sollen.'
+            WHERE id = @elementId;
+EOD;
+        $this->addSql($sql);
+
+        // Translation
+        $sql = <<<'EOD'
+            INSERT IGNORE INTO `s_core_config_element_translations` (`element_id`, `locale_id`, `label`, `description`)
+            VALUES ( @elementId, 2, 'Display only shop specific ratings', 'Defines whether only the ratings from the corresponding shop should be displayed for an article.' );
+EOD;
+        $this->addSql($sql);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Adds a missing help text description.

### 2. What does this change do, exactly?
It adds a meaningful description to the setting for displaying only sub shop votes in the backend.

### 3. Describe each step to reproduce the issue or behaviour.
* `Go to Grundeinstellungen > Artikelbewertungen`
* Mouseover the help text icon.
* You will only see the word `description` 😢 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.