### PR TITLE
Attributes in several AttributeBundle Searchers 

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Repository/Searcher/CustomerSearcher.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Repository/Searcher/CustomerSearcher.php
@@ -45,6 +45,7 @@ class CustomerSearcher extends GenericSearcher
         $builder->from(Customer::class, 'entity');
         $builder->innerJoin('entity.defaultBillingAddress', 'billing');
         $builder->innerJoin('entity.group', 'customerGroup');
+        $builder->leftJoin('entity.attribute', 'attribute');
         $builder->setAlias('entity');
 
         if ($criteria->params && $criteria->params['streamId']) {

--- a/engine/Shopware/Bundle/AttributeBundle/Repository/Searcher/OrderSearcher.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Repository/Searcher/OrderSearcher.php
@@ -43,6 +43,8 @@ class OrderSearcher extends GenericSearcher
         $query->leftJoin('entity.billing', 'billing');
         $query->leftJoin('entity.customer', 'customer');
         $query->leftJoin('billing.country', 'billingCountry');
+        $query->leftJoin('entity.documents', 'documents');
+        $query->leftJoin('entity.attribute', 'attribute');
         $query->setAlias('entity');
 
         return $query;
@@ -63,6 +65,7 @@ class OrderSearcher extends GenericSearcher
             'billing.zipCode^0.5',
             'billing.city^0.5',
             'billing.company^0.5',
+            'documents.documentId^1',
         ];
     }
 }

--- a/engine/Shopware/Bundle/AttributeBundle/Repository/Searcher/ProductSearcher.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Repository/Searcher/ProductSearcher.php
@@ -43,6 +43,7 @@ class ProductSearcher extends GenericSearcher
         $builder->select($this->getIdentifierField());
         $builder->from(Detail::class, 'entity');
         $builder->innerJoin('entity.article', 'article');
+        $builder->leftJoin('entity.attribute', 'attribute');
 
         if ($criteria->entity === 'Shopware\Models\Article\Article') {
             $builder->andWhere('entity.kind = 1');


### PR DESCRIPTION
### 1. Why is this change necessary?
You can't let existing Searchers  search for things that are stored in its attributes. Also the switch to the new search broke search by document number for orders.

### 2. What does this change do, exactly?
- Adds attribute relations to following searchers: ProductSearcher, OrderSearcher, CustomerSearcher.
- Adds document search by document number to OrderSearcher.


The added attributes are more a preparation as I couldn't find a good way to extend the getSearchFields without changing the interface yet.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22914

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.