### PR TITLE
Create Alias for shopware.api.customer_stream to fix cronjob

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -643,6 +643,8 @@
             <argument id="shopware.customer_stream.criteria_factory" type="service"/>
         </service>
 
+        <service id="shopware.api.customerstream" alias="shopware.api.customer_stream" />
+
         <service id="shopware.emotion.emotion_presetdata_transformer" class="Shopware\Components\Emotion\Preset\EmotionToPresetDataTransformer">
             <argument type="service" id="models" />
         </service>


### PR DESCRIPTION
### 1. Why is this change necessary?
The CustomerStream cronjob uses the API resource class as identifier. This causes issues as `Shopware\Components\Api\Manager::getResource()` is using plain `strtolower` instead of converting `CamelCase` to `snake_case` which is used in DI services.

### 2. What does this change do, exactly?
Adds an alias for `shopware.api.customer_stream` to `shopware.api.customerstream` so the services is found. Instead of using `strtolower` a proper transformation would be better but might break things...

### 3. Describe each step to reproduce the issue or behaviour.

- Try to run the customerstream cronjob (`php bin/console sw:cron:run Shopware_CronJob_RefreshCustomerStreams` in your shopware root) 
- Get error message `Uncaught ArgumentCountError: Too few arguments to function Shopware\Components\Api\Resource\CustomerStream::__construct(), 0 passed (...)`
- Apply fix and rerun cron
- Profit 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.