### PR TITLE
Update sAdmin.php

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -290,9 +290,7 @@ class sAdmin
         }
 
         // Check additional rules
-        if ($this->sManageRisks($data['id'], null, $user)
-            && $data['id'] != $user['additional']['user']['paymentpreset']
-        ) {
+        if ($this->sManageRisks($data['id'], null, $user)) {
             $resetPayment = $this->config->get('sPAYMENTDEFAULT');
         }
 


### PR DESCRIPTION



### 1. Why is this change necessary?
If this line is removed, riskmanagement works for all payments and does not exclude users default payment address. This is hardly neccessary, otherwise riskmanagement is worthless.

### 2. What does this change do, exactly?
Activates riskmanagement for users default payment.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.