### PR TITLE
[SW-21968] Disable button for newsletter after form submit

### DIFF
--- a/themes/Frontend/Bare/frontend/index/footer-navigation.tpl
+++ b/themes/Frontend/Bare/frontend/index/footer-navigation.tpl
@@ -103,7 +103,7 @@
         {/block}
 
         {block name="frontend_index_footer_column_newsletter_content"}
-            <div class="column--content">
+            <div class="column--content" data-newsletter="true">
                 <p class="column--desc">
                     {s name="sFooterNewsletter"}{/s}
                 </p>

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.newsletter.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.newsletter.js
@@ -12,7 +12,11 @@
 
             checkMailSelector: '.newsletter--checkmail',
 
-            additionalFormSelector: '.newsletter--additional-form'
+            additionalFormSelector: '.newsletter--additional-form',
+
+            formSelector: 'form',
+
+            submitButtonSelector: 'button[type=submit]',
         },
 
         init: function () {
@@ -23,9 +27,12 @@
             me.$checkMail = me.$el.find(me.opts.checkMailSelector);
             me.$addionalForm = me.$el.find(me.opts.additionalFormSelector);
             me.$captchaForm = me.$el.find(me.opts.captchaFormSelector);
+            me.$form = me.$el.find(me.opts.formSelector);
 
             me._on(me.$checkMail, 'change', $.proxy(me.refreshAction, me));
             $.subscribe(me.getEventName('plugin/swCaptcha/onSendRequestSuccess'), $.proxy(me.onCaptchaLoaded, me));
+
+            me._on(me.$form, 'submit', $.proxy(me.submit, me));
 
             $.publish('plugin/swNewsletter/onRegisterEvents', [ me ]);
 
@@ -58,6 +65,12 @@
             }
 
             $.publish('plugin/swNewsletter/onRefreshAction', [ me ]);
+        },
+
+        submit: function() {
+            var me = this;
+
+            me.$el.find(me.opts.submitButtonSelector).attr('disabled', 'disabled').addClass('disabled');
         },
 
         onCaptchaLoaded: function () {


### PR DESCRIPTION
### 1. Why is this change necessary?
The newsletter form can be submitted multiple times by clicking multiple times. 
When double-opt-in for newsletter is enabled an email will be send each time.

### 2. What does this change do, exactly?
Disables the submit button after the form is submitted.

### 3. Describe each step to reproduce the issue or behaviour.
1. Enable double-opt-in for newsletter
2. Fill out newsletter form for subscribing (in footer or on the newsletter page)
3. Click multiple times on the submit button

### 4. Please link to the relevant issues (if any).
[SW-21968](https://issues.shopware.com/issues/SW-21968)

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.