### PR TITLE
Add event `plugin/swAjaxVariant/onRequestDataComplete`

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -156,6 +156,7 @@
                 },
                 complete: function () {
                     $.loadingIndicator.close();
+                    $.publish('plugin/swAjaxVariant/onRequestDataComplete');
                 }
             });
         },


### PR DESCRIPTION
This event enables one, to react when the request loading the variants
through ajax is completed fully. In my case this was needed, because I
started another action that triggered the loadingIndicator to be
reopened. Opening multiple loadingIndicator is not supported or does not
work well. This new event enables one, to start an action after the
loading indicator is closed.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Resolves a bug.

### 2. What does this change do, exactly?

See commit message.

### 3. Describe each step to reproduce the issue or behaviour.

```
$.subscribe('plugin/swAjaxVariant/onRequestData', function() {
   // start another action that uses loading-indicator
});
```

### 4. Please link to the relevant issues (if any).

None

### 5. Which documentation changes (if any) need to be made because of this PR?

None

### 6. Checklist

- [ Are there any tests for the theme? ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.