### PR TITLE
handle orphaned image entries

### DIFF
--- a/engine/Shopware/Models/Article/Image.php
+++ b/engine/Shopware/Models/Article/Image.php
@@ -47,7 +47,7 @@ class Image extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ArticleImage", mappedBy="articleImage", orphanRemoval=true,cascade={"persist"})
+     * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ArticleImage", mappedBy="articleImage", orphanRemoval=true, cascade={"persist"})
      *
      * @var \Shopware\Models\Attribute\ArticleImage
      */
@@ -168,14 +168,14 @@ class Image extends ModelEntity
      *
      * @var Image
      *
-     * @ORM\ManyToOne(targetEntity="Image", inversedBy="children")
+     * @ORM\ManyToOne(targetEntity="Image", inversedBy="children", cascade={"persist"})
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id")
      */
     private $parent;
 
     /**
-     * @var \Doctrine\Common\Collections\ArrayCollection
-     * @ORM\OneToMany(targetEntity="Image", mappedBy="parent")
+     * @var Image[]|ArrayCollection
+     * @ORM\OneToMany(targetEntity="Image", mappedBy="parent", orphanRemoval=true, cascade={"persist"})
      */
     private $children;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
when removing a image association with a configuration some entries still exist in the db, leading to an error when loading the image entities again.

### 2. What does this change do, exactly?
add necessary doctrine annotations where needed

### 3. Describe each step to reproduce the issue or behaviour.
- edit a product with variations
- add a image to the product
- add a image configuration
- save and remove the image from the product
- in s_articles_img the entry for the variation is still present

### 4. Please link to the relevant issues (if any).
none as i know

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.