### PR TITLE
Remove unused parameter from removeResizeListener invocation

### DIFF
--- a/themes/Backend/ExtJs/backend/benchmark/template/local/vendor/js/chart.js
+++ b/themes/Backend/ExtJs/backend/benchmark/template/local/vendor/js/chart.js
@@ -10815,7 +10815,7 @@
                 var canvas = chart.canvas;
                 if (type === 'resize') {
                     // Note: the resize event is not supported on all browsers.
-                    removeResizeListener(canvas, listener);
+                    removeResizeListener(canvas);
                     return;
                 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`removeResizeListener` accepts only one parameter so the second parameter (overloading) is not needed.

### 2. What does this change do, exactly?
Remove the unused parameter in the `removeResizeListener` invocation.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.