### PR TITLE
Remove the CSS touch-callout property which does not officially exist

### DIFF
--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/touch-callout.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/touch-callout.less
@@ -5,7 +5,6 @@ Disables the default callout shown when you touch and hold a touch target.
 
 ######Support:
 - iOS 2.0<br/>
-- Android 4.1<br/>
 
 ######Example:
 `.touch-callout([value]);`
@@ -15,5 +14,4 @@ Disables the default callout shown when you touch and hold a touch target.
 
 .touch-callout(@type: none) {
     -webkit-touch-callout: @type;
-    touch-callout: @type;
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`touch-callout` is an exclusive property in webkit based browsers and only exists with the prefix.

### 2. What does this change do, exactly?
Remove the wrong `touch-callout` and the Android reference.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.