### PR TITLE
Fixed missing attributes in sORDER mail

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -1917,21 +1917,31 @@ EOT;
      */
     private function getUserDataForMail(array $userData)
     {
-        array_walk_recursive($userData['billingaddress'], function (&$value) {
-            $value = html_entity_decode($value);
-        });
-        array_walk_recursive($userData['shippingaddress'], function (&$value) {
-            $value = html_entity_decode($value);
-        });
-        array_walk_recursive($userData['additional']['country'], function (&$value) {
-            $value = html_entity_decode($value);
-        });
+        $userData['billingaddress'] = $this->htmlEntityDecodeRecursive($userData['billingaddress']);
+        $userData['shippingaddress'] = $this->htmlEntityDecodeRecursive($userData['shippingaddress']);
+        $userData['country'] = $this->htmlEntityDecodeRecursive($userData['country']);
 
         $userData['additional']['payment']['description'] = html_entity_decode(
             $userData['additional']['payment']['description']
         );
 
         return $userData;
+    }
+
+    /**
+     * Helper function to recursively apply html_entity_decode() to the given data.
+     *
+     * @param array|string $data
+     *
+     * @return array|string
+     */
+    private function htmlEntityDecodeRecursive($data)
+    {
+        $func = function ($item) use (&$func) {
+            return is_array($item) ? array_map($func, $item) : call_user_func('html_entity_decode', $item);
+        };
+
+        return array_map($func, $data);
     }
 
     /**

--- a/tests/Functional/Core/sOrderTest.php
+++ b/tests/Functional/Core/sOrderTest.php
@@ -206,15 +206,23 @@ class sOrderTest extends PHPUnit\Framework\TestCase
             'billingaddress' => [
                 1 => "I'll &quot;walk&quot; the &lt;b&gt;dog&lt;/b&gt; now",
                 2 => "I'll &quot;walk&quot; the &lt;b&gt;dog&lt;/b&gt; later",
+                'attributes' => [
+                    'foo' => "I'll &quot;walk&quot; the &lt;b&gt;dog&lt;/b&gt; now",
+                    'bar' => "I'll &quot;walk&quot; the &lt;b&gt;dog&lt;/b&gt; later",
+                ],
             ],
             'shippingaddress' => [
                 1 => "I won't &quot;walk&quot; the &lt;b&gt;dog&lt;/b&gt; now",
                 2 => "I won't &quot;walk&quot; the &lt;b&gt;dog&lt;/b&gt; later",
+                'attributes' => [
+                    'foo' => "I'll &quot;walk&quot; the &lt;b&gt;dog&lt;/b&gt; now",
+                    'bar' => "I'll &quot;walk&quot; the &lt;b&gt;dog&lt;/b&gt; later",
+                ],
+            ],
+            'country' => [
+                1 => '&lt;span&gt;dog&lt;/span&gt;',
             ],
             'additional' => [
-                'country' => [
-                    1 => '&lt;span&gt;dog&lt;/span&gt;',
-                ],
                 'payment' => [
                     'description' => '&lt;span&gt;dog&lt;/span&gt;',
                 ],
@@ -228,16 +236,25 @@ class sOrderTest extends PHPUnit\Framework\TestCase
         );
 
         $this->assertArrayHasKey('billingaddress', $processedUserData);
+        $this->assertArrayHasKey('attributes', $processedUserData['billingaddress']);
         $this->assertArrayHasKey('shippingaddress', $processedUserData);
+        $this->assertArrayHasKey('attributes', $processedUserData['shippingaddress']);
         $this->assertArrayHasKey('additional', $processedUserData);
+        $this->assertArrayHasKey('country', $processedUserData);
 
         $this->assertEquals("I'll \"walk\" the <b>dog</b> now", $processedUserData['billingaddress'][1]);
         $this->assertEquals("I'll \"walk\" the <b>dog</b> later", $processedUserData['billingaddress'][2]);
 
+        $this->assertEquals("I'll \"walk\" the <b>dog</b> now", $processedUserData['billingaddress']['attributes']['foo']);
+        $this->assertEquals("I'll \"walk\" the <b>dog</b> later", $processedUserData['billingaddress']['attributes']['bar']);
+
         $this->assertEquals("I won't \"walk\" the <b>dog</b> now", $processedUserData['shippingaddress'][1]);
         $this->assertEquals("I won't \"walk\" the <b>dog</b> later", $processedUserData['shippingaddress'][2]);
 
-        $this->assertEquals('<span>dog</span>', $processedUserData['additional']['country'][1]);
+        $this->assertEquals("I'll \"walk\" the <b>dog</b> now", $processedUserData['shippingaddress']['attributes']['foo']);
+        $this->assertEquals("I'll \"walk\" the <b>dog</b> later", $processedUserData['shippingaddress']['attributes']['bar']);
+
+        $this->assertEquals('<span>dog</span>', $processedUserData['country'][1]);
         $this->assertEquals('<span>dog</span>', $processedUserData['additional']['payment']['description']);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
This is a re-implementation of my initial approach in #1616 that broke after commit ece4a0798cab956e551829b52f0ca3413b99dab8. 

Without this fix the variables `{$billingaddress.attributes}` and `{$shippingaddress.attributes}` are always null because `html_entity_decode([])` returns `null`.

### 2. What does this change do, exactly?
Recursively `apply html_entity_decode()` to the passed data.

### 3. Describe each step to reproduce the issue or behaviour.
Place an order in the frontend. After that, look at the variables for the sORDER mail.


### 4. Please link to the relevant issues (if any).
No

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.