### PR TITLE
Extracted snippets enclosed in quotes into variables

### DIFF
--- a/themes/Frontend/Bare/frontend/account/abort.tpl
+++ b/themes/Frontend/Bare/frontend/account/abort.tpl
@@ -5,7 +5,8 @@
 {* Breadcrumb *}
 {block name='frontend_index_start'}
     {$smarty.block.parent}
-    {$sBreadcrumb = [['name' => "{s name='OneTimeAbortTitle'}{/s}", 'link' => {url}]]}
+    {s name="OneTimeAbortTitle" assign="snippetOneTimeAbortTitle"}{/s}
+    {$sBreadcrumb = [['name' => $snippetOneTimeAbortTitle, 'link' => {url}]]}
 {/block}
 
 {block name='frontend_index_content'}
@@ -25,7 +26,8 @@
 
                 {block name="frontend_account_logout_info_actions"}
                     <div class="panel--actions is--wide">
-                        <a class="btn is--secondary is--icon-left" href="{url controller='index'}" title="{"{s name='OneTimeAbortButton'}{/s}"|escape}">
+                        {s name="OneTimeAbortButton" assign="snippetOneTimeAbortButton"}{/s}
+                        <a class="btn is--secondary is--icon-left" href="{url controller='index'}" title="{$snippetOneTimeAbortButton|escape}">
                             <i class="icon--arrow-left"></i>{s name="OneTimeAbortButton"}{/s}
                         </a>
                     </div>

--- a/themes/Frontend/Bare/frontend/account/downloads.tpl
+++ b/themes/Frontend/Bare/frontend/account/downloads.tpl
@@ -3,7 +3,8 @@
 {* Breadcrumb *}
 {block name="frontend_index_start"}
     {$smarty.block.parent}
-    {$sBreadcrumb[] = ['name' => "{s name='MyDownloadsTitle'}{/s}", 'link' => {url}]}
+    {s name="MyDownloadsTitle" assign="snippetMyDownloadsTitle"}{/s}
+    {$sBreadcrumb[] = ['name' => $snippetMyDownloadsTitle, 'link' => {url}]}
 {/block}
 
 {* Main content *}
@@ -13,9 +14,9 @@
         {* Error message *}
         {block name="frontend_account_downloads_error_messages"}
             {if $sErrorCode}
-                {$errorText="{s name='DownloadsInfoNotFound'}{/s}"}
+                {s name="DownloadsInfoNotFound" assign="errorText"}{/s}
                 {if $sErrorCode == 1}
-                    {$errorText="{s name='DownloadsInfoAccessDenied'}{/s}"}
+                    {s name="DownloadsInfoAccessDenied" assign="errorText"}{/s}
                 {/if}
 
                 <div class="account--error">
@@ -43,7 +44,8 @@
         {if !$sDownloads}
             {block name="frontend_account_downloads_info_empty"}
                 <div class="account--error">
-                    {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='DownloadsInfoEmpty'}{/s}"}
+                    {s name="DownloadsInfoEmpty" assign="snippetDownloadsInfoEmpty"}{/s}
+                    {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetDownloadsInfoEmpty}
                 </div>
             {/block}
         {else}
@@ -97,7 +99,8 @@
                                         {block name="frontend_account_downloads_link"}
                                             <div class="download--actions panel--td column--actions">
                                                 {if $article.esdarticle && $offerPosition.cleared|in_array:$sDownloadAvailablePaymentStatus}
-                                                    <a href="{$article.esdLink}" title="{"{s name='DownloadsLink'}{/s}"|escape} {$article.name|escape}" class="btn is--primary is--small">
+                                                    {s name="DownloadsLink" assign="snippetDownloadsLink"}{/s}
+                                                    <a href="{$article.esdLink}" title="{$snippetDownloadsLink|escape} {$article.name|escape}" class="btn is--primary is--small">
                                                         {s name="DownloadsLink"}{/s}
                                                     </a>
                                                 {/if}

--- a/themes/Frontend/Bare/frontend/account/index.tpl
+++ b/themes/Frontend/Bare/frontend/account/index.tpl
@@ -3,7 +3,8 @@
 {* Breadcrumb *}
 {block name='frontend_index_start'}
     {$smarty.block.parent}
-    {assign var='sBreadcrumb' value=[['name' => "{s name='AccountTitle'}{/s}", 'link' => {url controller='account' action='index'}]]}
+    {s name="AccountTitle" assign="snippetAccountTitle"}{/s}
+    {assign var='sBreadcrumb' value=[['name' => $snippetAccountTitle, 'link' => {url controller='account' action='index'}]]}
 {/block}
 
 {block name="frontend_index_left_categories_my_account"}{/block}
@@ -27,7 +28,8 @@
 
         {* Optin successful *}
         {if $smarty.get.optinconfirmed && {config name=optinregister}}
-            {include file="frontend/_includes/messages.tpl" type="success" content="{s name="AccountOptinConfirmed"}{/s}"}
+            {s name="AccountOptinConfirmed" assign="snippetAccountOptinConfirmed"}{/s}
+            {include file="frontend/_includes/messages.tpl" type="success" content=$snippetAccountOptinConfirmed}
         {/if}
 
         {* Error messages *}
@@ -116,7 +118,7 @@
                     {/block}
 
                     {block name="frontend_account_index_payment_method_actions"}
-                        {$paymentMethodTitle = {"{s name='AccountLinkChangePayment'}{/s}"|escape}}
+                        {s name="AccountLinkChangePayment" assign="paymentMethodTitle"}{/s}
 
                         <div class="panel--actions is--wide">
                             <a href="{url controller='account' action='payment'}"

--- a/themes/Frontend/Bare/frontend/account/login.tpl
+++ b/themes/Frontend/Bare/frontend/account/login.tpl
@@ -3,7 +3,8 @@
 {* Breadcrumb *}
 {block name='frontend_index_start'}
     {$smarty.block.parent}
-    {$sBreadcrumb = [['name' => "{s name='AccountLoginTitle'}{/s}", 'link' => {url}]]}
+    {s name="AccountLoginTitle" assign="snippetAccountLoginTitle"}{/s}
+    {$sBreadcrumb = [['name' => $snippetAccountLoginTitle, 'link' => {url}]]}
 {/block}
 
 {* Main content *}
@@ -57,7 +58,8 @@
                 </fieldset>
 
                 <p class="password">
-                    <a href="{url action=password}" title="{"{s name='LoginLinkLostPassword'}{/s}"|escape}">
+                    {s name="LoginLinkLostPassword" assign="snippetLoginLinkLostPassword"}{/s}
+                    <a href="{url action=password}" title="{$snippetLoginLinkLostPassword|escape}">
                         {s name="LoginLinkLostPassword"}{/s}
                     </a>
                 </p>

--- a/themes/Frontend/Bare/frontend/account/logout.tpl
+++ b/themes/Frontend/Bare/frontend/account/logout.tpl
@@ -5,7 +5,8 @@
 {* Breadcrumb *}
 {block name='frontend_index_start'}
     {$smarty.block.parent}
-    {$sBreadcrumb = [['name' => "{s name='AccountLogoutTitle'}{/s}", 'link' => {url}]]}
+    {s name="AccountLogoutTitle" assign="snippetAccountLogoutTitle"}{/s}
+    {$sBreadcrumb = [['name' => $snippetAccountLogoutTitle, 'link' => {url}]]}
 {/block}
 
 {block name='frontend_index_content'}
@@ -26,10 +27,12 @@
 
                 {block name="frontend_account_logout_info_actions"}
                     <div class="panel--actions is--wide">
-                        <a class="btn is--secondary is--icon-left" href="{url controller='index'}" title="{"{s name='AccountLogoutButton'}{/s}"|escape}">
+                        {s name="AccountLogoutButton" assign="snippetAccountLogoutButton"}{/s}
+                        <a class="btn is--secondary is--icon-left" href="{url controller='index'}" title="{$snippetAccountLogoutButton|escape}">
                             <i class="icon--arrow-left"></i>{s name="AccountLogoutButton"}{/s}
                         </a>
-                        <a class="btn is--primary is--icon-right" href="{url controller='account'}" title="{"{s name='AccountLogoutAccountButton'}{/s}"|escape}">
+                        {s name="AccountLogoutAccountButton" assign="snippetAccountLogoutAccountButton"}{/s}
+                        <a class="btn is--primary is--icon-right" href="{url controller='account'}" title="{$snippetAccountLogoutAccountButton|escape}">
                             <i class="icon--arrow-right"></i>{s name="AccountLogoutAccountButton"}{/s}
                         </a>
                     </div>

--- a/themes/Frontend/Bare/frontend/account/order_item.tpl
+++ b/themes/Frontend/Bare/frontend/account/order_item.tpl
@@ -104,8 +104,9 @@
         {* Order actions *}
         {block name="frontend_account_order_item_actions"}
             <div class="order--actions panel--td column--actions">
+                {s name="OrderActionSlide" assign="snippetOrderActionSlide"}{/s}
                 <a href="#order{$offerPosition.ordernumber}"
-                   title="{"{s name="OrderActionSlide"}{/s}"|escape} {$offerPosition.ordernumber}"
+                   title="{$snippetOrderActionSlide|escape} {$offerPosition.ordernumber}"
                    class="btn is--small"
                    data-collapse-panel="true"
                    data-collapseTarget="#order{$offerPosition.ordernumber}">

--- a/themes/Frontend/Bare/frontend/account/order_item_details.tpl
+++ b/themes/Frontend/Bare/frontend/account/order_item_details.tpl
@@ -108,7 +108,8 @@
                             {block name='frontend_account_order_item_availability'}
                                 {if $article.modus == 0 && ($article.active == 0 || !$article.article.isAvailable)}
                                     {* show warning if article is not active or not available *}
-                                    {include file="frontend/_includes/messages.tpl" type="error" content="{s name='OrderItemInfoNotAvailable'}{/s}"}
+                                    {s name="OrderItemInfoNotAvailable" assign="snippetOrderItemInfoNotAvailable"}{/s}
+                                    {include file="frontend/_includes/messages.tpl" type="error" content=$snippetOrderItemInfoNotAvailable}
                                 {/if}
                             {/block}
 

--- a/themes/Frontend/Bare/frontend/account/orders.tpl
+++ b/themes/Frontend/Bare/frontend/account/orders.tpl
@@ -3,7 +3,8 @@
 {* Breadcrumb *}
 {block name='frontend_index_start'}
     {$smarty.block.parent}
-    {$sBreadcrumb[] = ['name' => "{s name='MyOrdersTitle'}{/s}", 'link' => {url}]}
+    {s name="MyOrdersTitle" assign="snippetMyOrdersTitle"}{/s}
+    {$sBreadcrumb[] = ['name' => $snippetMyOrdersTitle, 'link' => {url}]}
 {/block}
 
 {* Main content *}
@@ -28,7 +29,8 @@
         {if !$sOpenOrders}
             {block name="frontend_account_orders_info_empty"}
                 <div class="account--no-orders-info">
-                    {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='OrdersInfoEmpty'}{/s}"}
+                    {s name="OrdersInfoEmpty" assign="snippetOrdersInfoEmpty"}{/s}
+                    {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetOrdersInfoEmpty}
                 </div>
             {/block}
         {else}

--- a/themes/Frontend/Bare/frontend/account/partner_statistic.tpl
+++ b/themes/Frontend/Bare/frontend/account/partner_statistic.tpl
@@ -24,7 +24,8 @@
 {* Breadcrumb *}
 {block name='frontend_index_start'}
     {$smarty.block.parent}
-    {$sBreadcrumb[] = ['name' => "{s name='Provisions'}{/s}", 'link' => {url}]}
+    {s name="Provisions" assign="snippetProvisions"}{/s}
+    {$sBreadcrumb[] = ['name' => $snippetProvisions, 'link' => {url}]}
 {/block}
 
 {* Main content *}
@@ -124,7 +125,8 @@
         {else}
             {block name="frontend_account_partner_statistic_info_empty"}
                 <div class="account--no-orders-info">
-                    {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='PartnerStatisticInfoEmpty'}{/s}"}
+                    {s name="PartnerStatisticInfoEmpty" assign="snippetPartnerStatisticInfoEmpty"}{/s}
+                    {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetPartnerStatisticInfoEmpty}
                 </div>
             {/block}
         {/if}

--- a/themes/Frontend/Bare/frontend/account/password.tpl
+++ b/themes/Frontend/Bare/frontend/account/password.tpl
@@ -17,7 +17,8 @@
             {* Success message *}
             {block name='frontend_account_password_success'}
                 <div class="password--success">
-                    {include file="frontend/_includes/messages.tpl" type="success" content="{s name='PasswordInfoSuccess'}{/s}"}
+                    {s name="PasswordInfoSuccess" assign="snippetPasswordInfoSuccess"}{/s}
+                    {include file="frontend/_includes/messages.tpl" type="success" content=$snippetPasswordInfoSuccess}
                 </div>
                 <a href="{url controller='account' action='password'}"
                    class="btn is--secondary is--icon-left">

--- a/themes/Frontend/Bare/frontend/account/payment.tpl
+++ b/themes/Frontend/Bare/frontend/account/payment.tpl
@@ -3,7 +3,8 @@
 {* Breadcrumb *}
 {block name='frontend_index_start'}
     {$smarty.block.parent}
-    {$sBreadcrumb[] = ['name' => "{s name='ChangePaymentTitle'}{/s}", 'link' => {url}]}
+    {s name="ChangePaymentTitle" assign="snippetChangePaymentTitle"}{/s}
+    {$sBreadcrumb[] = ['name' => $snippetChangePaymentTitle, 'link' => {url}]}
     {$sActiveAction = 'payment'}
 {/block}
 
@@ -41,7 +42,8 @@
                                 <div class="account--actions">
                                     {block name="frontend_account_payment_action_button_back"}
                                         {if $sTarget}
-                                            <a class="btn is--secondary left" href="{url controller=$sTarget action=$sTargetAction|default:"index"}" title="{"{s name='PaymentLinkBack'}{/s}"|escape}">
+                                            {s name="PaymentLinkBack" assign="snippetPaymentLinkBack"}{/s}
+                                            <a class="btn is--secondary left" href="{url controller=$sTarget action=$sTargetAction|default:"index"}" title="{$snippetPaymentLinkBack|escape}">
                                                 {s name="PaymentLinkBack"}{/s}
                                             </a>
                                         {/if}

--- a/themes/Frontend/Bare/frontend/account/profile.tpl
+++ b/themes/Frontend/Bare/frontend/account/profile.tpl
@@ -3,7 +3,8 @@
 {* Breadcrumb *}
 {block name='frontend_index_start'}
     {$smarty.block.parent}
-    {$sBreadcrumb[] = ['name' => "{s name="ProfileHeadline"}{/s}", 'link' => {url}]}
+    {s name="ProfileHeadline" assign="snippetProfileHeadline"}{/s}
+    {$sBreadcrumb[] = ['name' => $snippetProfileHeadline, 'link' => {url}]}
 {/block}
 
 {* Main content *}
@@ -25,14 +26,16 @@
 
                                 {block name="frontend_account_profile_profile_success"}
                                     {if $section == 'profile' && $success}
