### PR TITLE
HttpCache Invalidation: Use the Procotol related to the Settings of the Shop

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -314,7 +314,7 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
         $url = sprintf(
             '%s://%s%s/',
-            'http',
+            $shop->getSecure() ? 'https' : 'http',
             $shop->getHost(),
             $shop->getBasePath()
         );


### PR DESCRIPTION
### 1. Why is this change necessary?
The Automatic Cache Invalidation for the HttpCache makes a internal Call to the Shop Homepage with the Invalidation Header.
This call is always made with `http://`
But if the Shop runs with `https://` only all `http://` Requests will be redirected to `https://` and the Cache Invalidation Headers will be removed on the redirect.

[NOTE]
I'm not sure if this information is important, but the Event will be triggered in a Command and the Service `httpCache` is not available in Line 799:
https://github.com/shopware/shopware/blob/5.5/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php#L799

So the Script is calling the Method `invalidateWithBANRequest()` in Line 806:
https://github.com/shopware/shopware/blob/5.5/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php#L806

[UPDATE]
I checked the `httpCache` Service and it seems like this service is only injected in Frontend Instances.
https://github.com/shopware/shopware/blob/5.5/engine/Shopware/Components/HttpCache/AppCache.php#L266

So the Service `httpCache` is not available in Command Instances and thus will use the proxyUrl (always with `http://`) generated by Shopware for the specific Store.

### 2. What does this change do, exactly?
This change checks whether the Store has the "secure" option enabled and uses http:// or https:// depending on the "secure" setting of the Store

### 3. Describe each step to reproduce the issue or behaviour.
Add a redirect from http:// to https:// to the VirtualHost or .htaccess and then try to invalidate the Cache for a Specific Product or Article.

example:
```
Shopware()->Events()->notify(
    'Shopware_Plugins_HttpCache_InvalidateCacheId',
    [
        'cacheId' => 'c1', // replace with category or article id
    ]
);
```

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.