### PR TITLE
Remove the delete operator as it does not remove variables

### DIFF
--- a/themes/Backend/ExtJs/backend/translation/controller/main.js
+++ b/themes/Backend/ExtJs/backend/translation/controller/main.js
@@ -357,7 +357,6 @@ Ext.define('Shopware.apps.Translation.controller.Main',
                 }
 
                 data.push({ valueField: field.emptyText, displayField: label || field.fieldLabel });
-                delete label;
             }
         });
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`delete` is meant to delete properties of objects. Variables can not be unset or deleted. `let` is recommended for scoped variables.
https://caniuse.com/#feat=let

Either this or we just remove the `delete` line.

### 2. What does this change do, exactly?
Replace the `delete` with a block scoped `let`.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.