### PR TITLE
backend order document search

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Repository/OrderRepository.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Repository/OrderRepository.php
@@ -91,6 +91,7 @@ class OrderRepository extends GenericRepository implements EsAwareRepository
                 'shippingCountryId' => ['type' => 'long'],
                 'groupKey' => $this->textMapping->getNotAnalyzedField(),
                 'email' => $this->getTextFieldWithRawData(),
+                'orderDocuments' => $this->getTextFieldWithRawData(),
                 'transactionId' => $this->textMapping->getNotAnalyzedField(),
                 'firstname' => $this->getTextFieldWithRawData(),
                 'lastname' => $this->getTextFieldWithRawData(),

--- a/engine/Shopware/Bundle/AttributeBundle/Repository/Searcher/OrderSearcher.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Repository/Searcher/OrderSearcher.php
@@ -42,6 +42,7 @@ class OrderSearcher extends GenericSearcher
         $query->leftJoin('entity.shop', 'shop');
         $query->leftJoin('entity.billing', 'billing');
         $query->leftJoin('entity.customer', 'customer');
+        $query->leftJoin('entity.documents', 'document');
         $query->leftJoin('billing.country', 'billingCountry');
         $query->setAlias('entity');
 
@@ -63,6 +64,7 @@ class OrderSearcher extends GenericSearcher
             'billing.zipCode^0.5',
             'billing.city^0.5',
             'billing.company^0.5',
+            'document.documentId^3',
         ];
     }
 }

--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -695,8 +695,11 @@ class Repository extends ModelRepository
         $orders = array_keys(array_flip(array_merge($orders, $billing)));
 
         $shipping = $this->searchAddressTable($term, 's_order_shippingaddress', $orders);
+        $orders = array_keys(array_flip(array_merge($orders, $shipping)));
 
-        return array_keys(array_flip(array_merge($orders, $shipping)));
+        $documents = $this->searchDocumentsTable($term, 's_order_documents', $orders);
+
+        return array_keys(array_flip(array_merge($orders, $documents)));
     }
 
     /**
@@ -766,6 +769,32 @@ class Repository extends ModelRepository
 
         if (!empty($excludedOrderIds)) {
             $query->andWhere('address.orderID NOT IN (:ids)');
+            $query->setParameter(':ids', $excludedOrderIds, Connection::PARAM_INT_ARRAY);
+        }
+        $query->setMaxResults(self::SEARCH_TERM_LIMIT);
+
+        return $query->execute()->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * @param string $term
+     * @param string $table
+     * @param int[]  $excludedOrderIds
+     *
+     * @return int[]
+     */
+    private function searchDocumentsTable($term, $table, array $excludedOrderIds = [])
+    {
+        $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $query->select('documents.orderID');
+        $query->from($table, 'documents');
+        $builder = Shopware()->Container()->get('shopware.model.search_builder');
+        $builder->addSearchTerm($query, $term, [
+            'documents.docID^1',
+        ]);
+
+        if (!empty($excludedOrderIds)) {
+            $query->andWhere('documents.orderID NOT IN (:ids)');
             $query->setParameter(':ids', $excludedOrderIds, Connection::PARAM_INT_ARRAY);
         }
         $query->setMaxResults(self::SEARCH_TERM_LIMIT);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
allows searching for orders via their order document numbers

### 2. What does this change do, exactly?
changes the order backend search indexer for ES and the default dbal search to include the order document numbers

### 3. Describe each step to reproduce the issue or behaviour.
add a document to a order and try to search the definied document id.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22627

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.