### PR TITLE
Use constants instead of numbers for comparison of ORM relations in Shopware_Controllers_Backend_Application

### DIFF
--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -21,6 +21,7 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Shopware\Components\Model\QueryBuilder;
 
 /**
@@ -827,7 +828,7 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
              *
              * So we have to remove the first level of the posted data.
              */
-            if ($mapping['type'] === 1) {
+            if ($mapping['type'] === ClassMetadataInfo::ONE_TO_ONE) {
                 $mappingData = $data[$mapping['fieldName']];
                 if (array_key_exists(0, $mappingData)) {
                     $data[$mapping['fieldName']] = $data[$mapping['fieldName']][0];
@@ -838,7 +839,7 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
                 continue;
             }
 
-            if ($mapping['type'] === 2) {
+            if ($mapping['type'] === ClassMetadataInfo::MANY_TO_ONE) {
                 /**
                  * @ORM\ManyToOne associations.
                  *
@@ -865,7 +866,7 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
                     //remove the foreign key data.
                     unset($data[$field]);
                 }
-            } elseif ($mapping['type'] === 8) {
+            } elseif ($mapping['type'] === ClassMetadataInfo::MANY_TO_MANY) {
                 /**
                  * @ORM\ManyToMany associations.
                  *


### PR DESCRIPTION
### 1. Why is this change necessary?
Improve code quality

### 2. What does this change do, exactly?
Using constants of `\Doctrine\ORM\Mapping\ClassMetadataInfo` instead of their raw values

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.