### PR TITLE
Adjust tracking code column type

### DIFF
--- a/_sql/migrations/1443-adjust-tracking-code-column-type.php
+++ b/_sql/migrations/1443-adjust-tracking-code-column-type.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+use Shopware\Components\Migrations\AbstractMigration;
+
+class Migrations_Migration1443 extends AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('ALTER TABLE `s_order` CHANGE `trackingcode` `trackingcode` TEXT COLLATE utf8_unicode_ci NOT NULL;');
+    }
+}

--- a/engine/Shopware/Models/Order/Order.php
+++ b/engine/Shopware/Models/Order/Order.php
@@ -411,7 +411,7 @@ class Order extends ModelEntity
     /**
      * @var string
      *
-     * @ORM\Column(name="trackingcode", type="string", length=255, nullable=false)
+     * @ORM\Column(name="trackingcode", type="text", nullable=false)
      */
     private $trackingCode;
 

--- a/tests/Functional/Models/Order/OrderTest.php
+++ b/tests/Functional/Models/Order/OrderTest.php
@@ -84,6 +84,20 @@ class Shopware_Tests_Models_Order_OrderTest extends Enlight_Components_Test_Test
         $this->assertSame($previousOrderStatus, $history[0]->getPreviousOrderStatus());
     }
 
+    public function testSaveMoreThan255CharactersAsTrackingCode()
+    {
+        $order = $this->createOrder();
+        $this->orderIsSaved($order);
+
+        $trackingCode = 'trackingCodeWithMoreThan255Characters_1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890';
+
+        $order->setTrackingCode($trackingCode);
+        $this->em->flush($order);
+        $this->em->refresh($order);
+
+        $this->assertSame($trackingCode, $order->getTrackingCode());
+    }
+
     public function createOrder()
     {
         $paymentStatusOpen = $this->em->getReference('\Shopware\Models\Order\Status', 17);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Splitting an order into multiple shipments is currently limited due to the tracking code column `s_order.trackingcode` allowing at most 255 characters. (If a tracking code has 20 characters, you can create a maximum of 12 shipments.) 

### 2. What does this change do, exactly?
This pull request changes the type of the tracking code field `s_order.trackingcode` from `VARCHAR(255)` to `TEXT` so that a unlimited number of tracking codes can be saved. This will help e.g. the plugin _DHL Adapter_ to be able to remove its current limit of 9 tracking codes/shipments per order.

### 3. Describe each step to reproduce the issue or behaviour.
Try to save more than 12 tracking codes of 20 characters each in an order.

### 4. Please link to the relevant issues (if any).
--

### 5. Which documentation changes (if any) need to be made because of this PR?
--

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.