### PR TITLE
Support Symfony 3.3 optional class for named services compiler pass

### DIFF
--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -44,6 +44,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -681,6 +682,7 @@ class Kernel implements HttpKernelInterface, TerminableInterface
         $container->addCompilerPass(new EventListenerCompilerPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new EventSubscriberCompilerPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new DoctrineEventSubscriberCompilerPass());
+        $container->addCompilerPass(new ResolveClassPass());
         $container->addCompilerPass(new FormPass());
         $container->addCompilerPass(new AddConstraintValidatorsPass());
         $container->addCompilerPass(new StaticResourcesCompilerPass());


### PR DESCRIPTION
Followed by https://github.com/Haehnchen/idea-php-symfony2-plugin/pull/1265. This makes the `class` in services optional which fallsback to the `id` then.

Note: I did not test this against a working installtion, but looks to me all is in to support this Symfony feature here also.

```
    <services>
        <service id="AppBundle\Mailer">
            <argument>sendmail</argument>
        </service>
    </services>
```

https://symfony.com/blog/new-in-symfony-3-3-optional-class-for-named-services

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Improve Symfony support by supporting id as classes in service files

### 2. What does this change do, exactly?

https://symfony.com/blog/new-in-symfony-3-3-optional-class-for-named-services

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

https://symfony.com/blog/new-in-symfony-3-3-optional-class-for-named-services

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist
