### PR TITLE
Remove platform override in composer.json for allowing newest PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,10 +127,7 @@
     },
     "config": {
         "autoloader-suffix": "Shopware",
-        "optimize-autoloader": true,
-        "platform": {
-            "php": "5.6.4"
-        }
+        "optimize-autoloader": true
     },
     "scripts": {
         "cs-check": "php-cs-fixer fix --dry-run -v",


### PR DESCRIPTION
### 1. Why is this change necessary?
When installing additional composer packages which are only available for PHP 7 composer won't install those. Also forcing a completely outdated version of PHP (PHP 5.6 life ends in 19 days) is not a very nice move as you should always use the newest compatible version of 3rd party libs.

### 2. What does this change do, exactly?
Removing `config.platform` key from `composer.json`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-23133

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.