### PR TITLE
fix missing help and support text for rich text config fields

### DIFF
--- a/engine/Library/ExtJs/components/Enlight.form.mixin.HelpSupportElements.js
+++ b/engine/Library/ExtJs/components/Enlight.form.mixin.HelpSupportElements.js
@@ -1,0 +1,191 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @category   Enlight
+ * @package    Enlight_ExtJs
+ * @copyright  Copyright (c) 2012, shopware AG (http://www.shopware.de)
+ * @license    http://enlight.de/license     New BSD License
+ */
+Ext.define('Enlight.form.mixin.HelpSupportElements',
+{
+    /**
+     * Support text which will be displayed under the form element.
+     * @string
+     */
+    supportText: '',
+
+    /**
+     * Help text which will be displayed in a tool tip next to the form element.
+     * @string
+     */
+    helpText: '',
+
+    /**
+     * Width (in pixel) for the help text tool tip.
+     * @default null
+     * @integer
+     */
+    helpWidth: null,
+
+    /**
+     * Title of the help tool tip.
+     * @default null
+     * @string
+     */
+    helpTitle: null,
+
+    /**
+     * Delay in millseconds before showing the
+     * help tooltip.
+     * @default 500
+     * @integer
+     */
+    helpTooltipDelay: 250,
+
+    /**
+     * Delay in milliseconds before hiding the
+     * help tooltip.
+     * @default 10000
+     * @integer
+     */
+    helpTooltipDismissDelay: 10000,
+
+    /**
+     * Property which holds of the DOM element of the support text.
+     * @default null
+     * @object
+     */
+    supportTextEl: null,
+
+    /**
+     * Property which holds of the help icon to display the help text
+     * in a tool tip.
+     * @default null
+     * @object
+     */
+    helpIconEl: null,
+
+    /**
+     * Using the "afterRender()"-method we're injecting
+     * the support and help texts into the form elements.
+     *
+     * @private
+     * @return void
+     */
+    initHelpSupportElements: function () {
+        var me = this;
+
+        if(me.helpText) {
+            me.createHelp();
+        }
+
+        if(me.supportText) {
+            me.createSupport();
+        }
+    },
+
+    /**
+     * Creates the support text and inject it into the form element.
+     *
+     * @public
+     * @return [object] supportText - DOM element
+     */
+    createSupport:function () {
+        var me = this,
+            row = new Ext.Element(document.createElement('tr')),
+            fillCell = new Ext.Element(document.createElement('td')),
+            cell = new Ext.Element(document.createElement('td')),
+            supportText = new Ext.Element(document.createElement('div'));
+
+        supportText.set({
+            cls: Ext.baseCSSPrefix +'form-support-text'
+        });
+
+        if(me.supportText) {
+            supportText.update(me.supportText);
+        }
+
+        supportText.appendTo(cell);
+
+        // If we're finding more than one item, just use the first one :)
+        var element = me.getEl().select('tbody');
+        if(element.elements.length > 1) {
+            element = element.elements[0];
+        }
+
+        if(me.fieldLabel || !me.hideEmptyLabel) {
+            fillCell.appendTo(row);
+        }
+
+        cell.appendTo(row);
+
+        if(me.helpText) {
+            var tmpCell = new Ext.Element(document.createElement('td'));
+            tmpCell.appendTo(row);
+        }
+
+        row.appendTo(element);
+        me.supportTextEl = supportText;
+        return supportText;
+    },
+
+    /**
+     * Creates the help text element. The method creates an new
+     * image which displays a tool tip with the help text on hover.
+     *
+     * @public
+     * @return [object] helpIcon - DOM element
+     */
+    createHelp:function () {
+        var me = this,
+            helpIcon = new Ext.Element(document.createElement('span')),
+            row = new Ext.Element(document.createElement('td'));
+
+        row.set({ width: 24, valign: 'top' });
+        helpIcon.set({ cls: Ext.baseCSSPrefix + 'form-help-icon' });
+        helpIcon.appendTo(row);
+
+        Ext.tip.QuickTipManager.register({
+            target:helpIcon,
+            cls: Ext.baseCSSPrefix + 'form-tooltip',
+            title:(me.helpTitle) ? me.helpTitle : '',
+            text:me.helpText,
+            width:(me.helpWidth) ? me.helpWidth : 225,
+            anchorToTarget: true,
+            anchor: 'right',
+            anchorSize: {
+                width: 24,
+                height: 24
+            },
+            defaultAlign: 'tr',
+            showDelay: me.helpTooltipDelay,
+            dismissDelay: me.helpTooltipDismissDelay
+        });
+
+        row.appendTo(this.inputRow);
+
+        this.helpIconEl = helpIcon;
+        return helpIcon;
+    }
+});

--- a/engine/Library/ExtJs/components/Enlight.form.mixin.HelpSupportElements.js
+++ b/engine/Library/ExtJs/components/Enlight.form.mixin.HelpSupportElements.js
@@ -93,7 +93,7 @@ Ext.define('Enlight.form.mixin.HelpSupportElements',
      * @private
      * @return void
      */
-    initHelpSupportElemes: function () {
+    initHelpSupportElements: function () {
         var me = this;
 
         if(me.helpText) {

--- a/engine/Library/ExtJs/components/Enlight.form.mixin.HelpSupportElements.js
+++ b/engine/Library/ExtJs/components/Enlight.form.mixin.HelpSupportElements.js
@@ -1,0 +1,191 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @category   Enlight
+ * @package    Enlight_ExtJs
+ * @copyright  Copyright (c) 2012, shopware AG (http://www.shopware.de)
+ * @license    http://enlight.de/license     New BSD License
+ */
+Ext.define('Enlight.form.mixin.HelpSupportElements',
+{
+    /**
+     * Support text which will be displayed under the form element.
+     * @string
+     */
+    supportText: '',
+
+    /**
+     * Help text which will be displayed in a tool tip next to the form element.
+     * @string
+     */
+    helpText: '',
+
+    /**
+     * Width (in pixel) for the help text tool tip.
+     * @default null
+     * @integer
+     */
+    helpWidth: null,
+
+    /**
+     * Title of the help tool tip.
+     * @default null
+     * @string
+     */
+    helpTitle: null,
+
+    /**
+     * Delay in millseconds before showing the
+     * help tooltip.
+     * @default 500
+     * @integer
+     */
+    helpTooltipDelay: 250,
+
+    /**
+     * Delay in milliseconds before hiding the
+     * help tooltip.
+     * @default 10000
+     * @integer
+     */
+    helpTooltipDismissDelay: 10000,
+
+    /**
+     * Property which holds of the DOM element of the support text.
+     * @default null
+     * @object
+     */
+    supportTextEl: null,
+
+    /**
+     * Property which holds of the help icon to display the help text
+     * in a tool tip.
+     * @default null
+     * @object
+     */
+    helpIconEl: null,
+
+    /**
+     * Using the "afterRender()"-method we're injecting
+     * the support and help texts into the form elements.
+     *
+     * @private
+     * @return void
+     */
+    initHelpSupportElemes: function () {
+        var me = this;
+
+        if(me.helpText) {
+            me.createHelp();
+        }
+
+        if(me.supportText) {
+            me.createSupport();
+        }
+    },
+
+    /**
+     * Creates the support text and inject it into the form element.
+     *
+     * @public
+     * @return [object] supportText - DOM element
+     */
+    createSupport:function () {
+        var me = this,
+            row = new Ext.Element(document.createElement('tr')),
+            fillCell = new Ext.Element(document.createElement('td')),
+            cell = new Ext.Element(document.createElement('td')),
+            supportText = new Ext.Element(document.createElement('div'));
+
+        supportText.set({
+            cls: Ext.baseCSSPrefix +'form-support-text'
+        });
+
+        if(me.supportText) {
+            supportText.update(me.supportText);
+        }
+
+        supportText.appendTo(cell);
+
+        // If we're finding more than one item, just use the first one :)
+        var element = me.getEl().select('tbody');
+        if(element.elements.length > 1) {
+            element = element.elements[0];
+        }
+
+        if(me.fieldLabel || !me.hideEmptyLabel) {
+            fillCell.appendTo(row);
+        }
+
+        cell.appendTo(row);
+
+        if(me.helpText) {
+            var tmpCell = new Ext.Element(document.createElement('td'));
+            tmpCell.appendTo(row);
+        }
+
+        row.appendTo(element);
+        me.supportTextEl = supportText;
+        return supportText;
+    },
+
+    /**
+     * Creates the help text element. The method creates an new
+     * image which displays a tool tip with the help text on hover.
+     *
+     * @public
+     * @return [object] helpIcon - DOM element
+     */
+    createHelp:function () {
+        var me = this,
+            helpIcon = new Ext.Element(document.createElement('span')),
+            row = new Ext.Element(document.createElement('td'));
+
+        row.set({ width: 24, valign: 'top' });
+        helpIcon.set({ cls: Ext.baseCSSPrefix + 'form-help-icon' });
+        helpIcon.appendTo(row);
+
+        Ext.tip.QuickTipManager.register({
+            target:helpIcon,
+            cls: Ext.baseCSSPrefix + 'form-tooltip',
+            title:(me.helpTitle) ? me.helpTitle : '',
+            text:me.helpText,
+            width:(me.helpWidth) ? me.helpWidth : 225,
+            anchorToTarget: true,
+            anchor: 'right',
+            anchorSize: {
+                width: 24,
+                height: 24
+            },
+            defaultAlign: 'tr',
+            showDelay: me.helpTooltipDelay,
+            dismissDelay: me.helpTooltipDismissDelay
+        });
+
+        row.appendTo(this.inputRow);
+
+        this.helpIconEl = helpIcon;
+        return helpIcon;
+    }
+});

--- a/engine/Library/ExtJs/overrides/Ext.form.Field.js
+++ b/engine/Library/ExtJs/overrides/Ext.form.Field.js
@@ -38,7 +38,7 @@ Ext.define('Enlight.form.Field',
         afterRender: function () {
             var me = this;
             me.callParent(arguments);
-            me.initHelpSupportElemes();
+            me.initHelpSupportElements();
         },
 
     }, function()

--- a/engine/Library/ExtJs/overrides/Ext.form.field.HtmlEditor.js
+++ b/engine/Library/ExtJs/overrides/Ext.form.field.HtmlEditor.js
@@ -31,9 +31,9 @@
  * @copyright  Copyright (c) 2012, shopware AG (http://www.shopware.de)
  * @license    http://enlight.de/license     New BSD License
  */
-Ext.define('Enlight.form.Field',
+Ext.define('Enlight.form.field.HtmlEditor',
     {
-        override: 'Ext.form.Field',
+        override: 'Ext.form.field.HtmlEditor',
 
         afterRender: function () {
             var me = this;
@@ -43,5 +43,5 @@ Ext.define('Enlight.form.Field',
 
     }, function()
     {
-        Ext.form.Field.mixin('helpSupportElems', Enlight.form.mixin.HelpSupportElements);
+        Ext.form.field.HtmlEditor.mixin('helpSupportElems', Enlight.form.mixin.HelpSupportElements);
 });

--- a/engine/Library/ExtJs/overrides/Ext.form.field.HtmlEditor.js
+++ b/engine/Library/ExtJs/overrides/Ext.form.field.HtmlEditor.js
@@ -38,7 +38,7 @@ Ext.define('Enlight.form.field.HtmlEditor',
         afterRender: function () {
             var me = this;
             me.callParent(arguments);
-            me.initHelpSupportElemes();
+            me.initHelpSupportElements();
         },
 
     }, function()

--- a/themes/Backend/ExtJs/backend/base/bootstrap.js
+++ b/themes/Backend/ExtJs/backend/base/bootstrap.js
@@ -21,6 +21,22 @@
  * our trademarks remain entirely with us.
  */
 
+{* Include default components *}
+{include file='ExtJs/components/Enlight.app.Window.js'}
+{include file='ExtJs/components/Enlight.app.SubWindow.js'}
+{include file='ExtJs/components/Enlight.app.SubApplication.js'}
+{include file='ExtJs/components/Enlight.app.Controller.js'}
+{include file='ExtJs/components/Ext.util.FileUpload.js'}
+{include file='ExtJs/components/Enlight.app.WindowManagement.js'}
+{include file='ExtJs/components/Enlight.form.mixin.HelpSupportElements.js'}
+{include file='ExtJs/components/Enlight.app.SubWindow.js'}
+{include file='ExtJs/components/Ext.ux.DataView.DragSelector.js'}
+{include file='ExtJs/components/Ext.ux.DataView.LabelEditor.js'}
+{include file='ExtJs/components/Ext.ux.form.field.BoxSelect.js'}
+{include file='ExtJs/components/Ext.ux.RowExpander.js'}
+{include file='ExtJs/components/Ext.ux.form.MultiSelect.js'}
+{include file='ExtJs/components/Ext.ux.form.ItemSelector.js'}
+
 {* Include overrides *}
 {include file='ExtJs/overrides/Ext.Base.js'}
 {include file='ExtJs/overrides/Ext.grid.header.Container.js'}
@@ -33,6 +49,7 @@
 {include file='ExtJs/overrides/Ext.button.Button.js'}
 {include file='ExtJs/overrides/Ext.LoadMask.js'}
 {include file='ExtJs/overrides/Ext.form.Field.js'}
+{include file='ExtJs/overrides/Ext.form.field.HtmlEditor.js'}
 {include file='ExtJs/overrides/Ext.toolbar.Paging.js'}
 {include file='ExtJs/overrides/Ext.Template.js'}
 {include file='ExtJs/overrides/Ext.form.Base.js'}
@@ -57,22 +74,6 @@
 {include file='ExtJs/overrides/Ext.form.field.Display.js'}
 {include file='ExtJs/overrides/Ext.String.js'}
 {include file='ExtJs/overrides/Ext.view.Table.js'}
-
-{* Include default components *}
-{include file='ExtJs/components/Enlight.app.Window.js'}
-{include file='ExtJs/components/Enlight.app.SubWindow.js'}
-{include file='ExtJs/components/Enlight.app.SubApplication.js'}
-{include file='ExtJs/components/Enlight.app.Controller.js'}
-{include file='ExtJs/components/Ext.util.FileUpload.js'}
-{include file='ExtJs/components/Enlight.app.WindowManagement.js'}
-{include file='ExtJs/components/Enlight.app.SubWindow.js'}
-{include file='ExtJs/components/Ext.ux.DataView.DragSelector.js'}
-{include file='ExtJs/components/Ext.ux.DataView.LabelEditor.js'}
-{include file='ExtJs/components/Ext.ux.form.field.BoxSelect.js'}
-{include file='ExtJs/components/Ext.ux.RowExpander.js'}
-{include file='ExtJs/components/Ext.ux.form.MultiSelect.js'}
-{include file='ExtJs/components/Ext.ux.form.ItemSelector.js'}
-
 
 //Shopware backend application components
 {include file='backend/base/application/Shopware.model.Helper.js'}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request. Guess, the same will apply for attribute fields.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

HTML input fields in plugin configuration forms doesn't display support and help text.

### 2. What does this change do, exactly?

Deep down in the rabbit hole `Ext.form.Field` is decorated to add elements for displaying help and support text for form inputs. Basically, most input elements derives form this class. Unfortunately, the HTML input component doesn't. It derives from `Ext.Component`. Thus, the decorations will not be applied for html inputs.
I moved the declaration stuff into a mixin and applied this to `Ext.form.Field` and `Ext.form.field.HtmlEditor`. If any ExtJs guru knows a more compliant and better way, I would be happy to change it ;)

### 3. Describe each step to reproduce the issue or behaviour.

Create plugin with config element of type `html` and add a `<description>` tag

Before:
![pluginoptinfoinfobubble](https://user-images.githubusercontent.com/11678100/47717239-8494d280-dc45-11e8-8f5b-f3d22bbd03aa.png)

After:
![bildschirmfoto 2018-10-30 um 11 33 17](https://user-images.githubusercontent.com/11678100/47717335-c3c32380-dc45-11e8-9543-7abcc636db8d.png)

Guess, the same will apply for attribute fields.

### 4. Please link to the relevant issues (if any).

Not aware of.

### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.