### PR TITLE
Added code to remove temporary file and directory after media was pro…

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Media.php
+++ b/engine/Shopware/Components/Api/Resource/Media.php
@@ -254,6 +254,9 @@ class Media extends Resource
         /** @var Album $album */
         $album = $this->getManager()->find(Album::class, $albumId);
         if (!$album) {
+            // Cleanup temporary file
+            unlink($file);
+            rmdir(dirname($file));
             throw new ApiException\CustomValidationException(
                 sprintf('Album by id %s not found', $albumId)
             );
@@ -268,6 +271,10 @@ class Media extends Resource
             throw new ApiException\CustomValidationException(
                 sprintf('Some error occurred while persisting your media')
             );
+        } finally {
+            // Cleanup temporary file
+            unlink($file);
+            rmdir(dirname($file));
         }
 
         if ($media->getType() === MediaModel::TYPE_IMAGE) {


### PR DESCRIPTION
…cessed

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If media data is uploaded via API Shopware creates first a tempory file, removes this file immediatly and creates a temporary directory under the same name. The media is then copied into this directory for further processing. However after media data is added to Shopware, these temporary directories are not removed afterwards! This is a massive problem if you bulk-add a lot of articles with images, as the temporary directory gets filled quickly with orphaned files. One of our servers had more than 350.000 temporary directories which occupied nearly the complete hd storage!

### 2. What does this change do, exactly?
It first unlink() the temporary file and afterwards rmdir() the created temporary directory.

### 3. Describe each step to reproduce the issue or behaviour.
Add an article via API with at least one image included and watch your temporary directory. You can see directories being created for every image. But these directories won't disappear after the article was uploaded.

### 4. Please link to the relevant issues (if any).
No issue opened (yet), we do require a fast solution to this problem.

### 5. Which documentation changes (if any) need to be made because of this PR?
No documentation changes required.

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.