### PR TITLE
Add new smarty blocks around paging & sorting actions

### DIFF
--- a/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
+++ b/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
@@ -1,71 +1,73 @@
 {* Paging which will be included in the "listing/listing_actions.tpl" *}
 {namespace name="frontend/listing/listing_actions"}
 
-<div class="listing--paging panel--paging">
+{block name='frontend_listing_actions_paging_inner'}
+    <div class="listing--paging panel--paging">
 
-    {* Pagination label *}
-    {block name='frontend_listing_actions_paging_label'}{/block}
+        {* Pagination label *}
+        {block name='frontend_listing_actions_paging_label'}{/block}
 
-    {* Pagination - Frist page *}
-    {block name="frontend_listing_actions_paging_first"}
-        {if $sPage > 1}
-            {s name="ListingLinkFirst" assign="snippetListingLinkFirst"}{/s}
-            <a href="{$baseUrl}?{$shortParameters.sPage}=1" title="{$snippetListingLinkFirst|escape}" class="paging--link paging--prev" data-action-link="true">
-                <i class="icon--arrow-left"></i>
-                <i class="icon--arrow-left"></i>
-            </a>
-        {/if}
-    {/block}
+        {* Pagination - Frist page *}
+        {block name="frontend_listing_actions_paging_first"}
+            {if $sPage > 1}
+                {s name="ListingLinkFirst" assign="snippetListingLinkFirst"}{/s}
+                <a href="{$baseUrl}?{$shortParameters.sPage}=1" title="{$snippetListingLinkFirst|escape}" class="paging--link paging--prev" data-action-link="true">
+                    <i class="icon--arrow-left"></i>
+                    <i class="icon--arrow-left"></i>
+                </a>
+            {/if}
+        {/block}
 
-    {* Pagination - Previous page *}
-    {block name='frontend_listing_actions_paging_previous'}
-        {if $sPage > 1}
-            {s name="ListingLinkPrevious" assign="snippetListingLinkPrevious"}{/s}
-            <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage-1}" title="{$snippetListingLinkPrevious|escape}" class="paging--link paging--prev" data-action-link="true">
-                <i class="icon--arrow-left"></i>
-            </a>
-        {/if}
-    {/block}
+        {* Pagination - Previous page *}
+        {block name='frontend_listing_actions_paging_previous'}
+            {if $sPage > 1}
+                {s name="ListingLinkPrevious" assign="snippetListingLinkPrevious"}{/s}
+                <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage-1}" title="{$snippetListingLinkPrevious|escape}" class="paging--link paging--prev" data-action-link="true">
+                    <i class="icon--arrow-left"></i>
+                </a>
+            {/if}
+        {/block}
 
-    {* Pagination - current page *}
-    {block name='frontend_listing_actions_paging_numbers'}
-        {if $pages > 1}
-            <a title="{$sCategoryContent.name|escape}" class="paging--link is--active">{$sPage}</a>
-        {/if}
-    {/block}
+        {* Pagination - current page *}
+        {block name='frontend_listing_actions_paging_numbers'}
+            {if $pages > 1}
+                <a title="{$sCategoryContent.name|escape}" class="paging--link is--active">{$sPage}</a>
+            {/if}
+        {/block}
 
-    {* Pagination - Next page *}
-    {block name='frontend_listing_actions_paging_next'}
-        {if $sPage < $pages}
-            {s name="ListingLinkNext" assign="snippetListingLinkNext"}{/s}
-            <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage+1}" title="{$snippetListingLinkNext|escape}" class="paging--link paging--next" data-action-link="true">
-                <i class="icon--arrow-right"></i>
-            </a>
-        {/if}
-    {/block}
+        {* Pagination - Next page *}
+        {block name='frontend_listing_actions_paging_next'}
+            {if $sPage < $pages}
+                {s name="ListingLinkNext" assign="snippetListingLinkNext"}{/s}
+                <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage+1}" title="{$snippetListingLinkNext|escape}" class="paging--link paging--next" data-action-link="true">
+                    <i class="icon--arrow-right"></i>
+                </a>
+            {/if}
+        {/block}
 
-    {* Pagination - Last page *}
-    {block name="frontend_listing_actions_paging_last"}
-        {if $sPage < $pages}
-            {s name="ListingLinkLast" assign="snippetListingLinkLast"}{/s}
-            <a href="{$baseUrl}?{$shortParameters.sPage}={$pages}" title="{$snippetListingLinkLast|escape}" class="paging--link paging--next" data-action-link="true">
-                <i class="icon--arrow-right"></i>
-                <i class="icon--arrow-right"></i>
-            </a>
-        {/if}
-    {/block}
+        {* Pagination - Last page *}
+        {block name="frontend_listing_actions_paging_last"}
+            {if $sPage < $pages}
+                {s name="ListingLinkLast" assign="snippetListingLinkLast"}{/s}
+                <a href="{$baseUrl}?{$shortParameters.sPage}={$pages}" title="{$snippetListingLinkLast|escape}" class="paging--link paging--next" data-action-link="true">
+                    <i class="icon--arrow-right"></i>
+                    <i class="icon--arrow-right"></i>
+                </a>
+            {/if}
+        {/block}
 
