### PR TITLE
Rename roules parameter to rules in keyframes mixin

### DIFF
--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/keyframes.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/keyframes.less
@@ -9,15 +9,15 @@ Please refer to <http://caniuse.com/#search=keyframe> to see the browser support
 `.keyframes([name-value], [frames-value]);`
 
 `@param: {String} name: The keyframe animation name`<br/>
-`@param: {String} roules: the animation frames`
+`@param: {String} rules: the animation frames`
 */
 
-.keyframes(@name, @roules) {
+.keyframes(@name, @rules) {
     @-webkit-keyframes @name {
-        @roules();
+        @rules();
     }
     @keyframes @name {
-        @roules();
+        @rules();
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`roules` is not a word that makes sense here or is known in english. I think it should be `rules` which makes more sense.

### 2. What does this change do, exactly?
Rename the parameter for the `keyframes` mixin.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.