### PR TITLE
[BUGFIX][SW-21936] Changed date format of createDate to prevent diffe…

### DIFF
--- a/themes/Frontend/Bare/frontend/blog/detail.tpl
+++ b/themes/Frontend/Bare/frontend/blog/detail.tpl
@@ -19,6 +19,7 @@
                     {/if}
 
                     <meta itemprop="wordCount" content="{$sArticle.description|strip_tags|count_words}">
+                    <meta itemprop="dateCreated" content="{$sArticle.displayDate|date_format:"%F%Z%R%z"}">
                 {/block}
 
                 {* Detail Box Header *}
@@ -43,7 +44,7 @@
 
                                 {* Date *}
                                 {block name='frontend_blog_detail_date'}
-                                    <span class="blog--metadata-date blog--metadata{if !$sArticle.author.name} is--first{/if}" itemprop="dateCreated">{$sArticle.displayDate|date:"DATETIME_SHORT"}</span>
+                                    <span class="blog--metadata-date blog--metadata{if !$sArticle.author.name} is--first{/if}">{$sArticle.displayDate|date:"DATETIME_SHORT"}</span>
                                 {/block}
 
                                 {* Category *}


### PR DESCRIPTION
…rent locale date settings


### 1. Why is this change necessary?
As the documentation of the date property of schmema.org mentioned, the type "date" should be in ISO-8601 format: http://schema.org/Date
Currently this format isn't use consistent in shopware. E.g. the blog property "dateCreated" shows different dates on different google locales (e.g. one uses MM/DD/YYYY, the other DD/MM/YYYY). So it is possible that google.com shows "06.12.2018" and google.de "12.06.2018".

### 2. What does this change do, exactly?
Changes the date format of the itemprop="dateCreated" in blog detail page to ISO-8601 format.

### 3. Describe each step to reproduce the issue or behaviour.
Visit the blog and open the developer console. Search for dateCreated and visit on different locales.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-21936

### 5. Which documentation changes (if any) need to be made because of this PR?
None