### PR TITLE
Add notify event to seo rebuild cli command

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -20,6 +20,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 * Add product notification attributes
 * Added `DISTINCT` for `priceListingQuery` to improve ES indexing performance with activated variant filter
 * Added media optimizer overview to backend systeminfo
+* Added `notify`-event `Shopware_Command_RebuildSeoIndexCommand_CreateRewriteTable` that is triggered after the SEO index is rebuilt via cli command `sw:rebuild:seo:index`
 
 ### Changes
 

--- a/engine/Shopware/Commands/RebuildSeoIndexCommand.php
+++ b/engine/Shopware/Commands/RebuildSeoIndexCommand.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Commands;
 
+use Shopware\Components\ContainerAwareEventManager;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -61,6 +62,11 @@ class RebuildSeoIndexCommand extends ShopwareCommand
     protected $modelManager;
 
     /**
+     * @var ContainerAwareEventManager
+     */
+    protected $events;
+
+    /**
      * {@inheritdoc}
      */
     protected function configure()
@@ -85,6 +91,7 @@ class RebuildSeoIndexCommand extends ShopwareCommand
         $this->modelManager = $this->container->get('models');
         $this->seoIndex = $this->container->get('SeoIndex');
         $this->rewriteTable = $this->modules->RewriteTable();
+        $this->events = $this->container->get('events');
 
         $shops = $input->getArgument('shopId');
 
@@ -141,6 +148,14 @@ class RebuildSeoIndexCommand extends ShopwareCommand
             $this->rewriteTable->sCreateRewriteTableBlog();
             $this->rewriteTable->createManufacturerUrls($context);
             $this->rewriteTable->sCreateRewriteTableStatic();
+
+            $this->events->notify(
+                'Shopware_Command_RebuildSeoIndexCommand_CreateRewriteTable',
+                [
+                    'shopContext' => $context,
+                    'cachedTime'  => $currentTime,
+                ]
+            );
         }
 
         $output->writeln('The SEO index was rebuild successfully.');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Currently, the only way to react to SEO Index rebuild via CLI is via a hook on a called function inside the command. A dedicated notify-event would be preferable as it is potentially more update-safe.

Also, every time a hook is used, a little kitten dies.

### 2. What does this change do, exactly?

Add a `notify`-event to `\Shopware\Commands\RebuildSeoIndexCommand::execute()` named `Shopware_Command_RebuildSeoIndexCommand_CreateRewriteTable`, triggered once for each subshop like in the CronJob implementation

### 3. Describe each step to reproduce the issue or behaviour.

Rebuild SEO-Index via CLI command. All options described [here](https://developers.shopware.com/blog/2017/07/24/seo-urls-in-plugins/) fail.

### 4. Please link to the relevant issues (if any).

-/-

### 5. Which documentation changes (if any) need to be made because of this PR?

The new event could be added to [this article](https://developers.shopware.com/blog/2017/07/24/seo-urls-in-plugins/).

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.