### PR TITLE
Swift mailer

### DIFF
--- a/_sql/migrations/1606-swift-mailer.php
+++ b/_sql/migrations/1606-swift-mailer.php
@@ -1,0 +1,93 @@
+<?php
+
+class Migrations_Migration1606 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+SET @formId = (SELECT id FROM `s_core_config_forms` WHERE name='Mail');
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+UPDATE `s_core_config_elements` SET
+`label` = 'SMTP Port',
+`description` =  NULL,
+`type` = 'number',
+`value` = 's:0:\"\";'
+WHERE `name` = 'mailer_port';
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+UPDATE `s_core_config_elements` SET
+`description` = NULL,
+`type` = 'select',
+`options` = 'a:1:{s:5:\"store\";a:3:{i:0;a:2:{i:0;s:0:\"\";i:1;s:22:\"keine Verschlüsselung\";}i:1;a:2:{i:0;s:3:\"ssl\";i:1;s:3:\"SSL\";}i:2;a:2:{i:0;s:3:\"tls\";i:1;s:3:\"TLS\";}}}'
+WHERE `name` = 'mailer_smtpsecure';
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+UPDATE `s_core_config_elements` SET
+`value` = 's:5:\"login\";',
+`description` = NULL,
+`type` = 'select',
+`options` = 'a:1:{s:5:\"store\";a:3:{i:0;a:2:{i:0;s:5:\"login\";i:1;s:5:\"login\";}i:1;a:2:{i:0;s:8:\"cram-md5\";i:1;s:8:\"cram-md5\";}i:2;a:2:{i:0;s:5:\"plain\";i:1;s:5:\"plain\";}}}'
+WHERE `name` = 'mailer_auth';
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+UPDATE `s_core_config_elements` SET
+`description` = NULL,
+`type` = 'select',
+`options` = 'a:1:{s:5:\"store\";a:4:{i:0;a:2:{i:0;s:4:\"mail\";i:1;s:8:\"Sendmail\";}i:1;a:2:{i:0;s:4:\"smtp\";i:1;s:4:\"SMTP\";}i:2;a:2:{i:0;s:5:\"gmail\";i:1;s:5:\"Gmail\";}i:3;a:2:{i:0;s:4:\"null\";i:1;s:22:\"NULL (nicht versenden)\";}}}'
+WHERE `name` = 'mailer_mailer';
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+UPDATE `s_core_config_elements` SET
+`label` = 'SMTP Host',
+`description` = NULL
+WHERE `name` = 'mailer_host';
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+UPDATE `s_core_config_elements` SET
+`options` = 'a:1:{s:9:\"inputType\";s:8:\"password\";}'
+WHERE `name` = 'mailer_password';
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+INSERT IGNORE INTO `s_core_config_elements` (`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`, `options`) VALUES
+(@formId, 'mailer_delivery_address', 's:0:\"\";', 'Umleitungsadresse', 'Eine E-Mail-Adresse, an die ALLE E-Mails gesendet werden sollen. Es besteht die Möglichkeit, durch Semikolon getrennt, mehrere E-Mail-Adressen zu hinterlegen.', 'text', 0, 0, 1, NULL);
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+INSERT IGNORE INTO `s_core_config_elements` (`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`, `options`) VALUES
+(@formId, 'mailer_delivery_whitelist', 's:0:\"\";', 'Ausnahmen von der Umleitung', 'Es erwartet ein PCRE-Suchmuster. Beispiel: /@shopware\\.com$|\\.shopware\\.com$/', 'text', 0, 0, 1, NULL);
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+INSERT IGNORE INTO `s_core_config_elements` (`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`, `options`) VALUES
+(@formId, 'mailer_bcc_address', 's:0:\"\";', 'BCC-Adresse', 'Eine E-Mail-Adresse an die alle E-Mails als Blindkopie gesendet werden soll.', 'text', 0, 0, 1, NULL);
+EOD;
+        $this->addSql($sql);
+
+        $sql = <<<'EOD'
+INSERT IGNORE INTO `s_core_config_elements` (`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`, `options`) VALUES
+(@formId, 'mailer_from_address', 's:0:\"\";', 'Absender-Adresse', 'Eine E-Mail-Adresse, die bei E-Mails ohne eigenen Absender genommen werden soll. Wenn keine hinterlegt ist, wird die Shopbetreiber-Adresse genommen.', 'text', 0, 0, 1, NULL),
+(@formId, 'mailer_from_name', 's:0:\"\";', 'Absender-Name', 'Ein Name, welcher bei E-Mails ohne eigenen Absender genommen werden soll. Wenn keine hinterlegt ist, wird der Shop-Name verwendet.', 'text', 0, 0, 1, NULL),
+(@formId, 'mailer_reply_to', 'b:0;', 'Antwort-Adresse setzen', 'Soll die Antwort-Adresse (Reply-To) automatisch gesetzt werden?', 'boolean', 0, 0, 1, NULL),
+(@formId, 'mailer_reply_to_address', 's:0:\"\";', 'Antwort-Adresse', 'Eine E-Mail-Adresse, die bei E-Mails als Antwort-Adresse genommen werden soll. Wenn keine hinterlegt ist, wird die Absender-Adresse genommen.', 'text', 0, 0, 1, NULL),
+(@formId, 'mailer_return_path', 's:0:\"\";', '„Wenn unzustellbar zurück an“', 'Welche Adresse soll als „Return-Path“ gesetzt werden?', 'text', 0, 0, 1, NULL);
+EOD;
+        $this->addSql($sql);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "zendframework/zend-escaper": "2.5.2",
         "oyejorge/less.php": "1.7.0.14",
         "guzzlehttp/guzzle": "5.3.3",
