### PR TITLE
Fix docker-compose appserver port forwarding

### DIFF
--- a/dev-ops/docker/docker-compose.override.yml
+++ b/dev-ops/docker/docker-compose.override.yml
@@ -4,7 +4,7 @@ version: "3.3"
 services:
   appserver:
     ports:
-      - "18000:80"
+      - "8088:80"
 
   app_mysql:
     ports:


### PR DESCRIPTION
### 1. Why is this change necessary?
1) When starting the docker-container of this repository via `./psh.phar docker:start` port 80 of the appserver is forwarded to `18000` on the local machine, but the command says it should be available under port `http://localhost:8088`.
2) After i ssh'd into the appserver and executing `./psh.phar init` the shopware instance is running with the shop url `localhost:8088` as configured in the .psh.yaml.dist.

So the appserver is available under `http://localhost:18000` and after entering this in the browser we get forwarded to `http://localhost:8088`.

### 2. What does this change do, exactly?
I adjusted the port forwarding of the appserver to match the message at the end of docker:start and the configured SW_HOST in /.psh.yaml.dist

### 3. Describe each step to reproduce the issue or behaviour.
* Run ./psh.phar docker:start
* Look at the shown webserver IP at the end of the command
* SSH into the appserver and init shopware with ./psh.phar init
* Go into your browser and enter 'http://localhost:18000'
* Get forwarded to 'http://localhost:8088'

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.