### PR TITLE
performance fix variant filter

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductListingVariationLoader.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductListingVariationLoader.php
@@ -422,8 +422,8 @@ class ProductListingVariationLoader
         $subPriceQuery->addSelect('IFNULL(prices.articledetailsID, onsalePriceList.articledetailsID) as articledetailsID');
         $subPriceQuery->addSelect('IFNULL(prices.price, onsalePriceList.price) as price');
         $subPriceQuery->from('s_articles_details', 'details');
-        $subPriceQuery->leftJoin('details', '(' . $priceListingQuery . ')', 'prices', 'details.id = prices.articledetailsID');
-        $subPriceQuery->leftJoin('details', '(' . $onSalePriceListingQuery . ')', 'onsalePriceList', 'details.id = onsalePriceList.articledetailsID');
+        $subPriceQuery->innerJoin('details', '(' . $priceListingQuery . ')', 'prices', 'details.id = prices.articledetailsID');
+        $subPriceQuery->innerJoin('details', '(' . $onSalePriceListingQuery . ')', 'onsalePriceList', 'details.id = onsalePriceList.articledetailsID');
 
         $query->innerJoin('availableVariant', '(' . $subPriceQuery . ')', 'prices', 'availableVariant.id = prices.articledetailsID');
 

--- a/engine/Shopware/Bundle/SearchBundleDBAL/VariantHelper.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/VariantHelper.php
@@ -316,8 +316,8 @@ class VariantHelper implements VariantHelperInterface
             'IFNULL(listing_price.product_id, onsale_listing_price.product_id) AS product_id',
         ]);
 
-        $subQuery->leftJoin('variant', '(' . $priceTable->getSQL() . ')', 'listing_price', implode(' AND ', $variantCondition));
-        $subQuery->leftJoin('variant', '(' . $onSalePriceTable->getSQL() . ')', 'onsale_listing_price', implode(' AND ', $variantOnSaleCondition));
+        $subQuery->innerJoin('variant', '(' . $priceTable->getSQL() . ')', 'listing_price', implode(' AND ', $variantCondition));
+        $subQuery->innerJoin('variant', '(' . $onSalePriceTable->getSQL() . ')', 'onsale_listing_price', implode(' AND ', $variantOnSaleCondition));
         $subQuery->resetQueryPart('groupBy');
 
         $query->addSelect('listing_price.*');


### PR DESCRIPTION
### 1. Why is this change necessary?
Every Listing and especially Filter queries took minutes to give a result.

### 2. What does this change do, exactly?
We changed expensive left Joins to more handsome innerJoins for using db-indizes, so we can see a massive better performance. Admittedly we can not verify if the query is still serving the correct content in any case. @shopware can you verify this and give feedback?

### 3. Describe each step to reproduce the issue or behaviour.
we have different customergroups but only one fallback "EK" price. we use the variant filter to filter size of clothings. For the left joins will be used no index.
You can use the attached query to test the slow query.
[query.txt](https://github.com/shopware/shopware/files/2459296/query.txt)

### 4. Please link to the relevant issues (if any).
103209


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change -> sql queries are not tested
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.