### PR TITLE
Fixed an off-by-one bug

### DIFF
--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Download.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Download.php
@@ -116,7 +116,7 @@ class Download
             return 0;
         }
 
-        $range = $size . '-' . $totalSize;
+        $range = $size . '-' . ($totalSize - 1);
 
         if (!function_exists('curl_init')) {
             throw new \Exception('PHP Extension "curl" is required to download a file');


### PR DESCRIPTION
The HTTP-Range header starts with 0, and should therefore not be until `$totalSize`. 

According to the documentation, to request the first 1024 bytes, one would request
the range of 0-1023. 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#Requesting_a_specific_range_from_a_server

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The current implementation is incompatible with the HTTP specs, and with the `BinaryFileResponse` as used by `Symfony`. 

### 2. What does this change do, exactly?
It makes sure the `Range` HTTP-Header contains the correct range, and not one byte too much.

### 3. Describe each step to reproduce the issue or behaviour.
Create a server with Symfony2 returning a `BinaryFileResponse`, and try to download a file from it. 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.