### PR TITLE
Fix overwrite protection time zone bug when saving an order detail or deleting one

### DIFF
--- a/themes/Backend/ExtJs/backend/order/controller/detail.js
+++ b/themes/Backend/ExtJs/backend/order/controller/detail.js
@@ -304,7 +304,7 @@ Ext.define('Shopware.apps.Order.controller.Detail', {
 
         e.record.save({
             params: {
-                changed: order.get('changed'),
+                changed: order.get('changed') ? order.get('changed').toISOString() : null,
             },
             callback:function (data, operation) {
                 var records = operation.getRecords(),
@@ -426,7 +426,7 @@ Ext.define('Shopware.apps.Order.controller.Detail', {
             store.remove(positions);
             store.getProxy().extraParams = {
                 orderID: orderId,
-                changed: order.get('changed')
+                changed: order.get('changed') ? order.get('changed').toISOString() : null,
             };
             store.sync({
                 callback:function (batch, operation) {

--- a/themes/Backend/ExtJs/backend/order/controller/list.js
+++ b/themes/Backend/ExtJs/backend/order/controller/list.js
@@ -321,7 +321,7 @@ Ext.define('Shopware.apps.Order.controller.List', {
             position.destroy({
                 params: {
                     orderID: position.get('orderId'),
-                    changed: order.get('changed'),
+                    changed: order.get('changed') ? order.get('changed').toISOString() : null,
                 },
                 callback: function(data, operation) {
                     if (orderPositionGrid) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request. It always triggers the order overwrite protection.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When client and server are in different timezones you cannot save an order detail nor remove one.

### 2. What does this change do, exactly?
Changes the format of the transferred timestamp to timezone-independent ISO format.

Like here: https://github.com/shopware/shopware/commit/d389efdd56a48b68e81791dd3c4fd17aeb927118#diff-3de4436f3f4322b381d75442bd6edbf0L62

### 3. Describe each step to reproduce the issue or behaviour.
Access a Shopware backend with a browser working in a different timezone as the server and try to edit/delete an order position.

### 5. Which documentation changes (if any) need to be made because of this PR?
N/A

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.