-                                        {include file="frontend/_includes/messages.tpl" type="success" content="{s name="ProfileSaveSuccessMessage"}{/s}"}
+                                        {s name="ProfileSaveSuccessMessage" assign="snippetProfileSaveSuccessMessage"}{/s}
+                                        {include file="frontend/_includes/messages.tpl" type="success" content=$snippetProfileSaveSuccessMessage}
                                     {/if}
                                 {/block}
 
                                 {* Error messages *}
                                 {block name="frontend_account_profile_profile_errors"}
                                     {if $section == 'profile' && $errorMessages}
-                                        {include file="frontend/register/error_message.tpl" error_messages=["{s name="ErrorFillIn" namespace="frontend/account/internalMessages"}{/s}"]}
+                                        {s name="ErrorFillIn" namespace="frontend/account/internalMessages" assign="snippetErrorFillIn"}{/s}
+                                        {include file="frontend/register/error_message.tpl" error_messages=[$snippetErrorFillIn]}
                                     {/if}
                                 {/block}
 
@@ -196,7 +199,8 @@
 
                                         {block name="frontend_account_profile_email_success"}
                                             {if $section == 'email' && $success}
-                                                {include file="frontend/_includes/messages.tpl" type="success" content="{s name="EmailSaveSuccessMessage"}{/s}"}
+                                                {s name="EmailSaveSuccessMessage" assign="snippetEmailSaveSuccessMessage"}{/s}
+                                                {include file="frontend/_includes/messages.tpl" type="success" content=$snippetEmailSaveSuccessMessage}
                                             {/if}
                                         {/block}
 
@@ -300,7 +304,8 @@
 
                                         {block name="frontend_account_profile_password_success"}
                                             {if $section == 'password' && $success}
-                                                {include file="frontend/_includes/messages.tpl" type="success" content="{s name="PasswordSaveSuccessMessage"}{/s}"}
+                                                {s name="PasswordSaveSuccessMessage" assign="snippetPasswordSaveSuccessMessage"}{/s}
+                                                {include file="frontend/_includes/messages.tpl" type="success" content=$snippetPasswordSaveSuccessMessage}
                                             {/if}
                                         {/block}
 

--- a/themes/Frontend/Bare/frontend/account/success_messages.tpl
+++ b/themes/Frontend/Bare/frontend/account/success_messages.tpl
@@ -1,19 +1,19 @@
 {if $sSuccessAction}
     {$successText=''}
     {if $sSuccessAction == 'address'}
-        {$successText="{s name='AccountAddressSuccess'}{/s}"}
+        {s name="AccountAddressSuccess" assign="successText"}{/s}
     {elseif $sSuccessAction == 'payment'}
-        {$successText="{s name='AccountPaymentSuccess'}{/s}"}
+        {s name="AccountPaymentSuccess" assign="successText"}{/s}
     {elseif $sSuccessAction == 'account'}
-        {$successText="{s name='AccountAccountSuccess'}{/s}"}
+        {s name="AccountAccountSuccess" assign="successText"}{/s}
     {elseif $sSuccessAction == 'newsletter'}
-        {$successText="{s name='AccountNewsletterSuccess'}{/s}"}
+        {s name="AccountNewsletterSuccess" assign="successText"}{/s}
     {elseif $sSuccessAction == 'optinnewsletter'}
-        {$successText="{s name='sMailConfirmation' namespace='frontend'}{/s}"}
+        {s name="sMailConfirmation" namespace="frontend" assign="successText"}{/s}
     {elseif $sSuccessAction == 'deletenewsletter'}
-        {$successText="{s name='NewsletterMailDeleted' namespace='frontend/account/internalMessages'}{/s}"}
+        {s name="NewsletterMailDeleted" namespace="frontend/account/internalMessages" assign="successText"}{/s}
     {elseif $sSuccessAction == 'resetPassword'}
-        {$successText="{s name='PasswordResetNewSuccess' namespace='frontend/account/reset_password'}{/s}"}
+        {s name="PasswordResetNewSuccess" namespace="frontend/account/reset_password" assign="successText"}{/s}
     {/if}
 
     <div class="account--success">

--- a/themes/Frontend/Bare/frontend/address/ajax_form.tpl
+++ b/themes/Frontend/Bare/frontend/address/ajax_form.tpl
@@ -4,7 +4,8 @@
 {* Error messages *}
 {block name="frontend_address_error_messages"}
     <div class="address-editor--errors is--hidden">
-        {include file="frontend/_includes/messages.tpl" type="error" content="{s namespace="frontend/account/internalMessages" name="ErrorFillIn"}{/s}"}
+        {s namespace="frontend/account/internalMessages" name="ErrorFillIn" assign="snippetErrorFillIn"}{/s}
+        {include file="frontend/_includes/messages.tpl" type="error" content=$snippetErrorFillIn}
     </div>
 {/block}
 

--- a/themes/Frontend/Bare/frontend/address/ajax_selection.tpl
+++ b/themes/Frontend/Bare/frontend/address/ajax_selection.tpl
@@ -95,7 +95,8 @@
                     {/block}
                 {else}
                     {block name="frontend_address_select_address_modal_empty_addresses"}
-                        {include file='frontend/_includes/messages.tpl' type="info" content="{s name='EmptyAddressesText'}{/s}"}
+                        {s name="EmptyAddressesText" assign="snippetEmptyAddressesText"}{/s}
+                        {include file='frontend/_includes/messages.tpl' type="info" content=$snippetEmptyAddressesText}
                     {/block}
                 {/if}
             </div>

--- a/themes/Frontend/Bare/frontend/address/create.tpl
+++ b/themes/Frontend/Bare/frontend/address/create.tpl
@@ -4,7 +4,8 @@
 {* Breadcrumb *}
 {block name="frontend_index_start"}
     {$smarty.block.parent}
-    {$sBreadcrumb[] = ["name" => "{s name="AddressesTitleCreate"}Create new address{/s}", "link" => {url}]}
+    {s name="AddressesTitleCreate" assign="snippetAddressesTitleCreate"}Create new address{/s}
+    {$sBreadcrumb[] = ["name" => $snippetAddressesTitleCreate, "link" => {url}]}
 {/block}
 
 {* Main content *}

--- a/themes/Frontend/Bare/frontend/address/delete.tpl
+++ b/themes/Frontend/Bare/frontend/address/delete.tpl
@@ -4,7 +4,8 @@
 {* Breadcrumb *}
 {block name="frontend_index_start"}
     {$smarty.block.parent}
-    {$sBreadcrumb[] = ["name" => "{s name="AddressesDeleteTitle"}Delete address{/s}", "link" => {url}]}
+    {s name="AddressesDeleteTitle" assign="snippetAddressesDeleteTitle"}Delete address{/s}
+    {$sBreadcrumb[] = ["name" => $snippetAddressesDeleteTitle, "link" => {url}]}
 {/block}
 
 {* Main content *}

--- a/themes/Frontend/Bare/frontend/address/edit.tpl
+++ b/themes/Frontend/Bare/frontend/address/edit.tpl
@@ -4,7 +4,8 @@
 {* Breadcrumb *}
 {block name="frontend_index_start"}
     {$smarty.block.parent}
-    {$sBreadcrumb[] = ["name" => "{s name="AddressesTitleEdit"}Change address{/s}", "link" => {url id=$formData.id}]}
+    {s name="AddressesTitleEdit" assign="snippetAddressesTitleEdit"}Change address{/s}
+    {$sBreadcrumb[] = ["name" => $snippetAddressesTitleEdit, "link" => {url id=$formData.id}]}
 {/block}
 
 {* Main content *}

--- a/themes/Frontend/Bare/frontend/address/error_messages.tpl
+++ b/themes/Frontend/Bare/frontend/address/error_messages.tpl
@@ -2,7 +2,7 @@
 <div class="account--error">
     {$message = ''}
     {if $type == 'delete'}
-        {$message = "{s name="AddressesDeleteErrorMessage"}{/s}"}
+        {s name="AddressesDeleteErrorMessage" assign="message"}{/s}
     {/if}
 
     {include file="frontend/register/error_message.tpl" error_messages=[$message]}

--- a/themes/Frontend/Bare/frontend/address/form.tpl
+++ b/themes/Frontend/Bare/frontend/address/form.tpl
@@ -4,7 +4,8 @@
 {block name="frontend_address_error_messages"}
     {include file="frontend/register/error_message.tpl" error_messages=$error_messages}
     {if $countryNotAvailableForShipping}
-        {include file="frontend/_includes/messages.tpl" type="error" content="{s name="CountryNotAvailableForShipping" namespace="frontend/address/index"}{/s}"}
+        {s name="CountryNotAvailableForShipping" namespace="frontend/address/index" assign="snippetCountryNotAvailableForShipping"}{/s}
+        {include file="frontend/_includes/messages.tpl" type="error" content=$snippetCountryNotAvailableForShipping}
     {/if}
 {/block}
 

--- a/themes/Frontend/Bare/frontend/address/index.tpl
+++ b/themes/Frontend/Bare/frontend/address/index.tpl
@@ -3,7 +3,8 @@
 {* Breadcrumb *}
 {block name="frontend_index_start"}
     {$smarty.block.parent}
-    {$sBreadcrumb[] = ["name" => "{s name="AddressesTitle"}My addresses{/s}", "link" => {url action="index"}]}
+    {s name="AddressesTitle" assign="snippetAddressesTitle"}My addresses{/s}
+    {$sBreadcrumb[] = ["name" => $snippetAddressesTitle, "link" => {url action="index"}]}
 {/block}
 
 {* Main content *}

--- a/themes/Frontend/Bare/frontend/address/success_messages.tpl
+++ b/themes/Frontend/Bare/frontend/address/success_messages.tpl
@@ -2,19 +2,19 @@
 <div class="account--success">
     {$content = ''}
     {if $type == 'create'}
-        {$content = "{s name='AddressesCreateSuccess'}{/s}"}
+        {s name="AddressesCreateSuccess" assign="content"}{/s}
     {elseif $type == 'default_billing'}
-        {$content = "{s name='AddressesSetDefaultBillingSuccess'}{/s}"}
+        {s name="AddressesSetDefaultBillingSuccess" assign="content"}{/s}
     {elseif $type == 'default_shipping'}
-        {$content = "{s name='AddressesSetDefaultShippingSuccess'}{/s}"}
+        {s name="AddressesSetDefaultShippingSuccess" assign="content"}{/s}
     {elseif $type == 'update'}
-        {$content = "{s name='AddressesUpdateSuccess'}{/s}"}
+        {s name="AddressesUpdateSuccess" assign="content"}{/s}
     {elseif $type == 'delete'}
-        {$content = "{s name='AddressesDeleteSuccess'}{/s}"}
+        {s name="AddressesDeleteSuccess" assign="content"}{/s}
     {/if}
 
     {* for your custom messages *}
     {block name="frontend_address_success_messages_content"}{/block}
 
-    {include file="frontend/_includes/messages.tpl" type="success" content="{$content}"}
+    {include file="frontend/_includes/messages.tpl" type="success" content=$content}
 </div>

--- a/themes/Frontend/Bare/frontend/blog/bookmarks.tpl
+++ b/themes/Frontend/Bare/frontend/blog/bookmarks.tpl
@@ -5,8 +5,9 @@
 
                 {* Twitter *}
                 {block name='frontend_blog_bookmarks_twitter'}
+                    {s name="BookmarkTwitterShare" assign="snippetBookmarkTwitterShare"}{/s}
                     <a href="http://twitter.com/home?status={$sArticle.title|escape:'url'}+-+{url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}"
-                        title="{"{s name='BookmarkTwitterShare'}{/s}"|escape}"
+                        title="{$snippetBookmarkTwitterShare|escape}"
                         class="blog--bookmark icon--twitter2"
                         rel="nofollow"
                         target="_blank">
@@ -15,8 +16,9 @@
 
                 {* Facebook *}
                 {block name='frontend_blog_bookmarks_facebook'}
+                    {s name="BookmarkFacebookShare" assign="snippetBookmarkFacebookShare"}{/s}
                     <a href="http://www.facebook.com/share.php?v=4&amp;src=bm&amp;u={url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}&amp;t={$sArticle.title|escape:'url'}"
-                        title="{"{s name='BookmarkFacebookShare'}{/s}"|escape}"
+                        title="{$snippetBookmarkFacebookShare|escape}"
                         class="blog--bookmark icon--facebook2"
                         rel="nofollow"
                         target="_blank">
@@ -25,8 +27,9 @@
 
                 {* Del.icio.us *}
                 {block name='frontend_blog_bookmarks_delicious'}
+                    {s name="BookmarkDeliciousShare" assign="snippetBookmarkDeliciousShare"}{/s}
                     <a href="http://del.icio.us/post?url={url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}&amp;title={$sArticle.title|escape:'url'}"
-                        title="{"{s name='BookmarkDeliciousShare'}{/s}"|escape}"
+                        title="{$snippetBookmarkDeliciousShare|escape}"
                         class="blog--bookmark icon--delicious"
                         rel="nofollow"
                         target="_blank">
@@ -35,8 +38,9 @@
 
                 {* Digg *}
                 {block name='frontend_blog_bookmarks_digg'}
+                    {s name="BookmarkDiggitShare" assign="snippetBookmarkDiggitShare"}{/s}
                     <a href="http://digg.com/submit?phase=2&amp;url={url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}&amp;title={$sArticle.title|escape:'url'}"
-                        title="{"{s name='BookmarkDiggitShare'}{/s}"|escape}"
+                        title="{$snippetBookmarkDiggitShare|escape}"
                         class="blog--bookmark icon--digg"
                         rel="nofollow"
                         target="_blank">

--- a/themes/Frontend/Bare/frontend/blog/box.tpl
+++ b/themes/Frontend/Bare/frontend/blog/box.tpl
@@ -46,8 +46,9 @@
                         {* Comments *}
                         {block name='frontend_blog_col_meta_data_comments'}
                             <span class="blog--metadata-comments blog--metadata is--nowrap{if $sArticle.sVoteAverage|round ==0} is--last{/if}">
+                                {s name="BlogLinkComments" namespace="frontend/blog/detail" assign="snippetBlogLinkComments"}{/s}
                                 <a href="{url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}#blog--comments-start"
-                                   title="{"{s name="BlogLinkComments" namespace="frontend/blog/detail"}{/s}"|escape}">
+                                   title="{$snippetBlogLinkComments|escape}">
                                     {if $sArticle.numberOfComments}{$sArticle.numberOfComments}{else}0{/if} {s name="BlogInfoComments"}{/s}
                                 </a>
                             </span>

--- a/themes/Frontend/Bare/frontend/blog/comment/form.tpl
+++ b/themes/Frontend/Bare/frontend/blog/comment/form.tpl
@@ -22,18 +22,18 @@
                 {if isset($sErrorFlag)}
                     {$type = "error"}
                     {if $sErrorFlag['sCaptcha']}
-                        {$snippet = "{s name="BlogInfoFailureCaptcha"}{/s}"}
+                        {s name="BlogInfoFailureCaptcha" assign="snippet"}{/s}
                     {elseif $sErrorFlag['invalidHash']}
-                        {$snippet = "{s name="BlogInfoFailureDoubleOptIn"}{/s}"}
+                        {s name="BlogInfoFailureDoubleOptIn" assign="snippet"}{/s}
                     {else}
-                        {$snippet = "{s name="BlogInfoFailureFields"}{/s}"}
+                        {s name="BlogInfoFailureFields" assign="snippet"}{/s}
                     {/if}
                 {else}
                     {$type = "success"}
                     {if {config name=OptInVote} && !{$smarty.get.sConfirmation} && !{$userLoggedIn}}
