### PR TITLE
[SW-23003] fix Exception Object Constructor call

### DIFF
--- a/engine/Shopware/Components/Thumbnail/Manager.php
+++ b/engine/Shopware/Components/Thumbnail/Manager.php
@@ -100,7 +100,7 @@ class Manager
         $imagePath = $media->getPath();
 
         if ($media->getType() !== $media::TYPE_IMAGE) {
-            throw new \Exception('File %s is not an image.', $imagePath);
+            throw new \Exception(sprintf('File %s is not an image.', $imagePath));
         }
 
         if (empty($thumbnailSizes)) {


### PR DESCRIPTION
### 1. Why is this change necessary?
see: https://issues.shopware.com/issues/SW-23003


### 2. What does this change do, exactly?
corrects the Exceptions Object initialisation

### 3. Describe each step to reproduce the issue or behaviour.
delete or rename an image file thats within an album and try to recrate thumbnails

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-23003


### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.