### PR TITLE
Prevent invalid IsNew-Attributes on articles

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/MarketingService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/MarketingService.php
@@ -61,7 +61,7 @@ class MarketingService implements Service\MarketingServiceInterface
         $marker = (int) $this->config->get('markAsNew');
 
         $attribute->setIsNew(
-            ($diff->days <= $marker || $product->getCreatedAt() > $today)
+            (($diff && $diff->days <= $marker) || $product->getCreatedAt() > $today)
         );
 
         $attribute->setComingSoon(


### PR DESCRIPTION
### 1. Why is this change necessary?
In case the `created`-column of `s_articles` contains a `NULL`-value, the badge `IsNew` will always be shown.

### 2. What does this change do, exactly?
It checks whether the calculated `$diff` is valid (`$today->diff(null)` returns `false`)

### 3. Describe each step to reproduce the issue or behaviour.
Set the value of the `created`-column of an article in the `s_articles`-table to `NULL`. The Listing should now mark the article as new

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.