-        "egulias/email-validator": "1.2.14",
+        "egulias/email-validator": "2.1.7",
         "elasticsearch/elasticsearch": "2.3.2",
         "ongr/elasticsearch-dsl": "2.2.2",
         "paragonie/random_compat": "2.0.11",
@@ -79,7 +79,8 @@
         "fig/link-util": "1.0.0",
         "league/flysystem": "1.0.46",
         "league/flysystem-aws-s3-v3": "1.0.19",
-        "superbalist/flysystem-google-storage": "6.0.0"
+        "superbalist/flysystem-google-storage": "6.0.0",
+        "swiftmailer/swiftmailer": "^5.4"
     },
     "suggest": {
         "ext-apcu": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a242299b9b8214d241e8c171367e94d2",
+    "content-hash": "901c2bfbc890b01e76dca527e9fc1f3c",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.82.6",
+            "version": "3.85.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "a254cef386f193249e2dea5ca54f66b3e2c00963"
+                "reference": "e232d117d0124ccb7059cd6db90f45dd23cda3f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a254cef386f193249e2dea5ca54f66b3e2c00963",
-                "reference": "a254cef386f193249e2dea5ca54f66b3e2c00963",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/e232d117d0124ccb7059cd6db90f45dd23cda3f3",
+                "reference": "e232d117d0124ccb7059cd6db90f45dd23cda3f3",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-01-04T23:01:07+00:00"
+            "time": "2019-01-11T19:22:05+00:00"
         },
         {
             "name": "bcremer/line-reader",
@@ -903,24 +903,29 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "1.2.14",
+            "version": "2.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "5642614492f0ca2064c01d60cc33284cc2f731a9"
+                "reference": "709f21f92707308cdf8f9bcfa1af4cb26586521e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/5642614492f0ca2064c01d60cc33284cc2f731a9",
-                "reference": "5642614492f0ca2064c01d60cc33284cc2f731a9",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/709f21f92707308cdf8f9bcfa1af4cb26586521e",
+                "reference": "709f21f92707308cdf8f9bcfa1af4cb26586521e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "^1.0.1",
-                "php": ">= 5.3.3"
+                "php": ">= 5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.24"
+                "dominicsayers/isemail": "dev-master",
+                "phpunit/phpunit": "^4.8.35||^5.7||^6.0",
+                "satooshi/php-coveralls": "^1.0.1"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
             },
             "type": "library",
             "extra": {
@@ -929,8 +934,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Egulias\\": "src/"
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "EmailValidator"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -942,7 +947,7 @@
                     "name": "Eduardo Gulias Davis"
                 }
             ],
-            "description": "A library for validating emails",
+            "description": "A library for validating emails against several RFCs",
             "homepage": "https://github.com/egulias/EmailValidator",
             "keywords": [
                 "email",
@@ -951,7 +956,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2017-02-03T22:48:59+00:00"
+            "time": "2018-12-04T22:38:24+00:00"
         },
         {
             "name": "elasticsearch/elasticsearch",
@@ -3216,6 +3221,60 @@
             ],
             "description": "Flysystem adapter for Google Cloud Storage",
             "time": "2018-01-08T08:59:24+00:00"