-                        {$snippet = "{s name="BlogInfoSuccessOptin"}{/s}"}
+                        {s name="BlogInfoSuccessOptin" assign="snippet"}{/s}
                     {else}
-                        {$snippet = "{s name="BlogInfoSuccess"}{/s}"}
+                        {s name="BlogInfoSuccess" assign="snippet"}{/s}
                     {/if}
                 {/if}
                 {include file="frontend/_includes/messages.tpl" type=$type content=$snippet}
@@ -48,8 +48,10 @@
                 {* Name *}
                 {block name='frontend_blog_comments_input_name'}
                     <div class="blog--comments-name">
+                        {s name="BlogLabelName" assign="snippetBlogLabelName"}{/s}
+                        {s name="RequiredField" namespace="frontend/register/index" assign="snippetRequiredField"}{/s}
                         <input name="name" type="text"
-                               placeholder="{"{s name="BlogLabelName"}{/s}"|escape}{"{s name="RequiredField" namespace="frontend/register/index"}{/s}"|escape}"
+                               placeholder="{$snippetBlogLabelName|escape}{$snippetRequiredField|escape}"
                                required="required" aria-required="true"
                                value="{$sFormData.name|escape}"
                                class="input--field{if $sErrorFlag.name} has--error{/if}" />
@@ -59,9 +61,10 @@
                 {* E-Mail *}
                 {block name='frontend_blog_comments_input_mail'}
                     <div class="blog--comments-email">
+                        {s name="BlogLabelMail" assign="snippetBlogLabelMail"}{/s}
+                        {s name="RequiredField" namespace="frontend/register/index" assign="snippetRequiredField"}{/s}
                         <input name="eMail" type="email"
-                            placeholder="{s name="BlogLabelMail"}{/s}{if {config name=OptInVote}}{s name="RequiredField"
-                            namespace="frontend/register/index"}{/s}{/if}"
+                            placeholder="{$snippetBlogLabelMail}{if {config name=OptInVote}}{$snippetRequiredField}{/if}"
                             {if {config name=OptInVote}}required="required" aria-required="true"{/if}
                             value="{$sFormData.eMail|escape}"
                             class="input--field{if $sErrorFlag.eMail} has--error{/if}" />
@@ -71,9 +74,10 @@
                 {* Summary *}
                 {block name='frontend_blog_comments_input_summary'}
                     <div class="blog--comments-summary">
+                        {s name="BlogLabelSummary" assign="snippetBlogLabelSummary"}{/s}
                         <input name="headline"
                                type="text"
-                               placeholder="{"{s name='BlogLabelSummary'}{/s}"|escape}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
+                               placeholder="{$snippetBlogLabelSummary|escape}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                required="required" aria-required="true"
                                value="{$sFormData.headline|escape}"
                                class="input--field{if $sErrorFlag.headline} has--error{/if}" />
@@ -102,7 +106,8 @@
                 {* Opinion *}
                 {block name='frontend_blog_comments_input_comment'}
                     <div class="blog--comments-opinion">
-                        <textarea name="comment" type="text" placeholder="{"{s name='BlogLabelComment'}{/s}"|escape}" class="input--field{if $sErrorFlag.comment} has--error{/if}" rows="5" cols="5">
+                        {s name="BlogLabelComment" assign="snippetBlogLabelComment"}{/s}
+                        <textarea name="comment" type="text" placeholder="{$snippetBlogLabelComment|escape}" class="input--field{if $sErrorFlag.comment} has--error{/if}" rows="5" cols="5">
                             {$sFormData.comment|escape}
                         </textarea>
                     </div>

--- a/themes/Frontend/Bare/frontend/blog/detail.tpl
+++ b/themes/Frontend/Bare/frontend/blog/detail.tpl
@@ -52,7 +52,8 @@
                                 {* Comments *}
                                 {block name='frontend_blog_detail_comments_count'}
                                     <span class="blog--metadata-comments blog--metadata">
-                                        <a data-scroll="true" data-scrollTarget="#blog--comments-start" href="#blog--comments-start" title="{"{s name="BlogLinkComments"}{/s}"|escape}">{$sArticle.comments|count|default:0} {s name="BlogInfoComments"}{/s}</a>
+                                        {s name="BlogLinkComments" assign="snippetBlogLinkComments"}{/s}
+                                        <a data-scroll="true" data-scrollTarget="#blog--comments-start" href="#blog--comments-start" title="{$snippetBlogLinkComments|escape}">{$sArticle.comments|count|default:0} {s name="BlogInfoComments"}{/s}</a>
                                     </span>
                                 {/block}
 
@@ -60,7 +61,8 @@
                                 {block name='frontend_blog_detail_rating'}
                                     {if $sArticle.sVoteAverage|round}
                                         <span class="blog--metadata-rating blog--metadata">
-                                            <a data-scroll="true" data-scrollTarget="#blog--comments-start" href="#blog--comments-start" class="blog--rating-link" rel="nofollow" title="{"{s name='BlogHeaderRating'}{/s}"|escape}">
+                                            {s name="BlogHeaderRating" assign="snippetBlogHeaderRating"}{/s}
+                                            <a data-scroll="true" data-scrollTarget="#blog--comments-start" href="#blog--comments-start" class="blog--rating-link" rel="nofollow" title="{$snippetBlogHeaderRating|escape}">
                                                 {include file="frontend/_includes/rating.tpl" points=$sArticle.sVoteAverage|round type="aggregated" count=$sArticle.comments|count}
                                             </a>
                                         </span>

--- a/themes/Frontend/Bare/frontend/blog/filter.tpl
+++ b/themes/Frontend/Bare/frontend/blog/filter.tpl
@@ -15,16 +15,18 @@
             {block name="frontend_blog_filter_date_content"}
                 <div class="blog--filter-content blog--sidebar-body collapse--content">
                     <ul class="filter--list list--unstyled">
+                        {s name="BlogHeaderFilterDateFormat" assign="snippetBlogHeaderFilterDateFormat"}{/s}
                         {foreach $sFilterDate as $date}
                             {if !$date.removeProperty}
                                 {if $smarty.get.sFilterDate==$date.dateFormatDate}
                                     {$filterDateActive=true}
-                                    <li class="filter--entry is--active"><a href="{$date.link}" class="filter--entry-link is--active is--bold" title="{$date.dateFormatDate|escape}">{$date.dateFormatDate|date_format:"{s name="BlogHeaderFilterDateFormat"}{/s}"} ({$date.dateCount})</a></li>
+                                    <li class="filter--entry is--active"><a href="{$date.link}" class="filter--entry-link is--active is--bold" title="{$date.dateFormatDate|escape}">{$date.dateFormatDate|date_format:$snippetBlogHeaderFilterDateFormat} ({$date.dateCount})</a></li>
                                 {else}
-                                    <li class="filter--entry{if $date@last} is--last{/if}"><a href="{$date.link}" class="filter--entry-link" title="{$date.dateFormatDate|escape}">{$date.dateFormatDate|date_format:"{s name="BlogHeaderFilterDateFormat"}{/s}"} ({$date.dateCount})</a></li>
+                                    <li class="filter--entry{if $date@last} is--last{/if}"><a href="{$date.link}" class="filter--entry-link" title="{$date.dateFormatDate|escape}">{$date.dateFormatDate|date_format:$snippetBlogHeaderFilterDateFormat} ({$date.dateCount})</a></li>
                                 {/if}
                             {elseif $filterDateActive}
-                                <li class="filter--entry close"><a href="{$date.link}" class="filter--entry-link" title="{"{s name='FilterLinkDefault' namespace='frontend/listing/filter_properties'}{/s}"|escape}">{s name='FilterLinkDefault' namespace='frontend/listing/filter_properties'}{/s}</a></li>
+                                {s name="FilterLinkDefault" namespace="frontend/listing/filter_properties" assign="snippetFilterLinkDefault"}{/s}
+                                <li class="filter--entry close"><a href="{$date.link}" class="filter--entry-link" title="{$snippetFilterLinkDefault|escape}">{s name='FilterLinkDefault' namespace='frontend/listing/filter_properties'}{/s}</a></li>
                             {/if}
                         {/foreach}
                     </ul>
@@ -60,7 +62,8 @@
                                     <li class="filter--entry{if $author@last} is--last{/if}"><a href="{$author.link}" class="filter--entry-link" title="{$author.name|escape}">{$author.name} ({$author.authorCount})</a></li>
                                 {/if}
                             {elseif $filterAuthorActive}
-                                <li class="filter--entry close"><a href="{$author.link}" class="filter--entry-link" title="{"{s name='FilterLinkDefault' namespace='frontend/listing/filter_properties'}{/s}"|escape}">{s name='FilterLinkDefault' namespace='frontend/listing/filter_properties'}{/s}</a></li>
+                                {s name="FilterLinkDefault" namespace="frontend/listing/filter_properties" assign="snippetFilterLinkDefault"}{/s}
+                                <li class="filter--entry close"><a href="{$author.link}" class="filter--entry-link" title="{$snippetFilterLinkDefault|escape}">{s name='FilterLinkDefault' namespace='frontend/listing/filter_properties'}{/s}</a></li>
                             {/if}
                         {/foreach}
                     </ul>
@@ -96,7 +99,8 @@
                                     <li class="filter--entry{if $tag@last} is--last{/if}"><a href="{$tag.link}" class="filter--entry-link" title="{$tag.name|escape}">{$tag.name} ({$tag.tagsCount})</a></li>
                                 {/if}
                             {elseif $filterTagsActive}
-                                <li class="filter--entry close"><a href="{$tag.link}" class="filter--entry-link" title="{"{s name='FilterLinkDefault' namespace='frontend/listing/filter_properties'}{/s}"|escape}">{s name='FilterLinkDefault' namespace='frontend/listing/filter_properties'}{/s}</a></li>
+                                {s name="FilterLinkDefault" namespace="frontend/listing/filter_properties" assign="snippetFilterLinkDefault"}{/s}
+                                <li class="filter--entry close"><a href="{$tag.link}" class="filter--entry-link" title="{$snippetFilterLinkDefault|escape}">{s name='FilterLinkDefault' namespace='frontend/listing/filter_properties'}{/s}</a></li>
                             {/if}
                         {/foreach}
                     </ul>

--- a/themes/Frontend/Bare/frontend/blog/listing.tpl
+++ b/themes/Frontend/Bare/frontend/blog/listing.tpl
@@ -6,8 +6,9 @@
     {* Blog Filter Button *}
     {block name='frontend_blog_listing_filter_button'}
         <div class="blog--filter-btn">
+            {s namespace="frontend/listing/listing_actions" name="ListingFilterButton" assign="snippetListingFilterButton"}{/s}
             <a href="#"
-               title="{"{s namespace='frontend/listing/listing_actions' name='ListingFilterButton'}{/s}"|escape}"
+               title="{$snippetListingFilterButton|escape}"
                class="filter--trigger btn is--icon-left"
                data-collapseTarget=".blog--filter-options"
                data-offcanvas="true"

--- a/themes/Frontend/Bare/frontend/blog/listing_actions.tpl
+++ b/themes/Frontend/Bare/frontend/blog/listing_actions.tpl
@@ -13,7 +13,8 @@
                 {* Pagination - Previous page *}
                 {block name='frontend_listing_actions_paging_previous'}
                     {if $sPage > 1}
-                        <a href="{$sPages.previous}" title="{"{s name='ListingLinkPrevious'}{/s}"|escape}" class="paging--link paging--prev">
+                        {s name="ListingLinkPrevious" assign="snippetListingLinkPrevious"}{/s}
+                        <a href="{$sPages.previous}" title="{$snippetListingLinkPrevious|escape}" class="paging--link paging--prev">
                             <i class="icon--arrow-left"></i>
                         </a>
                     {/if}
@@ -27,7 +28,8 @@
                 {* Pagination - Next page *}
                 {block name='frontend_listing_actions_paging_next'}
                     {if $sPage < $sNumberPages}
-                        <a href="{$sPages.next}" title="{"{s name='ListingLinkNext'}{/s}"|escape}" class="paging--link paging--next">
+                        {s name="ListingLinkNext" assign="snippetListingLinkNext"}{/s}
+                        <a href="{$sPages.next}" title="{$snippetListingLinkNext|escape}" class="paging--link paging--next">
                             <i class="icon--arrow-right"></i>
                         </a>
                     {/if}

--- a/themes/Frontend/Bare/frontend/blog/listing_sidebar.tpl
+++ b/themes/Frontend/Bare/frontend/blog/listing_sidebar.tpl
@@ -6,7 +6,8 @@
         {block name='frontend_listing_actions_filter_container'}
 
             {block name='frontend_listing_actions_filter_closebtn'}
-                <a href="#" title="{"{s name="ListingActionsCloseFilter"}{/s}"|escape}" class="blog--filter-close-btn">{s namespace='frontend/listing/listing_actions' name='ListingActionsCloseFilter'}{/s} <i class="icon--arrow-right"></i></a>
+                {s name="ListingActionsCloseFilter" assign="snippetListingActionsCloseFilter"}{/s}
+                <a href="#" title="{$snippetListingActionsCloseFilter|escape}" class="blog--filter-close-btn">{s namespace='frontend/listing/listing_actions' name='ListingActionsCloseFilter'}{/s} <i class="icon--arrow-right"></i></a>
             {/block}
 
             <div class="filter--container">

--- a/themes/Frontend/Bare/frontend/checkout/actions.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/actions.tpl
@@ -4,7 +4,8 @@
 
     {if !$sMinimumSurcharge && ($sInquiry || $sDispatchNoOrder)}
         {block name="frontend_checkout_actions_inquiry"}
-        <a href="{$sInquiryLink}" title="{"{s name='CheckoutActionsLinkOffer'}{/s}"|escape}" class="button-middle large">
+            {s name="CheckoutActionsLinkOffer" assign="snippetCheckoutActionsLinkOffer"}{/s}
+        <a href="{$sInquiryLink}" title="{$snippetCheckoutActionsLinkOffer|escape}" class="button-middle large">
             {s name="CheckoutActionsLinkOffer"}{/s}
         </a>
         {/block}
@@ -13,7 +14,8 @@
     {* Checkout *}
     {if !$sMinimumSurcharge && !$sDispatchNoOrder}
         {block name="frontend_checkout_actions_confirm"}
-        <a href="{if {config name=always_select_payment}}{url controller='checkout' action='shippingPayment'}{else}{url controller='checkout' action='confirm'}{/if}" title="{"{s name='CheckoutActionsLinkProceed'}{/s}"|escape}" class="button-right large right checkout" >
+            {s name="CheckoutActionsLinkProceed" assign="snippetCheckoutActionsLinkProceed"}{/s}
+        <a href="{if {config name=always_select_payment}}{url controller='checkout' action='shippingPayment'}{else}{url controller='checkout' action='confirm'}{/if}" title="{$snippetCheckoutActionsLinkProceed|escape}" class="button-right large right checkout" >
             {s name="CheckoutActionsLinkProceed"}{/s}
         </a>
         {/block}

--- a/themes/Frontend/Bare/frontend/checkout/ajax_cart.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/ajax_cart.tpl
@@ -78,21 +78,24 @@
                     {block name='frontend_checkout_ajax_cart_open_checkout'}
                         {if !($sDispatchNoOrder && !$sDispatches)}
                             {block name='frontend_checkout_ajax_cart_open_checkout_inner'}
