### PR TITLE
Normalized struct attributes in legacy struct converter for improved templating

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/Attribute.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/Attribute.php
@@ -29,7 +29,7 @@ namespace Shopware\Bundle\StoreFrontBundle\Struct;
  *
  * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
-class Attribute extends Struct implements \JsonSerializable
+class Attribute extends Struct implements \JsonSerializable, \ArrayAccess
 {
     /**
      * Internal storage which contains all struct data.
@@ -41,12 +41,12 @@ class Attribute extends Struct implements \JsonSerializable
     /**
      * @param array $data
      *
-     * @throws \Exception
+     * @throws \InvalidArgumentException
      */
     public function __construct($data = [])
     {
         if (!$this->isValid($data)) {
-            throw new \Exception('Class values should be serializable');
+            throw new \InvalidArgumentException('Class values should be serializable');
         }
         $this->storage = $data;
     }
@@ -71,12 +71,12 @@ class Attribute extends Struct implements \JsonSerializable
      * @param string $name
      * @param mixed  $value
      *
-     * @throws \Exception
+     * @throws \InvalidArgumentException
      */
     public function set($name, $value)
     {
         if (!$this->isValid($value)) {
-            throw new \Exception('Class values should be serializable');
+            throw new \InvalidArgumentException('Class values should be serializable');
         }
 
         $this->storage[$name] = $value;
@@ -136,5 +136,40 @@ class Attribute extends Struct implements \JsonSerializable
         }
 
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return $this->exists($offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \InvalidArgumentException
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->set($offset, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset)
+    {
+        if ($this->exists($offset)) {
+            unset($this->storage[$offset]);
+        }
     }
 }

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -150,6 +150,10 @@ class LegacyStructConverter
             $data['states'] = $this->convertStateStructList($country->getStates());
         }
 
+        if ($country->hasAttribute('core')) {
+            $data['attribute'] = $country->getAttribute('core');
+        }
+
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Country', $data, [
             'country' => $country,
         ]);
@@ -175,6 +179,10 @@ class LegacyStructConverter
         $data = json_decode(json_encode($state), true);
         $data += ['shortcode' => $state->getCode(), 'attributes' => $state->getAttributes()];
 
+        if ($state->hasAttribute('core')) {
+            $data['attribute'] = $state->getAttribute('core');
+        }
+
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_State', $data, [
             'state' => $state,
         ]);
@@ -198,6 +206,10 @@ class LegacyStructConverter
             'user_selected' => $group->isSelected(),
             'attributes' => $group->getAttributes(),
         ];
+
+        if ($group->hasAttribute('core')) {
+            $data['attribute'] = $group->getAttribute('core');
+        }
 
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Configurator_Group', $data, [
             'configurator_group' => $group,
@@ -418,6 +430,10 @@ class LegacyStructConverter
             'attributes' => $productStream->getAttributes(),
         ];
 
+        if ($productStream->hasAttribute('core')) {
+            $data['attribute'] = $productStream->getAttribute('core');
+        }
+
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Related_Product_Stream', $data, [
             'product_stream' => $productStream,
         ]);
@@ -562,6 +578,10 @@ class LegacyStructConverter
             'attributes' => $average->getAttributes(),
         ];
 
+        if ($average->hasAttribute('core')) {
+            $data['attribute'] = $average->getAttribute('core');
+        }
+
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Vote_Average', $data, [
             'average' => $average,
         ]);
@@ -585,7 +605,12 @@ class LegacyStructConverter
             'answer' => $vote->getAnswer(),
             'datum' => '0000-00-00 00:00:00',
             'answer_date' => '0000-00-00 00:00:00',
+            'attributes' => $vote->getAttributes(),
         ];
+
+        if ($vote->hasAttribute('core')) {
+            $data['attribute'] = $vote->getAttribute('core');
+        }
 
         if ($vote->getCreatedAt() instanceof \DateTime) {
             $data['datum'] = $vote->getCreatedAt()->format('Y-m-d H:i:s');
@@ -594,8 +619,6 @@ class LegacyStructConverter
         if ($vote->getAnsweredAt() instanceof \DateTime) {
             $data['answer_date'] = $vote->getAnsweredAt()->format('Y-m-d H:i:s');
         }
-
-        $data['attributes'] = $vote->getAttributes();
 
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Vote', $data, [
             'vote' => $vote,
@@ -617,7 +640,12 @@ class LegacyStructConverter
             'price' => $price->getCalculatedPrice(),
             'pseudoprice' => $price->getCalculatedPseudoPrice(),
             'referenceprice' => $price->getCalculatedReferencePrice(),
+            'attributes' => $price->getAttributes(),
         ];
