### PR TITLE
Changes HttpCache behaviour for checkout/info widget

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/HttpCache/CacheControl.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/CacheControl.php
@@ -168,7 +168,7 @@ class CacheControl
 
         $controller = $this->cacheRouteGeneration->getControllerRoute($request);
 
-        return $controller === 'widgets/checkout' && (!empty($this->session->offsetGet('sBasketQuantity')) || !empty($this->session->offsetGet('sNotesQuantity')));
+        return $controller === 'widgets/checkout';
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Since Shopware 5.3 the widget `checkout/info` can display the name of the currently logged in customer. This name would then be saved in the http cache and would be the same for every customer with an empty cart and notepad. With this change, every customer will only see their respective names in the widget.

### 2. What does this change do, exactly?
The Change makes the CacheControl disregard the state of the cart and notepad for the `checkout/info` widget, so it is never cached.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have the basic setting for `Create Shopware Login Cookie` (found under `Login / registration`) set to true.
2. Log into the storefront.
3. Have an empty cart and notepad.
4. Log out
5. Log in with another customer with an empty basket and notepad.

You will be greeted as the customer you logged in first.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
I don't know.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.