-    {* Pagination - Number of pages *}
-    {block name='frontend_listing_actions_count'}
-        {if $pages > 1}
-            <span class="paging--display">
-                {s name="ListingTextFrom"}{/s} <strong>{$pages}</strong>
-            </span>
-        {/if}
-    {/block}
+        {* Pagination - Number of pages *}
+        {block name='frontend_listing_actions_count'}
+            {if $pages > 1}
+                <span class="paging--display">
+                    {s name="ListingTextFrom"}{/s} <strong>{$pages}</strong>
+                </span>
+            {/if}
+        {/block}
 
-    {* Products per page selection *}
-    {block name='frontend_listing_actions_items_per_page'}
-        {include file="frontend/listing/actions/action-per-page.tpl"}
-    {/block}
-</div>
+        {* Products per page selection *}
+        {block name='frontend_listing_actions_items_per_page'}
+            {include file="frontend/listing/actions/action-per-page.tpl"}
+        {/block}
+    </div>
+{/block}

--- a/themes/Frontend/Bare/frontend/listing/actions/action-sorting.tpl
+++ b/themes/Frontend/Bare/frontend/listing/actions/action-sorting.tpl
@@ -1,36 +1,38 @@
 {* Sorting filter which will be included in the "listing/listing_actions.tpl" *}
 {namespace name="frontend/listing/listing_actions"}
 
-{$hideSortings = $sCategoryContent.hide_sortings || $sortings|count == 0}
+{block name='frontend_listing_actions_sort_inner'}
+    {$hideSortings = $sCategoryContent.hide_sortings || $sortings|count == 0}
 
-<form class="action--sort action--content block{if $hideSortings} is--hidden{/if}" method="get" data-action-form="true">
+    <form class="action--sort action--content block{if $hideSortings} is--hidden{/if}" method="get" data-action-form="true">
 
-    {* Necessary to reset the page to the first one *}
-    <input type="hidden" name="{$shortParameters.sPage}" value="1">
+        {* Necessary to reset the page to the first one *}
+        <input type="hidden" name="{$shortParameters.sPage}" value="1">
 
-    {* Sorting label *}
-    {block name='frontend_listing_actions_sort_label'}
-        <label class="sort--label action--label">{s name='ListingLabelSort'}{/s}</label>
-    {/block}
+        {* Sorting label *}
+        {block name='frontend_listing_actions_sort_label'}
+            <label class="sort--label action--label">{s name='ListingLabelSort'}{/s}</label>
+        {/block}
 
-    {* Sorting field *}
-    {block name='frontend_listing_actions_sort_field'}
-        {$listingMode = {config name=listingMode}}
+        {* Sorting field *}
+        {block name='frontend_listing_actions_sort_field'}
+            {$listingMode = {config name=listingMode}}
 
-        <div class="sort--select select-field">
-            <select name="{$shortParameters.sSort}"
-                    class="sort--field action--field"
-                    data-auto-submit="true"
-                    {if $listingMode != 'full_page_reload'}data-loadingindicator="false"{/if}>
+            <div class="sort--select select-field">
+                <select name="{$shortParameters.sSort}"
+                        class="sort--field action--field"
+                        data-auto-submit="true"
+                        {if $listingMode != 'full_page_reload'}data-loadingindicator="false"{/if}>
 
-                {foreach $sortings as $sorting}
-                    {block name="frontend_listing_actions_sort_field_release"}
-                        <option value="{$sorting->getId()}"{if $sSort eq $sorting->getId()} selected="selected"{/if}>{$sorting->getLabel()}</option>
-                    {/block}
-                {/foreach}
+                    {foreach $sortings as $sorting}
+                        {block name="frontend_listing_actions_sort_field_release"}
+                            <option value="{$sorting->getId()}"{if $sSort eq $sorting->getId()} selected="selected"{/if}>{$sorting->getLabel()}</option>
+                        {/block}
+                    {/foreach}
 
-                {block name='frontend_listing_actions_sort_values'}{/block}
-            </select>
-        </div>
-    {/block}
-</form>
+                    {block name='frontend_listing_actions_sort_values'}{/block}
+                </select>
+            </div>
+        {/block}
+    </form>
+{/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
The new blocks simplify template modifications and reduce code duplication.

### 2. What does this change do, exactly?
It adds two new smarty blocks:
- `frontend_listing_actions_paging_inner`
- `frontend_listing_actions_sort_inner`

### 3. Describe each step to reproduce the issue or behaviour.
If you want to makes changes to the template files `frontend/listing/listing_actions/action-pagination.tpl` or `frontend/listing/listing_actions/action-sorting.tpl` you have to copy the whole code without this blocks.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.