+
+        if ($price->hasAttribute('core')) {
+            $data['attribute'] = $price->getAttribute('core');
+        }
 
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Price', $data, [
             'price' => $price,
@@ -662,6 +690,10 @@ class LegacyStructConverter
             'attributes' => $media->getAttributes(),
         ];
 
+        if ($media->hasAttribute('core')) {
+            $data['attribute'] = $media->getAttribute('core');
+        }
+
         $attributes = $media->getAttributes();
         if ($attributes && isset($attributes['image'])) {
             $data['attribute'] = $attributes['image']->toArray();
@@ -697,6 +729,10 @@ class LegacyStructConverter
             ],
             'unit_attributes' => $unit->getAttributes(),
         ];
+
+        if ($unit->hasAttribute('core')) {
+            $data['unit_attribute'] = $unit->getAttribute('core');
+        }
 
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Unit', $data, [
             'unit' => $unit,
@@ -781,6 +817,10 @@ class LegacyStructConverter
                 'media' => $mediaValues,
                 'attributes' => $group->getAttributes(),
             ];
+
+            if ($group->hasAttribute('core')) {
+                $result[$groupId]['attribute'] = $group->getAttribute('core');
+            }
         }
 
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Property_Set', $result, [
@@ -803,6 +843,10 @@ class LegacyStructConverter
             'attributes' => $group->getAttributes(),
         ];
 
+        if ($group->hasAttribute('core')) {
+            $data['attribute'] = $group->getAttribute('core');
+        }
+
         foreach ($group->getOptions() as $option) {
             $data['options'][] = $this->convertPropertyOptionStruct($option);
         }
@@ -824,6 +868,10 @@ class LegacyStructConverter
             'name' => $option->getName(),
             'attributes' => $option->getAttributes(),
         ];
+
+        if ($option->hasAttribute('core')) {
+            $data['attribute'] = $option->getAttribute('core');
+        }
 
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Property_Option', $data, [
             'property_option' => $option,
@@ -849,6 +897,10 @@ class LegacyStructConverter
             'media' => $manufacturer->getCoverMedia() ? $this->convertMediaStruct($manufacturer->getCoverMedia()) : null,
             'attributes' => $manufacturer->getAttributes(),
         ];
+
+        if ($manufacturer->hasAttribute('core')) {
+            $data['attribute'] = $manufacturer->getAttribute('core');
+        }
 
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Manufacturer', $data, [
             'manufacturer' => $manufacturer,
@@ -950,7 +1002,12 @@ class LegacyStructConverter
             'instock' => $product->isCloseouts(),
             'articleID' => $product->getId(),
             'type' => $set->getType(),
+            'attributes' => $set->getAttributes(),
         ];
+
+        if ($set->hasAttribute('core')) {
+            $data['attribute'] = $set->getAttribute('core');
+        }
 
         //switch the template for the different configurator types.
         if ($set->getType() == 1) {
@@ -996,6 +1053,10 @@ class LegacyStructConverter
             $data['media'] = $this->convertMediaStruct($option->getMedia());
         }
 
+        if ($option->hasAttribute('core')) {
+            $data['attribute'] = $option->getAttribute('core');
+        }
+
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_Configurator_Option', $data, [
             'configurator_group' => $group,
             'configurator_options' => $option,
@@ -1025,7 +1086,12 @@ class LegacyStructConverter
             'metaTitle' => $blog->getMetaTitle(),
             'views' => $blog->getViews(),
             'mediaList' => array_map([$this, 'convertMediaStruct'], $blog->getMedias()),
+            'attributes' => $blog->getAttributes(),
         ];
+
+        if ($blog->hasAttribute('core')) {
+            $data['attribute'] = $blog->getAttribute('core');
+        }
 
         $data['media'] = reset($data['mediaList']);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
As every storefront struct has core attributes they should be available in the templating too. I added attribute serialization to every struct conversion to keep the templating data similar to each other.

### 2. What does this change do, exactly?
Every struct gets its attributes extracted, serialized and put back into the already serialized struct data without overriding already existing attribute entries.

Have a look at my (untested :see_no_evil:) [hotfix plugin](https://github.com/niemand-online/NoStructAttributesInTemplate) for that issue. We already use a similar plugin for blog attributes in production. This one will apply to all converted storefront structs.

### 3. Describe each step to reproduce the issue or behaviour.
As the attribute are not always available like for blog structs you cannot access these attributes in the blog emotion template.

### 4. Which documentation changes (if any) need to be made because of this PR?
Maybe some hints in the templating documentation that these values are available now.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.