### PR TITLE
Add error flag for billing address department

### DIFF
--- a/themes/Frontend/Bare/frontend/register/billing_fieldset.tpl
+++ b/themes/Frontend/Bare/frontend/register/billing_fieldset.tpl
@@ -33,7 +33,7 @@
                                placeholder="{s name='RegisterLabelDepartment'}{/s}"
                                id="register_billing_department"
                                value="{$form_data.department|escape}"
-                               class="register--field" />
+                               class="register--field{if isset($error_flags.department)} has--error{/if}" />
                     </div>
                 {/block}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If you add custom validators the field "department" wont be highlighted as the class "has--error" is not assigned.

### 2. What does this change do, exactly?
It adds a css class if the smarty variable "error_flags.department" is set.
Just like it is done in shipping_address.tpl

### 3. Describe each step to reproduce the issue or behaviour.
Create custom validator for department (e.g. max input length).

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.