### PR TITLE
Fix the equality checks for storageType

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.data.ClassCache.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.data.ClassCache.js
@@ -112,8 +112,8 @@ Ext.define('Shopware.data.ClassCache',
     setStorage: function(storageType) {
         var me = this, old = me.storage;
 
-        if (!storageType === 'localStorage'
-            || !storageType === 'localSession') {
+        if (storageType !== 'localStorage'
+            || storageType !== 'localSession') {
             return false;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently the `storageType` checks compare a boolean to a string which is always false. See https://codepen.io/DanielRuf/pen/majrwp?editors=0011

### 2. What does this change do, exactly?
Fix the `storageType` check which also probably fixes related issues.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.