### PR TITLE
[SW-20698] Fix emotion element identifier for duplication

### DIFF
--- a/engine/Shopware/Controllers/Backend/Emotion.php
+++ b/engine/Shopware/Controllers/Backend/Emotion.php
@@ -27,6 +27,7 @@ use Shopware\Components\Emotion\EmotionExporter;
 use Shopware\Components\Emotion\Exception\MappingRequiredException;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Components\Random;
+use Shopware\Models\Emotion\Data;
 use Shopware\Models\Emotion\Element;
 use Shopware\Models\Emotion\Emotion;
 use Shopware\Models\Emotion\Library\Field;
@@ -1541,7 +1542,14 @@ EOD;
      */
     private function getElementIdentifier(Element $el)
     {
-        return $el->getStartCol() . $el->getStartRow() . $el->getEndCol() . $el->getEndRow();
+        $data = array_map(function (Data $data) {
+            /** @var Field $field */
+            $field = $data->getField();
+
+            return $field->getName() . $data->getValue();
+        }, $el->getData()->toArray());
+
+        return md5(implode($data));
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Duplicating an emotion item will cause problems to the element's translation when `start_row`, `start_col`, `end_row` and `end_col` are the same for multiple elements in `s_emotion_element`.
The concatenated string of these values is used to create an identifier between the original element and the cloned element for duplicating its translation.

### 2. What does this change do, exactly?
Changing the identifier to the actual viewport values.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create an emotion item with two text elements
2. Translate both elements
3. Duplicate emotion item
3. Check the translation of text element #1 (should be the translation of #2)

### 4. Please link to the relevant issues (if any).
[SW-20698](https://issues.shopware.com/issues/SW-20698)

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.