### PR TITLE
Fix jquery preloader plugin reset function

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.preloader-button.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.preloader-button.js
@@ -83,7 +83,7 @@
         reset: function() {
             var me = this;
 
-            me.$el.find('.' + me.opts.loaderCls).prop('disabled', false).remove();
+            me.$el.prop('disabled', false).find('.' + me.opts.loaderCls).remove();
         }
     });
 })(jQuery, window);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The reset function doesn't work because the button remains disabled.

### 2. What does this change do, exactly?
Change the target to be deactivated from the loading icon to the button.


### 3. Describe each step to reproduce the issue or behaviour.
Create a Button with `data-preloader-button="true"` and use the 
`$('*[data-preloader-button="true"]').data('plugin_swPreloaderButton').reset();` function in your console to see the bug.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.