-                                <a href="{if {config name=always_select_payment}}{url controller='checkout' action='shippingPayment'}{else}{url controller='checkout' action='confirm'}{/if}" class="btn is--primary button--checkout is--icon-right" title="{"{s name='AjaxCartLinkConfirm'}{/s}"|escape}">
+                                {s name="AjaxCartLinkConfirm" assign="snippetAjaxCartLinkConfirm"}{/s}
+                                <a href="{if {config name=always_select_payment}}{url controller='checkout' action='shippingPayment'}{else}{url controller='checkout' action='confirm'}{/if}" class="btn is--primary button--checkout is--icon-right" title="{$snippetAjaxCartLinkConfirm|escape}">
                                     <i class="icon--arrow-right"></i>
                                     {s name='AjaxCartLinkConfirm'}{/s}
                                 </a>
                             {/block}
                         {else}
                             {block name='frontend_checkout_ajax_cart_open_checkout_inner_disabled'}
-                                <span class="btn is--disabled is--primary button--checkout is--icon-right" title="{"{s name='AjaxCartLinkConfirm'}{/s}"|escape}">
+                                {s name="AjaxCartLinkConfirm" assign="snippetAjaxCartLinkConfirm"}{/s}
+                                <span class="btn is--disabled is--primary button--checkout is--icon-right" title="{$snippetAjaxCartLinkConfirm|escape}">
                                     <i class="icon--arrow-right"></i>
                                     {s name='AjaxCartLinkConfirm'}{/s}
                                 </span>
                             {/block}
                         {/if}
                         {block name='frontend_checkout_ajax_cart_open_basket'}
-                            <a href="{url controller='checkout' action='cart'}" class="btn button--open-basket is--icon-right" title="{"{s name='AjaxCartLinkBasket'}{/s}"|escape}">
+                            {s name="AjaxCartLinkBasket" assign="snippetAjaxCartLinkBasket"}{/s}
+                            <a href="{url controller='checkout' action='cart'}" class="btn button--open-basket is--icon-right" title="{$snippetAjaxCartLinkBasket|escape}">
                                 <i class="icon--arrow-right"></i>
                                 {s name='AjaxCartLinkBasket'}{/s}
                             </a>

--- a/themes/Frontend/Bare/frontend/checkout/cart.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/cart.tpl
@@ -54,8 +54,9 @@
                                     {* Forward to the checkout *}
                                     {if !$sMinimumSurcharge && !($sDispatchNoOrder && !$sDispatches)}
                                         {block name="frontend_checkout_actions_checkout"}
+                                            {s name="CheckoutActionsLinkProceedShort" namespace="frontend/checkout/actions" assign="snippetCheckoutActionsLinkProceedShort"}{/s}
                                             <a href="{if {config name=always_select_payment}}{url controller='checkout' action='shippingPayment'}{else}{url controller='checkout' action='confirm'}{/if}"
-                                               title="{"{s name='CheckoutActionsLinkProceedShort' namespace="frontend/checkout/actions"}{/s}"|escape}"
+                                               title="{$snippetCheckoutActionsLinkProceedShort|escape}"
                                                class="btn btn--checkout-proceed is--primary right is--icon-right is--large">
                                                 {s name="CheckoutActionsLinkProceedShort" namespace="frontend/checkout/actions"}{/s}
                                                 <i class="icon--arrow-right"></i>
@@ -63,8 +64,9 @@
                                         {/block}
                                     {else}
                                         {block name="frontend_checkout_actions_checkout"}
+                                            {s name="CheckoutActionsLinkProceedShort" namespace="frontend/checkout/actions" assign="snippetCheckoutActionsLinkProceedShort"}{/s}
                                             <span
-                                               title="{"{s name='CheckoutActionsLinkProceedShort' namespace="frontend/checkout/actions"}{/s}"|escape}"
+                                               title="{$snippetCheckoutActionsLinkProceedShort|escape}"
                                                class="btn is--disabled btn--checkout-proceed is--primary right is--icon-right is--large">
                                                 {s name="CheckoutActionsLinkProceedShort" namespace="frontend/checkout/actions"}{/s}
                                                 <i class="icon--arrow-right"></i>
@@ -123,8 +125,9 @@
                                     {* Forward to the checkout *}
                                     {if !$sMinimumSurcharge && !($sDispatchNoOrder && !$sDispatches)}
                                         {block name="frontend_checkout_actions_confirm_bottom_checkout"}
+                                            {s name="CheckoutActionsLinkProceedShort" namespace="frontend/checkout/actions" assign="snippetCheckoutActionsLinkProceedShort"}{/s}
                                             <a href="{if {config name=always_select_payment}}{url controller='checkout' action='shippingPayment'}{else}{url controller='checkout' action='confirm'}{/if}"
-                                               title="{"{s name='CheckoutActionsLinkProceedShort' namespace="frontend/checkout/actions"}{/s}"|escape}"
+                                               title="{$snippetCheckoutActionsLinkProceedShort|escape}"
                                                class="btn btn--checkout-proceed is--primary right is--icon-right is--large">
                                                 {s name="CheckoutActionsLinkProceedShort" namespace="frontend/checkout/actions"}{/s}
                                                 <i class="icon--arrow-right"></i>
@@ -132,8 +135,9 @@
                                         {/block}
                                     {else}
                                         {block name="frontend_checkout_actions_confirm_bottom_checkout"}
+                                            {s name="CheckoutActionsLinkProceedShort" namespace="frontend/checkout/actions" assign="snippetCheckoutActionsLinkProceedShort"}{/s}
                                             <span
-                                               title="{"{s name='CheckoutActionsLinkProceedShort' namespace="frontend/checkout/actions"}{/s}"|escape}"
+                                               title="{$snippetCheckoutActionsLinkProceedShort|escape}"
                                                class="btn is--disabled btn--checkout-proceed is--primary right is--icon-right is--large">
                                                 {s name="CheckoutActionsLinkProceedShort" namespace="frontend/checkout/actions"}{/s}
                                                 <i class="icon--arrow-right"></i>
@@ -144,8 +148,9 @@
 
                                 {if !$sMinimumSurcharge && ($sInquiry || $sDispatchNoOrder)}
                                     {block name="frontend_checkout_actions_inquiry"}
+                                        {s name="CheckoutActionsLinkOffer" namespace="frontend/checkout/actions" assign="snippetCheckoutActionsLinkOffer"}{/s}
                                         <a href="{$sInquiryLink}"
-                                           title="{"{s name='CheckoutActionsLinkOffer' namespace="frontend/checkout/actions"}{/s}"|escape}"
+                                           title="{$snippetCheckoutActionsLinkOffer|escape}"
                                            class="btn btn--inquiry is--large is--full is--center">
                                             {s name="CheckoutActionsLinkOffer" namespace="frontend/checkout/actions"}{/s}
                                         </a>
@@ -166,7 +171,8 @@
             {* Empty basket *}
             {block name='frontend_basket_basket_is_empty'}
                 <div class="basket--info-messages">
-                    {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='CartInfoEmpty'}{/s}"}
+                    {s name="CartInfoEmpty" assign="snippetCartInfoEmpty"}{/s}
+                    {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetCartInfoEmpty}
                 </div>
             {/block}
         {/if}

--- a/themes/Frontend/Bare/frontend/checkout/cart_footer.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/cart_footer.tpl
@@ -31,7 +31,8 @@
 
                     <div class="add-voucher--panel is--hidden block-group">
                         {block name='frontend_checkout_cart_footer_add_voucher_field'}
-                            <input type="text" class="add-voucher--field is--medium block" name="sVoucher" placeholder="{"{s name='CheckoutFooterAddVoucherLabelInline'}{/s}"|escape}" />
+                            {s name="CheckoutFooterAddVoucherLabelInline" assign="snippetCheckoutFooterAddVoucherLabelInline"}{/s}
+                            <input type="text" class="add-voucher--field is--medium block" name="sVoucher" placeholder="{$snippetCheckoutFooterAddVoucherLabelInline|escape}" />
                         {/block}
 
                         {block name='frontend_checkout_cart_footer_add_voucher_button'}

--- a/themes/Frontend/Bare/frontend/checkout/confirm.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/confirm.tpl
@@ -4,9 +4,10 @@
 {block name='frontend_index_logo_trusted_shops'}
     {$smarty.block.parent}
     {if $theme.checkoutHeader}
