### PR TITLE
Fix order overwrite protection false positives

### DIFF
--- a/themes/Backend/ExtJs/backend/order/view/detail/overview.js
+++ b/themes/Backend/ExtJs/backend/order/view/detail/overview.js
@@ -774,10 +774,6 @@ Ext.define('Shopware.apps.Order.view.detail.Overview', {
                 store: me.paymentStatusStore,
                 displayField: 'description',
                 valueField: 'id'
-            },
-            {
-                xtype: 'hiddenfield',
-                name: 'changed'
             }
         ];
     },


### PR DESCRIPTION
### 1. Why is this change necessary?
Since Shopware 5.5.2 the overwrite protection dialog is triggered on every save of any order.

This is because ExtJS could not parse the "changed" timestamp because there still was a hidden "changed" field in the oder detail window. Because of this field the value for "changed" was always `null` in the JSON transferred to the server.

### 2. What does this change do, exactly?
This PR removes this field.

### 3. Describe each step to reproduce the issue or behaviour.
Save an order in Shopware 5.5.2.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.