### PR TITLE
Add fbclid as default ignored_url_parameter

### DIFF
--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -239,6 +239,7 @@ return array_replace_recursive([
            'cof',
            'siteurl',
            '_ga',
+           'fbclid',         // Facebook
         ],
     ],
     'bi' => [


### PR DESCRIPTION
### 1. Why is this change necessary?
The parameter `fbclid` is added to each external URL, see http://thisinterestsme.com/facebook-fbclid-parameter/ and therefore invalidates the cache for this URL. 

### 2. What does this change do, exactly?
Add the parameter to the default `ignored_url_parameters`.

### 3. Describe each step to reproduce the issue or behaviour.
See original PR where this feature was added https://github.com/shopware/shopware/pull/1195

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
Maybe the parameter should be added here as well, I am not sure how to indicate that this was added later and not with Shopware 5.5.0: https://developers.shopware.com/developers-guide/http-cache/#ignore-some-http-parameters

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.