### PR TITLE
cache plugin and namespace config for less database load

### DIFF
--- a/tests/Functional/Components/Plugin/NamespaceTest.php
+++ b/tests/Functional/Components/Plugin/NamespaceTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Functional\Components\Plugin;
+
+use PHPUnit\Framework\TestCase;
+
+class NamespaceTest extends TestCase
+{
+    /**
+     * @var \Shopware_Components_Plugin_Namespace
+     */
+    private $namespace;
+
+    /**
+     * @var string
+     */
+    private $testNamespaceName = 'Core';
+
+    /**
+     * @var \Enlight_Config
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        // Build Namespace Test Object and Set Manager
+        $pluginManager = new \Enlight_Plugin_PluginManager(Shopware());
+        $this->namespace = new \Shopware_Components_Plugin_Namespace(
+            $this->testNamespaceName,
+            null,
+            [],
+            Shopware()->Container()->get('shopware.plugin.cached_config_reader')
+        );
+        $this->namespace->setManager($pluginManager);
+
+        // Execute Storage (with init)
+        $this->storage = $this->namespace->Storage();
+    }
+
+    public function testListenerCache()
+    {
+        // And Check correctly set cache keys
+        $cache = Shopware()->Container()->get('cache');
+        $result = $cache->load('globalListenersPlugins' . $this->testNamespaceName);
+
+        $this->assertEquals(['name', 'listener', 'position', 'plugin'], array_keys($result[0]));
+    }
+
+    public function testPluginListCache()
+    {
+        // And Check correctly set cache keys
+        $cache = Shopware()->Container()->get('cache');
+        $result = $cache->load('globalAllPlugins' . $this->testNamespaceName);
+
+        $this->assertEquals(['name', 'id', 'label', 'description', 'source', 'active', 'installationDate', 'updateDate', 'version'], array_keys($result[0]));
+    }
+
+    public function testPluginStorage()
+    {
+        $this->assertGreaterThan(0, $this->storage->get('plugins')->count());
+    }
+
+    public function testListenerStorage()
+    {
+        $this->assertGreaterThan(0, $this->storage->get('listeners')->count());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
The multiple database queries coused a high database load on heavy used shops


### 2. What does this change do, exactly?
We cache the array result of the database requests and use it further than from cache.


### 3. Describe each step to reproduce the issue or behaviour.
Call homepage and trace your db queries.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.