### PR TITLE
[SW-22635] translate custom pages when displaying them in the sitemap

### DIFF
--- a/_sql/demo/latest.sql
+++ b/_sql/demo/latest.sql
@@ -5991,9 +5991,9 @@ INSERT INTO `s_core_shop_pages` (`shop_id`, `group_id`) VALUES
 (1, 1),
 (1, 2),
 (1, 3),
-(2, 7),
-(2, 9),
-(2, 10);
+(2, 1),
+(2, 2),
+(2, 3);
 
 TRUNCATE TABLE `s_core_tax_rules`;
 
@@ -6119,7 +6119,8 @@ INSERT IGNORE INTO `s_core_translations` (`id`, `objecttype`, `objectdata`, `obj
 (262, 'article', 'a:2:{s:10:"txtArtikel";s:24:"Munsterland Aperitif 16%";s:19:"txtlangbeschreibung";s:432:"<p>Io copia moeror immo pro audio modestia. Permaneo animosus etsi furax, aversor, faenum Pecus, mus me dux ferociter interpellatio certo. infrequentia Illis Quamquam Invidus, indutus voco tot Velociter, rare qui Limbus in Uter sub Ferito. Hinc lacrima Tutor gens Stabulaus antrum levis se voveo quemadmodum ruo illa sidereus. Luo Modicus tutela sedo Uxor contineo, ait ait crebra exsecror Ruga Sospes gratuita se Quae praevideo</p>";}', 3, '2'),
 (263, 'article', 'a:2:{s:10:"txtArtikel";s:24:"Shipping costs by weight";s:19:"txtlangbeschreibung";s:226:"<p>This article weighs 8 KG. These requires a calculation by weight. If you add it to the cart, it will be charged with 19,90 Euro. To do so, use the follwing access data: max.mustermann@mail.com &amp; Password: shopware .</p>";}', 248, '2'),
 (270, 'article', 'a:1:{s:10:"txtArtikel";s:19:"Beach Towel "Ibiza"";}', 178, '2'),
-(272, 'config_payment', 'a:5:{i:4;a:2:{s:11:"description";s:7:"Invoice";s:21:"additionalDescription";s:141:"Payment by invoice. Shopware provides automatic invoicing for all customers on orders after the first, in order to avoid defaults on payment.";}i:2;a:2:{s:11:"description";s:5:"Debit";s:21:"additionalDescription";s:15:"Additional text";}i:3;a:2:{s:11:"description";s:16:"Cash on delivery";s:21:"additionalDescription";s:25:"(including 2.00 Euro VAT)";}i:5;a:2:{s:11:"description";s:15:"Paid in advance";s:21:"additionalDescription";s:57:"The goods are delivered directly upon receipt of payment.";}i:6;a:1:{s:21:"additionalDescription";s:17:"SEPA direct debit";}}', 1, '2');
+(272, 'config_payment', 'a:5:{i:4;a:2:{s:11:"description";s:7:"Invoice";s:21:"additionalDescription";s:141:"Payment by invoice. Shopware provides automatic invoicing for all customers on orders after the first, in order to avoid defaults on payment.";}i:2;a:2:{s:11:"description";s:5:"Debit";s:21:"additionalDescription";s:15:"Additional text";}i:3;a:2:{s:11:"description";s:16:"Cash on delivery";s:21:"additionalDescription";s:25:"(including 2.00 Euro VAT)";}i:5;a:2:{s:11:"description";s:15:"Paid in advance";s:21:"additionalDescription";s:57:"The goods are delivered directly upon receipt of payment.";}i:6;a:1:{s:21:"additionalDescription";s:17:"SEPA direct debit";}}', 1, '2'),
+(273, 'page', 'a:1:{s:11:"description";s:7:"Imprint";}', 3, '2');
 
 
 TRUNCATE TABLE `s_core_units`;

--- a/engine/Shopware/Components/Translation.php
+++ b/engine/Shopware/Components/Translation.php
@@ -176,10 +176,10 @@ class Shopware_Components_Translation
     /**
      * Reads multiple translation data from storage.
      *
-     * @param int    $language
-     * @param string $type
-     * @param int    $key
-     * @param bool   $merge
+     * @param int       $language
+     * @param string    $type
+     * @param int|int[] $key
+     * @param bool      $merge
      *
      * @return array
      */
@@ -238,7 +238,7 @@ class Shopware_Components_Translation
      * @param int       $language
      * @param int       $fallback
      * @param string    $type
-     * @param int|array $key
+     * @param int|int[] $key
      * @param bool      $merge
      *
      * @return array|mixed

--- a/engine/Shopware/Controllers/Frontend/Sitemap.php
+++ b/engine/Shopware/Controllers/Frontend/Sitemap.php
@@ -22,6 +22,7 @@
  * our trademarks remain entirely with us.
  */
 use Shopware\Components\Model\QueryBuilder;
+use Shopware\Models\Shop\DetachedShop;
 
 /**
  * @category Shopware
@@ -35,10 +36,10 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
      */
     public function indexAction()
     {
-        $categoryTree = Shopware()->Modules()->sCategories()->sGetWholeCategoryTree();
+        $categoryTree = $this->getCategoryTree();
         $additionalTrees = $this->getAdditionalTrees();
 
-        $additionalTrees = Shopware()->Events()->filter(
+        $additionalTrees = $this->container->get('events')->filter(
             'Shopware_Modules_Sitemap_indexAction',
             $additionalTrees,
             ['subject' => $this]
@@ -46,6 +47,47 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
 
         $categoryTree = array_merge($categoryTree, $additionalTrees);
         $this->View()->assign('sCategoryTree', $categoryTree);
+    }
+
+    /**
+     * @return array
+     */
+    private function getCategoryTree()
+    {
+        $categoryTree = $this->container->get('modules')->sCategories()->sGetWholeCategoryTree();
+
+        $categoryTranslations = $this->fetchTranslations('category', $this->getTranslationKeys(
+            $categoryTree,
+            'id',
+            'sub'
+        ));
+
+        return $this->translateCategoryTree($categoryTree, $categoryTranslations);
+    }
+
+    /**
+     * @param array $categoryTree
+     * @param array $translations
+     *
+     * @return array
+     */
+    private function translateCategoryTree(array $categoryTree, array $translations)
+    {
+        foreach ($categoryTree as $key => $category) {
+            $translation = $this->fetchTranslation($category['id'], $translations);
+
+            if (!empty($translation['description'])) {
+                $translation['name'] = $translation['description'];
+            }
+
+            $categoryTree[$key] = array_merge($category, $translation);
+
+            if (!empty($category['sub'])) {
+                $categoryTree[$key]['sub'] = $this->translateCategoryTree($category['sub'], $translations);
+            }
+        }
+
+        return $categoryTree;
     }
 
     /**
@@ -69,10 +111,19 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
      */
     private function getCustomPages()
     {
-        $sites = $this->getSitesByShopId(Shopware()->Shop()->getId());
+        /** @var DetachedShop $shop */
+        $shop = $this->container->get('shop');
+
+        $sites = $this->getSitesByShopId($shop->getId());
+
+        $translations = $this->fetchTranslations('page', $this->getTranslationKeys(
+            $sites,
+            'id',
+            'children'
+        ));
 
         foreach ($sites as &$site) {
-            $site = $this->convertSite($site);
+            $site = $this->convertSite($site, $translations);
         }
 
         $staticPages = [
@@ -82,6 +133,28 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
         ];
 
         return $staticPages;
+    }
+
+    /**
+     * @param array  $array
+     * @param string $keyField
+     * @param string $recursiveField
+     *
+     * @return int[]
+     */
+    private function getTranslationKeys(array $array, $keyField, $recursiveField)
+    {
+        $translationkeys = [];
+
+        foreach ($array as $data) {
+            $translationkeys[] = $data[$keyField];
+
+            if (!empty($data[$recursiveField])) {
+                $translationkeys += $this->getTranslationKeys($data[$recursiveField], $keyField, $recursiveField);
+            }
+        }
+
+        return $translationkeys;
     }
 
     /**
@@ -101,8 +174,7 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
             WHERE shopPages.shop_id = ?
         ';
 
-        $statement = Shopware()->Db()->executeQuery($sql, [$shopId]);
-
+        $statement = $this->container->get('db')->executeQuery($sql, [$shopId]);
         $keys = $statement->fetchAll(PDO::FETCH_COLUMN);
 
         /** @var Shopware\Models\Site\Repository $siteRepository */
@@ -127,11 +199,13 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
      * Recursive helper function to convert a site to correct sitemap format
      *
      * @param array $site
+     * @param array $translations
      *
      * @return array
      */
-    private function convertSite($site)
+    private function convertSite($site, array $translations)
     {
+        $site = array_merge($site, $this->fetchTranslation($site['id'], $translations));
         $site['hideOnSitemap'] = !$this->filterLink($site['link']);
 
         $site = array_merge(
@@ -147,12 +221,53 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
 
         if (isset($site['children'])) {
             foreach ($site['children'] as &$child) {
-                $child = $this->convertSite($child);
+                $child = $this->convertSite($child, $translations);
             }
             $site['sub'] = $site['children'];
         }
 
         return $site;
+    }
+
+    /**
+     * @param string $type
+     * @param int[]  $ids
+     *
+     * @return array
+     */
+    private function fetchTranslations($type, array $ids)
+    {
+        /** @var DetachedShop $shop */
+        $shop = $this->container->get('shop');
+
+        $shopId = $shop->getId();
+        $fallbackShop = $shop->getFallback();
+
+        $fallbackId = null;
+        if ($fallbackShop !== null) {
+            $fallbackId = $fallbackShop->getId();
+        }
+
+        $translator = $this->container->get('translation');
+
+        return $translator->readBatchWithFallback($shopId, $fallbackId, $type, $ids, false);
+    }
+
+    /**
+     * @param int   $objectKey
+     * @param array $translations
+     *
+     * @return array
+     */
+    private function fetchTranslation($objectKey, array $translations)
+    {
+        foreach ($translations as $translation) {
+            if ((int) $translation['objectkey'] === $objectKey) {
+                return $translation['objectdata'];
+            }
+        }
+
+        return [];
     }
 
     /**
@@ -222,22 +337,15 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
         /** @var Shopware\Models\Emotion\Repository $emotionRepository */
         $emotionRepository = $this->get('models')->getRepository('Shopware\Models\Emotion\Emotion');
 
-        $shopId = Shopware()->Shop()->getId();
-        $fallbackId = null;
+        /** @var DetachedShop $shop */
+        $shop = $this->container->get('shop');
 
-        $fallbackShop = Shopware()->Shop()->getFallback();
-
-        if (!empty($fallbackShop)) {
-            $fallbackId = $fallbackShop->getId();
-        }
-
-        $translator = $this->container->get('translation');
-
-        $builder = $emotionRepository->getCampaignsByShopId($shopId);
+        $builder = $emotionRepository->getCampaignsByShopId($shop->getId());
         $campaigns = $builder->getQuery()->getArrayResult();
+        $translations = $this->fetchTranslations('emotion', array_column($campaigns, 'id'));
 
         foreach ($campaigns as &$campaign) {
-            $translation = $translator->readWithFallback($shopId, $fallbackId, 'emotion', $campaign['id']);
+            $translation = $this->fetchTranslation($campaign['id'], $translations);
 
             $translation['seo_title'] = $translation['seoTitle'];
             $translation['seo_keywords'] = $translation['seoKeywords'];

--- a/tests/Functional/Controllers/Frontend/SitemapTest.php
+++ b/tests/Functional/Controllers/Frontend/SitemapTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+use Shopware\Models\Shop\Shop;
+
+/**
+ * @category  Shopware
+ *
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class Shopware_Tests_Controllers_Frontend_SitemapTest extends Enlight_Components_Test_Controller_TestCase
+{
+    public static function tearDownAfterClass()
+    {
+        Shopware()->Models()->getRepository(Shop::class)->getActiveDefault()->registerResources();
+    }
+
+    /**
+     * @param int   $shopId
+     * @param array $sitemapData
+     *
+     * @dataProvider sitemapDataprovider
+     */
+    public function testIndex($shopId, array $sitemapData)
+    {
+        Shopware()->Models()->getRepository(Shop::class)->find($shopId)->registerResources();
+
+        $controller = $this->getController();
+        $controller->indexAction();
+
+        $sCategoryTree = $controller->View()->getAssign('sCategoryTree');
+
+        $this->assertEquals(200, $this->Response()->getHttpResponseCode());
+
+        foreach ($sitemapData as $name => $elements) {
+            $partialTree = array_filter($sCategoryTree, function (array $treeElement) use ($name) {
+                return $treeElement['name'] === $name;
+            });
+
+            $partialTree = reset($partialTree)['sub'];
+            $partialTreeNames = array_column($partialTree, 'name');
+
+            foreach ($elements as $element) {
+                $this->assertContains($element, $partialTreeNames);
+            }
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function sitemapDataprovider()
+    {
+        return [
+            [
+                1,
+                [
+                    'Genusswelten' => [
+                        'Tees und Zubehör',
+                        'Edelbrände',
+                        'Köstlichkeiten',
+                    ],
+                    'SitemapStaticPages' => [
+                        'Impressum',
+                    ],
+                ],
+            ],
+            [
+                2,
+                [
+                    'Worlds of indulgence' => [
+                        'Teas and Accessories',
+                        'Brandies',
+                        'Delights',
+                    ],
+                    'SitemapStaticPages' => [
+                        'Imprint',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return Shopware_Controllers_Frontend_Sitemap
+     */
+    private function getController()
+    {
+        /** @var Shopware_Controllers_Frontend_Sitemap $controller */
+        $controller = Enlight_Class::Instance(Shopware_Controllers_Frontend_Sitemap::class, [
+            $this->Request(),
+            $this->Response(),
+        ]);
+
+        $controller->setContainer(Shopware()->Container());
+        $controller->setView(new Enlight_View_Default(new Enlight_Template_Manager()));
+
+        return $controller;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
translations are missing for the custom pages displayed in the frontend sitemap

### 2. What does this change do, exactly?
translates custom pages and handles translation of emotions in less queries

### 3. Describe each step to reproduce the issue or behaviour.
- translate a custom page description
- add the corresponding custom page container to the english demo shop
- change language to english
- visit shop/sitemap

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22635

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.