### PR TITLE
Reset accountNumber field when saving a customer

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/emotion/backend/customer/payment_methods/controller/detail.js
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Views/emotion/backend/customer/payment_methods/controller/detail.js
@@ -106,7 +106,7 @@ Ext.define('Shopware.apps.Customer.PaymentMethods.controller.Detail', {
             switch (paymentMean.get('name')) {
                 case 'sepa':
                     values['paymentData[accountHolder]'] = "";
-                    values['paymentData[accountHolder]'] = "";
+                    values['paymentData[accountNumber]'] = "";
                     values['paymentData[bankCode]'] = "";
                     break;
                 case 'debit':


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
There was a duplicate line in the `onSaveCustomer` method and I think it should be actually the `accountNumber` field.

### 2. What does this change do, exactly?
Reset the `accountNumber` field as it was probably wanted.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.