### PR TITLE
Not be able to select a non-existing variant

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/ConfiguratorGatewayInterface.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/ConfiguratorGatewayInterface.php
@@ -72,28 +72,13 @@ interface ConfiguratorGatewayInterface
 
     /**
      * Returns all possible configurator combinations for the provided product.
-     * The returned array contains as array key the id of the configurator option.
-     * The array value contains an imploded array with all possible configurator option ids
-     * which can be combined with the option.
-     *
-     * Example (written with the configurator option names)
-     * array(
-     *     'white' => array('XL', 'L'),
-     *     'red'   => array('S', ...)
-     * )
-     *
-     * If the configurator contains only one group the function has to return an array indexed
-     * by the ids, which are selectable:
-     *
-     * Example (written with the configurator option names)
-     * array(
-     *     'white' => array(),
-     *     'red'   => array()
-     * )
+     * The returned array contains all combinations that are reachable by
+     * changing one of the group options in the given selection.
      *
      * @param Struct\BaseProduct $product
+     * @param int[]              $currentSelection
      *
      * @return array Indexed by the option id
      */
-    public function getProductCombinations(Struct\BaseProduct $product);
+    public function getProductCombinations(Struct\BaseProduct $product, array $currentSelection);
 }

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ConfiguratorGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ConfiguratorGateway.php
@@ -28,6 +28,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Shopware\Bundle\StoreFrontBundle\Gateway;
 use Shopware\Bundle\StoreFrontBundle\Struct;
+use Shopware_Components_Config;
 
 /**
  * @category  Shopware
@@ -67,21 +68,29 @@ class ConfiguratorGateway implements Gateway\ConfiguratorGatewayInterface
     private $connection;
 
     /**
+     * @var Shopware_Components_Config
+     */
+    private $shopwareConfig;
+
+    /**
      * @param Connection                                                      $connection
      * @param FieldHelper                                                     $fieldHelper
      * @param Hydrator\ConfiguratorHydrator                                   $configuratorHydrator
      * @param \Shopware\Bundle\StoreFrontBundle\Gateway\MediaGatewayInterface $mediaGateway
+     * @param Shopware_Components_Config                                      $shopwareConfig
      */
     public function __construct(
         Connection $connection,
         FieldHelper $fieldHelper,
         Hydrator\ConfiguratorHydrator $configuratorHydrator,
-        Gateway\MediaGatewayInterface $mediaGateway
+        Gateway\MediaGatewayInterface $mediaGateway,
+        Shopware_Components_Config $shopwareConfig
     ) {
         $this->connection = $connection;
         $this->configuratorHydrator = $configuratorHydrator;
         $this->fieldHelper = $fieldHelper;
         $this->mediaGateway = $mediaGateway;
+        $this->shopwareConfig = $shopwareConfig;
     }
 
     /**
@@ -161,39 +170,161 @@ class ConfiguratorGateway implements Gateway\ConfiguratorGatewayInterface
     /**
      * {@inheritdoc}
      */
