### PR TITLE
[SW-19130] Fix account section for guest login

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -72,8 +72,9 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
         $this->View()->assign('userInfo', $this->get('shopware_account.store_front_greeting_service')->fetch());
         $this->View()->assign('sUserLoggedIn', $this->admin->sCheckUser());
         $this->View()->assign('sAction', $this->Request()->getActionName());
+        $this->View()->assign('sOneTimeAccount', $this->isOneTimeAccount());
 
-        if ($this->isOneTimeAccount() && $this->request->getParams()['action'] !== 'abort') {
+        if ($this->isOneTimeAccount() && $this->request->getParams()['action'] === 'abort') {
             $this->logoutAction();
             $this->redirect(['controller' => 'register']);
         }

--- a/engine/Shopware/Controllers/Frontend/Address.php
+++ b/engine/Shopware/Controllers/Frontend/Address.php
@@ -72,6 +72,7 @@ class Shopware_Controllers_Frontend_Address extends Enlight_Controller_Action
         $this->View()->assign('userInfo', $this->get('shopware_account.store_front_greeting_service')->fetch());
         $this->View()->assign('sUserData', $this->admin->sGetUserData());
         $this->View()->assign('sAction', $this->Request()->getActionName());
+        $this->View()->assign('sOneTimeAccount', $this->isOneTimeAccount());
     }
 
     /**
@@ -491,5 +492,14 @@ class Shopware_Controllers_Frontend_Address extends Enlight_Controller_Action
             'sTarget' => $this->Request()->getParam('sTarget'),
             'sTargetAction' => $this->Request()->getParam('sTargetAction'),
         ];
+    }
+
+    /**
+     * @return bool
+     */
+    private function isOneTimeAccount()
+    {
+        return $this->container->get('session')->offsetGet('sOneTimeAccount')
+            || $this->View()->sUserData['additional']['user']['accountmode'] == 1;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When logedin as a one time account and going to to the account section (or changing the address in checkout) the user will be logged out with an empty basket.

### 2. What does this change do, exactly?
Only logout a one time account when the user really wants to by clicking on the appropriate link.  
This also fixes the sidebar navigation in the account to display only the logout link.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add a product to the basket
2. Go to checkout and create a one time account
3. Go to account page or change address in checkout

### 4. Please link to the relevant issues (if any).
[SW-19130](https://issues.shopware.com/issues/SW-19130)

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.