### PR TITLE
Update PluginExtractor.php

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginExtractor.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginExtractor.php
@@ -205,7 +205,6 @@ class PluginExtractor
 
         $backupFile = $oldFile . '.' . uniqid();
         $this->filesystem->rename($oldFile, $backupFile);
-        rename($oldFile, $backupFile);
 
         return $backupFile;
     }


### PR DESCRIPTION
remove duplicate creation of a backup folder

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When installing plugins, an error or warning is displayed because a directory that no longer exists is to be renamed. The directory is already renamed in the line before it

### 2. What does this change do, exactly?
./.

### 3. Describe each step to reproduce the issue or behaviour.
./.

### 4. Please link to the relevant issues (if any).
./.

### 5. Which documentation changes (if any) need to be made because of this PR?
./.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.