### PR TITLE
State description translation in customer orders

### DIFF
--- a/engine/Shopware/Controllers/Backend/Customer.php
+++ b/engine/Shopware/Controllers/Backend/Customer.php
@@ -24,6 +24,7 @@
 use Shopware\Bundle\AccountBundle\Service\CustomerUnlockServiceInterface;
 use Shopware\Components\CSRFWhitelistAware;
 use Shopware\Components\NumberRangeIncrementerInterface;
+use Shopware\Components\StateTranslatorService;
 use Shopware\Models\Customer\Address;
 use Shopware\Models\Customer\Customer;
 use Shopware\Models\Customer\PaymentData;
@@ -133,6 +134,16 @@ class Shopware_Controllers_Backend_Customer extends Shopware_Controllers_Backend
         $shop = $this->getShopRepository()->getBaseListQuery()->getArrayResult();
         $country = $this->getCountryRepository()->getCountriesQuery()->getArrayResult();
         $customerGroups = $this->getRepository()->getCustomerGroupsQuery()->getArrayResult();
+
+        /** @var \Shopware\Components\StateTranslatorServiceInterface $stateTranslator */
+        $stateTranslator = $this->get('shopware.components.state_translator');
+        $orderStatus = array_map(function ($orderStateItem) use ($stateTranslator) {
+            return $stateTranslator->translateState(StateTranslatorService::STATE_ORDER, $orderStateItem);
+        }, $orderStatus);
+
+        $paymentStatus = array_map(function ($paymentStateItem) use ($stateTranslator) {
+            return $stateTranslator->translateState(StateTranslatorService::STATE_PAYMENT, $paymentStateItem);
+        }, $paymentStatus);
 
         $this->View()->assign([
             'success' => true,


### PR DESCRIPTION
### 1. Why is this change necessary?
With the removal of the description of states you are forced to use the translation service. The customer backend controller hasn't seen the required changes and therefore just return the internal name which (at least) will be displayed as order and payment state instead.

### 2. What does this change do, exactly?
Translate both payment and order states loaded from _Shopware_Controllers_Backend_Customer::loadStores()_

### 3. Describe each step to reproduce the issue or behaviour.
Go to a customer and switch to the orders tab. There you will see only the internal state names.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.