### PR TITLE
Added event plugin/swAjaxVariant/onHistoryChanged

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -10,6 +10,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 
 * Added new event `TemplateMail_CreateMail_MailContext` to `engine/Shopware/Components/TemplateMail.php`
 * Added internal locking to sitemap generation so the sitemap isn't generated multiple times in parallel
+* Added event plugin/swAjaxVariant/onHistoryChanged in in order to listen to changes in browser history after variants did change 
 
 ## 5.5.4
 

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -135,6 +135,7 @@
 
                     if (pushState && me.hasHistorySupport) {
                         me.pushState(stateObj, ordernumber);
+                        $.publish('plugin/swAjaxVariant/onHistoryChanged', [me, response, values, stateObj.location]);
                     }
                 },
                 complete: function (response, status) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Makes it possbile to register actions which should occur after history did change

### 2. What does this change do, exactly?
Adds a jquery event with $.publish

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.