### PR TITLE
Use an RSA algorithm with a OAEP padding to prevent chosen-ciphertext…

### DIFF
--- a/engine/Shopware/Components/OpenSSLEncryption.php
+++ b/engine/Shopware/Components/OpenSSLEncryption.php
@@ -77,7 +77,7 @@ class OpenSSLEncryption
         $encryptedMessage = openssl_encrypt($data, $encryptionMethod, $key, false, $iv);
 
         $encryptedKey = '';
-        if (!true === openssl_public_encrypt($key, $encryptedKey, $publicKey)) {
+        if (!true === openssl_public_encrypt($key, $encryptedKey, $publicKey, OPENSSL_PKCS1_OAEP_PADDING)) {
             $errors = [];
             while ($errors[] = openssl_error_string());
             $errorString = implode("\n", $errors);


### PR DESCRIPTION
… attacks

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
By default `openssl_public_encrypt` does not use an algorithm with OAEP padding and so the generated strings are vulnerable to oracle padding and chosen ciphertext attacks.

### 2. What does this change do, exactly?
Set the padding parameter for `openssl_public_encrypt` to `OPENSSL_PKCS1_OAEP_PADDING` to improve the security.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.