### PR TITLE
Set correct regex for xss filter to filter data-* attributes correctly

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
@@ -28,7 +28,7 @@
 class Shopware_Plugins_Frontend_InputFilter_Bootstrap extends Shopware_Components_Plugin_Bootstrap
 {
     public $sqlRegex = 's_core_|s_order_|s_user|benchmark.*\(|(?:insert|replace).+into|update.+set|(?:delete|select).+from|(?:alter|rename|create|drop|truncate).+(?:database|table|procedure)|union.+select|prepare.+from.+execute|select.+into\s+(outfile|dumpfile)';
-    public $xssRegex = 'javascript:|src\s*=|\bon[a-z]+\s*=|style\s*=|\bdata-\w+';
+    public $xssRegex = 'javascript:|src\s*=|\bon[a-z]+\s*=|style\s*=|\bdata-\w+\s*=';
     public $rfiRegex = '\.\./|\\0';
 
     /**

--- a/tests/Unit/Plugin/Frontend/InputFilter/FilterTest.php
+++ b/tests/Unit/Plugin/Frontend/InputFilter/FilterTest.php
@@ -113,6 +113,23 @@ class FilterTest extends TestCase
     }
 
     /**
+     * @return array
+     */
+    public function dataDomainDataProvider()
+    {
+        return [
+            [
+                '<span data-hello="world" >',
+                null,
+            ],
+            [
+                'data-example.com',
+                'data-example.com',
+            ]
+        ];
+    }
+
+    /**
      * @dataProvider sqlProvider
      *
      * @param string $statement
@@ -150,6 +167,22 @@ class FilterTest extends TestCase
         $this->assertEquals(
             $expected['disabled'],
             \Shopware_Plugins_Frontend_InputFilter_Bootstrap::filterValue($input, '#PreventRegexMatch#', false)
+        );
+    }
+
+    /**
+     * @dataProvider dataDomainDataProvider
+     *
+     * @param string $input
+     * @param $expected
+     */
+    public function testDataDomain($input, $expected)
+    {
+        $regex = '#' . $this->inputFilter->xssRegex . '#msi';
+
+        $this->assertEquals(
+            $expected,
+            \Shopware_Plugins_Frontend_InputFilter_Bootstrap::filterValue($input, $regex, false)
         );
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Usage of URL domain names which contain `data-` could not be used. For example when a domain name contains `data-` then Shopware will set the `$_SERVER[HTTP_HOST]` to `NULL`

So we are not able to use Shopware without workarounds for our Domains `*.data-room.de` and `*.data-graphis.de`

### 2. What does this change do, exactly?

Adds the missing `=` to the xss regex to filter a html `data-*` attribute and keeps values like the `HTTP_HOST` with `data-` values.

### 3. Describe each step to reproduce the issue or behaviour.

Install Shopware to an domain which contains `data-` and call `$this->Request()->getHttpHost()` into a controller

### 4. Please link to the relevant issues (if any).

none

### 5. Which documentation changes (if any) need to be made because of this PR?

none

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits (only a single commit)
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.