### PR TITLE
Added new form element to exclude customergroup key

### DIFF
--- a/_sql/migrations/1453-add-customer-group-key-exemption-option.php
+++ b/_sql/migrations/1453-add-customer-group-key-exemption-option.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration1453 extends \Shopware\Components\Migrations\AbstractMigration
+{
+    /**
+     * Migration to make new "Exclude Customergroup" option visible in advanced menu without reinstallation
+     *
+     * @param string $modus
+     */
+    public function up($modus)
+    {
+        $sql = <<<'SQL'
+SET @pluginID = (SELECT DISTINCT `id` FROM `s_core_plugins` WHERE `name`='AdvancedMenu' AND `active`=1);
+SQL;
+        $this->addSql($sql);
+
+        $sql = <<<'SQL'
+SET @formID = (SELECT DISTINCT `id` FROM `s_core_config_forms` WHERE `plugin_id`=@pluginID);
+SQL;
+        $this->addSql($sql);
+
+        $sql = <<<'SQL'
+INSERT IGNORE INTO s_core_config_elements (form_id, name, value, label, description, type, required, position, scope, options) VALUES(
+@formID,
+'excludeCustomergroup',
+'i:0;',
+'Kundengruppen ausschließen',
+'Alle Kundengruppen erhalten das gleiche Menü (bessere Perfomance)',
+'boolean',
+0,
+0,
+1,
+0x613A303A7B7D
+);
+SQL;
+        $this->addSql($sql);
+
+        $sql = <<<'SQL'
+SET @elementID = (SELECT id FROM s_core_config_elements WHERE form_id=@formID AND `name`='excludeCustomergroup');
+SQL;
+        $this->addSql($sql);
+
+        $sql = <<<'SQL'
+INSERT IGNORE INTO s_core_config_element_translations (element_id, locale_id, label, description) VALUES (
+@elementID,
+2,
+'Exclude Customergroup',
+'All customergroups will have the same menu (better perfomance)');
+SQL;
+
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
@@ -140,7 +140,7 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
     public function getAdvancedMenu($category, $activeCategoryId, $depth = null)
     {
         $context = Shopware()->Container()->get('shopware_storefront.context_service')->getShopContext();
-        $cacheKey = 'Shopware_AdvancedMenu_Tree_' . $context->getShop()->getId() . '_' . $category . '_' . $context->getCurrentCustomerGroup()->getId();
+        $cacheKey = 'Shopware_AdvancedMenu_Tree_' . $context->getShop()->getId() . '_' . $category . ($this->Config()->get('excludeCustomergroup') ?: '_' . $context->getCurrentCustomerGroup()->getId());
         $cache = Shopware()->Container()->get('cache');
 
         if ($this->Config()->get('caching') && $cache->test($cacheKey)) {
@@ -196,6 +196,7 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
         $form->setElement('number', 'hoverDelay', [
             'label' => 'Hover Verzögerung (ms)',
             'value' => 250,
+            'scope' => \Shopware\Models\Config\Element::SCOPE_SHOP,
         ]);
 
         $form->setElement('text', 'levels', [
@@ -225,11 +226,20 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
         $form->setElement('boolean', 'caching', [
             'label' => 'Caching aktivieren',
             'value' => 1,
+            'scope' => \Shopware\Models\Config\Element::SCOPE_SHOP,
         ]);
 
         $form->setElement('number', 'cachetime', [
             'label' => 'Cachezeit',
             'value' => 86400,
+            'scope' => \Shopware\Models\Config\Element::SCOPE_SHOP,
+        ]);
+
+        $form->setElement('boolean', 'excludeCustomergroup', [
+            'label' => 'Kundengruppen ausschließen',
+            'value' => 0,
+            'description' => 'Alle Kundengruppen erhalten das gleiche Menü (bessere Perfomance)',
+            'scope' => \Shopware\Models\Config\Element::SCOPE_SHOP,
         ]);
 
         $this->translateForm();
@@ -245,6 +255,7 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
                 'cachetime' => ['label' => 'Caching time'],
                 'columnAmount' => ['label' => 'Teaser width'],
                 'hoverDelay' => ['label' => 'Hover delay (ms)'],
+                'excludeCustomergroup' => ['label' => 'Exclude Customergroup', 'description' => 'All customergroups will have the same menu (better perfomance)'],
             ],
         ];
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Imagine a shop with a lot of customergroups and a big menu (that is always the same). Every time a user logs in, a new menu will be generated and this will take a long time if you have +150 categories. There should be a way to exclude customergroups to be in the cache key.

![auswahl_009](https://user-images.githubusercontent.com/8600299/50957860-91dd0180-14bf-11e9-88a7-9b4657aba43a.png)

![auswahl_242](https://user-images.githubusercontent.com/8600299/50957875-9bff0000-14bf-11e9-8b0c-c222fcf73f51.jpg)

Espacially the checkout (login/register) is critical, because users will more likely dicard their shopping cart if the login takes longer then a few seconds.


### 2. What does this change do, exactly?
This change adds a new form field **excludeCustomergroup** which will decide if the customergroup will be used in the cache key or not.

The option (boolean) is set to 0 by default (same behavior as before) and even with the plugin not reinstalled it is not true and therefore the customergroups will be considered as usual. I also added the shop scope for caching, cachetime and hoverDelay.

### 3. Describe each step to reproduce the issue or behaviour.
Browse in a big shop (+150 categories) and login with customergroup which is not default.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.