+        {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish" assign="snippetFinishButtonBackToShop"}{/s}
         <a href="{url controller='index'}"
            class="btn is--small btn--back-top-shop is--icon-left"
-           title="{"{s name='FinishButtonBackToShop' namespace='frontend/checkout/finish'}{/s}"|escape}"
+           title="{$snippetFinishButtonBackToShop|escape}"
            xmlns="http://www.w3.org/1999/html">
             <i class="icon--arrow-left"></i>
             {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish"}{/s}
@@ -268,9 +269,11 @@
                                                             {block name="frontend_checkout_confirm_information_addresses_equal_panel_billing_invalid_data"}
                                                                 {if $invalidBillingAddress}
                                                                     {if $invalidShippingCountry}
-                                                                        {include file='frontend/_includes/messages.tpl' type="warning" content="{s namespace="frontend/address/index" name='CountryNotAvailableForShipping'}{/s}"}
+                                                                        {s namespace="frontend/address/index" name="CountryNotAvailableForShipping" assign="snippetCountryNotAvailableForShipping"}{/s}
+                                                                        {include file='frontend/_includes/messages.tpl' type="warning" content=$snippetCountryNotAvailableForShipping}
                                                                     {else}
-                                                                        {include file='frontend/_includes/messages.tpl' type="warning" content="{s name='ConfirmAddressInvalidAddress'}{/s}"}
+                                                                        {s name="ConfirmAddressInvalidAddress" assign="snippetConfirmAddressInvalidAddress"}{/s}
+                                                                        {include file='frontend/_includes/messages.tpl' type="warning" content=$snippetConfirmAddressInvalidAddress}
                                                                     {/if}
                                                                 {else}
                                                                     {block name="frontend_checkout_confirm_information_addresses_equal_panel_billing_set_as_default"}
@@ -387,7 +390,8 @@
 
                                                     {block name="frontend_checkout_confirm_information_addresses_billing_panel_body_invalid_data"}
                                                         {if $invalidBillingAddress}
-                                                            {include file='frontend/_includes/messages.tpl' type="warning" content="{s name='ConfirmAddressInvalidBillingAddress'}{/s}"}
+                                                            {s name="ConfirmAddressInvalidBillingAddress" assign="snippetConfirmAddressInvalidBillingAddress"}{/s}
+                                                            {include file='frontend/_includes/messages.tpl' type="warning" content=$snippetConfirmAddressInvalidBillingAddress}
                                                         {else}
                                                             {block name="frontend_checkout_confirm_information_addresses_billing_panel_body_set_as_default"}
                                                                 {if $activeBillingAddressId != $sUserData.additional.user.default_billing_address_id}
@@ -474,9 +478,11 @@
                                                     {block name="frontend_checkout_confirm_information_addresses_shipping_panel_body_invalid_data"}
                                                         {if $invalidShippingAddress}
                                                             {if $invalidShippingCountry}
-                                                                {include file='frontend/_includes/messages.tpl' type="warning" content="{s namespace="frontend/address/index" name='CountryNotAvailableForShipping'}{/s}"}
-                                                                    {else}
-                                                                {include file='frontend/_includes/messages.tpl' type="warning" content="{s name='ConfirmAddressInvalidShippingAddress'}{/s}"}
+                                                                {s namespace="frontend/address/index" name="CountryNotAvailableForShipping" assign="snippetCountryNotAvailableForShipping"}{/s}
+                                                                {include file='frontend/_includes/messages.tpl' type="warning" content=$snippetCountryNotAvailableForShipping}
+                                                            {else}
+                                                                {s name="ConfirmAddressInvalidShippingAddress" assign="snippetConfirmAddressInvalidShippingAddress"}{/s}
+                                                                {include file='frontend/_includes/messages.tpl' type="warning" content=$snippetConfirmAddressInvalidShippingAddress}
                                                             {/if}
                                                         {else}
                                                             {block name="frontend_checkout_confirm_information_addresses_shipping_panel_body_set_as_default"}
@@ -604,7 +610,8 @@
                                         {/block}
 
                                         {block name='frontend_checkout_confirm_add_voucher_field'}
-                                            <input type="text" class="add-voucher--field block" name="sVoucher" placeholder="{"{s name='CheckoutFooterAddVoucherLabelInline' namespace='frontend/checkout/cart_footer'}{/s}"|escape}" />
+                                            {s name="CheckoutFooterAddVoucherLabelInline" namespace="frontend/checkout/cart_footer" assign="snippetCheckoutFooterAddVoucherLabelInline"}{/s}
+                                            <input type="text" class="add-voucher--field block" name="sVoucher" placeholder="{$snippetCheckoutFooterAddVoucherLabelInline|escape}" />
                                         {/block}
 
                                         {block name='frontend_checkout_confirm_add_voucher_button'}
@@ -693,11 +700,13 @@
                     <div class="main--actions">
                         {if $sLaststock.hideBasket}
                             {block name='frontend_checkout_confirm_stockinfo'}
-                                {include file="frontend/_includes/messages.tpl" type="error" content="{s name='ConfirmErrorStock'}{/s}"}
+                                {s name="ConfirmErrorStock" assign="snippetConfirmErrorStock"}{/s}
+                                {include file="frontend/_includes/messages.tpl" type="error" content=$snippetConfirmErrorStock}
                             {/block}
                         {elseif ($invalidBillingAddress || $invalidShippingAddress)}
                             {block name='frontend_checkout_confirm_addressinfo'}
-                                {include file="frontend/_includes/messages.tpl" type="error" content="{s name='ConfirmErrorInvalidAddress'}{/s}"}
+                                {s name="ConfirmErrorInvalidAddress" assign="snippetConfirmErrorInvalidAddress"}{/s}
+                                {include file="frontend/_includes/messages.tpl" type="error" content=$snippetConfirmErrorInvalidAddress}
                             {/block}
                         {else}
                             {block name='frontend_checkout_confirm_submit'}

--- a/themes/Frontend/Bare/frontend/checkout/error_messages.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/error_messages.tpl
@@ -14,39 +14,45 @@
 
 {block name="frontend_checkout_error_payment_blocked"}
     {if $paymentBlocked}
-        {include file="frontend/_includes/messages.tpl" type="error" content="{s name='ConfirmInfoPaymentBlocked'}{/s}"}
+        {s name="ConfirmInfoPaymentBlocked" assign="snippetConfirmInfoPaymentBlocked"}{/s}
+        {include file="frontend/_includes/messages.tpl" type="error" content=$snippetConfirmInfoPaymentBlocked}
     {/if}
 {/block}
 
 {block name="frontend_checkout_error_messages_esd_note"}
     {if $sShowEsdNote}
-        {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='ConfirmInfoPaymentNotCompatibleWithESD'}{/s}"}
+        {s name="ConfirmInfoPaymentNotCompatibleWithESD" assign="snippetConfirmInfoPaymentNotCompatibleWithESD"}{/s}
+        {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetConfirmInfoPaymentNotCompatibleWithESD}
     {/if}
 {/block}
 
 {block name='frontend_checkout_error_messages_no_shipping'}
     {if $sDispatchNoOrder}
-        {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='ConfirmInfoNoDispatch'}{/s}"}
+        {s name="ConfirmInfoNoDispatch" assign="snippetConfirmInfoNoDispatch"}{/s}
+        {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetConfirmInfoNoDispatch}
     {/if}
 {/block}
     
 {* Minimum sum not reached *}
 {block name='frontend_checkout_error_messages_minimum_not_reached'}
     {if $sMinimumSurcharge}
-        {include file="frontend/_includes/messages.tpl" type="error" content="{s name='ConfirmInfoMinimumSurcharge'}{/s}"}
+        {s name="ConfirmInfoMinimumSurcharge" assign="snippetConfirmInfoMinimumSurcharge"}{/s}
+        {include file="frontend/_includes/messages.tpl" type="error" content=$snippetConfirmInfoMinimumSurcharge}
     {/if}
 {/block}
 
 {* Service article tos not accepted *}
 {block name='frontend_checkout_error_messages_service_error'}
     {if $agreementErrors && $agreementErrors.serviceError}
-        {include file="frontend/_includes/messages.tpl" type="error" content="{s name="ServiceErrorMessage"}{/s}"}
+        {s name="ServiceErrorMessage" assign="snippetServiceErrorMessage"}{/s}
+        {include file="frontend/_includes/messages.tpl" type="error" content=$snippetServiceErrorMessage}
     {/if}
 {/block}
 
 {* ESD article tos not accepted *}
 {block name='frontend_checkout_error_messages_esd_error'}
     {if $agreementErrors && $agreementErrors.esdError && {config name="showEsdWarning"}}
-        {include file="frontend/_includes/messages.tpl" type="error" content="{s name="EsdErrorMessage"}{/s}"}
+        {s name="EsdErrorMessage" assign="snippetEsdErrorMessage"}{/s}
+        {include file="frontend/_includes/messages.tpl" type="error" content=$snippetEsdErrorMessage}
     {/if}
 {/block}

--- a/themes/Frontend/Bare/frontend/checkout/finish.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/finish.tpl
@@ -46,9 +46,10 @@
 {block name='frontend_index_logo_trusted_shops'}
     {$smarty.block.parent}
     {if $theme.checkoutHeader}
+        {s name="FinishButtonBackToShop" assign="snippetFinishButtonBackToShop"}{/s}
         <a href="{url controller='index'}"
            class="btn is--small btn--back-top-shop is--icon-left"
-           title="{"{s name='FinishButtonBackToShop'}{/s}"|escape}">
+           title="{$snippetFinishButtonBackToShop|escape}">
             <i class="icon--arrow-left"></i>
             {s name="FinishButtonBackToShop"}{/s}
         </a>
@@ -70,7 +71,8 @@
                 {block name='frontend_checkout_finish_teaser_content'}
                     <div class="panel--body is--wide is--align-center">
                         {if $confirmMailDeliveryFailed}
-                            {include file="frontend/_includes/messages.tpl" type="error" content="{s name="FinishInfoConfirmationMailFailed"}{/s}"}
+                            {s name="FinishInfoConfirmationMailFailed" assign="snippetFinishInfoConfirmationMailFailed"}{/s}
+                            {include file="frontend/_includes/messages.tpl" type="error" content=$snippetFinishInfoConfirmationMailFailed}
                         {/if}
 
                         <p class="teaser--text">
@@ -87,12 +89,14 @@
 
                                 {strip}
                                 {* Back to the shop button *}
-                                <a href="{url controller='index'}" class="btn is--secondary teaser--btn-back is--icon-left" title="{"{s name='FinishButtonBackToShop'}{/s}"|escape}">
-                                    <i class="icon--arrow-left"></i>&nbsp;{"{s name="FinishButtonBackToShop"}{/s}"|replace:' ':'&nbsp;'}
+                                {s name="FinishButtonBackToShop" assign="snippetFinishButtonBackToShop"}{/s}
+                                <a href="{url controller='index'}" class="btn is--secondary teaser--btn-back is--icon-left" title="{$snippetFinishButtonBackToShop|escape}">
+                                    <i class="icon--arrow-left"></i>&nbsp;{$snippetFinishButtonBackToShop|replace:' ':'&nbsp;'}
                                 </a>
 
                                 {* Print button *}
-                                <a href="#" class="btn is--primary teaser--btn-print" onclick="self.print()" title="{"{s name='FinishLinkPrint'}{/s}"|escape}">
+                                {s name="FinishLinkPrint" assign="snippetFinishLinkPrint"}{/s}
+                                <a href="#" class="btn is--primary teaser--btn-print" onclick="self.print()" title="{$snippetFinishLinkPrint|escape}">
                                     {s name="FinishLinkPrint"}{/s}
                                 </a>
                                 {/strip}

--- a/themes/Frontend/Bare/frontend/checkout/header.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/header.tpl
@@ -12,13 +12,15 @@
                 {* Main shop logo *}
                 {block name='frontend_index_logo'}
                     <div class="logo--shop block">
-                        <a class="logo--link" href="{url controller='index'}" title="{"{config name=shopName}"|escapeHtml} - {"{s name='IndexLinkDefault' namespace="frontend/index/index"}{/s}"|escape}">
+                        {s name="IndexLinkDefault" namespace="frontend/index/index" assign="snippetIndexLinkDefault"}{/s}
+                        <a class="logo--link" href="{url controller='index'}" title="{"{config name=shopName}"|escapeHtml} - {$snippetIndexLinkDefault|escape}">
                             <picture>
                                 <source srcset="{link file=$theme.desktopLogo}" media="(min-width: 78.75em)">
                                 <source srcset="{link file=$theme.tabletLandscapeLogo}" media="(min-width: 64em)">
                                 <source srcset="{link file=$theme.tabletLogo}" media="(min-width: 48em)">
 
-                                <img srcset="{link file=$theme.mobileLogo}" alt="{"{config name=shopName}"|escapeHtml} - {"{s name='IndexLinkDefault' namespace="frontend/index/index"}{/s}"|escape}" />
+                                {s name="IndexLinkDefault" namespace="frontend/index/index" assign="snippetIndexLinkDefault"}{/s}
+                                <img srcset="{link file=$theme.mobileLogo}" alt="{"{config name=shopName}"|escapeHtml} - {$snippetIndexLinkDefault|escape}" />
                             </picture>
                         </a>
                     </div>

--- a/themes/Frontend/Bare/frontend/checkout/items/premium-product.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/items/premium-product.tpl
@@ -97,8 +97,9 @@
         <div class="panel--td column--actions block">
             <form action="{url action='deleteArticle' sDelete=$sBasketItem.id sTargetAction=$sTargetAction}"
                   method="post">
+                {s name="CartItemLinkDelete" assign="snippetCartItemLinkDelete"}{/s}
                 <button type="submit" class="btn is--small column--actions-link"
-                        title="{"{s name='CartItemLinkDelete'}{/s}"|escape}">
+                        title="{$snippetCartItemLinkDelete|escape}">
                     <i class="icon--cross"></i>
                 </button>
             </form>

--- a/themes/Frontend/Bare/frontend/checkout/items/product.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/items/product.tpl
@@ -163,8 +163,9 @@
         <div class="panel--td column--actions">
             <form action="{url action='deleteArticle' sDelete=$sBasketItem.id sTargetAction=$sTargetAction}"
                   method="post">
+                {s name="CartItemLinkDelete" assign="snippetCartItemLinkDelete"}{/s}
                 <button type="submit" class="btn is--small column--actions-link"
-                        title="{"{s name='CartItemLinkDelete'}{/s}"|escape}">
+                        title="{$snippetCartItemLinkDelete|escape}">
                     <i class="icon--cross"></i>
                 </button>
             </form>

--- a/themes/Frontend/Bare/frontend/checkout/items/voucher.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/items/voucher.tpl
@@ -66,8 +66,9 @@
     {block name='frontend_checkout_cart_item_voucher_delete_article'}
         <div class="panel--td column--actions block">
             <form action="{url action='deleteArticle' sDelete=voucher sTargetAction=$sTargetAction}" method="post">
+                {s name="CartItemLinkDelete" assign="snippetCartItemLinkDelete"}{/s}
                 <button type="submit" class="btn is--small column--actions-link"
-                        title="{"{s name='CartItemLinkDelete'}{/s}"|escape}">
+                        title="{$snippetCartItemLinkDelete|escape}">
                     <i class="icon--cross"></i>
                 </button>
             </form>

--- a/themes/Frontend/Bare/frontend/checkout/premiums.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/premiums.tpl
@@ -49,8 +49,9 @@
                                                                 <img srcset="{$premium.sArticle.image.thumbnails[0].sourceSet}"
                                                                      alt="{$premium.sArticle.articleName|escape}" />
                                                             {else}
+                                                                {s name="PremiumInfoNoPicture" assign="snippetPremiumInfoNoPicture"}{/s}
                                                                 <img src="{link file='frontend/_public/src/img/no-picture.jpg'}"
-                                                                     alt="{"{s name="PremiumInfoNoPicture"}{/s}"|escape}">
+                                                                     alt="{$snippetPremiumInfoNoPicture|escape}">
                                                             {/if}
                                                         </span>
                                                     {/block}

--- a/themes/Frontend/Bare/frontend/checkout/shipping_payment.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/shipping_payment.tpl
@@ -13,9 +13,10 @@
 {block name='frontend_index_logo_trusted_shops'}
     {$smarty.block.parent}
     {if $theme.checkoutHeader}
+        {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish" assign="snippetFinishButtonBackToShop"}{/s}
         <a href="{url controller='index'}"
            class="btn is--small btn--back-top-shop is--icon-left"
-           title="{"{s name='FinishButtonBackToShop' namespace='frontend/checkout/finish'}{/s}"|escape}">
+           title="{$snippetFinishButtonBackToShop|escape}">
             <i class="icon--arrow-left"></i>
             {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish"}{/s}
         </a>

--- a/themes/Frontend/Bare/frontend/compare/add_article.tpl
+++ b/themes/Frontend/Bare/frontend/compare/add_article.tpl
@@ -13,7 +13,8 @@
             {* Compare modal error message *}
             {block name="product_compare_error_title"}
                 <div class="modal--error">
-                    {include file="frontend/_includes/messages.tpl" type="info" content="{s name='CompareInfoMaxReached' namespace='frontend/compare/added'}{/s}"}
+                    {s name="CompareInfoMaxReached" namespace="frontend/compare/added" assign="snippetCompareInfoMaxReached"}{/s}
+                    {include file="frontend/_includes/messages.tpl" type="info" content=$snippetCompareInfoMaxReached}
                 </div>
             {/block}
         </div>

--- a/themes/Frontend/Bare/frontend/custom/ajax.tpl
+++ b/themes/Frontend/Bare/frontend/custom/ajax.tpl
@@ -1,7 +1,8 @@
 {block name='frontend_custom_ajax_buttons_offcanvas'}
     <div class="buttons--off-canvas">
         {block name='frontend_custom_ajax_buttons_offcanvas_inner'}
-            <a href="#" title="{"{s name="CustomAjaxActionClose"}{/s}"|escape}" class="close--off-canvas">
+            {s name="CustomAjaxActionClose" assign="snippetCustomAjaxActionClose"}{/s}
+            <a href="#" title="{$snippetCustomAjaxActionClose|escape}" class="close--off-canvas">
                 <i class="icon--arrow-left"></i>
                 {s name="CustomAjaxActionClose"}{/s}
             </a>

--- a/themes/Frontend/Bare/frontend/detail/actions.tpl
+++ b/themes/Frontend/Bare/frontend/detail/actions.tpl
@@ -1,7 +1,8 @@
 {block name='frontend_detail_actions_compare'}
     {if {config name="compareShow"}}
         <form action="{url controller='compare' action='add_article' articleID=$sArticle.articleID}" method="post" class="action--form">
-            <button type="submit" data-product-compare-add="true" title="{"{s name='DetailActionLinkCompare'}{/s}"|escape}" class="action--link action--compare">
+            {s name="DetailActionLinkCompare" assign="snippetDetailActionLinkCompare"}{/s}
+            <button type="submit" data-product-compare-add="true" title="{$snippetDetailActionLinkCompare|escape}" class="action--link action--compare">
                 <i class="icon--compare"></i> {s name="DetailActionLinkCompare"}{/s}
             </button>
         </form>
@@ -10,9 +11,10 @@
 
 {block name='frontend_detail_actions_notepad'}
     <form action="{url controller='note' action='add' ordernumber=$sArticle.ordernumber}" method="post" class="action--form">
+        {s name="DetailLinkNotepad" assign="snippetDetailLinkNotepad"}{/s}
         <button type="submit"
            class="action--link link--notepad"
-           title="{"{s name='DetailLinkNotepad'}{/s}"|escape}"
+           title="{$snippetDetailLinkNotepad|escape}"
            data-ajaxUrl="{url controller='note' action='ajaxAdd' ordernumber=$sArticle.ordernumber}"
            data-text="{s name="DetailNotepadMarked"}{/s}">
             <i class="icon--heart"></i> <span class="action--text">{s name="DetailLinkNotepadShort"}{/s}</span>
@@ -22,7 +24,8 @@
 
 {block name='frontend_detail_actions_review'}
     {if !{config name=VoteDisable}}
-        <a href="#content--product-reviews" data-show-tab="true" class="action--link link--publish-comment" rel="nofollow" title="{"{s name='DetailLinkReview'}{/s}"|escape}">
+        {s name="DetailLinkReview" assign="snippetDetailLinkReview"}{/s}
+        <a href="#content--product-reviews" data-show-tab="true" class="action--link link--publish-comment" rel="nofollow" title="{$snippetDetailLinkReview|escape}">
             <i class="icon--star"></i> {s name="DetailLinkReviewShort"}{/s}
         </a>
     {/if}
@@ -30,7 +33,8 @@
 
 {block name='frontend_detail_actions_voucher'}
     {if {config name=showTellAFriend}}
-        <a href="{$sArticle.linkTellAFriend}" rel="nofollow" title="{"{s name='DetailLinkVoucher'}{/s}"|escape}" class="action--link link--tell-a-friend">
+        {s name="DetailLinkVoucher" assign="snippetDetailLinkVoucher"}{/s}
+        <a href="{$sArticle.linkTellAFriend}" rel="nofollow" title="{$snippetDetailLinkVoucher|escape}" class="action--link link--tell-a-friend">
             <i class="icon--comment"></i> {s name="DetailLinkVoucherShort"}{/s}
         </a>
     {/if}

--- a/themes/Frontend/Bare/frontend/detail/comment/form.tpl
+++ b/themes/Frontend/Bare/frontend/detail/comment/form.tpl
@@ -10,7 +10,8 @@
 {* Display notice if the shop owner needs to unlock a comment before it will be listed *}
 {block name='frontend_detail_comment_post_notice'}
     {if {config name=VoteUnlock}}
-        {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='DetailCommentTextReview'}{/s}"}
+        {s name="DetailCommentTextReview" assign="snippetDetailCommentTextReview"}{/s}
+        {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetDetailCommentTextReview}
     {/if}
 {/block}
 

--- a/themes/Frontend/Bare/frontend/detail/config_step.tpl
+++ b/themes/Frontend/Bare/frontend/detail/config_step.tpl
@@ -1,6 +1,7 @@
 {block name='frontend_detail_configurator_error'}
     {if $sArticle.sError && $sArticle.sError.variantNotAvailable}
-        {include file="frontend/_includes/messages.tpl" type="error" content="{s name='VariantAreNotAvailable'}{/s}"}
+        {s name="VariantAreNotAvailable" assign="snippetVariantAreNotAvailable"}{/s}
+        {include file="frontend/_includes/messages.tpl" type="error" content=$snippetVariantAreNotAvailable}
     {/if}
 {/block}
 

--- a/themes/Frontend/Bare/frontend/detail/content/buy_container.tpl
+++ b/themes/Frontend/Bare/frontend/detail/content/buy_container.tpl
@@ -36,14 +36,13 @@
         {/block}
 
         {block name='frontend_detail_buy_laststock'}
+            {s name="DetailBuyInfoNotAvailable" namespace="frontend/detail/buy" assign="snippetDetailBuyInfoNotAvailable"}{/s}
             {if !$sArticle.isAvailable && !$sArticle.sConfigurator}
-                {include file="frontend/_includes/messages.tpl" type="error" content="{s name='DetailBuyInfoNotAvailable' namespace='frontend/detail/buy'}{/s}"}
-
+                {include file="frontend/_includes/messages.tpl" type="error" content=$snippetDetailBuyInfoNotAvailable}
             {elseif !$sArticle.isAvailable && $sArticle.isSelectionSpecified}
-                {include file="frontend/_includes/messages.tpl" type="error" content="{s name='DetailBuyInfoNotAvailable' namespace='frontend/detail/buy'}{/s}"}
-
+                {include file="frontend/_includes/messages.tpl" type="error" content=$snippetDetailBuyInfoNotAvailable}
             {elseif !$sArticle.isAvailable && !$sArticle.hasAvailableVariant}
-                {include file="frontend/_includes/messages.tpl" type="error" content="{s name='DetailBuyInfoNotAvailable' namespace='frontend/detail/buy'}{/s}"}
+                {include file="frontend/_includes/messages.tpl" type="error" content=$snippetDetailBuyInfoNotAvailable}
             {/if}
         {/block}
 

--- a/themes/Frontend/Bare/frontend/detail/content/header.tpl
+++ b/themes/Frontend/Bare/frontend/detail/content/header.tpl
@@ -15,8 +15,9 @@
                     {block name='frontend_detail_supplier_info'}
                         {if $sArticle.supplierImg}
                             <div class="product--supplier">
+                                {s name="DetailDescriptionLinkInformation" namespace="frontend/detail/description" assign="snippetDetailDescriptionLinkInformation"}{/s}
                                 <a href="{url controller='listing' action='manufacturer' sSupplier=$sArticle.supplierID}"
-                                   title="{"{s name="DetailDescriptionLinkInformation" namespace="frontend/detail/description"}{/s}"|escape}"
+                                   title="{$snippetDetailDescriptionLinkInformation|escape}"
                                    class="product--supplier-link">
                                     <img src="{$sArticle.supplierImg}" alt="{$sArticle.supplierName|escape}">
                                 </a>
@@ -28,7 +29,8 @@
                     {block name="frontend_detail_comments_overview"}
                         {if !{config name=VoteDisable}}
                             <div class="product--rating-container">
-                                <a href="#product--publish-comment" class="product--rating-link" rel="nofollow" title="{"{s namespace="frontend/detail/actions" name='DetailLinkReview'}{/s}"|escape}">
+                                {s namespace="frontend/detail/actions" name="DetailLinkReview" assign="snippetDetailLinkReview"}{/s}
+                                <a href="#product--publish-comment" class="product--rating-link" rel="nofollow" title="{$snippetDetailLinkReview|escape}">
                                     {include file='frontend/_includes/rating.tpl' points=$sArticle.sVoteAverage.average type="aggregated" count=$sArticle.sVoteAverage.count}
                                 </a>
                             </div>

--- a/themes/Frontend/Bare/frontend/detail/tabs/comment.tpl
+++ b/themes/Frontend/Bare/frontend/detail/tabs/comment.tpl
@@ -4,7 +4,8 @@
 {block name='frontend_detail_rating_buttons_offcanvas'}
     <div class="buttons--off-canvas">
         {block name='frontend_detail_rating_buttons_offcanvas_inner'}
-            <a href="#" title="{"{s name="OffcanvasCloseMenu" namespace="frontend/detail/description"}{/s}"|escape}" class="close--off-canvas">
+            {s name="OffcanvasCloseMenu" namespace="frontend/detail/description" assign="snippetOffcanvasCloseMenu"}{/s}
+            <a href="#" title="{$snippetOffcanvasCloseMenu|escape}" class="close--off-canvas">
                 <i class="icon--arrow-left"></i>
                 {s name="OffcanvasCloseMenu" namespace="frontend/detail/description"}{/s}
             </a>
@@ -21,21 +22,21 @@
                 {if $sErrorFlag['sCaptcha']}
                     {$file = 'frontend/_includes/messages.tpl'}
                     {$type = 'error'}
-                    {$content = "{s name='DetailCommentInfoFillOutCaptcha'}{/s}"}
+                    {s name="DetailCommentInfoFillOutCaptcha" assign="content"}{/s}
                 {else}
                     {$file = 'frontend/_includes/messages.tpl'}
                     {$type = 'error'}
-                    {$content = "{s name='DetailCommentInfoFillOutFields'}{/s}"}
+                    {s name="DetailCommentInfoFillOutFields" assign="content"}{/s}
                 {/if}
             {else}
                 {if {config name="OptinVote"} && !{$smarty.get.sConfirmation} && !{$userLoggedIn}}
                     {$file = 'frontend/_includes/messages.tpl'}
                     {$type = 'success'}
-                    {$content = "{s name='DetailCommentInfoSuccessOptin'}{/s}"}
+                    {s name="DetailCommentInfoSuccessOptin" assign="content"}{/s}
                 {else}
                     {$file = 'frontend/_includes/messages.tpl'}
                     {$type = 'success'}
-                    {$content = "{s name='DetailCommentInfoSuccess'}{/s}"}
+                    {s name="DetailCommentInfoSuccess" assign="content"}{/s}
                 {/if}
             {/if}
 

--- a/themes/Frontend/Bare/frontend/detail/tabs/description.tpl
+++ b/themes/Frontend/Bare/frontend/detail/tabs/description.tpl
@@ -4,7 +4,8 @@
 {block name='frontend_detail_description_buttons_offcanvas'}
     <div class="buttons--off-canvas">
         {block name='frontend_detail_description_buttons_offcanvas_inner'}
-            <a href="#" title="{"{s name="OffcanvasCloseMenu" namespace="frontend/detail/description"}{/s}"|escape}" class="close--off-canvas">
+            {s name="OffcanvasCloseMenu" namespace="frontend/detail/description" assign="snippetOffcanvasCloseMenu"}{/s}
+            <a href="#" title="{$snippetOffcanvasCloseMenu|escape}" class="close--off-canvas">
                 <i class="icon--arrow-left"></i>
                 {s name="OffcanvasCloseMenu" namespace="frontend/detail/description"}{/s}
             </a>
@@ -68,7 +69,8 @@
                 {block name='frontend_detail_actions_contact'}
                     {if $sInquiry}
                         <li class="list--entry">
-                            <a href="{$sInquiry}" rel="nofollow" class="content--link link--contact" title="{"{s name='DetailLinkContact' namespace="frontend/detail/actions"}{/s}"|escape}">
+                            {s name="DetailLinkContact" namespace="frontend/detail/actions" assign="snippetDetailLinkContact"}{/s}
+                            <a href="{$sInquiry}" rel="nofollow" class="content--link link--contact" title="{$snippetDetailLinkContact|escape}">
                                 <i class="icon--arrow-right"></i> {s name="DetailLinkContact" namespace="frontend/detail/actions"}{/s}
                             </a>
                         </li>
@@ -81,10 +83,11 @@
                         {* Vendor landing page link *}
                         {block name='frontend_detail_description_links_supplier'}
                             <li class="list--entry">
+                                {s name="DetailDescriptionLinkInformation" assign="snippetDetailDescriptionLinkInformation"}{/s}
                                 <a href="{url controller='listing' action='manufacturer' sSupplier=$sArticle.supplierID}"
                                    target="{$information.target}"
                                    class="content--link link--supplier"
-                                   title="{"{s name="DetailDescriptionLinkInformation"}{/s}"|escape}">
+                                   title="{$snippetDetailDescriptionLinkInformation|escape}">
 
                                     <i class="icon--arrow-right"></i> {s name="DetailDescriptionLinkInformation"}{/s}
                                 </a>
@@ -126,7 +129,8 @@
                     {foreach $sArticle.sDownloads as $download}
                         {block name='frontend_detail_description_downloads_content_link'}
                             <li class="list--entry">
-                                <a href="{$download.filename}" target="_blank" class="content--link link--download" title="{"{s name="DetailDescriptionLinkDownload"}{/s}"|escape} {$download.description|escape}">
+                                {s name="DetailDescriptionLinkDownload" assign="snippetDetailDescriptionLinkDownload"}{/s}
+                                <a href="{$download.filename}" target="_blank" class="content--link link--download" title="{$snippetDetailDescriptionLinkDownload|escape} {$download.description|escape}">
                                     <i class="icon--arrow-right"></i> {s name="DetailDescriptionLinkDownload"}{/s} {$download.description}
                                 </a>
                             </li>

--- a/themes/Frontend/Bare/frontend/forms/form-elements.tpl
+++ b/themes/Frontend/Bare/frontend/forms/form-elements.tpl
@@ -12,7 +12,8 @@
                         {block name='frontend_forms_form_elements_form_builder'}
                             <div {if $sSupport.sElements[$sKey].typ eq 'textarea'}class="textarea"{elseif $sSupport.sElements[$sKey].typ eq 'checkbox'}class="forms--checkbox"{elseif $sSupport.sElements[$sKey].typ eq 'select'}class="field--select select-field"{/if}>
 
-                                {$sSupport.sFields[$sKey]|replace:'%*%':"{s name='RequiredField' namespace='frontend/register/index'}{/s}"}
+                                {s name="RequiredField" namespace="frontend/register/index" assign="snippetRequiredField"}{/s}
+                                {$sSupport.sFields[$sKey]|replace:'%*%':$snippetRequiredField}
 
                                 {if $sSupport.sElements[$sKey].typ eq 'checkbox'}
                                     {$sSupport.sLabels.$sKey|replace:':':''}

--- a/themes/Frontend/Bare/frontend/index/header.tpl
+++ b/themes/Frontend/Bare/frontend/index/header.tpl
@@ -11,20 +11,23 @@
     <meta name="robots" content="{block name='frontend_index_header_meta_robots'}{s name='IndexMetaRobots'}{/s}{/block}" />
     <meta name="revisit-after" content="{s name='IndexMetaRevisit'}{/s}" />
     <meta name="keywords" content="{block name='frontend_index_header_meta_keywords'}{if $sCategoryContent.metaKeywords}{$sCategoryContent.metaKeywords|escapeHtml}{else}{s name='IndexMetaKeywordsStandard'}{/s}{/if}{/block}" />
-    <meta name="description" content="{block name='frontend_index_header_meta_description'}{"{s name='IndexMetaDescriptionStandard'}{/s}"|truncate:$SeoDescriptionMaxLength:'…'}{/block}" />
+    {s name="IndexMetaDescriptionStandard" assign="snippetIndexMetaDescriptionStandard"}{/s}
+    <meta name="description" content="{block name='frontend_index_header_meta_description'}{$snippetIndexMetaDescriptionStandard|truncate:$SeoDescriptionMaxLength:'…'}{/block}" />
 
     {* Meta opengraph tags *}
     {block name='frontend_index_header_meta_tags_opengraph'}
         <meta property="og:type" content="website" />
         <meta property="og:site_name" content="{{config name=sShopname}|escapeHtml}" />
         <meta property="og:title" content="{{config name=sShopname}|escapeHtml}" />
-        <meta property="og:description" content="{block name='frontend_index_header_meta_description_og'}{"{s name='IndexMetaDescriptionStandard'}{/s}"|truncate:$SeoDescriptionMaxLength:'…'}{/block}" />
+        {s name="IndexMetaDescriptionStandard" assign="snippetIndexMetaDescriptionStandard"}{/s}
+        <meta property="og:description" content="{block name='frontend_index_header_meta_description_og'}{$snippetIndexMetaDescriptionStandard|truncate:$SeoDescriptionMaxLength:'…'}{/block}" />
         <meta property="og:image" content="{link file=$theme.desktopLogo fullPath}" />
 
         <meta name="twitter:card" content="website" />
         <meta name="twitter:site" content="{{config name=sShopname}|escapeHtml}" />
         <meta name="twitter:title" content="{{config name=sShopname}|escapeHtml}" />
-        <meta name="twitter:description" content="{block name='frontend_index_header_meta_description_twitter'}{"{s name='IndexMetaDescriptionStandard'}{/s}"|truncate:$SeoDescriptionMaxLength:'…'}{/block}" />
+        {s name="IndexMetaDescriptionStandard" assign="snippetIndexMetaDescriptionStandard"}{/s}
+        <meta name="twitter:description" content="{block name='frontend_index_header_meta_description_twitter'}{$snippetIndexMetaDescriptionStandard|truncate:$SeoDescriptionMaxLength:'…'}{/block}" />
         <meta name="twitter:image" content="{link file=$theme.desktopLogo fullPath}" />
     {/block}
 

--- a/themes/Frontend/Bare/frontend/index/index.tpl
+++ b/themes/Frontend/Bare/frontend/index/index.tpl
@@ -28,7 +28,8 @@
             {* Message if javascript is disabled *}
             {block name="frontend_index_no_script_message"}
                 <noscript class="noscript-main">
-                    {include file="frontend/_includes/messages.tpl" type="warning" content="{s name="IndexNoscriptNotice"}{/s}" borderRadius=false}
+                    {s name="IndexNoscriptNotice" assign="snippetIndexNoscriptNotice"}{/s}
+                    {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetIndexNoscriptNotice borderRadius=false}
                 </noscript>
             {/block}
 

--- a/themes/Frontend/Bare/frontend/index/logo-container.tpl
+++ b/themes/Frontend/Bare/frontend/index/logo-container.tpl
@@ -3,13 +3,15 @@
     {* Main shop logo *}
     {block name='frontend_index_logo'}
         <div class="logo--shop block">
-            <a class="logo--link" href="{url controller='index'}" title="{"{config name=shopName}"|escapeHtml} - {"{s name='IndexLinkDefault' namespace="frontend/index/index"}{/s}"|escape}">
+            {s name="IndexLinkDefault" namespace="frontend/index/index" assign="snippetIndexLinkDefault"}{/s}
+            <a class="logo--link" href="{url controller='index'}" title="{"{config name=shopName}"|escapeHtml} - {$snippetIndexLinkDefault|escape}">
                 <picture>
                     <source srcset="{link file=$theme.desktopLogo}" media="(min-width: 78.75em)">
                     <source srcset="{link file=$theme.tabletLandscapeLogo}" media="(min-width: 64em)">
                     <source srcset="{link file=$theme.tabletLogo}" media="(min-width: 48em)">
 
-                    <img srcset="{link file=$theme.mobileLogo}" alt="{"{config name=shopName}"|escapeHtml} - {"{s name='IndexLinkDefault' namespace="frontend/index/index"}{/s}"|escape}" />
+                    {s name="IndexLinkDefault" namespace="frontend/index/index" assign="snippetIndexLinkDefault"}{/s}
+                    <img srcset="{link file=$theme.mobileLogo}" alt="{"{config name=shopName}"|escapeHtml} - {$snippetIndexLinkDefault|escape}" />
                 </picture>
             </a>
         </div>

--- a/themes/Frontend/Bare/frontend/index/shop-navigation.tpl
+++ b/themes/Frontend/Bare/frontend/index/shop-navigation.tpl
@@ -13,7 +13,8 @@
         {* Search form *}
         {block name='frontend_index_search'}
             <li class="navigation--entry entry--search" role="menuitem" data-search="true" aria-haspopup="true"{if $theme.focusSearch && {controllerName|lower} == 'index'} data-activeOnStart="true"{/if}>
-                <a class="btn entry--link entry--trigger" href="#show-hide--search" title="{"{s namespace='frontend/index/search' name="IndexTitleSearchToggle"}{/s}"|escape}">
+                {s namespace="frontend/index/search" name="IndexTitleSearchToggle" assign="snippetIndexTitleSearchToggle"}{/s}
+                <a class="btn entry--link entry--trigger" href="#show-hide--search" title="{$snippetIndexTitleSearchToggle|escape}">
                     <i class="icon--search"></i>
 
                     {block name='frontend_index_search_display'}

--- a/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
+++ b/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
@@ -9,7 +9,8 @@
     {* Pagination - Frist page *}
     {block name="frontend_listing_actions_paging_first"}
         {if $sPage > 1}
-            <a href="{$baseUrl}?{$shortParameters.sPage}=1" title="{"{s name='ListingLinkFirst'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">
+            {s name="ListingLinkFirst" assign="snippetListingLinkFirst"}{/s}
+            <a href="{$baseUrl}?{$shortParameters.sPage}=1" title="{$snippetListingLinkFirst|escape}" class="paging--link paging--prev" data-action-link="true">
                 <i class="icon--arrow-left"></i>
                 <i class="icon--arrow-left"></i>
             </a>
@@ -19,7 +20,8 @@
     {* Pagination - Previous page *}
     {block name='frontend_listing_actions_paging_previous'}
         {if $sPage > 1}
-            <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage-1}" title="{"{s name='ListingLinkPrevious'}{/s}"|escape}" class="paging--link paging--prev" data-action-link="true">
+            {s name="ListingLinkPrevious" assign="snippetListingLinkPrevious"}{/s}
+            <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage-1}" title="{$snippetListingLinkPrevious|escape}" class="paging--link paging--prev" data-action-link="true">
                 <i class="icon--arrow-left"></i>
             </a>
         {/if}
@@ -35,7 +37,8 @@
     {* Pagination - Next page *}
     {block name='frontend_listing_actions_paging_next'}
         {if $sPage < $pages}
-            <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage+1}" title="{"{s name='ListingLinkNext'}{/s}"|escape}" class="paging--link paging--next" data-action-link="true">
+            {s name="ListingLinkNext" assign="snippetListingLinkNext"}{/s}
+            <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage+1}" title="{$snippetListingLinkNext|escape}" class="paging--link paging--next" data-action-link="true">
                 <i class="icon--arrow-right"></i>
             </a>
         {/if}
@@ -44,7 +47,8 @@
     {* Pagination - Last page *}
     {block name="frontend_listing_actions_paging_last"}
         {if $sPage < $pages}
-            <a href="{$baseUrl}?{$shortParameters.sPage}={$pages}" title="{"{s name='ListingLinkLast'}{/s}"|escape}" class="paging--link paging--next" data-action-link="true">
+            {s name="ListingLinkLast" assign="snippetListingLinkLast"}{/s}
+            <a href="{$baseUrl}?{$shortParameters.sPage}={$pages}" title="{$snippetListingLinkLast|escape}" class="paging--link paging--next" data-action-link="true">
                 <i class="icon--arrow-right"></i>
                 <i class="icon--arrow-right"></i>
             </a>

--- a/themes/Frontend/Bare/frontend/listing/customer_stream/listing.tpl
+++ b/themes/Frontend/Bare/frontend/listing/customer_stream/listing.tpl
@@ -30,7 +30,8 @@
 
         {block name="frontend_listing_no_filter_result"}
             <div class="listing-no-filter-result">
-                {include file="frontend/_includes/messages.tpl" type="info" content="{s name=noFilterResult}Für die Filterung wurden keine Ergebnisse gefunden!{/s}" visible=false}
+                {s name="noFilterResult" assign="snippetNoFilterResult"}Für die Filterung wurden keine Ergebnisse gefunden!{/s}
+                {include file="frontend/_includes/messages.tpl" type="info" content=$snippetNoFilterResult visible=false}
             </div>
         {/block}
 

--- a/themes/Frontend/Bare/frontend/listing/filter/facet-date-range.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/facet-date-range.tpl
@@ -17,10 +17,11 @@
         {$rangeMax = $facet->getMax()}
 
         {block name="frontend_listing_filter_facet_date_range_input"}
+            {s name="datePickerInputPlaceholder" namespace="frontend/index/datepicker" assign="snippetDatePickerInputPlaceholder"}{/s}
             <input type="text"
                    class="filter-panel--input"
                    id="{$facet->getFacetName()|escape:'htmlall'}"
-                   placeholder="{"{s name="datePickerInputPlaceholder" namespace="frontend/index/datepicker"}{/s}"|escape:'htmlall'}"
+                   placeholder="{$snippetDatePickerInputPlaceholder|escape:'htmlall'}"
                    data-datepicker="true"
                    data-mode="range"
                    data-enableTime="{$enableTime}"

--- a/themes/Frontend/Bare/frontend/listing/header.tpl
+++ b/themes/Frontend/Bare/frontend/listing/header.tpl
@@ -5,7 +5,7 @@
 
 {block name='frontend_index_header_meta_tags_opengraph'}
 
-    {$description = "{s name='IndexMetaDescriptionStandard'}{/s}"}
+    {s name="IndexMetaDescriptionStandard" assign="description"}{/s}
     {if $sCategoryContent.cmstext}
         {$description = "{$sCategoryContent.cmstext|trim|strip_tags|escapeHtml}"}
     {elseif $sCategoryContent.metaDescription}

--- a/themes/Frontend/Bare/frontend/listing/listing.tpl
+++ b/themes/Frontend/Bare/frontend/listing/listing.tpl
@@ -64,7 +64,8 @@
 
                     {block name="frontend_listing_no_filter_result"}
                         <div class="listing-no-filter-result">
-                            {include file="frontend/_includes/messages.tpl" type="info" content="{s name=noFilterResult}Für die Filterung wurden keine Ergebnisse gefunden!{/s}" visible=false}
+                            {s name="noFilterResult" assign="snippetNoFilterResult"}Für die Filterung wurden keine Ergebnisse gefunden!{/s}
+                            {include file="frontend/_includes/messages.tpl" type="info" content=$snippetNoFilterResult visible=false}
                         </div>
                     {/block}
 

--- a/themes/Frontend/Bare/frontend/listing/manufacturer.tpl
+++ b/themes/Frontend/Bare/frontend/listing/manufacturer.tpl
@@ -3,7 +3,7 @@
 {namespace name="frontend/listing/listing"}
 
 {block name='frontend_index_header_meta_tags_opengraph'}
-    {$description = "{s name='IndexMetaDescriptionStandard'}{/s}"}
+    {s name="IndexMetaDescriptionStandard" assign="description"}{/s}
     {if $manufacturer->getDescription()}
         {$description = "{$manufacturer->getDescription()|strip_tags|trim|truncate:240}"}
     {/if}

--- a/themes/Frontend/Bare/frontend/listing/product-box/button-detail.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/button-detail.tpl
@@ -9,7 +9,7 @@
     {/block}
 
     {block name="frontend_listing_product_box_button_detail_label"}
-        {$label = "{s name="ListingButtonDetail" namespace="frontend/listing/box_article"}Details{/s}"}
+        {s name="ListingButtonDetail" namespace="frontend/listing/box_article" assign="label"}Details{/s}
     {/block}
 
     {block name="frontend_listing_product_box_button_detail_container"}

--- a/themes/Frontend/Bare/frontend/listing/product-box/product-actions.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/product-actions.tpl
@@ -21,8 +21,9 @@
         {* Note button *}
         {block name='frontend_listing_box_article_actions_save'}
             <form action="{url controller='note' action='add' ordernumber=$sArticle.ordernumber _seo=false}" method="post">
+                {s name="DetailLinkNotepad" namespace="frontend/detail/actions" assign="snippetDetailLinkNotepad"}{/s}
                 <button type="submit"
-                   title="{"{s name='DetailLinkNotepad' namespace='frontend/detail/actions'}{/s}"|escape}"
+                   title="{$snippetDetailLinkNotepad|escape}"
                    class="product--action action--note"
                    data-ajaxUrl="{url controller='note' action='ajaxAdd' ordernumber=$sArticle.ordernumber _seo=false}"
                    data-text="{s name="DetailNotepadMarked"}{/s}">

--- a/themes/Frontend/Bare/frontend/listing/text.tpl
+++ b/themes/Frontend/Bare/frontend/listing/text.tpl
@@ -28,7 +28,8 @@
                         {block name="frontend_listing_text_content_short"}
                             <div class="teaser--text-short is--hidden">
                                 {$sCategoryContent.cmstext|strip_tags|truncate:200}
-                                <a href="#" title="{"{s namespace="frontend/listing/listing" name="ListingActionsOpenOffCanvas"}{/s}"|escape}" class="text--offcanvas-link">
+                                {s namespace="frontend/listing/listing" name="ListingActionsOpenOffCanvas" assign="snippetListingActionsOpenOffCanvas"}{/s}
+                                <a href="#" title="{$snippetListingActionsOpenOffCanvas|escape}" class="text--offcanvas-link">
                                     {s namespace="frontend/listing/listing" name="ListingActionsOpenOffCanvas"}{/s} &raquo;
                                 </a>
                             </div>
@@ -40,7 +41,8 @@
 
                                 {* Close Button *}
                                 {block name="frontend_listing_text_content_offcanvas_close"}
-                                    <a href="#" title="{"{s namespace="frontend/listing/listing" name="ListingActionsCloseOffCanvas"}{/s}"|escape}" class="close--off-canvas">
+                                    {s namespace="frontend/listing/listing" name="ListingActionsCloseOffCanvas" assign="snippetListingActionsCloseOffCanvas"}{/s}
+                                    <a href="#" title="{$snippetListingActionsCloseOffCanvas|escape}" class="close--off-canvas">
                                         <i class="icon--arrow-left"></i> {s namespace="frontend/listing/listing" name="ListingActionsCloseOffCanvas"}{/s}
                                     </a>
                                 {/block}

--- a/themes/Frontend/Bare/frontend/newsletter/detail.tpl
+++ b/themes/Frontend/Bare/frontend/newsletter/detail.tpl
@@ -22,7 +22,8 @@
 
                     {* Error message *}
                     {block name='frontend_newsletter_listing_error_message'}
-                        {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='NewsletterDetailInfoEmpty'}{/s}"}
+                        {s name="NewsletterDetailInfoEmpty" assign="snippetNewsletterDetailInfoEmpty"}{/s}
+                        {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetNewsletterDetailInfoEmpty}
                     {/block}
                 {/if}
 

--- a/themes/Frontend/Bare/frontend/newsletter/index.tpl
+++ b/themes/Frontend/Bare/frontend/newsletter/index.tpl
@@ -3,7 +3,8 @@
 {* Breadcrumb *}
 {block name='frontend_index_start'}
     {$smarty.block.parent}
-    {$sBreadcrumb = [['name' => "{s name='NewsletterTitle'}{/s}", 'link' => {url}]]}
+    {s name="NewsletterTitle" assign="snippetNewsletterTitle"}{/s}
+    {$sBreadcrumb = [['name' => $snippetNewsletterTitle, 'link' => {url}]]}
 {/block}
 
 {* Meta description *}

--- a/themes/Frontend/Bare/frontend/newsletter/listing.tpl
+++ b/themes/Frontend/Bare/frontend/newsletter/listing.tpl
@@ -68,7 +68,8 @@
             {else}
                 {* Error message *}
                 {block name='frontend_newsletter_listing_error_message'}
-                    {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='NewsletterListingInfoEmpty'}{/s}"}
+                    {s name="NewsletterListingInfoEmpty" assign="snippetNewsletterListingInfoEmpty"}{/s}
+                    {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetNewsletterListingInfoEmpty}
                 {/block}
             {/if}
 

--- a/themes/Frontend/Bare/frontend/note/index.tpl
+++ b/themes/Frontend/Bare/frontend/note/index.tpl
@@ -2,7 +2,8 @@
 
 {* Breadcrumb *}
 {block name='frontend_index_start'}
-    {$sBreadcrumb = [['name' => "{s name='NoteTitle'}{/s}", 'link' => {url}]]}
+    {s name="NoteTitle" assign="snippetNoteTitle"}{/s}
+    {$sBreadcrumb = [['name' => $snippetNoteTitle, 'link' => {url}]]}
     {$smarty.block.parent}
 {/block}
 

--- a/themes/Frontend/Bare/frontend/note/item.tpl
+++ b/themes/Frontend/Bare/frontend/note/item.tpl
@@ -120,10 +120,11 @@
                     {if {config name="compareShow"}}
                         <div class="note--compare">
                             <form action="{url controller='compare' action='add_article' articleID=$sBasketItem.articleID}" method="post">
+                                {s name="ListingBoxLinkCompare" assign="snippetListingBoxLinkCompare"}{/s}
                                 <button type="submit"
                                    data-product-compare-add="true"
                                    class="compare--link"
-                                   title="{"{s name='ListingBoxLinkCompare'}{/s}"|escape}">
+                                   title="{$snippetListingBoxLinkCompare|escape}">
                                     <i class="icon--compare"></i> {s name='ListingBoxLinkCompare'}{/s}
                                 </button>
                             </form>
@@ -136,7 +137,8 @@
         {* Remove article *}
         {block name="frontend_note_item_delete"}
             <form action="{url controller='note' action='delete' sDelete=$sBasketItem.id}" method="post">
-                <button type="submit" title="{"{s name='NoteLinkDelete'}{/s}"|escape}" class="note--delete">
+                {s name="NoteLinkDelete" assign="snippetNoteLinkDelete"}{/s}
+                <button type="submit" title="{$snippetNoteLinkDelete|escape}" class="note--delete">
                     <i class="icon--cross"></i>
                 </button>
             </form>

--- a/themes/Frontend/Bare/frontend/plugins/compare/index.tpl
+++ b/themes/Frontend/Bare/frontend/plugins/compare/index.tpl
@@ -13,9 +13,10 @@
 
 {* Compare button *}
 {block name='frontend_listing_box_article_actions_buy_now'}
+    {s name="ListingBoxLinkCompare" assign="snippetListingBoxLinkCompare"}{/s}
     <a href="{url controller='compare' action='add_article' articleID=$sArticle.articleID}"
        rel="nofollow"
-       title="{"{s name='ListingBoxLinkCompare'}{/s}"|escape}"
+       title="{$snippetListingBoxLinkCompare|escape}"
        class="product--action action--compare btn is--secondary is--icon-right">
         {s name='ListingBoxLinkCompare'}{/s}
         <i class="icon--arrow-right"></i>
@@ -25,7 +26,8 @@
 
 {* Compare button 2 *}
 {block name='frontend_detail_actions_notepad'}
-    <a href="{url controller='compare' action='add_article' articleID=$sArticle.articleID}" rel="nofollow" title="{"{s name='DetailActionLinkCompare'}{/s}"|escape}" class="action--link action--compare">
+    {s name="DetailActionLinkCompare" assign="snippetDetailActionLinkCompare"}{/s}
+    <a href="{url controller='compare' action='add_article' articleID=$sArticle.articleID}" rel="nofollow" title="{$snippetDetailActionLinkCompare|escape}" class="action--link action--compare">
         <i class="icon--compare"></i> {s name="DetailActionLinkCompare"}{/s}
     </a>
     {$smarty.block.parent}
@@ -33,7 +35,8 @@
 
 {* Compare button note *}
 {block name='frontend_note_item_actions_compare'}
-    <a href="{url controller='compare' action='add_article' articleID=$sBasketItem.articleID}" class="product--action action--compare btn is--secondary" title="{"{s name='ListingBoxLinkCompare'}{/s}"|escape}" rel="nofollow">
+    {s name="ListingBoxLinkCompare" assign="snippetListingBoxLinkCompare"}{/s}
+    <a href="{url controller='compare' action='add_article' articleID=$sBasketItem.articleID}" class="product--action action--compare btn is--secondary" title="{$snippetListingBoxLinkCompare|escape}" rel="nofollow">
         {s name='ListingBoxLinkCompare'}{/s}
     </a>
 {/block}

--- a/themes/Frontend/Bare/frontend/plugins/notification/index.tpl
+++ b/themes/Frontend/Bare/frontend/plugins/notification/index.tpl
@@ -3,23 +3,23 @@
 
     {if $NotifyValid == true}
         {$messageType="success"}
-        {$messageContent="{s name='DetailNotifyInfoValid'}{/s}"}
+        {s name="DetailNotifyInfoValid" assign="messageContent"}{/s}
     {elseif $NotifyInvalid == true && $NotifyAlreadyRegistered != true}
         {$messageType="warning"}
-        {$messageContent="{s name='DetailNotifyInfoInvalid'}{/s}"}
+        {s name="DetailNotifyInfoInvalid" assign="messageContent"}{/s}
     {elseif $NotifyEmailError == true}
         {$messageType="error"}
-        {$messageContent="{s name='DetailNotifyInfoErrorMail'}{/s}"}
+        {s name="DetailNotifyInfoErrorMail" assign="messageContent"}{/s}
     {elseif $WaitingForOptInApprovement}
         {$messageType="success"}
-        {$messageContent="{s name='DetailNotifyInfoSuccess'}{/s}"}
+        {s name="DetailNotifyInfoSuccess" assign="messageContent"}{/s}
     {elseif $NotifyAlreadyRegistered == true}
         {$messageType="warning"}
-        {$messageContent="{s name='DetailNotifyAlreadyRegistered'}{/s}"}
+        {s name="DetailNotifyAlreadyRegistered" assign="messageContent"}{/s}
     {else}
         {if $NotifyValid != true}
             {$messageType="warning"}
-            {$messageContent="{s name='DetailNotifyHeader'}{/s}"}
+            {s name="DetailNotifyHeader" assign="messageContent"}{/s}
         {/if}
     {/if}
 

--- a/themes/Frontend/Bare/frontend/register/index.tpl
+++ b/themes/Frontend/Bare/frontend/register/index.tpl
@@ -15,9 +15,10 @@
     {$smarty.block.parent}
     {block name='frontend_register_index_back_to_shop_button'}
         {if $theme.checkoutHeader && !$toAccount}
+            {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish" assign="snippetFinishButtonBackToShop"}{/s}
             <a href="{url controller='index'}"
                class="btn is--small btn--back-top-shop is--icon-left"
-               title="{"{s name='FinishButtonBackToShop' namespace='frontend/checkout/finish'}{/s}"|escape}">
+               title="{$snippetFinishButtonBackToShop|escape}">
                 <i class="icon--arrow-left"></i>
                 {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish"}{/s}
             </a>
@@ -119,9 +120,11 @@
                     {block name='frontend_register_index_form_optin_success'}
                         {if $smarty.get.optinsuccess && ({config name=optinregister} || {config name=optinaccountless})}
                             {if $isAccountless}
-                                {include file="frontend/_includes/messages.tpl" type="success" content="{s name="RegisterInfoSuccessOptinAccountless"}{/s}"}
+                                {s name="RegisterInfoSuccessOptinAccountless" assign="snippetRegisterInfoSuccessOptinAccountless"}{/s}
+                                {include file="frontend/_includes/messages.tpl" type="success" content=$snippetRegisterInfoSuccessOptinAccountless}
                             {else}
-                                {include file="frontend/_includes/messages.tpl" type="success" content="{s name="RegisterInfoSuccessOptin"}{/s}"}
+                                {s name="RegisterInfoSuccessOptin" assign="snippetRegisterInfoSuccessOptin"}{/s}
+                                {include file="frontend/_includes/messages.tpl" type="success" content=$snippetRegisterInfoSuccessOptin}
                             {/if}
                         {/if}
                     {/block}
@@ -129,7 +132,8 @@
                     {* Invalid hash while option verification process *}
                     {block name='frontend_register_index_form_optin_invalid_hash'}
                         {if $smarty.get.optinhashinvalid && ({config name=optinregister} || {config name=optinaccountless})}
-                            {include file="frontend/_includes/messages.tpl" type="error" content="{s name="RegisterInfoInvalidHash"}{/s}"}
+                            {s name="RegisterInfoInvalidHash" assign="snippetRegisterInfoInvalidHash"}{/s}
+                            {include file="frontend/_includes/messages.tpl" type="error" content=$snippetRegisterInfoInvalidHash}
                         {/if}
                     {/block}
 

--- a/themes/Frontend/Bare/frontend/register/login.tpl
+++ b/themes/Frontend/Bare/frontend/register/login.tpl
@@ -62,7 +62,8 @@
 
                         {block name='frontend_register_login_input_lostpassword'}
                             <div class="register--login-lostpassword">
-                                <a href="{url controller=account action=password}" title="{"{s name="LoginLinkLostPassword"}{/s}"|escape}">
+                                {s name="LoginLinkLostPassword" assign="snippetLoginLinkLostPassword"}{/s}
+                                <a href="{url controller=account action=password}" title="{$snippetLoginLinkLostPassword|escape}">
                                     {s name="LoginLinkLostPassword"}{/s}
                                 </a>
                             </div>

--- a/themes/Frontend/Bare/frontend/search/ajax.tpl
+++ b/themes/Frontend/Bare/frontend/search/ajax.tpl
@@ -24,7 +24,8 @@
                                     {if $search_result.image.thumbnails[0]}
                                         <img srcset="{$search_result.image.thumbnails[0].sourceSet}" alt="{$search_result.name|escape}" class="media--image">
                                     {else}
-                                        <img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{"{s name='ListingBoxNoPicture'}{/s}"|escape}" class="media--image">
+                                        {s name="ListingBoxNoPicture" assign="snippetListingBoxNoPicture"}{/s}
+                                        <img src="{link file='frontend/_public/src/img/no-picture.jpg'}" alt="{$snippetListingBoxNoPicture|escape}" class="media--image">
                                     {/if}
                                 </span>
                             {/block}

--- a/themes/Frontend/Bare/frontend/search/fuzzy.tpl
+++ b/themes/Frontend/Bare/frontend/search/fuzzy.tpl
@@ -3,9 +3,11 @@
 {* Breadcrumb *}
 {block name='frontend_index_start'}
     {if $sRequests.sSearchOrginal}
-        {$sBreadcrumb = [['name' => "{s name="SearchResultsFor"}{/s}"]]}
+        {s name="SearchResultsFor" assign="snippetSearchResultsFor"}{/s}
+        {$sBreadcrumb = [['name' => $snippetSearchResultsFor]]}
     {else}
-        {$sBreadcrumb = [['name' => "{s name="SearchResultsEmpty"}{/s}"]]}
+        {s name="SearchResultsEmpty" assign="snippetSearchResultsEmpty"}{/s}
+        {$sBreadcrumb = [['name' => $snippetSearchResultsEmpty]]}
     {/if}
     {$smarty.block.parent}
 {/block}
@@ -20,13 +22,15 @@
 
                     {* No results found *}
                     {block name='frontend_search_message_no_results'}
-                        {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='SearchFuzzyHeadlineNoResult'}{/s}"}
+                        {s name="SearchFuzzyHeadlineNoResult" assign="snippetSearchFuzzyHeadlineNoResult"}{/s}
+                        {include file="frontend/_includes/messages.tpl" type="warning" content=$snippetSearchFuzzyHeadlineNoResult}
                     {/block}
                 {else}
 
                     {* Given search term is too short *}
                     {block name='frontend_search_message_shortterm'}
-                        {include file="frontend/_includes/messages.tpl" type="error" content="{s name='SearchFuzzyInfoShortTerm'}{/s}"}
+                        {s name="SearchFuzzyInfoShortTerm" assign="snippetSearchFuzzyInfoShortTerm"}{/s}
+                        {include file="frontend/_includes/messages.tpl" type="error" content=$snippetSearchFuzzyInfoShortTerm}
                     {/block}
                 {/if}
             {/if}

--- a/themes/Frontend/Bare/frontend/sitemap/index.tpl
+++ b/themes/Frontend/Bare/frontend/sitemap/index.tpl
@@ -2,7 +2,8 @@
 
 {* Breadcrumb *}
 {block name="frontend_index_start"}
-    {$sBreadcrumb = [['name' => "{s name='SitemapTitle'}{/s}", 'link' => {url controller=sitemap}]]}
+    {s name="SitemapTitle" assign="snippetSitemapTitle"}{/s}
+    {$sBreadcrumb = [['name' => $snippetSitemapTitle, 'link' => {url controller=sitemap}]]}
     {$smarty.block.parent}
 {/block}
 
@@ -48,19 +49,22 @@
 
                                     {if $categoryTree.name == 'SitemapStaticPages'}
                                         {block name="frontend_sitemap_navigation_staticpages"}
-                                            <a href="{$categoryTree.link}" title="{"{s name='SitemapStaticPages'}{/s}"|escape}" class="sitemap--navigation-head-link is--active">
+                                            {s name="SitemapStaticPages" assign="snippetSitemapStaticPages"}{/s}
+                                            <a href="{$categoryTree.link}" title="{$snippetSitemapStaticPages|escape}" class="sitemap--navigation-head-link is--active">
                                                 {s name='SitemapStaticPages'}{/s}
                                             </a>
                                         {/block}
                                     {elseif $categoryTree.name == 'SitemapSupplierPages'}
                                         {block name="frontend_sitemap_navigation_supplierpages"}
-                                            <a href="{$categoryTree.link}" title="{"{s name='SitemapSupplierPages'}{/s}"|escape}" class="sitemap--navigation-head-link is--active">
+                                            {s name="SitemapSupplierPages" assign="snippetSitemapSupplierPages"}{/s}
+                                            <a href="{$categoryTree.link}" title="{$snippetSitemapSupplierPages|escape}" class="sitemap--navigation-head-link is--active">
                                                 {s name='SitemapSupplierPages'}{/s}
                                             </a>
                                         {/block}
                                     {elseif $categoryTree.name == 'SitemapLandingPages'}
                                         {block name="frontend_sitemap_navigation_landingpages"}
-                                            <a href="{$categoryTree.link}" title="{"{s name='SitemapLandingPages'}{/s}"|escape}" class="sitemap--navigation-head-link is--active">
+                                            {s name="SitemapLandingPages" assign="snippetSitemapLandingPages"}{/s}
+                                            <a href="{$categoryTree.link}" title="{$snippetSitemapLandingPages|escape}" class="sitemap--navigation-head-link is--active">
                                                 {s name='SitemapLandingPages'}{/s}
                                             </a>
                                         {/block}

--- a/themes/Frontend/Bare/frontend/tellafriend/index.tpl
+++ b/themes/Frontend/Bare/frontend/tellafriend/index.tpl
@@ -10,10 +10,12 @@
     <div class="content tellafriend--content right">
 
         {if $sSuccess}
-            {include file="frontend/_includes/messages.tpl" type="success" content="{s name='TellAFriendHeaderSuccess'}{/s}"}
+            {s name="TellAFriendHeaderSuccess" assign="snippetTellAFriendHeaderSuccess"}{/s}
+            {include file="frontend/_includes/messages.tpl" type="success" content=$snippetTellAFriendHeaderSuccess}
         {else}
             {if $sError}
-                {include file="frontend/_includes/messages.tpl" type="error" content="{s name='TellAFriendInfoFields'}{/s}"}
+                {s name="TellAFriendInfoFields" assign="snippetTellAFriendInfoFields"}{/s}
+                {include file="frontend/_includes/messages.tpl" type="error" content=$snippetTellAFriendInfoFields}
             {/if}
         {/if}
 

--- a/themes/Frontend/Bare/widgets/checkout/info.tpl
+++ b/themes/Frontend/Bare/widgets/checkout/info.tpl
@@ -1,7 +1,8 @@
 {* Notepad entry *}
 {block name="frontend_index_checkout_actions_notepad"}
     <li class="navigation--entry entry--notepad" role="menuitem">
-        <a href="{url controller='note'}" title="{"{s namespace='frontend/index/checkout_actions' name='IndexLinkNotepad'}{/s}"|escape}" class="btn">
+        {s namespace="frontend/index/checkout_actions" name="IndexLinkNotepad" assign="snippetIndexLinkNotepad"}{/s}
+        <a href="{url controller='note'}" title="{$snippetIndexLinkNotepad|escape}" class="btn">
             <i class="icon--heart"></i>
             {if $sNotesQuantity > 0}
                 <span class="badge notes--quantity">
@@ -68,7 +69,8 @@
 {* Cart entry *}
 {block name="frontend_index_checkout_actions_cart"}
     <li class="navigation--entry entry--cart" role="menuitem">
-        <a class="btn is--icon-left cart--link" href="{url controller='checkout' action='cart'}" title="{"{s namespace='frontend/index/checkout_actions' name='IndexLinkCart'}{/s}"|escape}">
+        {s namespace="frontend/index/checkout_actions" name="IndexLinkCart" assign="snippetIndexLinkCart"}{/s}
+        <a class="btn is--icon-left cart--link" href="{url controller='checkout' action='cart'}" title="{$snippetIndexLinkCart|escape}">
             <span class="cart--display">
                 {if $sUserLoggedIn}
                     {s name='IndexLinkCheckout' namespace='frontend/index/checkout_actions'}{/s}


### PR DESCRIPTION
### 1. Why is this change necessary?
If you use quotes in snippets generated smarty php will either syntactically or logically break.

It will also improve parsing errors like this:
![image](https://user-images.githubusercontent.com/1133593/47954793-f3986100-df8e-11e8-99f5-66b2a7a87131.png)
![image](https://user-images.githubusercontent.com/1133593/47954794-f6935180-df8e-11e8-838a-13dce5141633.png)

### 2. What does this change do, exactly?
Use variables instead of generated literals.

### 3. Describe each step to reproduce the issue or behaviour.
* Set an error message to something like: `This error can be solved <a href="/">here</a>.`
* The quotes will break the generated smarty php up into a `string divided by string` and renders as `NaN`.
* One could use single quotes instead although it is not easier to maintain or explain to end users.

### 4. Which documentation changes (if any) need to be made because of this PR?
A best practice hint to [smarty snippet assign](https://shyim.me/faq/smarty-assign-tpl/) would be nice.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.