### PR TITLE
Rename CSS property to break-inside as column-break-inside is not a v…

### DIFF
--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/column-count.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/column-count.less
@@ -18,5 +18,6 @@ Please refer to <http://caniuse.com/multicolumn> to see the browser support tabl
 
 .column-break-inside(@type: avoid) {
     -webkit-column-break-inside: @type;
-    column-break-inside: @type;
+    page-break-inside: @type;
+    break-inside: @type;
 }


### PR DESCRIPTION
…alid CSS property

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`column-break-inside` is not a valid CSS selector so this will only work in webkit browsers.

### 2. What does this change do, exactly?
Use the right `break-inside` property.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.