### PR TITLE
added event TemplateMail_CreateMail_MailContext to change mail context

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -2,6 +2,10 @@
 
 This changelog references changes done in Shopware 5.5 patch versions.
 
+## 5.5.5
+
+* Added new event `TemplateMail_CreateMail_MailContext`
+
 ## 5.5.4
 
 [View all changes from v5.5.3...v5.5.4](https://github.com/shopware/shopware/compare/v5.5.3...v5.5.4)

--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -190,6 +190,7 @@ class Shopware_Components_TemplateMail
 
         $config = Shopware()->Config();
         $inheritance = Shopware()->Container()->get('theme_inheritance');
+        $eventManager = Shopware()->Container()->get('events');
 
         if ($this->getShop() !== null) {
             $defaultContext = [
@@ -207,8 +208,6 @@ class Shopware_Components_TemplateMail
             }
 
             if ($theme) {
-                $eventManager = Shopware()->Container()->get('events');
-
                 $keys = $eventManager->filter(
                     'TemplateMail_CreateMail_Available_Theme_Config',
                     $this->themeVariables,
@@ -237,6 +236,15 @@ class Shopware_Components_TemplateMail
 
         // Save current context to mail model
         $mailContext = json_decode(json_encode($context), true);
+
+        $mailContext = $eventManager->filter(
+            'TemplateMail_CreateMail_MailContext',
+            $mailContext,
+            [
+                'mailModel' => $mailModel,
+            ]
+        );
+
         $mailModel->setContext($mailContext);
         $this->getModelManager()->flush($mailModel);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
if you want to add some information to a mail context, you have to override the createMail-method in Shopware_Components_TemplateMail, which isn't really fun and can break stuff

### 2. What does this change do, exactly?
adds the event TemplateMail_CreateMail_MailContext, where you can change the mail context

### 3. Describe each step to reproduce the issue or behaviour.
try to add information to the context of a mail

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.