### PR TITLE
fix StateManager miscalculation for iOS > 10

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
@@ -1136,7 +1136,7 @@
                 return width;
             }
 
-            return (width = document.documentElement.clientWidth) !== 0 ? width : document.body.clientWidth;
+            return (width >= document.documentElement.clientWidth) ? width : document.body.clientWidth;
         },
 
         /**
@@ -1153,7 +1153,7 @@
                 return height;
             }
 
-            return (height = document.documentElement.clientHeight) !== 0 ? height : document.body.clientHeight;
+            return (height >= document.documentElement.clientHeight) ? height : document.body.clientHeight;
         },
 
         /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
- this fixes wrong calculation for viewport-width in statemanager since iOS ignores "user-scalable=no" meta-value

### 2. What does this change do, exactly?
- it returns the correct value if window is zoomed
- it makes the operation more readable

### 3. Describe each step to reproduce the issue or behaviour.
- use Safari on iPad on iOS > 10 (wich is ignoring "user-scalable=no")
- scroll to elements relying on State Manager e.g. .column-headline in footer on https://www.shopwaredemo.de/
-  pinch-zoom a little bit (zoom > 1)
- tap mutiple times on title-element (e.g. "Newsletter")
- see content collapsing

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.