### PR TITLE
Added command to refresh topseller

### DIFF
--- a/engine/Shopware/Commands/RefreshTopsellerCommand.php
+++ b/engine/Shopware/Commands/RefreshTopsellerCommand.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RefreshTopsellerCommand extends ShopwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sw:refresh:topseller')
+            ->setDescription('Refreshes the topseller index')
+            ->setHelp('The <info>%command.name%</info> refreshes the topseller index')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Refreshing the topseller index. This may take a while depending on the shop size.');
+        /** @var \Shopware_Components_TopSeller $topseller */
+        $topseller = $this->container->get('TopSeller');
+        $topseller->updateElapsedTopSeller();
+
+        $output->writeln('The topseller index was refreshed successfully.');
+    }
+}

--- a/engine/Shopware/Components/DependencyInjection/commands.xml
+++ b/engine/Shopware/Components/DependencyInjection/commands.xml
@@ -130,6 +130,11 @@
             <tag name="console.command" command="sw:refresh:search:index"/>
         </service>
 
+        <service id="shopware.commands.refresh_topseller_command"
+                 class="Shopware\Commands\RefreshTopsellerCommand">
+            <tag name="console.command" command="sw:refresh:topseller"/>
+        </service>
+
         <service id="shopware.commands.session_cleanup_command"
                  class="Shopware\Commands\SessionCleanupCommand">
             <tag name="console.command" command="sw:session:cleanup"/>


### PR DESCRIPTION
### 1. Why is this change necessary?
Topseller can currently only be refreshed via backend or cron. 

### 2. What does this change do, exactly?
Adds a console command to refresh the topseller index.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.