### PR TITLE
Add font-display to font-face implementation

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/fonts.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/fonts.less
@@ -10,6 +10,7 @@
     url('@{OpenSansPath}/Light/OpenSans-Light.ttf?@{shopware-revision}') format('truetype');
     font-weight: 300;
     font-style: normal;
+    font-display: auto;
 }
 /* END Light */
 
@@ -23,6 +24,7 @@
     url('@{OpenSansPath}/Regular/OpenSans-Regular.ttf?@{shopware-revision}') format('truetype');
     font-weight: normal;
     font-style: normal;
+    font-display: auto;
 }
 /* END Regular */
 
@@ -36,6 +38,7 @@
     url('@{OpenSansPath}/Semibold/OpenSans-Semibold.ttf?@{shopware-revision}') format('truetype');
     font-weight: 600;
     font-style: normal;
+    font-display: auto;
 }
 /* END Semibold */
 
@@ -49,6 +52,7 @@
     url('@{OpenSansPath}/Bold/OpenSans-Bold.ttf?@{shopware-revision}') format('truetype');
     font-weight: bold;
     font-style: normal;
+    font-display: auto;
 }
 /* END Bold */
 
@@ -62,5 +66,6 @@
     url('@{OpenSansPath}/ExtraBold/OpenSans-ExtraBold.ttf?@{shopware-revision}') format('truetype');
     font-weight: 800;
     font-style: normal;
+    font-display: auto;
 }
 /* END Extrabold */


### PR DESCRIPTION
https://developers.google.com/web/updates/2016/02/font-display

due to new rules in googles pagespeed insights the property 'font-display: auto;' should be added to font-face implementation.
this property should allow users to see the text while the font is loading.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
due to new rules in googles pagespeed insights the property 'font-display: auto;' should be added to font-face implementation. https://developers.google.com/web/updates/2016/02/font-display

### 2. What does this change do, exactly?
this property should allow users to see the text while the font is loading.

### 3. Describe each step to reproduce the issue or behaviour.
test it here: https://jsbin.com/nigahi/latest/edit?html,output

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ x ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.