### PR TITLE
Fix time zone conversion bug

### DIFF
--- a/engine/Library/ExtJs/overrides/Ext.JSON.js
+++ b/engine/Library/ExtJs/overrides/Ext.JSON.js
@@ -1,0 +1,41 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+(function () {
+    var serverTimeZoneOffsetToUtcInSeconds = parseInt('{$serverTimeZoneOffsetToUtcInSeconds}', 10);
+    var pad = function(number) {
+        return number < 10 ? "0" + number : number;
+    };
+
+    Ext.JSON.encodeDate = function (date) {
+        var dateShiftedByTimeZoneOffset = new Date(date.getTime());
+        dateShiftedByTimeZoneOffset.setSeconds(dateShiftedByTimeZoneOffset.getSeconds() + serverTimeZoneOffsetToUtcInSeconds);
+
+        return '"' + dateShiftedByTimeZoneOffset.getUTCFullYear() + "-"
+            + pad(dateShiftedByTimeZoneOffset.getUTCMonth() + 1) + "-"
+            + pad(dateShiftedByTimeZoneOffset.getUTCDate()) + "T"
+            + pad(dateShiftedByTimeZoneOffset.getUTCHours()) + ":"
+            + pad(dateShiftedByTimeZoneOffset.getUTCMinutes()) + ":"
+            + pad(dateShiftedByTimeZoneOffset.getUTCSeconds()) + '"';
+    }
+})();

--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -43,80 +43,80 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      *
      * @var \Shopware\Models\Article\Repository
      */
-    protected $repository;
+    protected $repository = null;
 
     /**
      * Repository for the shop model
      *
      * @var Repository
      */
-    protected $shopRepository;
+    protected $shopRepository = null;
 
     /**
      * Repository for the customer model
      *
      * @var \Shopware\Models\Customer\Repository
      */
-    protected $customerRepository;
+    protected $customerRepository = null;
 
     /**
      * Repository for the category model
      *
      * @var \Shopware\Models\Category\Repository
      */
-    protected $categoryRepository;
+    protected $categoryRepository = null;
 
     /**
      * @var \Shopware\Components\Model\ModelRepository
      */
-    protected $articleDetailRepository;
+    protected $articleDetailRepository = null;
 
     /**
      * @var \Shopware\Components\Model\ModelRepository
      */
-    protected $customerGroupRepository;
+    protected $customerGroupRepository = null;
 
     /**
      * Entity Manager
      *
      * @var null
      */
-    protected $manager;
+    protected $manager = null;
 
     /**
      * @var \Shopware\Components\Model\ModelRepository
      */
-    protected $configuratorDependencyRepository;
+    protected $configuratorDependencyRepository = null;
 
     /**
      * @var \Shopware\Components\Model\ModelRepository
      */
-    protected $configuratorPriceVariationRepository;
+    protected $configuratorPriceVariationRepository = null;
 
     /**
      * @var \Shopware\Components\Model\ModelRepository
      */
-    protected $configuratorGroupRepository;
+    protected $configuratorGroupRepository = null;
 
     /**
      * @var \Shopware\Components\Model\ModelRepository
      */
-    protected $configuratorOptionRepository;
+    protected $configuratorOptionRepository = null;
 
     /**
      * @var Shopware_Components_Translation
      */
-    protected $translation;
+    protected $translation = null;
 
     /**
      * @var \Shopware\Components\Model\ModelRepository
      */
-    protected $configuratorSetRepository;
+    protected $configuratorSetRepository = null;
 
     /**
      * @var \Shopware\Components\Model\ModelRepository
      */
