### PR TITLE
Make sure itemprop priceCurrency is always available.

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -11,6 +11,10 @@ This changelog references changes done in Shopware 5.5 patch versions.
 * Added new event `TemplateMail_CreateMail_MailContext` to `engine/Shopware/Components/TemplateMail.php`
 * Added internal locking to sitemap generation so the sitemap isn't generated multiple times in parallel
 
+### Changes
+
+* Make sure itemprop priceCurrency is available for products with price groups, too.
+
 ## 5.5.4
 
 [View all changes from v5.5.3...v5.5.4](https://github.com/shopware/shopware/compare/v5.5.3...v5.5.4)

--- a/themes/Frontend/Bare/frontend/detail/content/buy_container.tpl
+++ b/themes/Frontend/Bare/frontend/detail/content/buy_container.tpl
@@ -76,9 +76,8 @@
                         <meta itemprop="lowPrice" content="{$lowestPrice}"/>
                         <meta itemprop="highPrice" content="{$highestPrice}"/>
                         <meta itemprop="offerCount" content="{$sArticle.sBlockPrices|count}"/>
-                    {else}
-                        <meta itemprop="priceCurrency" content="{$Shop->getCurrency()->getCurrency()}"/>
                     {/if}
+                    <meta itemprop="priceCurrency" content="{$Shop->getCurrency()->getCurrency()}"/>
                     {include file="frontend/detail/data.tpl" sArticle=$sArticle sView=1}
                 {/block}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The test tool for structured data, offered by google doesn't succeed for
products with price groups: the currency information was missing on
the global AggregateOffer type

### 2. What does this change do, exactly?
Make sure itemprop priceCurrency is available for products with price groups, too. We extracted the code snippet from the if clause.

### 3. Describe each step to reproduce the issue or behaviour.
Open any product detail page with product price groups activated in this tool: https://search.google.com/ The error will appear.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.