### PR TITLE
Media Garbage Collector: Take account for attribute html fields

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/GarbageCollectorFactory.php
+++ b/engine/Shopware/Bundle/MediaBundle/GarbageCollectorFactory.php
@@ -26,6 +26,7 @@ namespace Shopware\Bundle\MediaBundle;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Connection;
+use Shopware\Bundle\AttributeBundle\Service\TypeMapping;
 use Shopware\Bundle\MediaBundle\Struct\MediaPosition;
 
 /**
@@ -141,7 +142,7 @@ class GarbageCollectorFactory
             ->andWhere('column_type = :columnType')
             ->setParameters([
                 'entityName' => \Shopware\Models\Media\Media::class,
-                'columnType' => 'single_selection',
+                'columnType' => TypeMapping::TYPE_SINGLE_SELECTION,
             ])
             ->execute()
             ->fetchAll();
@@ -158,13 +159,28 @@ class GarbageCollectorFactory
             ->andWhere('column_type = :columnType')
             ->setParameters([
                 'entityName' => \Shopware\Models\Media\Media::class,
-                'columnType' => 'multi_selection',
+                'columnType' => TypeMapping::TYPE_MULTI_SELECTION,
             ])
             ->execute()
             ->fetchAll();
 
         foreach ($multiSelectionColumns as $attribute) {
             $mediaPositions[] = new MediaPosition($attribute['table_name'], $attribute['column_name'], 'id', MediaPosition::PARSE_PIPES);
+        }
+
+        // values as path in html/smarty code
+        $htmlColumns = $this->connection->createQueryBuilder()
+            ->select(['table_name', 'column_name'])
+            ->from('s_attribute_configuration')
+            ->andWhere('column_type = :columnType')
+            ->setParameters([
+                'columnType' => TypeMapping::TYPE_HTML,
+            ])
+            ->execute()
+            ->fetchAll();
+
+        foreach ($htmlColumns as $attribute) {
+            $mediaPositions[] = new MediaPosition($attribute['table_name'], $attribute['column_name'], 'path', MediaPosition::PARSE_HTML);
         }
 
         return $mediaPositions;


### PR DESCRIPTION
### 1. Why is this change necessary?

The Media Garbage Collector moves unused media items to the trash bin. If one created attribute fields as HTML/rich text field and used images in the editor, these usage will not be taken into account for cleaning unused files.

### 2. What does this change do, exactly?

Added a routine to check all html in attributes.

### 3. Describe each step to reproduce the issue or behaviour.

1. Upload new image into a desired album (not trash bin) in media manager.
2. Create attribute field of type "html" on an entity of your choice.
3. Navigate to entity and use the HTML editor to select the uploaded image. Save.
4. Spin on media gargabe collector via cronjob or console command.
5. You image has been moved from the former album to trash bin.

### 4. Please link to the relevant issues (if any).

None aware of.

### 5. Which documentation changes (if any) need to be made because of this PR?

None aware of.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.