-    protected $propertyValueRepository;
+    protected $propertyValueRepository = null;
 
     public function initAcl()
     {
@@ -155,7 +155,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     public function saveAction()
     {
         $data = $this->Request()->getParams();
-
         if ($this->Request()->has('id')) {
             /** @var Article $article */
             $article = $this->getRepository()->find((int) $this->Request()->getParam('id'));
@@ -168,15 +167,8 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
                 $lastChanged = $article->getChanged();
             }
 
-            if ($lastChanged->getTimestamp() < 0 && $article->getChanged()->getTimestamp() < 0) {
-                $lastChanged = $article->getChanged();
-            }
-
-            $diff = abs($article->getChanged()->getTimestamp() - $lastChanged->getTimestamp());
-
-            // We have timestamp conversion issues on Windows Users
-            if ($diff > 1) {
-                $namespace = $this->get('snippets')->getNamespace('backend/article/controller/main');
+            if ($article->getChanged()->getTimestamp() !== $lastChanged->getTimestamp()) {
+                $namespace = Shopware()->Snippets()->getNamespace('backend/article/controller/main');
 
                 $this->View()->assign([
                     'success' => false,

--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -74,6 +74,16 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
         ];
     }
 
+    public function indexAction()
+    {
+        parent::indexAction();
+
+        $this->View()->assign(
+            'serverTimeZoneOffsetToUtcInSeconds',
+            (new DateTime())->getOffset()
+        );
+    }
+
     /**
      * Returns all supported detail status as an array. The status are used on the detail
      * page in the position grid to edit or create an order position.

--- a/engine/Shopware/Controllers/Backend/Customer.php
+++ b/engine/Shopware/Controllers/Backend/Customer.php
@@ -278,40 +278,24 @@ class Shopware_Controllers_Backend_Customer extends Shopware_Controllers_Backend
                 return;
             }
 
-            /** @var Customer $customer */
             $customer = $this->getRepository()->find($id);
-            $paymentData = $this->getManager()->getRepository(PaymentData::class)->findOneBy(
+            $paymentData = $this->getManager()->getRepository('Shopware\Models\Customer\PaymentData')->findOneBy(
                 ['customer' => $customer, 'paymentMean' => $paymentId]
             );
 
-            if ($customer->getChanged() !== null) {
-                // Check whether the customer has been modified in the meantime
-                try {
-                    $changed = new \DateTime($params['changed']);
-                } catch (Exception $e) {
-                    // If we have a invalid date caused by imports
-                    $changed = $customer->getChanged();
-                }
+            // Check whether the customer has been modified in the meantime
+            $changed = new \DateTime($params['changed']);
+            if ($customer->getChanged() !== null && $customer->getChanged()->getTimestamp() != $changed->getTimestamp()) {
+                $namespace = Shopware()->Snippets()->getNamespace('backend/customer/controller/main');
 
-                if ($changed->getTimestamp() < 0 && $customer->getChanged()->getTimestamp() < 0) {
-                    $changed = $customer->getChanged();
-                }
+                $this->View()->assign([
+                    'success' => false,
+                    'data' => $this->getCustomer($customer->getId()),
+                    'overwriteAble' => true,
+                    'message' => $namespace->get('customer_has_been_changed', 'The customer has been changed in the meantime. To prevent overwriting these changes, saving the customer was aborted. Please close the customer and re-open it.'),
+                ]);
 
-                $diff = abs($customer->getChanged()->getTimestamp() - $changed->getTimestamp());
-
-                // We have timestamp conversion issues on Windows Users
-                if ($diff > 1) {
-                    $namespace = Shopware()->Snippets()->getNamespace('backend/customer/controller/main');
-
-                    $this->View()->assign([
-                        'success' => false,
-                        'data' => $this->getCustomer($customer->getId()),
-                        'overwriteAble' => true,
-                        'message' => $namespace->get('customer_has_been_changed', 'The customer has been changed in the meantime. To prevent overwriting these changes, saving the customer was aborted. Please close the customer and re-open it.'),
-                    ]);
-
-                    return;
-                }
+                return;
             }
         } else {
             //check if the user has the rights to create a new customer

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -442,32 +442,17 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
         // Get all passed order data
         $data = $this->Request()->getParams();
 
-        if ($order->getChanged() !== null) {
-            try {
-                $changed = new \DateTime($data['changed']);
-            } catch (Exception $e) {
-                // If we have a invalid date caused by imports
-                $changed = $order->getChanged();
-            }
+        $changed = new \DateTime($data['changed']);
+        // Check whether the order has been modified in the meantime
+        if ($order->getChanged() !== null && $order->getChanged()->getTimestamp() != $changed->getTimestamp()) {
+            $this->View()->assign([
+                'success' => false,
+                'data' => $this->getOrder($order->getId()),
+                'overwriteAble' => true,
+                'message' => $namespace->get('order_has_been_changed', 'The order has been changed in the meantime. To prevent overwriting these changes, saving the order was aborted. Please close the order and re-open it.'),
+            ]);
 
-            if ($changed->getTimestamp() < 0 && $changed->getChanged()->getTimestamp() < 0) {
-                $changed = $order->getChanged();
-            }
-
-            // We have timestamp conversion issues on Windows Users
-            $diff = abs($order->getChanged()->getTimestamp() - $changed->getTimestamp());
-
-            // Check whether the order has been modified in the meantime
-            if ($diff > 1) {
-                $this->View()->assign([
-                    'success' => false,
-                    'data' => $this->getOrder($order->getId()),
-                    'overwriteAble' => true,
-                    'message' => $namespace->get('order_has_been_changed', 'The order has been changed in the meantime. To prevent overwriting these changes, saving the order was aborted. Please close the order and re-open it.'),
-                ]);
-
-                return;
-            }
+            return;
         }
 
         // Prepares the associated data of an order.

--- a/themes/Backend/ExtJs/backend/article/model/article.js
+++ b/themes/Backend/ExtJs/backend/article/model/article.js
@@ -59,7 +59,7 @@ Ext.define('Shopware.apps.Article.model.Article', {
         { name: 'metaTitle', type: 'string', useNull: true },
         { name: 'keywords', type: 'string', useNull: true },
         { name: 'added', type: 'date', dateFormat: 'd.m.Y' },
-        { name: 'changed', type: 'date', dateFormat: 'c' },
+        { name: 'changed', type: 'date' },
         { name: 'active', type: 'boolean', defaultValue: true },
         { name: 'taxId', type: 'int', useNull: true },
         { name: 'highlight', type: 'boolean' },

--- a/themes/Backend/ExtJs/backend/base/bootstrap.js
+++ b/themes/Backend/ExtJs/backend/base/bootstrap.js
@@ -57,6 +57,7 @@
 {include file='ExtJs/overrides/Ext.form.field.Display.js'}
 {include file='ExtJs/overrides/Ext.String.js'}
 {include file='ExtJs/overrides/Ext.view.Table.js'}
+{include file='ExtJs/overrides/Ext.JSON.js'}
 
 {* Include default components *}
 {include file='ExtJs/components/Enlight.app.Window.js'}

--- a/themes/Backend/ExtJs/backend/customer/model/customer.js
+++ b/themes/Backend/ExtJs/backend/customer/model/customer.js
@@ -50,7 +50,7 @@ Ext.define('Shopware.apps.Customer.model.Customer', {
     fields: [
         // {block name="backend/customer/model/customer/fields"}{/block}
         { name: 'newPassword', type: 'string' },
-        { name: 'changed', type: 'date', dateFormat: 'c' },
+        { name: 'changed', type: 'date' },
         { name: 'amount', type: 'float' },
         { name: 'orderCount', type: 'int' },
         { name: 'failedLogins', type: 'int' },

--- a/themes/Backend/ExtJs/backend/order/model/order.js
+++ b/themes/Backend/ExtJs/backend/order/model/order.js
@@ -48,7 +48,7 @@ Ext.define('Shopware.apps.Order.model.Order', {
     fields: [
         //{block name="backend/order/model/order/fields"}{/block}
         { name : 'id', type: 'int' },
-        { name : 'changed', type: 'date', dateFormat: 'c' },
+        { name : 'changed', type: 'date' },
         { name : 'number', type: 'string' },
         { name : 'customerId', type: 'int' },
         { name : 'customerEmail', type: 'string'},


### PR DESCRIPTION
### 1. Why is this change necessary?

Shopware has some issues when the web server and the browser are in different time zones. This is because ExtJS submits date fields without the timezone. For explanation imagine the following scenario:

The web server runs on a server with GMT as timezone. In Shopware there is an order with order time "12:00:00 UTC (+0000)". This order is now shown in a Browser that runs in a different time zone, e.g. Europe/Berlin. The browser displays the time as "14:00 (CEST +0200)". When the user now hits the save button, the order time gets changed to "14:00 UTC (+0000)".

![oct-16-2018 18-04-50](https://user-images.githubusercontent.com/6232639/47033975-6c698180-d176-11e8-9ce6-69064a22f308.gif) (Server runs in Europe/Berlin, SW 5.4.6)

This also leads to false positives with the optimistic locking / overwrite protection added in #1474. When an order is edited by a client with a different time zone it cannot be saved at all because the overwrite protection is always triggered. Even when clicking "yes" in the confirmation prompt, this will just cause the prompt to be shown again on the next try.

![oct-23-2018 14-16-35](https://user-images.githubusercontent.com/6232639/47359958-5441b700-d6ce-11e8-820e-d67f69597017.gif) (Server runs in Europe/Berlin, SW 5.5.1)

**The problem result from the following issue:**
When ExtJS formats a date object before it gets submitted to the server, it is converted to a string representation. Unfortunately, this representation is a local time string without a timezone specification, e.g. `2007-12-24T18:21`. When this time string is interpreted by the server, it assumes it to be specified in the server's default timezone. As the time zone of client and server differ, the time is now shifted by the relative offset between the client and the server, which is wrong.

Every date field in all ExtJS models suffer from this bug. This PR is general fix for all models with a date field. It is fully backwards compatible.

### 2. What does this change do, exactly?

Every date representation that is formatted for JSON serialization by ExtJs will be transformed into the local time zone of the server before being sent to the server. 

Unfortunately, just formatting the datetime in ISO 8601 format is insufficient. This is because a PHP DateTime object created from such an ISO string "lives" in the wrong time zone (UTC). When this date is saved by Doctrine it is not converted into the timezone of the server and therefore leads to a wrong date-time written to the database. See the following code example:

```php
<?php

// Create a DateTime object for 18:21 GMT
$dateTime = new \DateTime('2007-12-24T18:21Z');
// Our server lives in Europe/Berlin, therefore we need to persists 19:21 to the database.
// What doctrine persists:
echo $dateTime->format('Y-m-d H:i:s'); // 2007-12-24 18:21:00
echo PHP_EOL;
// What would be correct to persists: 
$dateTime->setTimeZone(new \DateTimeZone('Europe/Berlin'));
echo $dateTime->format('Y-m-d H:i:s'); // 2007-12-24 19:21:00
echo PHP_EOL;
```

This PR also reverts the commit d389efd because that fix lead to massive problem with the overwrite protection where every attempted order save caused the confirmation prompt to be shown on every Shopware installation, even if the order was not modified in the mean time. This is because ExtJS cannot handle the option `dateFormat: 'c'` in the ExtJS models correctly. (I could not find what the actual problem here was, but is is not necessary anymore with my fix).
Also this fix is not necessary anymore at this PR is a general solution for the problem and also solved problems with the overwrite-protection.

### 3. Describe each step to reproduce the issue or behaviour.

Access the Shopware backend with a client that runs in a different time zone as the web server. Open an order in the backend and save it. (You do not need to change anything.) After the order has been saved, you can see that the "created" time stamp has been shifted by the time zone offset between client and server. The more often you save the order, the further the "created" time stamp is shifted.

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.