### PR TITLE
Inlined test for existing image

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -608,13 +608,11 @@ class Article extends Resource implements BatchInterface
 
             /** @var Detail $variant */
             foreach ($builder->getQuery()->getResult() as $variant) {
-                $exist = $this->getCollectionElementByProperty(
+                if (!$force && $this->getCollectionElementByProperty(
                     $variant->getImages(),
                     'parent',
                     $mapping->getImage()
-                );
-
-                if (!$force && $exist) {
+                )) {
                     continue;
                 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When using Shopware\Components\Api\Resource\Article::generateVariantImages with $force= true, the result of this test is always ignored. Inlining (and lazily evaluating) it improves performance for products with many variants and images vastly.

### 2. What does this change do, exactly?
Skips the test for existing images if the method is called with $force=true

### 3. Describe each step to reproduce the issue or behaviour.
- Create an article with ~20 variants and ~20 images each.
- call Shopware\Components\Api\Resource\Article::generateVariantImages for your article, using force=true
- weep.
![image](https://user-images.githubusercontent.com/2804586/51262324-6f148680-19b2-11e9-9289-425502e6b620.png) 

- after applying this patch:
![image](https://user-images.githubusercontent.com/2804586/51262409-98cdad80-19b2-11e9-8c96-e6fb4ac80b1c.png)


### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.