### PR TITLE
Fix og:type of listings and detail pages

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/data.tpl
+++ b/themes/Frontend/Bare/frontend/detail/data.tpl
@@ -103,7 +103,7 @@
     {if $sArticle.sBlockPrices && (!$sArticle.sConfigurator || $sArticle.pricegroupActive)}
         {foreach $sArticle.sBlockPrices as $blockPrice}
             {if $blockPrice.from == 1}
-                <input id="price_{$sArticle.ordernumber}" type="hidden" value="{$blockPrice.price|replace:",":"."}">
+                <input id="price_{$sArticle.ordernumber}" type="hidden" value="{$blockPrice.price.price_numeric}">
             {/if}
         {/foreach}
     {/if}

--- a/themes/Frontend/Bare/frontend/detail/header.tpl
+++ b/themes/Frontend/Bare/frontend/detail/header.tpl
@@ -5,7 +5,7 @@
 
 {* Meta opengraph tags *}
 {block name='frontend_index_header_meta_tags_opengraph'}
-    <meta property="og:type" content="product" />
+    <meta property="og:type" content="product.item" />
     <meta property="og:site_name" content="{{config name=sShopname}|escapeHtml}" />
     <meta property="og:url" content="{url sArticle=$sArticle.articleID title=$sArticle.articleName}" />
     <meta property="og:title" content="{$sArticle.articleName|escapeHtml}" />
@@ -13,8 +13,8 @@
     <meta property="og:image" content="{$sArticle.image.source}" />
 
     <meta property="product:brand" content="{$sArticle.supplierName|escapeHtml}" />
-    <meta property="product:price" content="{$sArticle.price}" />
-    <meta property="product:product_link" content="{url sArticle=$sArticle.articleID title=$sArticle.articleName}" />
+    <meta property="product:price:amount" content="{$sArticle.price.price_numeric}" />
+    <meta property="product:price:currency" content="{$sArticle.price|currency}" />
 
     <meta name="twitter:card" content="product" />
     <meta name="twitter:site" content="{{config name=sShopname}|escapeHtml}" />

--- a/themes/Frontend/Bare/frontend/listing/header.tpl
+++ b/themes/Frontend/Bare/frontend/listing/header.tpl
@@ -14,7 +14,7 @@
 
     {$description = $description|truncate:$SeoDescriptionMaxLength:'…'}
 
-    <meta property="og:type" content="product" />
+    <meta property="og:type" content="product.group" />
     <meta property="og:site_name" content="{{config name=sShopname}|escapeHtml}" />
     <meta property="og:title" content="{$sCategoryContent.name|escapeHtml}" />
     <meta property="og:description" content="{$description|escapeHtml}" />


### PR DESCRIPTION
### 1. Why is this change necessary?
Set the correct `og:type` for listings and article details.
Fixes some outdated open graph attributes for products.

### 2. What does this change do, exactly?
Replaces open graph`og:type` `product` with `product.group` on listing pages.
Replaces open graph`og:type` `product` with `product.item` on detail pages.
Replaces open graph`product:price` with `product:price:amount` and `product:price:currency`.
Removes invalid open graph`product:product_link`.

### 3. Describe each step to reproduce the issue or behaviour.
Compare the current attributes with the official reference athttp://ogp.me/ and https://developers.facebook.com/docs/reference/opengraph/ or 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.