+        },
+        {
+            "name": "swiftmailer/swiftmailer",
+            "version": "v5.4.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swiftmailer/swiftmailer.git",
+                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/181b89f18a90f8925ef805f950d47a7190e9b950",
+                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.1",
+                "symfony/phpunit-bridge": "~3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/swift_required.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Corbyn"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Swiftmailer, free feature-rich PHP mailer",
+            "homepage": "https://swiftmailer.symfony.com",
+            "keywords": [
+                "email",
+                "mail",
+                "mailer"
+            ],
+            "time": "2018-07-31T09:26:32+00:00"
         },
         {
             "name": "symfony/cache",

--- a/engine/Shopware/Components/Check/Data/System.xml
+++ b/engine/Shopware/Components/Check/Data/System.xml
@@ -11,6 +11,9 @@
         <name>mysql</name><group>core</group><required>5.6.0</required><database>1</database>
     </requirement>
     <requirement>
+        <name>sendmail</name><group>core</group><required>1</required>
+    </requirement>
+    <requirement>
         <name>pdo</name><group>extension</group><required>1</required>
     </requirement>
     <requirement>

--- a/engine/Shopware/Components/Check/Requirements.php
+++ b/engine/Shopware/Components/Check/Requirements.php
@@ -24,6 +24,8 @@
 
 namespace Shopware\Components\Check;
 
+use Symfony\Component\Process\ExecutableFinder;
+
 /**
  * @category Shopware
  *
@@ -405,6 +407,22 @@ class Requirements
         }
 
         return version_compare($required, $version, '<=');
+    }
+
+    /**
+     * Checks sendmail
+     *
+     * @return bool
+     */
+    private function checkSendmail()
+    {
+        $command = 'sendmail';
+        $default = '/usr/sbin/sendmail';
+
+        $finder = new ExecutableFinder();
+        $bin = $finder->find($command, $default);
+
+        return !empty($bin) && is_executable($bin);
     }
 
     /**

--- a/engine/Shopware/Components/DependencyInjection/Bridge/Mail.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Mail.php
@@ -24,7 +24,8 @@
 
 namespace Shopware\Components\DependencyInjection\Bridge;
 
-use Shopware\Components\DependencyInjection\Container;
+use Enlight_Components_Mail as MailMessage;
+use Shopware_Components_Config as Config;
 
 /**
  * @category Shopware
@@ -34,26 +35,20 @@ use Shopware\Components\DependencyInjection\Container;
 class Mail
 {
     /**
-     * @param Container                   $container
-     * @param \Shopware_Components_Config $config
-     * @param array                       $options
+     * @param Config $config
+     * @param array  $options
      *
-     * @return \Enlight_Components_Mail|null
+     * @return MailMessage
      */
-    public function factory(Container $container, \Shopware_Components_Config $config, array $options)
+    public function factory(Config $config, array $options)
     {
-        if (!$container->load('MailTransport')) {
-            return null;
+        $mail = new MailMessage();
+        if (!empty($options['charset'])) {
+            $mail->setCharset($options['charset']);
+        } elseif ($config->get('charset')) {
+            $mail->setCharset($config->get('charset'));
         }
 
-        if (isset($options['charset'])) {
-            $defaultCharSet = $options['charset'];
-        } elseif (!empty($config->CharSet)) {
-            $defaultCharSet = $config->CharSet;
-        } else {
-            $defaultCharSet = null;
-        }
-
-        return new \Enlight_Components_Mail($defaultCharSet);
+        return $mail;
     }
 }

--- a/engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
@@ -24,89 +24,122 @@
 
 namespace Shopware\Components\DependencyInjection\Bridge;
 
+use Shopware_Components_Config;
+use Swift_FileSpool;
+use Swift_MailTransport;
+use Swift_NullTransport;
+use Swift_SendmailTransport;
+use Swift_SmtpTransport;
+use Swift_SpoolTransport;
+use Swift_Transport;
+use Symfony\Component\Process\ExecutableFinder;
+
 /**
- * @category Shopware
+ * @category  Shopware
  *
  * @copyright Copyright (c) shopware AG (http://www.shopware.de)
  */
 class MailTransport
 {
     /**
-     * @param \Enlight_Loader             $loader
-     * @param \Shopware_Components_Config $config
-     * @param array                       $options
+     * @param Shopware_Components_Config $config
+     * @param array                      $options
      *
-     * @return \Enlight_Class|\Zend_Mail_Transport_Abstract
+     * @return Swift_Transport
      */
-    public function factory(\Enlight_Loader $loader, \Shopware_Components_Config $config, array $options)
+    public function factory(Shopware_Components_Config $config, array $options)
     {
         if (!isset($options['type']) && !empty($config->MailerMailer) && $config->MailerMailer != 'mail') {
             $options['type'] = $config->MailerMailer;
         }
         if (empty($options['type'])) {
-            $options['type'] = 'sendmail';
+            $options['type'] = 'mail';
+        } elseif ($options['type'] == 'gmail') {
+            $options['type'] = 'smtp';
+            $options['ssl'] = 'ssl';
+            $options['auth'] = 'login';
+            $options['host'] = 'smtp.gmail.com';
+            $options['port'] = 465;
         }
-
         if ($options['type'] == 'smtp') {
-            if (!isset($options['username']) && !empty($config->MailerUsername)) {
-                if (!empty($config->MailerAuth)) {
-                    $options['auth'] = $config->MailerAuth;
-                } elseif (empty($options['auth'])) {
-                    $options['auth'] = 'login';
-                }
-                $options['username'] = $config->MailerUsername;
-                $options['password'] = $config->MailerPassword;
-            }
-            if (!isset($options['ssl']) && !empty($config->MailerSMTPSecure)) {
-                $options['ssl'] = $config->MailerSMTPSecure;
-            }
-            if (!isset($options['port']) && !empty($config->MailerPort)) {
-                $options['port'] = $config->MailerPort;
-            }
-            if (!isset($options['name']) && !empty($config->MailerHostname)) {
-                $options['name'] = $config->MailerHostname;
-            }
-            if (!isset($options['host']) && !empty($config->MailerHost)) {
-                $options['host'] = $config->MailerHost;
-            }
-        }
-
-        if (!$loader->loadClass($options['type'])) {
-            $transportName = ucfirst(strtolower($options['type']));
-            $transportName = 'Zend_Mail_Transport_' . $transportName;
-        } else {
-            $transportName = $options['type'];
-        }
-        unset($options['type'], $options['charset']);
-
-        if ($transportName == 'Zend_Mail_Transport_Smtp') {
-            $transport = \Enlight_Class::Instance($transportName, [$options['host'], $options]);
-        } elseif (!empty($options)) {
-            $transport = \Enlight_Class::Instance($transportName, [$options]);
-        } else {
-            $transport = \Enlight_Class::Instance($transportName);
-        }
-        /* @var \Zend_Mail_Transport_Abstract $transport */
-        \Enlight_Components_Mail::setDefaultTransport($transport);
-
-        if (!isset($options['from']) && !empty($config->Mail)) {
-            $options['from'] = ['email' => $config->Mail, 'name' => $config->Shopname];
-        }
-
-        if (!empty($options['from']['email'])) {
-            \Enlight_Components_Mail::setDefaultFrom(
-                $options['from']['email'],
-                !empty($options['from']['name']) ? $options['from']['name'] : null
+            $transport = new Swift_SmtpTransport();
+            $this->setSmtpOptions(
+                $transport,
+                $this->getSmtpOptions($options, $config)
             );
+
+            return $transport;
+        } elseif ($options['type'] == 'mail') {
+            $command = 'sendmail';
+            $default = '/usr/sbin/sendmail';
+
+            $finder = new ExecutableFinder();
+            $bin = $finder->find($command, $default);
+
+            if (!empty($bin) && is_executable($bin)) {
+                return new Swift_SendmailTransport($bin . ' -bs');
+            }
+
+            return new Swift_MailTransport();
+        } elseif ($options['type'] == 'file') {
+            return new Swift_SpoolTransport(new Swift_FileSpool($options['path']));
         }
 
-        if (!empty($options['replyTo']['email'])) {
-            \Enlight_Components_Mail::setDefaultReplyTo(
-                $options['replyTo']['email'],
-                !empty($options['replyTo']['name']) ? $options['replyTo']['name'] : null
-            );
+        return new Swift_NullTransport();
+    }
+
+    private function getSmtpOptions(array $options, Shopware_Components_Config $config)
+    {
+        if (!isset($options['username']) && !empty($config->MailerUsername)) {
+            if (!empty($config->MailerAuth)) {
+                $options['auth'] = $config->MailerAuth;
+            } elseif (empty($options['auth'])) {
+                $options['auth'] = 'login';
+            }
+            if ($options['auth'] == 'crammd5') {
+                $options['auth'] = 'cram-md5';
+            }
+            $options['username'] = $config->MailerUsername;
+            $options['password'] = $config->MailerPassword;
+        }
+        if (!isset($options['ssl']) && !empty($config->MailerSMTPSecure)) {
+            $options['ssl'] = $config->MailerSMTPSecure;
+        }
+        if (!isset($options['port']) && !empty($config->MailerPort)) {
+            $options['port'] = $config->MailerPort;
+        }
+        if (!isset($options['name']) && !empty($config->MailerHostname)) {
+            $options['name'] = $config->MailerHostname;
+        }
+        if (!isset($options['host']) && !empty($config->MailerHost)) {
+            $options['host'] = $config->MailerHost;
         }
 
-        return $transport;
+        return $options;
+    }
+
+    private function setSmtpOptions(Swift_SmtpTransport $transport, $options)
+    {
+        if (isset($options['host'])) {
+            $transport->setHost($options['host']);
+        }
+        if (isset($options['port'])) {
+            $transport->setPort($options['port']);
+        }
+        if (!empty($options['ssl'])) {
+            $transport->setEncryption($options['ssl']);
+        }
+        if (isset($options['username'])) {
+            $transport->setUsername($options['username']);
+        }
+        if (isset($options['password'])) {
+            $transport->setPassword($options['password']);
+        }
+        if (isset($options['auth'])) {
+            $transport->setAuthMode($options['auth']);
+        }
+        if (isset($options['name'])) {
+            $transport->setLocalDomain($options['name']);
+        }
     }
 }

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -80,21 +80,42 @@
             <argument type="service" id="session.save_handler"/>
         </service>
 
-        <service id="mailtransport_factory" class="Shopware\Components\DependencyInjection\Bridge\MailTransport" />
-        <service id="shopware.mail_transport" alias="MailTransport" />
-        <service id="MailTransport" class="Zend_Mail_Transport_Abstract">
-            <factory service="mailtransport_factory" method="factory" />
-            <argument type="service" id="Loader"/>
+        <service id="mailtransport_factory" class="Shopware\Components\DependencyInjection\Bridge\MailTransport"/>
+        <service id="shopware.mail_transport" alias="MailTransport"/>
+        <service id="mailtransport" class="Swift_Transport">
+            <factory service="mailtransport_factory" method="factory"/>
             <argument type="service" id="config"/>
             <argument>%shopware.mail%</argument>
         </service>
 
-        <service id="mail_factory" class="Shopware\Components\DependencyInjection\Bridge\Mail" />
-        <service id="mail" class="Enlight_Components_Mail">
-            <factory service="mail_factory" method="factory" />
-            <argument type="service" id="service_container"/>
+        <service id="mail_factory" class="Shopware\Components\DependencyInjection\Bridge\Mail"/>
+        <service id="mail" class="Enlight_Components_Mail" shared="false">
+            <factory service="mail_factory" method="factory"/>
             <argument type="service" id="config"/>
             <argument>%shopware.mail%</argument>
+        </service>
+
+        <service id="mailer_config_listener" class="Shopware\Components\Mail\ConfigListener">
+            <argument>%shopware.mail%</argument>
+            <argument type="service" id="config"/>
+        </service>
+        <service id="mailer_redirecting_listener" class="Shopware\Components\Mail\RedirectingListener">
+            <argument type="service" id="config"/>
+        </service>
+        <service id="mailer_event_listener" class="Shopware\Components\Mail\EventListener">
+            <argument type="service" id="events"/>
+        </service>
+        <service id="mailer" class="Swift_Mailer">
+            <argument type="service" id="mailtransport"/>
+            <call method="registerPlugin">
+                <argument type="service" id="mailer_config_listener"/>
+            </call>
+            <call method="registerPlugin">
+                <argument type="service" id="mailer_redirecting_listener"/>
+            </call>
+            <call method="registerPlugin">
+                <argument type="service" id="mailer_event_listener"/>
+            </call>
         </service>
 
         <service id="templatemail_factory" class="Shopware\Components\DependencyInjection\Bridge\TemplateMail" />

--- a/engine/Shopware/Components/Mail/ConfigListener.php
+++ b/engine/Shopware/Components/Mail/ConfigListener.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Mail;
+
+use Swift_Events_SendEvent as SendEvent;
+use Swift_Events_SendListener as SendListenerInterface;
+
+/**
+ * Class ConfigListener
+ */
+class ConfigListener implements SendListenerInterface
+{
+    private $options;
+
+    private $config;
+
+    public function __construct(array $options, \Shopware_Components_Config $config)
+    {
+        $this->options = $options;
+        $this->config = $config;
+    }
+
+    public function beforeSendPerformed(SendEvent $event)
+    {
+        $mail = $event->getMessage();
+
+        if (empty($mail->getFrom())) {
+            if (!empty($this->options['from']['email'])) {
+                $mail->setFrom(
+                    $this->options['from']['email'],
+                    !empty($this->options['from']['name']) ? $this->options['from']['name'] : null
+                );
+            } elseif ($this->config->get('mailer_from_address')) {
+                $mail->setFrom(
+                    $this->config->get('mailer_from_address'),
+                    $this->config->get('mailer_from_name')
+                );
+            } elseif ($this->config->get('mail')) {
+                $mail->setFrom(
+                    $this->config->get('mail'),
+                    $this->config->get('shopName')
+                );
+            }
+        }
+
+        if (empty($mail->getReplyTo())) {
+            if (!empty($this->options['replyTo']['email'])) {
+                $mail->setReplyTo(
+                    $this->options['replyTo']['email'],
+                    !empty($this->options['replyTo']['name']) ? $this->options['replyTo']['name'] : null
+                );
+            } elseif ($this->config->get('mailer_reply_to')) {
+                $mail->setReplyTo(
+                    $this->config->get('mailer_reply_to_address') ?: $mail->getFrom()
+                );
+            }
+        }
+
+        if (empty($mail->getReturnPath())) {
+            if (!empty($this->options['return_path'])) {
+                $mail->setReturnPath($this->options['return_path']);
+            } elseif ($this->config->get('mailer_return_path')) {
+                $mail->setReturnPath($this->config->get('mailer_return_path'));
+            }
+        }
+
+        if ($this->config->get('mailer_bcc_address')) {
+            $addresses = $mail->getBcc();
+            $newAddresses = array_map('trim', explode(';', $this->config->get('mailer_bcc_address')));
+            $addresses = array_merge($addresses, array_combine($newAddresses, array_fill(0, count($newAddresses), null)));
+            $mail->setBcc($addresses);
+        }
+    }
+
+    public function sendPerformed(SendEvent $event)
+    {
+    }
+}

--- a/engine/Shopware/Components/Mail/EventListener.php
+++ b/engine/Shopware/Components/Mail/EventListener.php
@@ -22,25 +22,36 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Tests\Unit\Library;
+namespace Shopware\Components\Mail;
 
-use PHPUnit\Framework\TestCase;
-use Zend\Mail\Protocol\ProtocolTrait;
+use Enlight_Event_EventManager as EventManager;
+use Swift_Events_SendEvent as SendEvent;
+use Swift_Events_SendListener as SendListenerInterface;
 
 /**
- * @category Shopware
- *
- * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ * Class SendListener
  */
-class ZendMailProtocolTest extends TestCase
+class EventListener implements SendListenerInterface
 {
-    use ProtocolTrait;
+    private $eventManager;
 
-    /**
-     * Check if the required TLS version is used
-     */
-    public function testGetCryptoMethod()
+    public function __construct(EventManager $eventManager)
     {
-        $this->assertGreaterThan(STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT, $this->getCryptoMethod(), 'TLS protocol version should be greater than TLSv1.0');
+        $this->eventManager = $eventManager;
+    }
+
+    public function beforeSendPerformed(SendEvent $event)
+    {
+        $this->eventManager->notify(
+            'Enlight_Components_Mail_Send',
+            [
+                'mail' => $event->getMessage(),
+                'transport' => $event->getTransport(),
+            ]
+        );
+    }
+
+    public function sendPerformed(SendEvent $event)
+    {
     }
 }

--- a/engine/Shopware/Components/Mail/RedirectingListener.php
+++ b/engine/Shopware/Components/Mail/RedirectingListener.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Mail;
+
+use Swift_Events_SendEvent;
+use Swift_Plugins_RedirectingPlugin;
+
+/**
+ * Class RedirectingListener
+ */
+class RedirectingListener extends Swift_Plugins_RedirectingPlugin
+{
+    /**
+     * The recipient who will receive all messages.
+     *
+     * @var bool
+     */
+    private $hasRecipient;
+
+    public function __construct(\Shopware_Components_Config $config)
+    {
+        $recipient = $config->get('mailer_delivery_address');
+        if (!empty($recipient)) {
+            $this->hasRecipient = true;
+            $recipient = explode(';', $recipient);
+        } else {
+            $this->hasRecipient = false;
+            $recipient = [];
+        }
+        $whitelist = $config->get('mailer_delivery_whitelist');
+        if (!empty($whitelist)) {
+            $whitelist = (array) $whitelist;
+        } else {
+            $whitelist = [];
+        }
+        parent::__construct($recipient, $whitelist);
+    }
+
+    /**
+     * Invoked immediately before the Message is sent.
+     *
+     * @param Swift_Events_SendEvent $evt
+     */
+    public function beforeSendPerformed(Swift_Events_SendEvent $evt)
+    {
+        if ($this->hasRecipient) {
+            parent::beforeSendPerformed($evt);
+        }
+    }
+
+    /**
+     * Invoked immediately after the Message is sent.
+     *
+     * @param Swift_Events_SendEvent $evt
+     */
+    public function sendPerformed(Swift_Events_SendEvent $evt)
+    {
+        if ($this->hasRecipient) {
+            parent::sendPerformed($evt);
+        }
+    }
+}

--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -251,7 +251,7 @@ class Shopware_Components_TemplateMail
 
         $this->getStringCompiler()->setContext(array_merge($defaultContext, $context));
 
-        $mail = clone Shopware()->Container()->get('mail');
+        $mail = Shopware()->Container()->get('mail');
 
         return $this->loadValues($mail, $mailModel, $overrideConfig);
     }
@@ -312,8 +312,11 @@ class Shopware_Components_TemplateMail
             if (!$mediaService->has($attachment->getPath())) {
                 Shopware()->Container()->get('corelogger')->error('Could not load file: ' . $attachment->getPath());
             } else {
-                $fileAttachment = $mail->createAttachment($mediaService->read($attachment->getPath()));
-                $fileAttachment->filename = $attachment->getFileName();
+                $mailAttachment = new Swift_Attachment(
+                    $mediaService->read($attachment->getPath()),
+                    $attachment->getFileName()
+                );
+                $mail->attach($mailAttachment);
             }
         }
 

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -934,9 +934,8 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
             return;
         }
 
