### PR TITLE
fix type annotation: ean is not a float

### DIFF
--- a/engine/Shopware/Models/Article/Detail.php
+++ b/engine/Shopware/Models/Article/Detail.php
@@ -224,7 +224,7 @@ class Detail extends ModelEntity
     private $height = null;
 
     /**
-     * @var float ean
+     * @var string ean
      * @ORM\Column(name="ean", type="string", nullable=true)
      */
     private $ean = null;
@@ -676,7 +676,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @return float
+     * @return string
      */
     public function getEan()
     {
@@ -684,7 +684,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @param float $ean
+     * @param string $ean
      */
     public function setEan($ean)
     {


### PR DESCRIPTION

### 1. Why is this change necessary?

The field `ean` is stored into database as a string. Therefore it will be handled by Doctrine as a string, too. The annotation `float` would be misleading.

It may be discussed if `string` is the best choice here. But `float` does not make any sense to me.

### 2. What does this change do, exactly?

Nothing in runtime. Just for correct IDE support and less confusion.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] ~~I have written tests and verified that they fail without my change~~ Not possible
- [X] I have squashed any insignificant commits
- [ ] ~~This change has comments for package types, values, functions, and non-obvious lines of code~~ Fixes them!
- [X] I have read the contribution requirements and fulfil them.