### PR TITLE
Correctly check the plugin search term length if it is 0

### DIFF
--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/navigation.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/navigation.js
@@ -189,7 +189,7 @@ Ext.define('Shopware.apps.PluginManager.controller.Navigation', {
             navigation = me.getNavigation(),
             storeListing = me.getStoreListing();
 
-        if (!term || term.length < 0) {
+        if (!term || term.length === 0) {
             return;
         }
 
@@ -407,7 +407,7 @@ Ext.define('Shopware.apps.PluginManager.controller.Navigation', {
 
         me.displayListingPage();
         me.removeNavigationSelection();
-        
+
         storeListing.store.clearFilter();
 
         navigation.disable();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The check for `length < 0` always return `false` as `length` can never be smaller than `0`.

### 2. What does this change do, exactly?
Fixes the length check, a length property can never be smaller than `0`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.