### PR TITLE
Created a new block around the search results

### DIFF
--- a/themes/Backend/ExtJs/backend/search/index.tpl
+++ b/themes/Backend/ExtJs/backend/search/index.tpl
@@ -3,30 +3,32 @@
 {block name="backend/search/index"}
     <div class="search-wrapper">
         <div class="arrow-top"></div>
-        {if !$searchResult.articles && !$searchResult.customers && !$searchResult.orders}
-            {block name="backend/search/index/result_empty_header"}
-                <div class="header">
-                    <div class="inner">
-                        {s name="title/empty_search"}No search results{/s}
+        {block name="backend/search/index/result"}
+            {if !$searchResult.articles && !$searchResult.customers && !$searchResult.orders}
+                {block name="backend/search/index/result_empty_header"}
+                    <div class="header">
+                        <div class="inner">
+                            {s name="title/empty_search"}No search results{/s}
+                        </div>
                     </div>
-                </div>
-            {/block}
+                {/block}
 
-            {block name="backend/search/index/result_empty_content"}
-                <div class="result-container">
-                    <div class="empty">{s name="item/empty"}No search results{/s}</div>
-                </div>
-            {/block}
-        {else}
-            {if $searchResult.articles}
-                {include file="backend/search/articles.tpl"}
+                {block name="backend/search/index/result_empty_content"}
+                    <div class="result-container">
+                        <div class="empty">{s name="item/empty"}No search results{/s}</div>
+                    </div>
+                {/block}
+            {else}
+                {if $searchResult.articles}
+                    {include file="backend/search/articles.tpl"}
+                {/if}
+                {if $searchResult.customers}
+                    {include file="backend/search/customers.tpl"}
+                {/if}
+                {if $searchResult.orders}
+                    {include file="backend/search/orders.tpl"}
+                {/if}
             {/if}
-            {if $searchResult.customers}
-                {include file="backend/search/customers.tpl"}
-            {/if}
-            {if $searchResult.orders}
-                {include file="backend/search/orders.tpl"}
-            {/if}
-        {/if}
+        {/block}
     </div>
 {/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
Before this commit, it was impossible to extend the search-results using a custom type (like a custom model) because template extensions would appear outside of the search results popup. 


### 2. What does this change do, exactly?
It creates another smarty-block to define the stuff *inside* the results popup. 


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.