-        $mail = clone $this->container->get('mail');
+        $mail = $this->get('mail');
         $mail = $this->addAttachments($mail, $orderId, $attachments);
-        $mail->clearRecipients();
         $mail->setSubject($this->Request()->getParam('subject', ''));
 
         if ($this->Request()->getParam('isHtml')) {
@@ -1012,8 +1011,8 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
                 'content' => $mail->getPlainBodyText(),
                 'contentHtml' => $mail->getPlainBody(),
                 'subject' => $mail->getPlainSubject(),
-                'to' => implode(', ', $mail->getTo()),
-                'fromMail' => $mail->getFrom(),
+                'to' => implode(', ', array_keys($mail->getTo())),
+                'fromMail' => $mail->getFromAddress(),
                 'fromName' => $mail->getFromName(),
                 'sent' => false,
                 'isHtml' => !empty($mail->getPlainBody()),
@@ -1658,7 +1657,7 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
                 continue;
             }
 
-            $mail->addAttachment($this->createAttachment($filePath, $fileName));
+            $mail->attach($this->createAttachment($filePath, $fileName));
         }
 
         return $mail;
@@ -1670,20 +1669,18 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
      * @param string $filePath
      * @param string $fileName
      *
-     * @return Zend_Mime_Part
+     * @return Swift_Attachment
      */
     private function createAttachment($filePath, $fileName)
     {
         $filesystem = $this->container->get('shopware.filesystem.private');
 
-        $content = $filesystem->read($filePath);
-        $zendAttachment = new Zend_Mime_Part($content);
-        $zendAttachment->type = 'application/pdf';
-        $zendAttachment->disposition = Zend_Mime::DISPOSITION_ATTACHMENT;
-        $zendAttachment->encoding = Zend_Mime::ENCODING_BASE64;
-        $zendAttachment->filename = $fileName;
+        $mailAttachment = new Swift_Attachment(
+            $filesystem->read($filePath),
+            $fileName
+        );
 
-        return $zendAttachment;
+        return $mailAttachment;
     }
 
     /**
@@ -1996,8 +1993,8 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
                     'content' => $mail->getPlainBodyText(),
                     'contentHtml' => $mail->getPlainBody(),
                     'subject' => $mail->getPlainSubject(),
-                    'to' => implode(', ', $mail->getTo()),
-                    'fromMail' => $mail->getFrom(),
+                    'to' => implode(', ', array_keys($mail->getTo())),
+                    'fromMail' => $mail->getFromAddress(),
                     'fromName' => $mail->getFromName(),
                     'sent' => false,
                     'isHtml' => !empty($mail->getPlainBody()),

--- a/engine/Shopware/Controllers/Backend/Widgets.php
+++ b/engine/Shopware/Controllers/Backend/Widgets.php
@@ -664,7 +664,8 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
     public function sendMailToMerchantAction()
     {
         $params = $this->Request()->getParams();
-        $mail = clone Shopware()->Container()->get('mail');
+        /** @var \Enlight_Components_Mail $mail */
+        $mail = $this->get('mail');
 
         $toMail = $params['toMail'];
         $fromName = $params['fromName'];
