### PR TITLE
Fixed CSRF-token verification loophole

### DIFF
--- a/engine/Shopware/Components/CSRFTokenValidator.php
+++ b/engine/Shopware/Components/CSRFTokenValidator.php
@@ -136,10 +136,6 @@ class CSRFTokenValidator implements SubscriberInterface
             return;
         }
 
-        if ($request->isPost() && $request->isXmlHttpRequest()) {
-            return;
-        }
-
         // skip whitelisted actions
         if ($this->isWhitelisted($controller)) {
             return;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Currently, the CSRF-token validation for POST-Requests can be bypassed entirely by providing the header `X_REQUESTED_WITH: XMLHttpRequest`. This also means that there is no CSRF-token validation for any Ajax-Requests

### 2. What does this change do, exactly?

With this change, this is no longer possible

### 3. Describe each step to reproduce the issue or behaviour.

Send a POST-request (e.g. changing an address / confirming an order) using curl on the command line. Provide the header stated above and no CSRF-Token.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.