### PR TITLE
Increase progress bar update frequency on cli thumbnail generation

### DIFF
--- a/engine/Shopware/Commands/ThumbnailGenerateCommand.php
+++ b/engine/Shopware/Commands/ThumbnailGenerateCommand.php
@@ -170,6 +170,7 @@ class ThumbnailGenerateCommand extends ShopwareCommand
         $total = $paginator->count();
 
         $progressBar = new ProgressBar($this->output, $total);
+        $progressBar->setRedrawFrequency(10);
         $progressBar->start();
 
         /* @var Media $media */


### PR DESCRIPTION
### 1. Why is this change necessary?

Did you ever thought the function is not working when the progress bar is not moving? I do ;) Given, you are trying to generate new thumbnails via CLI the progress bar updates veeeeery rarely. In fact only every 10%. If you have e.g. 20k images to process, this may be once every 2-3 hours. Someone may think it's dead, if it's not moving ;)

```
Generating Thumbnails for Album Artikel (ID: -1)
    0/27189 [>---------------------------]   0%
 2718/27189 [==>-------------------------]   9%
 5436/27189 [=====>----------------------]  19%
 8154/27189 [========>-------------------]  29%
10872/27189 [===========>----------------]  39%
13590/27189 [=============>--------------]  49%
16308/27189 [================>-----------]  59%
19026/27189 [===================>--------]  69%
21744/27189 [======================>-----]  79%
24462/27189 [=========================>--]  89%
27180/27189 [===========================>]  99%
27189/27189 [============================] 100%
```

### 2. What does this change do, exactly?

It reduces the update frequency to every 10th image.

### 3. Describe each step to reproduce the issue or behaviour.

Generate thumbs on a installation with lots of images via cli. Wait for progress bar to move.

### 4. Please link to the relevant issues (if any).

None I'm aware of.

### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.