### PR TITLE
AJAX add to cart: add article before accessories

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -1549,6 +1549,8 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
         $orderNumber = $this->Request()->getParam('sAdd');
         $quantity = $this->Request()->getParam('sQuantity');
 
+        $this->basket->sAddArticle($orderNumber, $quantity);
+        
         $this->View()->assign(
             'basketInfoMessage',
             $this->getInstockInfo($orderNumber, $quantity)
@@ -1560,8 +1562,6 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
                 $this->Request()->getParam('sAddAccessoriesQuantity')
             );
         }
-
-        $this->basket->sAddArticle($orderNumber, $quantity);
 
         $this->forward('ajaxCart');
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

When putting an article with accessories into the cart via ajax action, the accessories will be put first before the article. This will result in a reverse sort order in cart, which is confusing for the customer. Also, this behavior isn't equivalent to the corresponding non-ajax action, which will add the items in the reverse order (article first, accessories second).

### 2. What does this change do, exactly?

Change article/accessories order for ajax add to cart action. 

### 3. Describe each step to reproduce the issue or behaviour.

Make a request like this:

POST /checkout/ajaxAddArticleCart
Payload:
sActionIdentifier: 
sAddAccessories: 
sAdd: L2.1.00305.0
sQuantity: 1
sAddAccessories[0]: A0.6.00005
sAddAccessoriesQuantity[0]: 1
sAddAccessories[1]: A0.6.00183
sAddAccessoriesQuantity[1]: 1
isXHR: 1

### 4. Please link to the relevant issues (if any).

Not aware of.

### 5. Which documentation changes (if any) need to be made because of this PR?

Not aware of.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.