### PR TITLE
Make Country::$allowShipping default to true to restore backwards compatibility with 5.5.2

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -44,6 +44,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 * Changed default groupKey to get correct subpages of custom pages in mobile menu
 * Changed some mailer options to combo boxes to avoid wrong entries
 * Changed CSV import of snippets to only remove one apostrophe from the beginning of a line 
+* New countries created via programming interfaces default to allowing shipping to restore backwards compatibility to versions before Shopware 5.5.3.
 
 ## 5.5.3
 

--- a/_sql/migrations/1448-set-default-country-allow-shipping-true.php
+++ b/_sql/migrations/1448-set-default-country-allow-shipping-true.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+class Migrations_Migration1448 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('ALTER TABLE `s_core_countries` ALTER COLUMN `allow_shipping` SET DEFAULT 1');
+    }
+}

--- a/engine/Shopware/Models/Country/Country.php
+++ b/engine/Shopware/Models/Country/Country.php
@@ -175,7 +175,7 @@ class Country extends ModelEntity
      *
      * @ORM\Column(name="allow_shipping", type="boolean", nullable=false)
      */
-    private $allowShipping = false;
+    private $allowShipping = true;
 
     /**
      * @var \Doctrine\Common\Collections\ArrayCollection


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Commit https://github.com/shopware/shopware/commit/affcab35459c2a3528b113b0822214a757dd695f#diff-83a08850c6e3a09dfc2638a5828a6fa5R178, released in Shopware v5.5.3, was a breaking change that broke backwards compatibility with the 5.5 series and any previous version of Shopware.

Newly created instances of the `Country` set `allowShipping` to `false` in Shopware v5.5.3 by default.

For example, before this fix, countries programmatically created could no longer be used as part of a new customer's address when creating a customer via the Resource API, as that API would not allow creating a customer with an address located in a country to which shipping is disabled.

To be compatible to Shopware 5.5.3, one had to call `$country->setAllowShipping(true);`, which was not required in previous versions. Hence, `allowShipping` is now set to `true` by default, making any special handling for Shopware 5.5.3 unnecessary.

### 2. What does this change do, exactly?

`Country::$allowShipping` is now `true` by default when creating new instances.

### 3. Describe each step to reproduce the issue or behaviour.

An example case, which shows the broken backwards compatibility:

A country where `allowShipping` is `false` cannot be in the shipping or billing address of a _new_ customer when creating one via the [Customer API Resource](https://github.com/shopware/shopware/blob/affcab35459c2a3528b113b0822214a757dd695f/engine/Shopware/Components/Api/Resource/Customer.php#L46). Attempting to do so causes the following exception:

`Shopware\Components\Api\Exception\CustomValidationException: Country by id 38 is not available for shipping`

> thrown in [shopware/engine/Shopware/Components/Api/Resource/Customer.php:602](https://github.com/shopware/shopware/blob/affcab35459c2a3528b113b0822214a757dd695f/engine/Shopware/Components/Api/Resource/Customer.php#L602)


### 4. Please link to the relevant issues (if any).

No known relevant issues.

### 5. Which documentation changes (if any) need to be made because of this PR?

None, besides the included change entry in `UPGRADE-5.5.md`.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.