### PR TITLE
Added exposure of the current shopId

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php
+++ b/engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php
@@ -69,6 +69,10 @@ class Shopware_Controllers_Backend_Seo extends Shopware_Controllers_Backend_ExtJ
         ]);
     }
 
+    /**
+     * Assigns the amount of the seo links which to build for this shop
+     * Bind for: Shopware_Controllers_Seo_filterCounts
+     */
     public function getCountAction()
     {
         $shopId = (int) $this->Request()->getParam('shopId', 1);
@@ -93,7 +97,8 @@ class Shopware_Controllers_Backend_Seo extends Shopware_Controllers_Backend_ExtJ
 
         $counts = $this->get('events')->filter(
             'Shopware_Controllers_Seo_filterCounts',
-            $counts
+            $counts,
+            ['shopId' => $shopId]
         );
 
         $this->View()->assign([


### PR DESCRIPTION
### 1. Why is this change necessary?
Helps to get only the subjects for the current shop.
No PHPDoc above the function


### 2. What does this change do, exactly?
Adds 'shopId' as to Enlight_Event_EventArgs for the subscriber
Adds a PHPDoc 


### 3. Describe each step to reproduce the issue or behaviour.
Try to use the shop Id in a query to get only the entries for the current shop

### 4. Please link to the relevant issues (if any).
///

### 5. Which documentation changes (if any) need to be made because of this PR?
////

### 6. Checklist
- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

### 7. Comments
The tests work without my change but with my change too.
Is there a reason that this parameter isn't published at the moment?
