### PR TITLE
Fixed InvalidArgumentException in ReflectionHelper for shopware compo…

### DIFF
--- a/engine/Shopware/Components/ReflectionHelper.php
+++ b/engine/Shopware/Components/ReflectionHelper.php
@@ -99,6 +99,12 @@ class ReflectionHelper
     private function verifyClass(\ReflectionClass $class, $docPath, array $directories = [])
     {
         $fileName = $class->getFileName();
+
+		// if shopware is installed via composer and $class is not in vendor dir, change $docPath
+        if (strpos($docPath, '/vendor/') !== false && strpos($fileName, '/vendor/') === false) {
+            $docPath = substr($docPath, 0, strlen('vendor/shopware/shopware/') * -1);
+        }
+        
         $fileDir = substr($fileName, 0, strlen($docPath));
 
         // Trying to execute a class outside of the Shopware DocumentRoot


### PR DESCRIPTION
### 1. Why is this change necessary?
When installing Shopware via composer, 
it is not possible to add own CustomerSearchBundleDBAL ConditionHandlers via Plugins.
Since shopware 5.4 is supporting installations via composer, 
the shopware core should consider this when dealing with the docPath.

### 2. What does this change do, exactly?
It adds a check in the verifyClass function of the ReflectionHelper Class, to determine
if shopware is installed via composer (the docPath points to a subdir of vendor) and the
class that should be verified is outside of the vendor dir.
If this is the case, the docPath is changed to the current docRoot.

### 3. Describe each step to reproduce the issue or behaviour.
Install shopware via composer and develope a plugin with a CustomerSearchBundleDBAL ConditionHandler.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.