### PR TITLE
Use in jQuery plugin swRegister correct input ids for ajax validation

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -44,6 +44,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 * Changed default groupKey to get correct subpages of custom pages in mobile menu
 * Changed some mailer options to combo boxes to avoid wrong entries
 * Changed CSV import of snippets to only remove one apostrophe from the beginning of a line 
+* Changed the jQuery swRegister plugin to use the correct input ids for input validation if they were changed by data attributes
 
 ## 5.5.3
 

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
@@ -495,15 +495,15 @@
             me.$targetElement = $(relatedTarget);
 
             switch (id) {
-                case 'register_personal_email':
-                case 'register_personal_emailConfirmation':
+                case me.$personalEmail.prop('id'):
+                case me.$personalEmailConfirmation.prop('id'):
                     if (hasEmailConfirmation && (me.$personalEmail.val().length <= 0 || me.$personalEmailConfirmation.val().length <= 0)) {
                         break;
                     }
                     action = 'ajax_validate_email';
                     break;
-                case 'register_personal_password':
-                case 'register_personal_passwordConfirmation':
+                case me.$personalPassword.prop('id'):
+                case me.$personalPasswordConfirmation.prop('id'):
                     if (hasPasswordConfirmation && (me.$personalPassword.val().length <= 0 || me.$personalPasswordConfirmation.val().length <= 0)) {
                         break;
                     }


### PR DESCRIPTION
### 1. Why is this change necessary?
If you want to change the ids of input fields, on elements which make use of the AJAX validation, the jquery register plugin does not take these changes into account.

### 2. What does this change do, exactly?
Use the changed ids.

### 3. Describe each step to reproduce the issue or behaviour.
Change the ids of one element which needs to be validated using AJAX and provide the new id as selector for the jquery.swRegister plugin. The field will not be validated with the AJAX validation.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.