### PR TITLE
Fix: DataTime Bug

### DIFF
--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -1141,7 +1141,7 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
                     break;
                 }
                 //Fix: check if type is 'DateTime', otherwise return
-                if(!is_a($value, 'DateTime')) {
+                if (!$value instanceof \DateTime) {
 					break; 
 				}
                 $date = new DateTime($value);

--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -1140,10 +1140,12 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
                     $value = '%' . $value . '%';
                     break;
                 }
+                
                 //Fix: check if type is 'DateTime', otherwise return
                 if (!$value instanceof \DateTime) {
                     break; 
                 }
+                
                 $date = new DateTime($value);
                 $value = $date->format('Y-m-d');
                 if (!$this->isSearchExpression($expression)) {

--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -413,7 +413,7 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
                 'property' => $violation->getPropertyPath(),
             ];
         }
-
+        /** @var catch wrong date conversion $errors */
         if (!empty($errors)) {
             return ['success' => false, 'violations' => $errors];
         }

--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -1142,8 +1142,8 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
                 }
                 //Fix: check if type is 'DateTime', otherwise return
                 if (!$value instanceof \DateTime) {
-					break; 
-				}
+                    break; 
+                }
                 $date = new DateTime($value);
                 $value = $date->format('Y-m-d');
                 if (!$this->isSearchExpression($expression)) {

--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -1140,7 +1140,10 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
                     $value = '%' . $value . '%';
                     break;
                 }
-
+                //Fix: check if type is 'DateTime', otherwise return
+                if(!is_a($value, 'DateTime')) {
+					break; 
+				}
                 $date = new DateTime($value);
                 $value = $date->format('Y-m-d');
                 if (!$this->isSearchExpression($expression)) {

--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -413,7 +413,6 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
                 'property' => $violation->getPropertyPath(),
             ];
         }
-        /** @var catch wrong date conversion $errors */
         if (!empty($errors)) {
             return ['success' => false, 'violations' => $errors];
         }


### PR DESCRIPTION
Fix: application crashed if isnt datatime but has Format like 3070-0408-121221

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Plugins with a search function will Response Error: 503 - Service Unavailable

### 2. What does this change do, exactly?
Fixes the problem that a string in **String** format is no longer initialized as a **date**, cause execute further lines like shopware\engine\Shopware\Controllers\Backend\Application.php :
    --> error is not caught that it is a string
    $date = new DateTime($value);
    $value = $date->format('Y-m-d');

### 3. Describe each step to reproduce the issue or behaviour.
When entering a Format like "3070-0408-121221" or "3070-04131308-12111662221" on search bar with a plugin like Shopware example "SwagProductListingExtension."

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
shopware\engine\Shopware\Controllers\Backend

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.