### PR TITLE
Correctly use typeof keyword and use strict comparison

### DIFF
--- a/engine/Library/ExtJs/components/Enlight.app.WindowManagement.js
+++ b/engine/Library/ExtJs/components/Enlight.app.WindowManagement.js
@@ -417,11 +417,11 @@ Ext.define('Enlight.app.WindowManagement', {
             }
 
             Ext.each(subApp.windowManager.zIndexStack, function (item) {
-                if (typeof(item) !== 'undefined' && item.$className === 'Ext.window.Window' || item.$className === 'Shopware.apps.Deprecated.view.main.Window' || item.$className === 'Enlight.app.Window' || item.$className == 'Ext.Window' && item.$className !== "Ext.window.MessageBox") {
+                if (typeof item !== 'undefined' && item.$className === 'Ext.window.Window' || item.$className === 'Shopware.apps.Deprecated.view.main.Window' || item.$className === 'Enlight.app.Window' || item.$className === 'Ext.Window' && item.$className !== "Ext.window.MessageBox") {
                     activeWindows.push(item);
                 }
 
-                if (item.alternateClassName === 'Ext.window.Window' || item.alternateClassName === 'Shopware.apps.Deprecated.view.main.Window' || item.alternateClassName === 'Enlight.app.Window' || item.alternateClassName == 'Ext.Window' && item.$className !== "Ext.window.MessageBox") {
+                if (item.alternateClassName === 'Ext.window.Window' || item.alternateClassName === 'Shopware.apps.Deprecated.view.main.Window' || item.alternateClassName === 'Enlight.app.Window' || item.alternateClassName === 'Ext.Window' && item.$className !== "Ext.window.MessageBox") {
                     activeWindows.push(item);
                 }
             });

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/app.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/app.js
@@ -233,7 +233,7 @@ Ext.define('Shopware.apps.PluginManager', {
                 return;
             }
             Ext.each(subApp.windowManager.zIndexStack, function (item) {
-                if (typeof(item) !== 'undefined' && me.windowClasses.indexOf(item.$className) > -1) {
+                if (typeof item !== 'undefined' && me.windowClasses.indexOf(item.$className) > -1) {
                     activeWindows.push(item);
                 }
             });

--- a/themes/Backend/ExtJs/backend/base/component/Shopware.grid.plugin.Translation.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.grid.plugin.Translation.js
@@ -325,7 +325,7 @@ Ext.define('Shopware.grid.plugin.Translation', {
         }
 
         // Check if sub applications are supported
-        if(typeof(Shopware.app.Application.addSubApplication) !== 'function') {
+        if(typeof Shopware.app.Application.addSubApplication !== 'function') {
             Ext.Error.raise('Your ExtJS application does not support sub applications');
         }
 

--- a/themes/Backend/ExtJs/backend/base/component/element/button.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/button.js
@@ -41,7 +41,7 @@ Ext.define('Shopware.apps.Base.view.element.Button', {
                 window.openAction(me.controller);
             }
         // Add support of own button handler
-        } else if (typeof(me.handler) == 'string' && me.handler.indexOf('function') !== -1) {
+        } else if (typeof me.handler === 'string' && me.handler.indexOf('function') !== -1) {
             eval('me.handler =' + me.handler + ';');
         }
 

--- a/themes/Backend/ExtJs/backend/base/component/element/date.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/date.js
@@ -40,7 +40,7 @@ Ext.define('Shopware.apps.Base.view.element.Date', {
     formatValue: function(value) {
         if(!value) {
             return null;
-        } else if (typeof(value) == 'string') {
+        } else if (typeof value === 'string') {
             return (value === "0000-00-00") ? null : new Date(value);
         } else {
             return value;

--- a/themes/Backend/ExtJs/backend/base/component/element/date_time.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/date_time.js
@@ -55,7 +55,7 @@ Ext.define('Shopware.apps.Base.view.element.DateTime', {
     formatValue: function(value) {
         if(!value) {
             return null;
-        } else if (typeof(value) == 'string') {
+        } else if (typeof value === 'string') {
             value = value.replace(' ', 'T');
             value += '+00:00';
             value = new Date(value);

--- a/themes/Backend/ExtJs/backend/base/component/element/select.js
+++ b/themes/Backend/ExtJs/backend/base/component/element/select.js
@@ -61,13 +61,13 @@ Ext.define('Shopware.apps.Base.view.element.Select', {
             me.valueField = me.displayField;
         }
         // Eval the store string if it contains a statement.
-        if (typeof(me.store) == 'string' && me.store.indexOf('new ') !== -1) {
+        if (typeof me.store === 'string' && me.store.indexOf('new ') !== -1) {
             eval('me.store = ' + me.store + ';');
             // if is no custom store remove value field for reasons of compatibility
             if(!me.isCustomStore) {
                 me.valueField = me.displayField;
             }
-        } else if (typeof(me.store) === 'string' && me.store.substring(0, 5) !== 'base.') {
+        } else if (typeof me.store === 'string' && me.store.substring(0, 5) !== 'base.') {
             me.store = me.getStoreById(me.store);
         }
 

--- a/themes/Backend/ExtJs/backend/category/controller/tree.js
+++ b/themes/Backend/ExtJs/backend/category/controller/tree.js
@@ -398,10 +398,10 @@ Ext.define('Shopware.apps.Category.controller.Tree', {
                     return false;
                 }
 
-                if (typeof(item) !== 'undefined' && item.$className === 'Ext.window.Window' || item.$className === 'Enlight.app.Window' || item.$className == 'Ext.Window') {
+                if (typeof item !== 'undefined' && item.$className === 'Ext.window.Window' || item.$className === 'Enlight.app.Window' || item.$className === 'Ext.Window') {
                     activeWindows.push(item);
                 }
-                if (item.alternateClassName === 'Ext.window.Window' || item.alternateClassName === 'Enlight.app.Window' || item.alternateClassName == 'Ext.Window') {
+                if (item.alternateClassName === 'Ext.window.Window' || item.alternateClassName === 'Enlight.app.Window' || item.alternateClassName === 'Ext.Window') {
                     activeWindows.push(item);
                 }
             });

--- a/themes/Backend/ExtJs/backend/config/view/element/button.js
+++ b/themes/Backend/ExtJs/backend/config/view/element/button.js
@@ -39,7 +39,7 @@ Ext.define('Shopware.apps.Config.view.element.Button', {
                 window.openAction(me.controller);
             }
         // Add support of own button handler
-        } else if (typeof(me.handler) == 'string' && me.handler.indexOf('function') !== -1) {
+        } else if (typeof me.handler === 'string' && me.handler.indexOf('function') !== -1) {
             eval('me.handler =' + me.handler + ';');
         }
 

--- a/themes/Backend/ExtJs/backend/config/view/element/date_time.js
+++ b/themes/Backend/ExtJs/backend/config/view/element/date_time.js
@@ -44,7 +44,7 @@ Ext.define('Shopware.apps.Config.view.element.DateTime', {
 
         if(!me.value) {
             me.value = null;
-        } else if (typeof(me.value) == 'string') {
+        } else if (typeof me.value === 'string') {
             me.value = me.value.replace(' ', 'T');
             me.value += '+00:00';
             me.value = new Date(me.value);

--- a/themes/Backend/ExtJs/backend/form/model/form.js
+++ b/themes/Backend/ExtJs/backend/form/model/form.js
@@ -50,7 +50,7 @@ Ext.define('Shopware.apps.Form.model.Form', {
             method: 'POST',
             params : { id : this.data.id },
             success: function(response, opts) {
-                if(typeof(callback) !== 'function') {
+                if(typeof callback !== 'function') {
                     return false;
                 }
 

--- a/themes/Backend/ExtJs/backend/index/controller/main.js
+++ b/themes/Backend/ExtJs/backend/index/controller/main.js
@@ -87,7 +87,7 @@ Ext.define('Shopware.apps.Index.controller.Main', {
                 }, 2000);
             }
 
-            if (enableBetaFeedback && (typeof(Storage) !== "undefined")) {
+            if (enableBetaFeedback && (typeof Storage !== "undefined")) {
                 var item = window.localStorage.getItem("hideBetaFeedback");
                 if (!item) {
                     Ext.Function.defer(function() {

--- a/themes/Backend/ExtJs/backend/mail/model/mail.js
+++ b/themes/Backend/ExtJs/backend/mail/model/mail.js
@@ -100,14 +100,14 @@ Ext.define('Shopware.apps.Mail.model.Mail', {
             method: 'POST',
             params : { id : this.data.id },
             success: function(response, opts) {
-                if(typeof(callback) !== 'function') {
+                if(typeof callback !== 'function') {
                     return false;
                 }
 
                 callback.call(this, true, response);
             },
             failure: function(response, opts) {
-                if(typeof(callback) !== 'function') {
+                if(typeof callback !== 'function') {
                     return false;
                 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`typeof` is a keyword, not a function. Also strict comparison is generally better.

### 2. What does this change do, exactly?
Change `typeof($var)` to `typeof $var` and change a few loose comparisons to strict comparisons.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.