### PR TITLE
Adding shopware mail template name to zend mail object

### DIFF
--- a/engine/Library/Enlight/Components/Mail.php
+++ b/engine/Library/Enlight/Components/Mail.php
@@ -71,6 +71,13 @@ class Enlight_Components_Mail extends Zend_Mail
     protected $_plainSubject = null;
 
     /**
+     * Property for the template name. Can be filled by setTemplateName function.
+     *
+     * @var null
+     */
+    protected $templateName = null;
+
+    /**
      * Magic setter method
      *
      * @param string $name
@@ -310,6 +317,22 @@ class Enlight_Components_Mail extends Zend_Mail
         $this->_plainSubject = $subject;
 
         return parent::setSubject($subject);
+    }
+
+    /**
+     * @param string $templateName
+     */
+    public function setTemplateName($templateName)
+    {
+        $this->templateName = $templateName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTemplateName()
+    {
+        return $this->templateName;
     }
 
     /**

--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -317,6 +317,8 @@ class Shopware_Components_TemplateMail
             }
         }
 
+        $mail->setTemplateName($mailModel->getName());
+
         return $mail;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
There is only one real Event for checking the Mail before sending it Enlight_Components_Mail_Send - other events are only notify-events. Therefore it would be nice to know which Mail will be sent (sORDER / sREGISTERCONFIRMATION etc.) in case you want to send a mail with third party (mailchimp, emarsys etc.)

Right now there is no indicator whatsoever which mail will be sent. You can only differ these mails by their subject, which will eventually change (subshop, some admin etc.)

### 2. What does this change do, exactly?
It sets a template name available in the Zendmail object, which is needed for external services and other catches.

### 3. Describe each step to reproduce the issue or behaviour.
New protected template (setter/getter) which can be set in the TemplateMail Class

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.