### PR TITLE
Add CustomEventPolyfill for removing Error in IE11

### DIFF
--- a/themes/Frontend/Responsive/Theme.php
+++ b/themes/Frontend/Responsive/Theme.php
@@ -81,6 +81,7 @@ class Theme extends \Shopware\Components\Theme
         'vendors/js/jquery/jquery.min.js',
         'src/js/jquery.symbol-polyfill.js',
         'vendors/js/picturefill/picturefill.min.js',
+        'vendors/js/customEventPolyfill/customeventpolyfill.min.js',
         'vendors/js/jquery.transit/jquery.transit.js',
         'vendors/js/jquery.event.move/jquery.event.move.js',
         'vendors/js/jquery.event.swipe/jquery.event.swipe.js',

--- a/themes/Frontend/Responsive/frontend/_public/vendors/js/customEventPolyfill/customeventpolyfill.js
+++ b/themes/Frontend/Responsive/frontend/_public/vendors/js/customEventPolyfill/customeventpolyfill.js
@@ -1,0 +1,15 @@
+// https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
+(function () {
+    if ( typeof window.CustomEvent === "function" ) return false;
+
+    function CustomEvent ( event, params ) {
+        params = params || { bubbles: false, cancelable: false, detail: undefined };
+        var evt = document.createEvent( 'CustomEvent' );
+        evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+        return evt;
+    }
+
+    CustomEvent.prototype = window.Event.prototype;
+
+    window.CustomEvent = CustomEvent;
+})();

--- a/themes/Frontend/Responsive/frontend/_public/vendors/js/customEventPolyfill/customeventpolyfill.min.js
+++ b/themes/Frontend/Responsive/frontend/_public/vendors/js/customEventPolyfill/customeventpolyfill.min.js
@@ -1,0 +1,1 @@
+!function(){if("function"==typeof window.CustomEvent)return!1;function t(t,e){e=e||{bubbles:!1,cancelable:!1,detail:void 0};var n=document.createEvent("CustomEvent");return n.initCustomEvent(t,e.bubbles,e.cancelable,e.detail),n}t.prototype=window.Event.prototype,window.CustomEvent=t}();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`jquery.transit` is causing an CustomEvent Error in IE11 while scrolling. This Error can be reproduced on [shopwaredemo.de](shopwaredemo.de)

### 2. What does this change do, exactly?
I've added the customEventPolyfill for removing this error.

### 3. Describe each step to reproduce the issue or behaviour.
Just open [shopwaredemo.de](shopwaredemo.de) with an IE11 (Win7) and start scrolling up and down. You will get a lot off Errors in the Console.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.