### PR TITLE
Correct spelling error

### DIFF
--- a/engine/Shopware/Components/MultiEdit/Resource/Product/BatchProcess.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/BatchProcess.php
@@ -142,7 +142,7 @@ class BatchProcess
                 case 'bigint':
                 case 'decimal':
                 case 'float':
-                    $attributes[$attribute] = ['set', 'add', 'subtract', 'devide', 'multiply'];
+                    $attributes[$attribute] = ['set', 'add', 'subtract', 'divide', 'multiply'];
                     break;
                 case 'text':
                 case 'string':
@@ -210,6 +210,7 @@ class BatchProcess
                 case 'removestring':
                     $builder->set("{$prefix}.$column", new \Doctrine\ORM\Query\Expr\Literal("REPLACE({$prefix}.{$column}, '{$operation['value']}', '')"));
                     break;
+                case 'divide':
                 case 'devide':
                     $builder->set("{$prefix}.$column", $builder->expr()->quot("{$prefix}.$column", $operationValue));
                     break;


### PR DESCRIPTION
### 1. Why is this change necessary?
Because "devide" doesn't exist in english language it's mandatory to correct this spelling error. Therefore "devide" becomes "divide"

### 2. What does this change do, exactly?
The misspelled "devide" becomes "divide"

### 3. Describe each step to reproduce the issue or behaviour.
Just replace "devide" by "divide" at two different places in the BatchProcess.php class 

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.