### PR TITLE
jquery.emotion.js: Update the wrapperSelector in the init function for not overriding the plugin when changing the class

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
@@ -345,7 +345,7 @@
 
             me.$contentMain = $('.content-main');
             me.$container = me.$el.parents('.content--emotions');
-            me.$wrapper = me.$el.parents('.emotion--wrapper');
+            me.$wrapper = me.$el.parents(me.opts.wrapperSelector);
 
             me.$elements = me.$el.find(me.opts.elementSelector);
             me.$gridSizer = me.$el.find(me.opts.gridSizerSelector);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
It's necessary for not overriding the Init function of this Plugin when just changing the `emotion--wrapper` class

### 2. What does this change do, exactly?
The Init function uses the Classname of the `wrapperSelector` defined in the Plugin Options.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.