### PR TITLE
Only show active stores for article preview

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -522,7 +522,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
         $id = $this->Request()->getParam('articleId');
         $priceGroups = $this->getRepository()->getPriceGroupQuery()->getArrayResult();
         $suppliers = $this->getRepository()->getSuppliersQuery()->getArrayResult();
-        $shops = $this->getShopRepository()->createQueryBuilder('shops')->getQuery()->getArrayResult();
+        $shops = $this->getShopRepository()->createQueryBuilder('shops')->andWhere('shops.active = 1')->getQuery()->getArrayResult();
         $taxes = $this->getRepository()->getTaxesQuery()->getArrayResult();
         $templates = $this->getTemplates();
         $units = $this->getRepository()->getUnitsQuery()->getArrayResult();


### PR DESCRIPTION
### 1. Why is this change necessary?
If you have lots of shops but not all of them are active they are still shown in the shop selection list for article preview. By filtering for active only you can make the list shorter while having the same functionality as disabled shops automatically redirect to the home page of the default shop.

### 2. What does this change do, exactly?
Extending `Shopware_Controllers_Backend_Article::loadStores` to filter the shop store to include only active shops.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
None known

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.