### PR TITLE
Update HasPseudoPriceConditionHandler.php

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/ConditionHandler/HasPseudoPriceConditionHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/ConditionHandler/HasPseudoPriceConditionHandler.php
@@ -73,7 +73,7 @@ class HasPseudoPriceConditionHandler implements ConditionHandlerInterface, Crite
     ) {
         $this->listingPriceSwitcher->joinPrice($query, $this->criteria, $context);
 
-        $query->andWhere('listing_price.pseudoprice > 0');
+        $query->andWhere('listing_price.pseudoprice > listing_price.price');
     }
 
     public function setCriteria(Criteria $criteria)


### PR DESCRIPTION
Trigger only articles where pseudoprice is higher than normal price.

### 1. Why is this change necessary?
This is necessary to hide products - in eg. a product stream - that have a pseudoprice, but where the pseudo price is lower than the normal price.

### 2. What does this change do, exactly?
Changes the SQL to select only products where pseudoprice is lower than normal price.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.