-    public function getProductCombinations(Struct\BaseProduct $product)
+    public function getProductCombinations(Struct\BaseProduct $product, array $currentSelection)
     {
-        $query = $this->connection->createQueryBuilder();
-
-        $query->select([
-            'relations.option_id',
-            "GROUP_CONCAT(DISTINCT assignedRelations.option_id, '' SEPARATOR '|') as combinations",
-        ]);
-
-        $query->from('s_article_configurator_option_relations', 'relations')
-            ->innerJoin('relations', 's_articles_details', 'variant', 'variant.id = relations.article_id AND variant.articleID = :articleId AND variant.active = 1')
-            ->innerJoin(
-                'variant',
-                's_articles',
-                'product',
-                'product.id = variant.articleID AND (
-                    (variant.laststock * variant.instock) >= (variant.laststock * variant.minpurchase)
-                )'
+        $queryBuilder = $this->getQuery();
+        $queryBuilder->select(
+                'otherConfiguratorGroup.id AS groupId',
+                'includedOption.id AS optionId'
             )
-            ->leftJoin('relations', 's_article_configurator_option_relations', 'assignedRelations', 'assignedRelations.article_id = relations.article_id AND assignedRelations.option_id != relations.option_id')
-            ->groupBy('relations.option_id')
-            ->setParameter(':articleId', $product->getId());
+            // load additional groups from same configurator set
+            ->innerJoin(
+                'configuratorSet',
+                's_article_configurator_set_group_relations',
+                'otherGroupRelation',
+                $queryBuilder->expr()->eq('otherGroupRelation.set_id', 'configuratorSet.id')
+            )
+            ->innerJoin(
+                'otherGroupRelation',
+                's_article_configurator_groups',
+                'otherConfiguratorGroup',
+                $queryBuilder->expr()->eq('otherGroupRelation.group_id', 'otherConfiguratorGroup.id')
+            )
+            // load options to additional groups from the same configurator set
+            ->innerJoin(
+                'configuratorOption',
+                's_article_configurator_set_option_relations',
+                'alternateOptionRelation',
+                $queryBuilder->expr()->eq('alternateOptionRelation.option_id', 'configuratorOption.id')
+            )
+            ->innerJoin(
+                'alternateOptionRelation',
+                's_article_configurator_set_group_relations',
+                'alternateGroupRelation',
+                $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->eq('alternateGroupRelation.set_id', 'alternateOptionRelation.set_id'),
+                    $queryBuilder->expr()->eq('alternateGroupRelation.group_id', 'configuratorOption.group_id')
+                )
+            )
+            // load additional options from the same group except the selected one
+            ->leftJoin(
+                'configuratorOption',
+                's_article_configurator_options',
+                'alternateOption',
+                $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->eq('alternateOption.group_id', 'configuratorOption.group_id'),
+                    $queryBuilder->expr()->neq('alternateOption.id', 'configuratorOption.id')
+                )
+            )
+            ->innerJoin(
+                'alternateGroupRelation',
+                's_article_configurator_set_option_relations',
+                'veryAlternateOptionRelation',
+                $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->eq('veryAlternateOptionRelation.set_id', 'alternateGroupRelation.set_id '),
+                    $queryBuilder->expr()->eq('veryAlternateOptionRelation.option_id', 'alternateOption.id')
+                )
+            )
+            // map alternative values to chosen values
+            ->innerJoin(
+                'groupRelation',
+                's_article_configurator_set_group_relations',
+                'includedGroupRelation',
+                $queryBuilder->expr()->eq('includedGroupRelation.set_id', 'groupRelation.set_id')
+            )
+            ->innerJoin(
+                'includedGroupRelation',
+                's_article_configurator_set_option_relations',
+                'includedOptionRelation',
+                $queryBuilder->expr()->eq('includedGroupRelation.set_id', 'includedOptionRelation.set_id')
+            )
+            ->innerJoin(
+                'includedOptionRelation',
+                's_article_configurator_options',
+                'includedOption',
+                $queryBuilder->expr()->eq('includedOptionRelation.option_id', 'includedOption.id')
+            )
+            ->where(
+                $queryBuilder->expr()->eq('products.id', ':productId'),
+                $queryBuilder->expr()->eq('includedOption.group_id', 'otherConfiguratorGroup.id')
+            )
+            ->setParameter('productId', $product->getId())
+            ->groupBy(
+                'otherConfiguratorGroup.id',
+                'includedOption.id'
+            )
+        ;
 
