### PR TITLE
Use rsync to delete old cache directory

### DIFF
--- a/var/cache/clear_cache.sh
+++ b/var/cache/clear_cache.sh
@@ -17,4 +17,10 @@ rm -f $DIR/../../web/cache/*.txt
 
 $DIR/../../bin/console sw:generate:attributes
 
+if [[ -x "$(command -v rsync)" ]]; then
+    mkdir $DIR/blank
+    rsync -a --delete $DIR/blank $DIR/delete/
+    rm -Rf $DIR/blank
+fi
+
 rm -Rf $DIR/delete/


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
rm -Rf is really slow for small directory (my case 50gb in delete). Fastest easy solution is rsync
https://www.slashroot.in/which-is-the-fastest-method-to-delete-files-in-linux
https://www.dynamsoft.com/help/saw/start%20delta%20transfer.htm used by rsync

### 2. What does this change do, exactly?
Use rsync if available.

### 3. Describe each step to reproduce the issue or behaviour.
Clear a really large cache.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] I have read the contribution requirements and fulfil them.