### PR TITLE
Add posibility for "IN" filter on numeric columns in multi-edit

### DIFF
--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Grammar.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Grammar.php
@@ -104,11 +104,11 @@ class Grammar
                 case 'integer':
                 case 'decimal':
                 case 'float':
-                    $attributes[$formattedColumn] = ['>', '>=', '<', '<=', '=', '!=', 'ISNULL'];
+                    $attributes[$formattedColumn] = ['>', '>=', '<', '<=', '=', '!=', 'ISNULL', 'IN', 'NOT IN'];
                     break;
                 case 'text':
                 case 'string':
-                    $attributes[$formattedColumn] = ['=', '~', '!~', 'IN', '!=', 'ISNULL'];
+                    $attributes[$formattedColumn] = ['=', '~', '!~', 'IN', '!=', 'ISNULL', 'NOT IN'];
                     break;
                 case 'boolean':
                     $attributes[$formattedColumn] = ['ISTRUE', 'ISFALSE', 'ISNULL'];
@@ -163,6 +163,7 @@ class Grammar
             ],
             'binaryOperators' => [
                 'IN' => ['('],
+                'NOT IN' => ['('],
                 '>=' => ['/(^-{0,1}[0-9.]+$)/', '/"(.*?)"/'],
                 '=' => ['/(^-{0,1}[0-9.]+$)/', '/"(.*?)"/'],
                 '!=' => ['/(^-{0,1}[0-9.]+$)/', '/"(.*?)"/'],

--- a/themes/Backend/ExtJs/backend/article_list/resource/lexer.js
+++ b/themes/Backend/ExtJs/backend/article_list/resource/lexer.js
@@ -136,7 +136,7 @@ Ext.define('Lexer', {
             }
 
             // subOperators, Lists and OR are not possible in simple queries
-            if (token == 'IN' || tokenType == 'subOperators' || (tokenType == 'boolOperators' && token == 'OR')) {
+            if (token == 'IN' || token == 'NOT IN' || tokenType == 'subOperators' || (tokenType == 'boolOperators' && token == 'OR')) {
                 me.setExpressionNotSimple();
             } else if (tokenType == 'boolOperators' && token == 'AND') {
                 me.addToSimpleResult();
@@ -148,7 +148,7 @@ Ext.define('Lexer', {
             }
 
             // Check for list
-            if (token == 'IN') {
+            if (token == 'IN' || token == 'NOT IN') {
                 me.inList = true;
             }
 
@@ -381,7 +381,7 @@ Ext.define('Lexer', {
                 me.setSuggestion('value');
                 return { rules: me.grammar.values, message: '{s name=lexer/value}Value{/s}'}
             }
-            if (token == 'IN') {
+            if (token == 'IN' || token == 'NOT IN') {
                 me.setSuggestion(['(']);
                 return { rules: '(', message: '{s name=lexer/openingBrace}({/s}'}
             }

--- a/themes/Backend/ExtJs/backend/article_list/view/add_filter/grid.js
+++ b/themes/Backend/ExtJs/backend/article_list/view/add_filter/grid.js
@@ -314,7 +314,7 @@ Ext.define('Shopware.apps.ArticleList.view.AddFilter.Grid', {
 
         operators = me.filterableColumns[record.get('name')];
         Ext.each(operators, function(operator) {
-            if (operator != 'IN' ) {
+            if (operator != 'IN' || operator != 'NOT IN' ) {
                 operatorStore.add({ name: operator });
             }
         });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When you want to filter a huge amount of IDs like category.id IN (1,2,3,4,5,6)...

### 2. What does this change do, exactly?
Adds the posibility to use the IN-Filter on numeric values (it was already possible for string values)

### 3. Describe each step to reproduce the issue or behaviour.
Add a new filter in the article overview in the backend and filter for article.id or category.id

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.