### PR TITLE
Standardized shopId and added more description info

### DIFF
--- a/engine/Shopware/Commands/PluginConfigListCommand.php
+++ b/engine/Shopware/Commands/PluginConfigListCommand.php
@@ -30,6 +30,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @category Shopware
@@ -46,8 +47,15 @@ class PluginConfigListCommand extends ShopwareCommand
         $this
             ->setName('sw:plugin:config:list')
             ->setDescription('Lists plugin configuration.')
+            /* @deprecated since 5.6, to be removed in 6.0 */
             ->addOption(
                 'shop',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Get configuration for shop id (deprecated)'
+            )
+            ->addOption(
+                'shopId',
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Get configuration for shop id'
@@ -82,10 +90,20 @@ EOF
         /** @var ModelManager $em */
         $em = $this->container->get('models');
 
+        $shopId = null;
+
         if ($input->getOption('shop')) {
-            $shop = $em->getRepository('Shopware\Models\Shop\Shop')->find($input->getOption('shop'));
+            $io = new SymfonyStyle($input, $output);
+            $io->warning('Option "--shop" will be removed by "--shopId" in the next major Version');
+            $shopId = $input->getOption('shop');
+        } elseif ($input->getOption('shopId')) {
+            $shopId = $input->getOption('shopId');
+        }
+
+        if ($shopId) {
+            $shop = $em->getRepository('Shopware\Models\Shop\Shop')->find($shopId);
             if (!$shop) {
-                $output->writeln(sprintf('Could not find shop with id %s.', $input->getOption('shop')));
+                $output->writeln(sprintf('Could not find shop with id %s.', $shopId));
 
                 return 1;
             }

--- a/engine/Shopware/Commands/PluginConfigSetCommand.php
+++ b/engine/Shopware/Commands/PluginConfigSetCommand.php
@@ -30,6 +30,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @category Shopware
@@ -61,8 +62,15 @@ class PluginConfigSetCommand extends ShopwareCommand
                 InputArgument::REQUIRED,
                 'Configuration value. Can be true, false, null, an integer or an array specified with brackets: [value,anothervalue]. Everything else will be interpreted as string.'
             )
+            /* @deprecated since 5.6, to be removed in 6.0 */
             ->addOption(
                 'shop',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Set configuration for shop id (deprecated)'
+            )
+            ->addOption(
+                'shopId',
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Set configuration for shop id'
@@ -90,10 +98,20 @@ class PluginConfigSetCommand extends ShopwareCommand
         /** @var ModelManager $em */
         $em = $this->container->get('models');
 
+        $shopId = null;
+
         if ($input->getOption('shop')) {
-            $shop = $em->getRepository('Shopware\Models\Shop\Shop')->find($input->getOption('shop'));
+            $io = new SymfonyStyle($input, $output);
+            $io->warning('Option "--shop" will be removed by "--shopId" in the next major Version');
+            $shopId = $input->getOption('shop');
+        } elseif ($input->getOption('shopId')) {
+            $shopId = $input->getOption('shopId');
+        }
+
+        if ($shopId) {
+            $shop = $em->getRepository('Shopware\Models\Shop\Shop')->find($shopId);
             if (!$shop) {
-                $output->writeln(sprintf('Could not find shop with id %s.', $input->getOption('shop')));
+                $output->writeln(sprintf('Could not find shop with id %s.', $shopId));
 
                 return 1;
             }

--- a/engine/Shopware/Commands/RebuildSeoIndexCommand.php
+++ b/engine/Shopware/Commands/RebuildSeoIndexCommand.php
@@ -27,7 +27,9 @@ namespace Shopware\Commands;
 use Shopware\Components\ContainerAwareEventManager;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class RebuildSeoIndexCommand extends ShopwareCommand
 {
@@ -74,7 +76,9 @@ class RebuildSeoIndexCommand extends ShopwareCommand
         $this
             ->setName('sw:rebuild:seo:index')
             ->setDescription('Rebuild the SEO index')
-            ->addArgument('shopId', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The Id of the shop')
+            /* @deprecated since 5.6, to be removed in 6.0 */
+            ->addArgument('shopId', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The Id of the shop (deprecated)')
+            ->addOption('shopId', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The Id of the shop (mulitple IDs -> shopId={1,2})')
             ->setHelp('The <info>%command.name%</info> rebuilds the SEO index')
         ;
     }
@@ -93,7 +97,15 @@ class RebuildSeoIndexCommand extends ShopwareCommand
         $this->rewriteTable = $this->modules->RewriteTable();
         $this->events = $this->container->get('events');
 
-        $shops = $input->getArgument('shopId');
+        $shops = null;
+
+        if ($input->getArgument('shopId')) {
+            $io = new SymfonyStyle($input, $output);
+            $io->warning('Argument "shopId" will be removed by Option "--shopId" in the next major Version');
+            $shops = $input->getArgument('shopId');
+        } elseif ($input->getOption('shopId')) {
+            $shops = $input->getOption('shopId');
+        }
 
         if (empty($shops)) {
             /** @var \Doctrine\DBAL\Query\QueryBuilder $query */

--- a/engine/Shopware/Commands/ThemeCacheGenerateCommand.php
+++ b/engine/Shopware/Commands/ThemeCacheGenerateCommand.php
@@ -47,7 +47,7 @@ class ThemeCacheGenerateCommand extends ShopwareCommand
     {
         $this
             ->setName('sw:theme:cache:generate')
-            ->addOption('shopId', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The Id of the shop')
+            ->addOption('shopId', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The Id of the shop (mulitple IDs -> shopId={1,2})')
             ->addOption('current', 'c', InputOption::VALUE_NONE, 'Compile from current asset timestamp')
             ->setDescription('Generates theme caches.')
         ;

--- a/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
+++ b/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
@@ -54,7 +54,9 @@ class WarmUpHttpCacheCommand extends ShopwareCommand
         $this
             ->setName('sw:warm:http:cache')
             ->setDescription('Warm up http cache (everything by default)')
-            ->addArgument('shopId', InputArgument::OPTIONAL, 'The Id of the shop')
+            /* @deprecated since 5.6, to be removed in 6.0 */
+            ->addArgument('shopId', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The Id of the shop (deprecated)')
+            ->addOption('shopId', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The Id of the shop (mulitple IDs -> shopId={1,2})')
             ->addOption('clear-cache', 'c', InputOption::VALUE_NONE, 'Clear complete httpcache before warmup')
             ->addOption('concurrent-requests', 'b', InputOption::VALUE_OPTIONAL, 'Integer representing the maximum number of requests that are allowed to be sent concurrently. To many URLs at a time may cause script timeouts, memory issues or block your HTTP server', 1)
             ->addOption('category', 'k', InputOption::VALUE_NONE, 'Warm up categories')
@@ -82,18 +84,30 @@ class WarmUpHttpCacheCommand extends ShopwareCommand
         /** @var UrlProviderFactoryInterface $urlProviderFactory */
         $urlProviderFactory = $this->container->get('shopware_cache_warmer.url_provider_factory');
 
-        // Get every shop to warm
-        $shopId = $input->getArgument('shopId');
+        $shopIds = null;
+
+        if ($input->getArgument('shopId')) {
+            $io = new SymfonyStyle($input, $output);
+            $io->warning('Argument "shopId" will be removed by Option "--shopId" in the next major Version');
+            $shopIds = $input->getArgument('shopId');
+        } elseif ($input->getOption('shopId')) {
+            $shopIds = $input->getOption('shopId');
+        }
+
+        /** @var \Shopware\Models\Shop\Repository $shopRepository */
         $shopRepository = $this->container->get('models')->getRepository(Shop::class);
+        $shops = null;
 
-        if (!empty($shopId)) {
-            $shop = $shopRepository->getById($shopId);
+        if (!empty($shopIds)) {
+            foreach ($shopIds as $shopId) {
+                $shop = $shopRepository->getById($shopId);
 
-            if (!$shop) {
-                throw new \RuntimeException(sprintf('Shop with id %d not found', $shopId));
+                if (!$shop) {
+                    throw new \RuntimeException(sprintf('Shop with id %d not found', $shopId));
+                }
+
+                $shops[] = $shop;
             }
-
-            $shops = [$shop];
         } else {
             $shops = $shopRepository->getActiveShopsFixed();
         }

--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -22,7 +22,6 @@
  * our trademarks remain entirely with us.
  */
 
-use League\Flysystem\Adapter\Local;
 use Shopware\Bundle\AccountBundle\Form\Account\EmailUpdateFormType;
 use Shopware\Bundle\AccountBundle\Form\Account\PasswordUpdateFormType;
 use Shopware\Bundle\AccountBundle\Form\Account\ProfileUpdateFormType;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Commands and the options/arguments should be standardized. Especially at the beginning this can be annoying and confusing. Sometimes it is an option, then an argument, then it takes multiple IDs then only single and then it is called shop instead of shopId.

### 2. What does this change do, exactly?
Changed 2 arguments to options / added more info how to use multiple IDs / changed optionname from **shop** to **shopId**

**EDIT**: Added 4 deprecation warnings + TODOs for removal in the next major version

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.