### PR TITLE
Add parentheses to perform "instanceof" operator before logical NOT o…

### DIFF
--- a/themes/Backend/ExtJs/backend/article/controller/media.js
+++ b/themes/Backend/ExtJs/backend/article/controller/media.js
@@ -421,7 +421,7 @@ Ext.define('Shopware.apps.Article.controller.Media', {
 
         // Handle single choice
         if (selModel.getCount() === 1) {
-            if (!selModel.selected instanceof Ext.data.Model) {
+            if (!(selModel.selected instanceof Ext.data.Model)) {
                 return false;
             }
 
@@ -650,7 +650,7 @@ Ext.define('Shopware.apps.Article.controller.Media', {
             downloadButton.setDisabled(disabled);
         }
 
-        if (!disabled) {
+        if (!disabled && selected !== null) {
             previewButton.setDisabled(selected.get('main') === 1);
         }
     },
@@ -665,9 +665,11 @@ Ext.define('Shopware.apps.Article.controller.Media', {
     onMediaMoved: function(mediaStore, draggedRecord, targetRecord) {
         var index, indexOfDragged;
 
-        if (!mediaStore instanceof Ext.data.Store
-                || !draggedRecord instanceof Ext.data.Model
-                || !targetRecord instanceof Ext.data.Model) {
+        if (
+            !(mediaStore instanceof Ext.data.Store) ||
+            !(draggedRecord instanceof Ext.data.Model) ||
+            !(targetRecord instanceof Ext.data.Model)
+        ) {
             return false;
         }
         index = mediaStore.indexOf(targetRecord);

--- a/themes/Backend/ExtJs/backend/article_list/controller/filter.js
+++ b/themes/Backend/ExtJs/backend/article_list/controller/filter.js
@@ -464,7 +464,7 @@ Ext.define('Shopware.apps.ArticleList.controller.Filter', {
             grid = me.getSimpleGrid();
 
         // If no operators available, disable value editor and operator editor
-        if (!operators instanceof Array) {
+        if (!(operators instanceof Array)) {
             operatorColumn.setEditor(false);
             valueColumn.setEditor(false);
             return;
@@ -526,7 +526,7 @@ Ext.define('Shopware.apps.ArticleList.controller.Filter', {
                 operators = me.filterableColumns[columnName];
 
             // If no operators available, disable value editor and operator editor
-            if (!operators instanceof Array) {
+            if (!(operators instanceof Array)) {
                 operatorColumn.setEditor(false);
                 valueColumn.setEditor(false);
                 return;

--- a/themes/Backend/ExtJs/backend/benchmark/view/settings/industry_field.js
+++ b/themes/Backend/ExtJs/backend/benchmark/view/settings/industry_field.js
@@ -17,7 +17,7 @@ Ext.define('Shopware.apps.Benchmark.view.settings.IndustryField', {
     initComponent: function () {
         var me = this;
 
-        if (!me.store || !me.store instanceof Ext.data.Store) {
+        if (!me.store || !(me.store instanceof Ext.data.Store)) {
             throw new Error('The industry field requires a store');
         }
 

--- a/themes/Backend/ExtJs/backend/newsletter_manager/controller/admin.js
+++ b/themes/Backend/ExtJs/backend/newsletter_manager/controller/admin.js
@@ -337,7 +337,7 @@ Ext.define('Shopware.apps.NewsletterManager.controller.Admin', {
             values = form.getValues(),
             record = form.getRecord();
 
-        if(!record instanceof Ext.data.Model){
+        if(!(record instanceof Ext.data.Model)){
             return;
         }
 

--- a/themes/Backend/ExtJs/backend/theme/view/config_sets/window.js
+++ b/themes/Backend/ExtJs/backend/theme/view/config_sets/window.js
@@ -54,10 +54,10 @@ Ext.define('Shopware.apps.Theme.view.config_sets.Window', {
 
         me.store.each(function(theme) {
 
-            if (!theme.getConfigSets() instanceof Ext.data.Store) {
+            if (!(theme.getConfigSets() instanceof Ext.data.Store)) {
                 return true;
             }
-            if (!theme.getConfigSets().getCount() > 0) {
+            if (!(theme.getConfigSets().getCount() > 0)) {
                 return true;
             }
             var item = me.createFieldSet(theme);


### PR DESCRIPTION
…perator

Check for null and undefined before accessing variables

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`instanceof` checks have to be done before the variables are negated as otherwise it would always evaluate to false.


### 2. What does this change do, exactly?
Fix the `instanceof` checks.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.