@@ -689,12 +690,9 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
         $compiler->setContext($defaultContext);
 
         // Send eMail to customer
-        $mail->IsHTML(false);
-        $mail->From = $compiler->compileString($fromMail);
-        $mail->FromName = $compiler->compileString($fromName);
-        $mail->Subject = $compiler->compileString($subject);
-        $mail->Body = $compiler->compileString($content);
-        $mail->clearRecipients();
+        $mail->setFrom($compiler->compileString($fromMail), $compiler->compileString($fromName));
+        $mail->setSubject($compiler->compileString($subject));
+        $mail->setBody($compiler->compileString($content));
         $mail->addTo($toMail);
 
         if (!$mail->send()) {

--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -22,7 +22,6 @@
  * our trademarks remain entirely with us.
  */
 
-use League\Flysystem\Adapter\Local;
 use Shopware\Bundle\AccountBundle\Form\Account\EmailUpdateFormType;
 use Shopware\Bundle\AccountBundle\Form\Account\PasswordUpdateFormType;
 use Shopware\Bundle\AccountBundle\Form\Account\ProfileUpdateFormType;

--- a/engine/Shopware/Controllers/Frontend/Forms.php
+++ b/engine/Shopware/Controllers/Frontend/Forms.php
@@ -62,7 +62,6 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
      * @throws \Exception
      * @throws \DomainException
      * @throws \Enlight_Exception
-     * @throws \Zend_Mail_Exception
      * @throws \Enlight_Event_Exception
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
@@ -94,7 +93,6 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
      * Commit form via email (default) or database (ticket system)
      *
      * @throws \Enlight_Exception
-     * @throws \Zend_Mail_Exception
      * @throws \Enlight_Event_Exception
      */
     public function commitForm()
@@ -639,7 +637,6 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
      * @param int $formId
      *
      * @throws \Enlight_Exception
-     * @throws \Zend_Mail_Exception
      * @throws \Enlight_Event_Exception
      */
     private function handleFormPost($formId)

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -942,7 +942,7 @@ class sOrder
             $mail = $event->getReturn();
         }
 
