### PR TITLE
Make class DeleteResult namespaced PSR-0 compatible

### DIFF
--- a/recovery/update/src/Cleanup.php
+++ b/recovery/update/src/Cleanup.php
@@ -27,6 +27,7 @@ namespace Shopware\Recovery\Update;
 use DirectoryIterator;
 use FilesystemIterator;
 use RecursiveIteratorIterator;
+use Shopware\Recovery\Update\Results\DeleteResult;
 
 class Cleanup
 {

--- a/recovery/update/src/Results/DeleteResult.php
+++ b/recovery/update/src/Results/DeleteResult.php
@@ -22,7 +22,7 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Recovery\Update;
+namespace Shopware\Recovery\Update\Results;
 
 class DeleteResult
 {


### PR DESCRIPTION
### 1. Why is this change necessary?
The class `\Shopware\Recovery\Update\DeleteResult` is placed in a subfolder of the "Update" folder which means it isn't PSR-0 compatible. This is compensated by composer autoloading optimisation but still not a good practice.

### 2. What does this change do, exactly?
Change FQN class to `\Shopware\Recovery\Update\Results\DeleteResult`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.