-        /** @var $statement \Doctrine\DBAL\Driver\ResultStatement */
-        $statement = $query->execute();
-
-        $data = $statement->fetchAll(\PDO::FETCH_KEY_PAIR);
-
-        foreach ($data as &$row) {
-            $row = explode('|', $row);
+        if (!empty($currentSelection)) {
+            $queryBuilder->andWhere(
+                    $queryBuilder->expr()->in('configuratorOption.id', ':selection'),
+                    $queryBuilder->expr()->notIn('includedOption.id', ':selection')
+                )
+                ->setParameter('selection', $currentSelection, Connection::PARAM_INT_ARRAY)
+            ;
         }
 
-        return $data;
+        $possibleSelections = [];
+        $rows = $queryBuilder->execute()->fetchAll(\PDO::FETCH_ASSOC);
+
+        foreach ($rows as $alternation) {
+            $groupId = (int) $alternation['groupId'];
+            $alternateOptionId = (int) $alternation['optionId'];
+
+            $possibleSelection = $currentSelection;
+            $possibleSelection[$groupId] = $alternateOptionId;
+
+            if ($this->selectionHasVariants($product, $possibleSelection)) {
+                $possibleSelections[] = $possibleSelection;
+            }
+        }
+
+        return $possibleSelections;
+    }
+
+    /**
+     * @param Struct\BaseProduct $product
+     * @param int[]              $possibleSelection
+     *
+     * @return bool
+     */
+    protected function selectionHasVariants(Struct\BaseProduct $product, $possibleSelection)
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+
+        $queryBuilder->from('s_articles_details', 'variants')
+            ->select(
+                'variants.id AS id',
+                'COUNT(1) AS relationCount'
+            )
+            ->innerJoin(
+                'variants',
+                's_article_configurator_option_relations',
+                'relation',
+                $queryBuilder->expr()->eq('relation.article_id', 'variants.id')
+            )
+            ->where(
+                $queryBuilder->expr()->eq('variants.articleID', ':productId'),
+                $queryBuilder->expr()->in('relation.option_id', ':selection'),
+                'variants.active'
+            )
+            ->groupBy('variants.id')
+            ->having($queryBuilder->expr()->eq('relationCount', ':count'))
+            ->setParameter('productId', $product->getId())
+            ->setParameter('selection', $possibleSelection, Connection::PARAM_INT_ARRAY)
+            ->setParameter('count', count($possibleSelection))
+        ;
+
+        if ($this->shopwareConfig->get('hideNoInstock')) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->gte(
+                    'variants.laststock * variants.instock',
+                    'variants.laststock * variants.minpurchase'
+                )
+            );
+        }
+
+        return $queryBuilder->execute()->fetchColumn() !== false;
     }
 
     /**

--- a/engine/Shopware/Bundle/StoreFrontBundle/services.xml
+++ b/engine/Shopware/Bundle/StoreFrontBundle/services.xml
@@ -196,6 +196,7 @@
             <argument type="service" id="shopware_storefront.field_helper_dbal"/>
             <argument type="service" id="shopware_storefront.configurator_hydrator_dbal"/>
             <argument type="service" id="shopware_storefront.media_gateway" />
+            <argument type="service" id="config" />
         </service>
 
         <service class="Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\ConfiguratorOptionsGateway" id="shopware_storefront.configurator_options_gateway">


### PR DESCRIPTION
### 1. Why is this change necessary?
Not created or afterwards deleted product variants may be selectable in the storefront which lead to a selection of the default product variant instead of the expected configurated variant.

### 2. What does this change do, exactly?
The logic changes from:
> does configuration option x has a variant with this option in this set

to

> is there a possible one step change to an other configuration that result in an existing product variant

This is majorly done via SQL and less with storefront structs than before. A lot of joins are used that are optimized to use existing indices to maintain execution speed.

### 3. Describe each step to reproduce the issue or behaviour.
* have a product with a set that contains at least three groups with at least two options
![configuration](https://user-images.githubusercontent.com/1133593/46506124-94321e80-c833-11e8-88ba-53c69635b98c.png)
* generate variants
![generated-variants](https://user-images.githubusercontent.com/1133593/46506272-f559f200-c833-11e8-948b-aab473aee969.png)
* delete a variant that is not the default variant
![delete-variant](https://user-images.githubusercontent.com/1133593/46506312-1b7f9200-c834-11e8-8b7b-ec825301b665.png)
* open the product in storefront
* choose configuration that just got deleted
![say-wut](https://user-images.githubusercontent.com/1133593/46506554-fccdcb00-c834-11e8-9dba-6a17ba6009c2.png)
* get forwarded to default variant
![see-ordernumber](https://user-images.githubusercontent.com/1133593/46506626-30a8f080-c835-11e8-949d-d309bb0044e9.png)
![wrong-item-in-card](https://user-images.githubusercontent.com/1133593/46506733-88475c00-c835-11e8-8429-37b04022ed17.png)
* ![questionaningans](http://www.memes.at/faces/staring_at_pc.gif)
* install [this plugin](https://github.com/niemand-online/NoBugfixToDisableNonExistingVariants) that hotfixes this PR
![first-plugin-that-fixes-a-pr-in-human-history](https://user-images.githubusercontent.com/1133593/46506880-2dfacb00-c836-11e8-8c86-008fc95f4e73.png)
* retry
![image](https://user-images.githubusercontent.com/1133593/46507475-ede91780-c838-11e8-923f-4c63f3acba68.png)
* ![success](https://i.kym-cdn.com/entries/icons/facebook/000/022/628/Screen_Shot_2017-04-05_at_2.58.07_PM.jpg)

### 4. Which documentation changes (if any) need to be made because of this PR?
The interface documentation already changed but as this changes the interface signature there is a need for a upgrade hint.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
- [x] Attribute @yarisade for finding this bug, keeping our sanity during the night where we solved this