### PR TITLE
Fixes the sorting-order of product-ids

### DIFF
--- a/engine/Shopware/Bundle/SitemapBundle/Provider/ProductUrlProvider.php
+++ b/engine/Shopware/Bundle/SitemapBundle/Provider/ProductUrlProvider.php
@@ -141,7 +141,7 @@ class ProductUrlProvider implements UrlProviderInterface
         }
 
         reset($products);
-        $this->lastId = array_pop($products)['id'];
+        $this->lastId = array_pop($productIds);
 
         return $urls;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The sorting of the product-ids is non-existent, meaning the `lastId` in Shopware 5.5.4 is not guaranteed to be the "highest" id. 

Due to this not being guaranteed, some products appear more than once in the sitemap, because the `lastId` will be for example 200, even though it fetched 5000 products. Therefore fetching the remaining 4800 products again. 

### 2. What does this change do, exactly?
It uses the already-sorted array of `$productIds` instead. 

### 3. Describe each step to reproduce the issue or behaviour.
1. Have lots of products
2. var_dump the output of `array_column($products, 'id)`
3. See that the order is way off, and `array_pop` would not guarantee the "highest" / "last" id. 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.