### PR TITLE
SW-22921 - adds .raw to field name in aggregations for product attrib…

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleES/FacetHandler/ProductAttributeFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/FacetHandler/ProductAttributeFacetHandler.php
@@ -32,6 +32,7 @@ use ONGR\ElasticsearchDSL\Search;
 use Shopware\Bundle\AttributeBundle\Service\ConfigurationStruct;
 use Shopware\Bundle\AttributeBundle\Service\CrudService;
 use Shopware\Bundle\AttributeBundle\Service\TypeMapping;
+use Shopware\Bundle\ESIndexingBundle\MappingInterface;
 use Shopware\Bundle\SearchBundle\Condition\ProductAttributeCondition;
 use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\SearchBundle\CriteriaPartInterface;
@@ -63,13 +64,19 @@ class ProductAttributeFacetHandler implements HandlerInterface, ResultHydratorIn
     private $crudService;
 
     /**
+     * @var MappingInterface
+     */
+    private $productMappingService;
+
+    /**
      * ProductAttributeFacetHandler constructor.
      *
      * @param CrudService $crudService
      */
-    public function __construct(CrudService $crudService)
+    public function __construct(CrudService $crudService, MappingInterface $productMappingService)
     {
         $this->crudService = $crudService;
+        $this->productMappingService = $productMappingService;
     }
 
     /**
@@ -90,7 +97,7 @@ class ProductAttributeFacetHandler implements HandlerInterface, ResultHydratorIn
         ShopContextInterface $context
     ) {
         /** @var ProductAttributeFacet $criteriaPart */
-        $field = 'attributes.core.' . $criteriaPart->getField();
+        $field = $this->getAggregationField($criteriaPart, $context);
         $this->criteriaParts[] = $criteriaPart;
 
         switch ($criteriaPart->getMode()) {
@@ -369,5 +376,46 @@ class ProductAttributeFacetHandler implements HandlerInterface, ResultHydratorIn
         }, $aggregation['buckets']);
 
         return $aggregation;
+    }
+
+    /**
+     * According to https://www.elastic.co/guide/en/elasticsearch/reference/5.6/_executing_aggregations.html
+     * aggregations for text fields shall use a keyword field, so according to the shopware elasticsearch product
+     * mapping we need to use the *.raw field for the aggregation.
+     *
+     * @param CriteriaPartInterface $criteriaPart
+     * @param ShopContextInterface  $context
+     *
+     * @return string
+     */
+    private function getAggregationField(CriteriaPartInterface $criteriaPart, ShopContextInterface $context)
+    {
+        /** @var ProductAttributeFacet $criteriaPart */
+        $field = 'attributes.core.' . $criteriaPart->getField();
+
+        if ($this->isTextAttribute($criteriaPart, $context)) {
+            $field .= '.raw';
+        }
+
+        return $field;
+    }
+
+    /**
+     * @param CriteriaPartInterface $criteriaPart
+     * @param ShopContextInterface  $context
+     *
+     * @return bool
+     */
+    private function isTextAttribute(CriteriaPartInterface $criteriaPart, ShopContextInterface $context)
+    {
+        /** @var ProductAttributeFacet $criteriaPart */
+        $productMappingService = $this->productMappingService->get($context->getShop());
+
+        if (isset($productMappingService['properties']['attributes']['properties']['core']['properties'][$criteriaPart->getField()]['type'])
+            && $productMappingService['properties']['attributes']['properties']['core']['properties'][$criteriaPart->getField()]['type'] == 'text') {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/engine/Shopware/Bundle/SearchBundleES/services.xml
+++ b/engine/Shopware/Bundle/SearchBundleES/services.xml
@@ -155,6 +155,7 @@
 
         <service id="shopware_search_es.product_attribute_facet_handler" class="Shopware\Bundle\SearchBundleES\FacetHandler\ProductAttributeFacetHandler">
             <argument type="service" id="shopware_attribute.crud_service" />
+            <argument type="service" id="shopware_elastic_search.product_mapping"/>
             <tag name="shopware_search_es.search_handler" />
         </service>
 


### PR DESCRIPTION
…ute filters of type text

### 1. Why is this change necessary?
If you build a product attribute filter with the data type text for the listing view, it will return unexpected values when you work with ElasticSearch. If you deactivate ElasticSearch, the correct values will be returned.

### 2. What does this change do, exactly?
The Change adds '.raw' to the aggregation field name if the data type of the product attribute is text.

### 3. Describe each step to reproduce the issue or behaviour.
The product need to have an attribute of data type text and the values begin with a capital letter . Add a product filter in the backend with that product attribute. In the frontend the Filter Drop Down shows the values with a lowercase letter. So clicking on that value doesnt work, no products are schown.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22921

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.