### PR TITLE
[SW-23002] Feature/sysinfo check fileinfo extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Visit the forum at <http://forum.shopware.com/>
 -   <a href="http://php.net/manual/en/book.zip.php" target="_blank">zip</a>
 -   <a href="http://php.net/manual/en/book.zlib.php" target="_blank">zlib</a>
 -   <a href="http://php.net/manual/en/ref.pdo-mysql.php" target="_blank">PDO/MySQL</a>
+-   <a href="http://php.net/manual/de/book.fileinfo.php" target="_blank">fileinfo</a>
 
 ### Installation via Git
 

--- a/engine/Shopware/Components/Check/Data/System.xml
+++ b/engine/Shopware/Components/Check/Data/System.xml
@@ -56,6 +56,9 @@
         <name>simplexml</name><group>extension</group><required>1</required>
     </requirement>
     <requirement>
+        <name>fileinfo</name><group>extension</group><required>1</required>
+    </requirement>
+    <requirement>
         <name>ini_set</name><group>config</group><required>1</required>
     </requirement>
     <requirement>


### PR DESCRIPTION
### 1. Why is this change necessary?
add check for php extension fileinfo, required for file/image upload.

### 2. What does this change do, exactly?
It add a php extension check for fileinfo

### 3. Describe each step to reproduce the issue or behaviour.
use a php installation without fileinfo extension and you can not upload any files

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-23002

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.