-        if (!($mail instanceof \Zend_Mail)) {
+        if (!($mail instanceof \Enlight_Components_Mail)) {
             $mail = Shopware()->TemplateMail()->createMail('sORDER', $context);
         }
 
@@ -958,7 +958,7 @@ class sOrder
             'variables' => $variables,
         ]);
 
-        if (!($mail instanceof \Zend_Mail)) {
+        if (!($mail instanceof \Enlight_Components_Mail)) {
             return;
         }
 

--- a/tests/Functional/Components/TemplateMailTest.php
+++ b/tests/Functional/Components/TemplateMailTest.php
@@ -97,9 +97,9 @@ class Shopware_Tests_Components_TemplateMailTest extends Enlight_Components_Test
 
         $this->assertEquals($templateMock->getSubject(), $result->getSubject());
         $this->assertEquals($templateMock->getFromName(), $result->getFromName());
-        $this->assertEquals($templateMock->getFromMail(), $result->getFrom());
-        $this->assertEquals($templateMock->getContent(), $result->getBodyText(true));
-        $this->assertEquals($templateMock->getContentHtml(), $result->getBodyHtml(true));
+        $this->assertEquals($templateMock->getFromMail(), $result->getFromAddress());
+        $this->assertEquals($templateMock->getContent(), $result->getBodyText());
+        $this->assertEquals($templateMock->getContentHtml(), $result->getBodyHtml());
     }
 
     /**
@@ -123,9 +123,9 @@ class Shopware_Tests_Components_TemplateMailTest extends Enlight_Components_Test
 
         $this->assertEquals('Ihr Bestellung bei Shopware 3.5 Demo', $result->getSubject());
         $this->assertEquals('Shopware 3.5 Demo', $result->getFromName());
-        $this->assertEquals('info@example.com', $result->getFrom());
-        $this->assertEquals('Testbestellung bei Shopware 3.5 Demo', $result->getBodyText(true));
-        $this->assertEquals('Testbestellung HTML bei Shopware 3.5 Demo', $result->getBodyHtml(true));
+        $this->assertEquals('info@example.com', $result->getFromAddress());
+        $this->assertEquals('Testbestellung bei Shopware 3.5 Demo', $result->getBodyText());
+        $this->assertEquals('Testbestellung HTML bei Shopware 3.5 Demo', $result->getBodyHtml());
     }
 
     /**
@@ -145,9 +145,9 @@ class Shopware_Tests_Components_TemplateMailTest extends Enlight_Components_Test
 
         $this->assertEquals('Ihr Bestellung bei Shopware 3.5 Demo', $result->getSubject());
         $this->assertEquals('Shopware 3.5 Demo', $result->getFromName());
-        $this->assertEquals('info@example.com', $result->getFrom());
-        $this->assertEquals('Testbestellung bei Shopware 3.5 Demo', $result->getBodyText(true));
-        $this->assertEquals('Testbestellung HTML bei Shopware 3.5 Demo', $result->getBodyHtml(true));
+        $this->assertEquals('info@example.com', $result->getFromAddress());
+        $this->assertEquals('Testbestellung bei Shopware 3.5 Demo', $result->getBodyText());
+        $this->assertEquals('Testbestellung HTML bei Shopware 3.5 Demo', $result->getBodyHtml());
     }
 
     /**

--- a/tests/Functional/Core/sOrderTest.php
+++ b/tests/Functional/Core/sOrderTest.php
@@ -90,6 +90,9 @@ class sOrderTest extends PHPUnit\Framework\TestCase
             ],
         ];
 
+        // Fix Swift_RfcComplianceException
+        $this->module->sUserData['additional']['user']['email'] = 'info@example.com';
+
         $this->module->sendMail($variables);
     }
 

--- a/tests/Functional/Regressions/Ticket5217Test.php
+++ b/tests/Functional/Regressions/Ticket5217Test.php
@@ -42,6 +42,6 @@ class Shopware_RegressionTests_Ticket5217 extends Enlight_Components_Test_TestCa
         $mail->addTo('test@example.com');
 
         $mail = $mail->send($mailTransport);
-        $this->assertInstanceOf('Zend_Mail', $mail);
+        $this->assertInstanceOf(Enlight_Components_Mail::class, $mail);
     }
 }

--- a/tests/Unit/Components/MailTest.php
+++ b/tests/Unit/Components/MailTest.php
@@ -38,15 +38,6 @@ class MailTest extends TestCase
         $mail = new \Enlight_Components_Mail();
         $mail->setFrom('foo@example.com', 'Sender\'s name');
 
-        $this->assertSame('foo@example.com', $mail->getFrom());
-    }
-
-    public function testCodeInjectionInFromHeader()
-    {
-        $mail = new \Enlight_Components_Mail();
-
-        $this->expectException(\RuntimeException::class);
-
-        $mail->setFrom('"AAA\" code injection"@domain', 'Sender\'s name');
+        $this->assertSame('foo@example.com', $mail->getFromAddress());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Replace zend mail with swift mailer.
Features:

Redirect Plugin for redirect all mails to a address
NULL-Transporter: Disable mails in the backend
Global BBC Address
Additionally config for mailer_from, reply_to and return_path
 mail() function is deprecated see swiftmailer/swiftmailer#866 (due to security reasons)
Sendmail is now the default transport
Sendmail is now a system requirement

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.