### PR TITLE
Fix install plugins without migrations

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
@@ -636,6 +636,9 @@ SQL;
     private function applyMigrations(PluginComponent $plugin, string $mode, bool $keepUserData = false): void
     {
         $manager = new PluginMigrationManager($this->pdo, $plugin, $this->logger);
+        if (!is_dir($manager->getMigrationPath())) {
+            return;
+        }
         $manager->run($mode, $keepUserData);
     }
 }

--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -22,7 +22,6 @@
  * our trademarks remain entirely with us.
  */
 
-use League\Flysystem\Adapter\Local;
 use Shopware\Bundle\AccountBundle\Form\Account\EmailUpdateFormType;
 use Shopware\Bundle\AccountBundle\Form\Account\PasswordUpdateFormType;
 use Shopware\Bundle\AccountBundle\Form\Account\ProfileUpdateFormType;


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix error:

"DirectoryIterator::__construct(.../Resources/migrations): failed to open dir: No such file or directory"

on Shopware 5.6 Branch with normal plugins.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.