### PR TITLE
Ie11 compatibility in backend restored

### DIFF
--- a/themes/Backend/ExtJs/backend/customer/model/address.js
+++ b/themes/Backend/ExtJs/backend/customer/model/address.js
@@ -68,7 +68,7 @@ Ext.define('Shopware.apps.Customer.model.Address', {
         { name: 'additionalAddressLine2', type: 'string', useNull: true },
         { name: 'countryId', type: 'int' },
         { name: 'stateId', type: 'int', useNull: true },
-        { name: 'phone', type: 'string', useNull: true },
+        { name: 'phone', type: 'string', useNull: true }
     ],
 
     associations: [

--- a/themes/Backend/ExtJs/backend/customer/view/detail/window.js
+++ b/themes/Backend/ExtJs/backend/customer/view/detail/window.js
@@ -616,7 +616,7 @@ Ext.define('Shopware.apps.Customer.view.detail.Window', {
                         return me.countryStateStore.getById(stateId).get('name');
                     }
                 }
-            },
+            }
         );
     },
 


### PR DESCRIPTION
* IE11 compatibility restored

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently, the backend doesnt work as expected with internet explorer 11. There's always a syntax error.

### 2. What does this change do, exactly?
Removes "," on last array item or functions

### 3. Describe each step to reproduce the issue or behaviour.
Just use a Internet Explorer 11 in the backend. After the login you'll get extjs popup that the customer module can't be loaded properly.

### 4. Please link to the relevant issues (if any).
none found

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.