### PR TITLE
Fixes the changetime on Product-Sitemap

### DIFF
--- a/engine/Shopware/Bundle/SitemapBundle/Provider/ProductUrlProvider.php
+++ b/engine/Shopware/Bundle/SitemapBundle/Provider/ProductUrlProvider.php
@@ -137,7 +137,7 @@ class ProductUrlProvider implements UrlProviderInterface
 
         $urls = [];
         for ($i = 0, $productCount = count($products); $i < $productCount; ++$i) {
-            $urls[] = new Url($routes[$i], new \DateTime($product[$i]['changed']), 'weekly');
+            $urls[] = new Url($routes[$i], new \DateTime($products[$i]['changetime']), 'weekly');
         }
 
         reset($products);


### PR DESCRIPTION
### 1. Why is this change necessary?
The lastmod currently defaults to "now" (for some reason), not sure why not `null`. It does not reflect the actual `changetime` of the product. 

### 2. What does this change do, exactly?
Makes sure it (1) uses the correct product, and not the last one, and (2) uses the correct column for changetime.

### 3. Describe each step to reproduce the issue or behaviour.
1. Generate sitemap. 
2. Lookup `lastmod` for a product. 
3. Compare to timestamp in backend for the product.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
