### PR TITLE
leftJoining article attributes instead of inner

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/QueryBuilderFactory.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/QueryBuilderFactory.php
@@ -173,7 +173,7 @@ class QueryBuilderFactory implements QueryBuilderFactoryInterface
                  AND product.active = 1'
             );
         }
-        $query->innerJoin(
+        $query->leftJoin(
             'variant',
             's_articles_attributes',
             'productAttribute',


### PR DESCRIPTION
### 1. Why is this change necessary?
The current INNER JOIN excludes results that don't have an entry within `s_articles_attributes`. That is unnecessary -- many details/variants won't have an entry. Neither will articles by default. 

### 2. What does this change do, exactly?
Replaces the INNER JOIN by a LEFT JOIN. 

### 3. Describe each step to reproduce the issue or behaviour.
```php
$context = Shopware()->Container()->get('shopware_storefront.context_service')
    ->createProductContext($shopId);

$criteria = new Criteria();
$criteria->addBaseCondition(
    $this->getCondition('SW10123.3')
);
$results = Shopware()->Container()->get('shopware_search.product_number_search')
    ->search($criteria, $context);
```

Now look at the `$results` - if the detail did not have an `Attribute`, it will not have found it. 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.