### PR TITLE
[SW-22587] Fix price update for removed or unavailable products in basket

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2897,6 +2897,10 @@ SQL;
             $additionalInfo = $cartItem->getAdditionalInfo();
             $priceResult = [];
 
+            if ($prices === null) {
+                continue;
+            }
+
             foreach ($prices as $price) {
                 if ($additionalInfo['pricegroupActive'] && $price['from'] === '1') {
                     $priceResult[$price['pricegroup']] = $price;

--- a/tests/Functional/Core/sBasketTest.php
+++ b/tests/Functional/Core/sBasketTest.php
@@ -1945,6 +1945,40 @@ class sBasketTest extends PHPUnit\Framework\TestCase
         }
     }
 
+    public function testsGetBasketWithInvalidProduct()
+    {
+        $this->assertEquals([], $this->module->sGetBasket());
+
+        $this->module->sSYSTEM->sSESSION_ID = uniqid(rand());
+        $this->session->offsetSet('sessionId', $this->module->sSYSTEM->sSESSION_ID);
+
+        $randomArticle = $this->db->fetchRow(
+            'SELECT * FROM s_articles_details detail
+            INNER JOIN s_articles article
+              ON article.id = detail.articleID
+            WHERE detail.active = 1
+            LIMIT 1'
+        );
+
+        $this->db->insert(
+            's_order_basket',
+            [
+                'price' => 2,
+                'quantity' => 1,
+                'sessionID' => $this->session->get('sessionId'),
+                'ordernumber' => $randomArticle['ordernumber'],
+                'articleID' => $randomArticle['articleID'],
+            ]
+        );
+
+        $this->assertEquals(1, count($this->module->sGetBasket()['content']));
+
+        $this->db->delete('s_articles_details', ['articleID = ?' => $randomArticle['articleID']]);
+        $this->db->delete('s_articles', ['id = ?' => $randomArticle['articleID']]);
+
+        $this->assertEquals([], $this->module->sGetBasket());
+    }
+
     /**
      * @covers \sBasket::sAddNote
      */


### PR DESCRIPTION
### 1. Why is this change necessary?
When the basket contains a product which has been removed in some way (deleting oder changing product number) the checkout throws an error. 

### 2. What does this change do, exactly?
Skip the price update for unavailable products in basket.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add product to basket
2. Delete product
3. Refresh basket

### 4. Please link to the relevant issues (if any).
[SW-22587](https://issues.shopware.com/issues/SW-22587)

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.