### PR TITLE
Listing Boxes should use Flexbox instead of floating – It behaves smoother and is modern

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_mixins/flexbox.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_mixins/flexbox.less
@@ -1,0 +1,18 @@
+.flexboxContainer() {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-wrap: wrap;
+    flex-wrap: wrap;
+}
+
+.flexboxChild(@width: initial) {
+    -webkit-flex: @width;
+    -ms-flex: @width;
+    flex: @width;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+}

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/listing.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/listing.less
@@ -208,7 +208,7 @@ It contains the viewport specific styles inside media queries.
 }
 
 .listing {
-    .clearfix();
+    .flexboxContainer();
     margin: -2% 0 0 -2%;
     padding: 0 0 2% 0;
 }

--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/product-box.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/product-box.less
@@ -104,11 +104,8 @@ Shopware provides 3 product box types:<br/>
 
     //  Product box
 .product--box {
-    .clearfix();
     display: block;
-    width: 100%;
     padding: 2% 0 0 2%;
-    float: left;
 
     .box--content {
         .unitize-padding(10, 10);
@@ -357,7 +354,7 @@ Creates a corner product badge on a product-box.
 }
 
 .box--minimal {
-    width: 50%;
+    .flexboxChild(50%);
 
     .product--image {
         .unitize-height(120);
@@ -514,7 +511,7 @@ Creates a corner product badge on a product-box.
     }
 
     .box--minimal {
-        width: 33.3%;
+        .flexboxChild(33.3%);
     }
 
     .box--image {
@@ -562,11 +559,11 @@ Creates a corner product badge on a product-box.
     .is--ctl-listing.is--no-sidebar {
         .box--basic {
             .image--top(180);
-            width: 50%;
+            .flexboxChild(50%);
         }
 
         .box--minimal {
-            width: 25%;
+            .flexboxChild(25%);
 
             .product--image {
                 .unitize-height(180);
@@ -574,17 +571,17 @@ Creates a corner product badge on a product-box.
         }
 
         .box--image {
-            width: 50%;
+            .flexboxChild(50%);
         }
 
         .has--sidebar-filter {
             .box--basic {
                 .image--left(160);
-                width: 100%;
+                .flexboxChild(100%);
             }
 
             .box--minimal {
-                width: 33.3%;
+                .flexboxChild(33.3%);
             }
         }
     }
@@ -594,16 +591,16 @@ Creates a corner product badge on a product-box.
 
     .box--basic {
         .image--top(180);
-        width: 50%;
+        .flexboxChild(50%);
     }
 
     .box--minimal {
-        width: 25%;
+        .flexboxChild(25%);
     }
 
     .box--image {
         .image--top(280);
-        width: 50%;
+        .flexboxChild(50%);
     }
 
     .is--ctl-search,
@@ -613,21 +610,21 @@ Creates a corner product badge on a product-box.
         }
 
         .box--minimal {
-            width: 20%;
+            .flexboxChild(20%);
         }
 
         .box--image {
-            width: 33.3%;
+            .flexboxChild(33.3%);
         }
 
         .has--sidebar-filter {
             .box--basic {
                 .image--top(180);
-                width: 50%;
+                .flexboxChild(50%);
             }
 
             .box--minimal {
-                width: 25%;
+                .flexboxChild(25%);
             }
         }
     }
@@ -644,7 +641,7 @@ Creates a corner product badge on a product-box.
     }
 
     .box--minimal {
-        width: 25%;
+        .flexboxChild(25%);
 
         .buybox--form {
             .buy-btn--cart-text {
@@ -665,7 +662,7 @@ Creates a corner product badge on a product-box.
     .is--ctl-listing.is--no-sidebar {
 
         .box--minimal {
-            width: 20%;
+            .flexboxChild(20%);
         }
 
         .has--sidebar-filter {

--- a/themes/Frontend/Responsive/frontend/_public/src/less/mixins.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/mixins.less
@@ -11,6 +11,7 @@ Mixins can be used by adding the mixin class onto an element inside Shopware.
 `.border-radius(3px);`
 */
 
+@import "_mixins/flexbox.less";
 @import "_mixins/icon-element";
 @import "_mixins/linear-gradient";
 @import "_mixins/visibility-helper";


### PR DESCRIPTION
### 1. Why is this change necessary?

For example on Article listing pages like category pages, articles will behave ugly when their short description texts have different lengths and result in different amounts of line breaks. Due to this, the responsive layout is very unstable and tends to look ugly if short description texts have different length.

Example: [Screenshot with the issue](https://pbs.twimg.com/media/DtMmlh3X4AEG6Bi.jpg)

Flexbox is a modern standard while being compatible with a decent amount of older browsers, too. It makes layouting of grids with columns far more easy and solves the described problem smoothly.

### 2. What does this change do, exactly?

Clearfixes and left floats were thrown out of the listing boxes layout. Flexbox will take care of the layouting by preserving also a width of a "column" in percentage value (just like before).
If there is no bug in my changes, it should do exactly the same as before. In addition in fixes the described ugly behaviour.

Expected result is: [Screenshot with fix](https://pbs.twimg.com/media/DtMnJ3eX4AY2jhf.jpg)

See the change in action here on this shop: https://lifefoto.de/foto-fineart-papier/?p=1
Although implemented and therefor overwritten in a child template, it should perform exactly as in this PR.

### 3. Describe each step to reproduce the issue or behaviour.

* Create a category
* Create some articles (e.g. 4) with short descriptions of different length (e.g. 80, 140 and 200 characters)
* On the shop frontend, visit the category and see the articles of different height form an ugly experience

### 4. Please link to the relevant issues (if any).

- none -

### 5. Which documentation changes (if any) need to be made because of this PR?

I guess none.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.