### PR TITLE
Search for Detail if Article wasn't found

### DIFF
--- a/engine/Shopware/Components/Backend/GlobalSearch.php
+++ b/engine/Shopware/Components/Backend/GlobalSearch.php
@@ -65,7 +65,7 @@ class GlobalSearch
     public function search($term)
     {
         return [
-            'articles' => $this->getArticles($term),
+            'articles' => $this->getArticles($term) ?: $this->getDetails($term),
             'customers' => $this->getCustomers($term),
             'orders' => $this->getOrders($term),
         ];
@@ -86,6 +86,22 @@ class GlobalSearch
 
         return $result->getData();
     }
+    
+	/**
+	 * @param string $term
+	 *
+	 * @return array
+	 */
+	private function getDetails($term)
+	{
+		$criteria = new SearchCriteria(Detail::class);
+		$criteria->term = $term;
+		$criteria->limit = 5;
+		
+		$result = $this->productRepository->search($criteria);
+		
+		return $result->getData();
+	}
 
     /**
      * @param string $term


### PR DESCRIPTION
### 1. Why is this change necessary?
It's nice to be able to search for article-numbers in the backend search. Currently, only "main" products show up -- no variants. Even when searching for the exact variant number, no results will be found. 

### 2. What does this change do, exactly?
This includes article-number results for Details in the results, but only
if the article-search hasn't turned up anything.

### 3. Describe each step to reproduce the issue or behaviour.
1. Search for a variant article-number in the backend. 
2. Be disappointed that it hasn't been found. 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.