### PR TITLE
Add DISTINCT to priceListingQuery to improve ES indexing performance

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductListingVariationLoader.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductListingVariationLoader.php
@@ -388,7 +388,7 @@ class ProductListingVariationLoader
         $priceTable = $this->listingPriceHelper->getPriceTable($context);
         $priceTable->andWhere('defaultPrice.articledetailsID IN (:variants)');
 
-        $priceListingQuery->select('prices.`articledetailsID` as articledetailsID');
+        $priceListingQuery->select('DISTINCT prices.`articledetailsID` as articledetailsID');
         $priceListingQuery->addSelect('prices.`articleID` as articleID');
         $priceListingQuery->addSelect($this->listingPriceHelper->getSelection($context) . 'as price');
         $priceListingQuery->from('s_articles', 'product');


### PR DESCRIPTION
### 1. Why is this change necessary?
The ES indexing is very slow if the variant filter has been activated. This is amongst other things caused by the priceListingQuery and the related onSalePriceListingQuery. The results of these queries contain duplicate rows which makes them really slow. 

### 2. What does this change do, exactly?
The DISTINCT of the `articledetailsID` leads to one result per detailID, which is enough for these subqueries. We tested this change and went from 9 hours to 1 minute indexing time for 7000 articles (inclusive variants). 

### 3. Describe each step to reproduce the issue or behaviour.
Create a bunch of articles with variants (more than 1000 for comparable results) and try to index them with activated variant filter. You can see the performance improvement with this change compared to the old query without the DISTINCT. 

### 4. Please link to the relevant issues (if any).
Nope. 

### 5. Which documentation changes (if any) need to be made because of this PR?
None. 

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.