### PR TITLE
Autoselect Variant with non default configurator

### DIFF
--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -1104,11 +1104,10 @@ class sArticles
              * Check if a variant should be loaded. And load the configuration for the variant for pre selection.
              *
              * Requires the following scenario:
-             * 1. $number has to be set (without a number we can't load a configuration)
-             * 2. $number is equals to $productNumber (if the order number is invalid or inactive fallback to main variant)
-             * 3. $configuration is empty (Customer hasn't not set an own configuration)
+             * - a valid configurator has to be set
+             * - $number has to be set and is equals to $productNumber (if the order number is invalid or inactive fallback to main variant)
              */
-            if ($providedNumber && $providedNumber == $productNumber && empty($configuration) || $type === 0) {
+            if ($providedNumber && $providedNumber == $productNumber || $type !== false) {
                 $selection = $product->getSelectedOptions();
             }
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
If you change your configurator to not standard (e.g. image or selection) the default variant will not be auto selected (if no `number` parameter is passed)

### 2. What does this change do, exactly?
Allow any configurator be valid. Also remove not initialized variable `$configuration`.

### 3. Describe each step to reproduce the issue or behaviour.
Without PR create a variant article and check autoselection in frontend. Then change the variant article to image and load the article in frontend again without any `number` parameter. This won't select the default selection.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.