### PR TITLE
Allow the Override of a Plugin Constructor

### DIFF
--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -65,7 +65,7 @@ abstract class Plugin implements ContainerAwareInterface, SubscriberInterface
     /**
      * @param bool $isActive
      */
-    final public function __construct($isActive)
+    public function __construct($isActive)
     {
         $this->isActive = (bool) $isActive;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
To allow manipulation before loading any Plugins etc.

### 2. What does this change do, exactly?
Removing final from the Plugin __construct

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.