### PR TITLE
Resolve one-to-many relations in backend applications

### DIFF
--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -866,7 +866,7 @@ class Shopware_Controllers_Backend_Application extends Shopware_Controllers_Back
                     //remove the foreign key data.
                     unset($data[$field]);
                 }
-            } elseif ($mapping['type'] === ClassMetadataInfo::MANY_TO_MANY) {
+            } elseif (in_array($mapping['type'], [ClassMetadataInfo::MANY_TO_MANY, ClassMetadataInfo::ONE_TO_MANY], true)) {
                 /**
                  * @ORM\ManyToMany associations.
                  *


### PR DESCRIPTION
### 1. Why is this change necessary?
Without this fix it was not possible to save extjs models with a one-to-many relation. A specific backend application can extend the changed behaviour to make it work right away but this change had to be done on multiple applications.

### 2. What does this change do, exactly?
It extends the analysis of referenced models by loading models from arrays for a one-to-many relation.

### 3. Describe each step to reproduce the issue or behaviour.
Two levels of nested extjs relations is my understanding.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.