### PR TITLE
Fix performance leak in sGetSimilarArticles

### DIFF
--- a/engine/Shopware/Core/sMarketing.php
+++ b/engine/Shopware/Core/sMarketing.php
@@ -511,50 +511,119 @@ class sMarketing
     {
         $limit = empty($limit) ? 6 : (int) $limit;
         $productId = empty($articleId) ? (int) $this->sSYSTEM->_GET['sArticle'] : (int) $articleId;
+        $sql = <<<SQL
+SELECT u.articleID, u.articleName, u.Rel 
+  FROM (
+    
+    ( 
+    SELECT DISTINCT
+   
+      a.id as articleID, 
+      a.name as articleName, 
+      3 as Rel
+      
+    FROM s_articles a
+    
+      INNER JOIN s_articles_categories_ro ac 
+        ON ac.articleID = a.id 
+        AND ac.categoryID = {$this->categoryId}
+        
+      INNER JOIN s_categories c 
+        ON c.id = ac.categoryID 
+        AND c.active = 1
+      
+      LEFT JOIN s_articles_avoid_customergroups ag 
+        ON ag.articleID = a.id 
+        AND ag.customergroupID = {$this->customerGroupId}
+      
+      INNER JOIN s_articles_similar s 
+        ON s.articleID = a.id 
+        AND s.relatedarticle = a.id
+        
+      INNER JOIN s_articles_categories_ro s1 
+        ON s1.articleID = a.id
+        
+      INNER JOIN s_articles_categories_ro s2 
+        ON s2.categoryID = s1.categoryID 
+        AND s2.articleID = a.id
+        
+      WHERE a.active = 1
+        AND ag.articleID IS NULL
+        AND a.id != {$productId}
+        
+    LIMIT {$limit}
+  ) 
+  UNION ( SELECT DISTINCT
+   
+      a.id as articleID, 
+      a.name as articleName, 
+      2 as Rel
+      
+    FROM s_articles a
+    
+      INNER JOIN s_articles_categories_ro ac 
+        ON ac.articleID = a.id 
+        AND ac.categoryID = {$this->categoryId}
+        
+      INNER JOIN s_categories c 
+        ON c.id = ac.categoryID 
+        AND c.active = 1
+      
+      LEFT JOIN s_articles_avoid_customergroups ag 
+        ON ag.articleID = a.id 
+        AND ag.customergroupID = {$this->customerGroupId}
+      
+      INNER JOIN s_articles_similar s 
+        ON s.articleID = a.id 
+        AND s.relatedarticle = a.id
+        
+      WHERE a.active = 1
+        AND ag.articleID IS NULL
+        AND a.id != {$productId}
+        
+    LIMIT {$limit}
+  
+  ) UNION ( SELECT DISTINCT
+   
+      a.id as articleID, 
+      a.name as articleName, 
+      1 as Rel
+              
+    FROM s_articles a
+    
+      INNER JOIN s_articles_categories_ro ac 
+        ON ac.articleID = a.id 
+        AND ac.categoryID = {$this->categoryId}
+        
+      INNER JOIN s_categories c 
+        ON c.id = ac.categoryID 
+        AND c.active = 1
+      
+      LEFT JOIN s_articles_avoid_customergroups ag 
+        ON ag.articleID = a.id 
+        AND ag.customergroupID = {$this->customerGroupId}
+        
+      INNER JOIN s_articles_categories_ro s1 
+        ON s1.articleID = a.id
+        
+      INNER JOIN s_articles_categories_ro s2 
+        ON s2.categoryID = s1.categoryID 
+        AND s2.articleID = a.id
+        
+      WHERE a.active = 1
+        AND ag.articleID IS NULL
+        AND a.id != {$productId}
+    
+    LIMIT {$limit}
+  ) 
+) AS u    
+GROUP BY u.articleID
+ORDER BY u.Rel DESC
 
-        $sql = "
-            SELECT
-              a.id as articleID,
-              a.name as articleName,
-              IF(s.id, 2, 0) + -- Similar article
-              IF(s2.id, 1, 0)  -- Same category
-                as relevance
+LIMIT {$limit};
 
-            FROM s_articles a
+SQL;
 
-            INNER JOIN s_articles_categories_ro ac
-                ON ac.articleID=a.id
-                AND ac.categoryID = {$this->categoryId}
-            INNER JOIN s_categories c
-                ON c.id = ac.categoryID
-                AND c.active = 1
-
-            LEFT JOIN s_articles_avoid_customergroups ag
-            ON ag.articleID=a.id
-            AND ag.customergroupID={$this->customerGroupId}
-
-            LEFT JOIN s_articles o
-            ON o.id=$productId
-
-            LEFT JOIN s_articles_similar s
-            ON s.articleID=o.id
-            AND s.relatedarticle=a.id
-
-            LEFT JOIN s_articles_categories_ro s1
-            ON s1.articleID=o.id
-
-            LEFT JOIN s_articles_categories_ro s2
-            ON s2.categoryID=s1.categoryID
-            AND s2.articleID=a.id
-
-            WHERE a.active = 1
-            AND ag.articleID IS NULL
-            AND a.id!=$productId
-
-            GROUP BY a.id
-            ORDER BY relevance DESC
-            LIMIT $limit
-        ";
         $similarProductIds = $this->db->fetchCol($sql);
 
         $similarProducts = [];


### PR DESCRIPTION
The function sGetSimilarArticles generates SQL code that does not perform well on shops with many articles (e.g. 300k), since the left joins unneccessary create multiple lines. In an example case the result with 350k articles, 500  categories (approx 3 categories for 1 article - its a book store - ) this query generates over 2,1 million lines  and runs on a quite big dedecated server for 7-15sek, since the big result tables needs to be written to disc my the database.

To group and sort 2,1 million lines for 4 random lines picket by a simple relevance is not good.

When a crawler comes by a shop and crawls many unavailable products (ignoring the sitemap) the server is flooded by long running queries and begins to lag.

The idea here is, to split those 3 relevances into independent queries und unionize the result. This yields the exact same four randomized results (in terms of relevance, whilst of course not the exact same 4, since the DB does not have to order the result).

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Performance leak is severe. Brought a PX91 NVME Hetzner Server to its knees.

### 2. What does this change do, exactly?
The way 4 random products are picked ordered by the same relevance as before.

### 3. Describe each step to reproduce the issue or behaviour.
Crawl non existing products, or non-available products to call the Product-Not-Found-Error page in a "big" shop (read above).

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ - ] I have written tests and verified that they fail without my change -- no its live on www.beam-shop.de and the performance impact on an up to date mariaDB is enourmous (Factor 15000)
- [ x ] I have squashed any insignificant commits
- [ - ] This change has comments for package types, values, functions, and non-obvious lines of code - Its "just" SQL. Not more complex than before.
- [ x ] I have read the contribution requirements and fulfil them. - Think so