### PR TITLE
cache ConfigReader

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -461,6 +461,7 @@
 
         <service id="shopware.plugin.cached_config_reader" class="Shopware\Components\Plugin\CachedConfigReader">
             <argument type="service" id="shopware.plugin.config_reader" />
+            <argument type="service" id="cache" />
         </service>
 
         <service id="shopware.plugin.config_reader" class="Shopware\Components\Plugin\DBALConfigReader">

--- a/engine/Shopware/Components/Plugin/CachedConfigReader.php
+++ b/engine/Shopware/Components/Plugin/CachedConfigReader.php
@@ -25,6 +25,7 @@
 namespace Shopware\Components\Plugin;
 
 use Shopware\Models\Shop\Shop;
+use Zend_Cache_Core as Cache;
 
 /**
  * @category Shopware
@@ -39,16 +40,18 @@ class CachedConfigReader implements ConfigReader
     private $reader;
 
     /**
-     * @var array
+     * @var Cache
      */
-    private $configStorage;
+    private $cache;
 
     /**
      * @param ConfigReader $reader
+     * @param Cache        $cache
      */
-    public function __construct(ConfigReader $reader)
+    public function __construct(ConfigReader $reader, Cache $cache)
     {
         $this->reader = $reader;
+        $this->cache = $cache;
     }
 
     /**
@@ -62,10 +65,14 @@ class CachedConfigReader implements ConfigReader
             $cacheKey = $pluginName;
         }
 
-        if (!isset($this->configStorage[$cacheKey])) {
-            $this->configStorage[$cacheKey] = $this->reader->getByPluginName($pluginName, $shop);
+        if ($this->cache->test($cacheKey)) {
+            return $this->cache->load($cacheKey, true);
         }
 
-        return $this->configStorage[$cacheKey];
+        $config = $this->reader->getByPluginName($pluginName, $shop);
+
+        $this->cache->save($config, $cacheKey, ['Shopware_Config'], 86400);
+
+        return $config;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Cache configs of plugins for more than the current stack.

### 2. What does this change do, exactly?
It uses Cache with lifetime in CachedConfigReader.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.