### PR TITLE
Changed itemSize calculation of swProductSlider for correct itemSize …

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -11,6 +11,11 @@ This changelog references changes done in Shopware 5.5 patch versions.
 * Added new event `TemplateMail_CreateMail_MailContext` to `engine/Shopware/Components/TemplateMail.php`
 * Added internal locking to sitemap generation so the sitemap isn't generated multiple times in parallel
 
+### Changes
+
+* Changed `itemSize` calculation of `swProductSlider` for correct `itemSize` and observance of `minItemWidth`/`minItemHeight` on product slider with padding
+
+
 ## 5.5.4
 
 [View all changes from v5.5.3...v5.5.4](https://github.com/shopware/shopware/compare/v5.5.3...v5.5.4)

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js
@@ -505,7 +505,7 @@
         setSizes: function (orientation) {
             var me = this,
                 o = orientation || me.opts.orientation,
-                containerSize = (o === 'vertical') ? me.$el.innerHeight() : me.$el.innerWidth(),
+                containerSize = (o === 'vertical') ? me.$container.height() : me.$container.width(),
                 itemSize = (o === 'vertical') ? me.opts.itemMinHeight : me.opts.itemMinWidth;
 
             me.itemsPerPage = Math.floor(containerSize / itemSize);


### PR DESCRIPTION
…and observance of minItemWidth and minItemHeight on product slider with padding

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

It fixes the calculation of itemSize on swProductSlider with padding for correct itemSize and observance of minItemWidth/minItemHeight. 


### 2. What does this change do, exactly?

It calculates the containerSize of swProductSlider correctly on the container of all slider items and not on the size of the whole slider to avoid display errors in some viewports and that itemSize could fall below minItemWidth/minItemHeight on product slider with padding.   

### 3. Describe each step to reproduce the issue or behaviour.

Adding a larger padding to swProductSlider and resize the viewport. 


### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/SW-23145


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.