### PR TITLE
Add missing iframe ID for better accessibility

### DIFF
--- a/recovery/install/templates/license.php
+++ b/recovery/install/templates/license.php
@@ -13,7 +13,7 @@
 </p>
 
 <form action="<?= $menuHelper->getCurrentUrl(); ?>" method="post">
-    <iframe class="license--agreement" src="<?= $tosUrl; ?>"></iframe>
+    <iframe id="license--agreement" class="license--agreement" src="<?= $tosUrl; ?>"></iframe>
 
     <p>
         <label>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
iframes should have an ID for better accessibility (screen readers).
Other internal iframes have IDs.

### 2. What does this change do, exactly?
Add an ID to the license agreement iframe.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.