### PR TITLE
Made Shopware()->DocPath() compatible with composer installations

### DIFF
--- a/engine/Shopware/Application.php
+++ b/engine/Shopware/Application.php
@@ -51,11 +51,6 @@ class Shopware extends Enlight_Application
     protected $appPath;
 
     /**
-     * @var string
-     */
-    protected $docPath;
-
-    /**
      * @var Container
      */
     protected $container;
@@ -70,7 +65,6 @@ class Shopware extends Enlight_Application
 
         $this->container = $container;
         $this->appPath = __DIR__ . DIRECTORY_SEPARATOR;
-        $this->docPath = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR;
 
         parent::__construct();
     }
@@ -155,7 +149,7 @@ class Shopware extends Enlight_Application
      */
     public function DocPath($path = null)
     {
-        return $this->normalizePath($this->docPath, $path);
+        return $this->normalizePath($this->container->getParameter('shopware.app.rootDir'), $path);
     }
 
     /**

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -23,10 +23,12 @@
  */
 use Shopware\Components\Logger;
 
-if (file_exists($this->DocPath() . 'config_' . $this->Environment() . '.php')) {
-    $customConfig = $this->loadConfig($this->DocPath() . 'config_' . $this->Environment() . '.php');
+$projectDir = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR;
+
+if (file_exists($projectDir . 'config_' . $this->Environment() . '.php')) {
+    $customConfig = $this->loadConfig($projectDir . 'config_' . $this->Environment() . '.php');
 } elseif (file_exists($this->DocPath() . 'config.php')) {
-    $customConfig = $this->loadConfig($this->DocPath() . 'config.php');
+    $customConfig = $this->loadConfig($projectDir . 'config.php');
 } else {
     $customConfig = [];
 }
@@ -49,13 +51,13 @@ return array_replace_recursive([
         'private' => [
             'type' => 'local',
             'config' => [
-                'root' => realpath(__DIR__ . '/../../../files/'),
+                'root' => $projectDir . 'files' . DIRECTORY_SEPARATOR,
             ],
         ],
         'public' => [
             'type' => 'local',
             'config' => [
-                'root' => realpath(__DIR__ . '/../../../web/'),
+                'root' => $projectDir . 'web' . DIRECTORY_SEPARATOR,
                 'url' => '',
             ],
         ],
@@ -78,7 +80,7 @@ return array_replace_recursive([
                         'private' => 0700 & ~umask(),
                     ],
                 ],
-                'root' => realpath(__DIR__ . '/../../../'),
+                'root' => $projectDir,
             ],
             'ftp' => [
                 'type' => 'ftp',
@@ -175,8 +177,8 @@ return array_replace_recursive([
         'Default' => $this->AppPath('Plugins_Default'),
         'Local' => $this->AppPath('Plugins_Local'),
         'Community' => $this->AppPath('Plugins_Community'),
-        'ShopwarePlugins' => $this->DocPath('custom_plugins'),
-        'ProjectPlugins' => $this->DocPath('custom_project'),
+        'ShopwarePlugins' => $projectDir . 'custom/plugins/',
+        'ProjectPlugins' => $projectDir . 'custom/project/',
     ],
     'template' => [
         'compileCheck' => true,
@@ -188,7 +190,7 @@ return array_replace_recursive([
         'forceCache' => false,
         'cacheDir' => $this->getCacheDir() . '/templates',
         'compileDir' => $this->getCacheDir() . '/templates',
-        'templateDir' => $this->DocPath('themes'),
+        'templateDir' => $projectDir . 'themes',
     ],
     'mail' => [
         'charset' => 'utf-8',
@@ -306,19 +308,19 @@ return array_replace_recursive([
         ],
     ],
     'app' => [
-        'rootDir' => $this->DocPath(),
-        'downloadsDir' => $this->DocPath('files_downloads'),
-        'documentsDir' => $this->DocPath('files_documents'),
+        'rootDir' => $projectDir,
+        'downloadsDir' => $projectDir . 'files/downloads',
+        'documentsDir' => $projectDir . 'files/documents',
     ],
     'web' => [
-        'webDir' => $this->DocPath('web'),
-        'cacheDir' => $this->DocPath('web_cache'),
+        'webDir' => $projectDir . 'web',
+        'cacheDir' => $projectDir . 'web/cache',
     ],
     'mpdf' => [
         // Passed to \Mpdf\Mpdf::__construct:
         'defaultConfig' => [
             'tempDir' => $this->getCacheDir() . '/mpdf/',
-            'fontDir' => $this->DocPath('engine_Library_Mpdf_ttfonts_'),
+            'fontDir' => $projectDir . 'engine/Library/Mpdf/ttfonts/',
             'fonttrans' => [
                 'helvetica' => 'arial',
                 'verdana' => 'arial',


### PR DESCRIPTION
### 1. Why is this change necessary?
When used in a composer installation the method `Shopware()->DocPath()` would return `vendor/shopware/shopware/` instead of the actual project root directory.

### 2. What does this change do, exactly?
The project root is now determined by `dirname(dirname(dirname(__DIR__)))` and will be used throughout the config. Also the `Shopware()->DocPath()` method now return the config value of `app.rootDir`.

### 3. Describe each step to reproduce the issue or behaviour.
Run `Shopware()->DocPath()` in a composer installation.

### 4. Please link to the relevant issues (if any).
Dunno.

### 5. Which documentation changes (if any) need to be made because of this PR?
Dunno.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.