### PR TITLE
autoselect variant in sArticle, based on setting in backend

### DIFF
--- a/_sql/migrations/1606-make-configurators-autoselect.php
+++ b/_sql/migrations/1606-make-configurators-autoselect.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+use Shopware\Components\Migrations\AbstractMigration;
+
+class Migrations_Migration1606 extends AbstractMigration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function up($modus)
+    {
+        $sql = <<<SQL
+        SET @form_id = (SELECT form.id FROM s_core_config_forms form WHERE form.`name` = "Frontend79" LIMIT 1);
+INSERT INTO `s_core_config_elements` (`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`, `options`)
+VALUES
+	(@form_id, 'configuratorAutoselectVariant', 'b:0;', 'Autoselect default variant', 'Always select the default variant for each configurator.', 'boolean', 0, 0, 1, NULL);
+SQL;
+        $this->addSql($sql);
+
+        $sql = <<<SQL
+        SET @element_id = (SELECT element.id FROM s_core_config_elements element WHERE element.name = "configuratorAutoselectVariant" LIMIT 1);
+INSERT INTO `s_core_config_element_translations` (`element_id`, `locale_id`, `label`, `description`)
+VALUES
+	(@element_id, 1, 'Autoauswahl bei allen Konfiguratoren', 'Wähle bei allen Konfiguratoren immer die Standardvariante aus.'),
+	(@element_id, 2, 'Autoselect default variant', 'Always select the default variant for each configurator.')
+	;
+SQL;
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -1108,7 +1108,7 @@ class sArticles
              * 2. $number is equals to $productNumber (if the order number is invalid or inactive fallback to main variant)
              * 3. $configuration is empty (Customer hasn't not set an own configuration)
              */
-            if ($providedNumber && $providedNumber == $productNumber && empty($configuration) || $type === 0) {
+            if ($providedNumber && $providedNumber == $productNumber || $type === 0 || $this->config->get('configuratorAutoselectVariant')) {
                 $selection = $product->getSelectedOptions();
             }
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
If you change your configurator to not standard (e.g. image or selection) the default variant will not be auto selected (if no number parameter is passed)

### 2. What does this change do, exactly?
Allow any configurator be valid. Also remove not initialized variable $configuration. This is behind a settings toggle so you can still have the old behaviour.

### 3. Describe each step to reproduce the issue or behaviour.
Without PR create a variant article and check autoselection in frontend. Then change the variant article to image and load the article in frontend again without any number parameter. This won't select the default selection.

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/1933 (this 

### 5. Which documentation changes (if any) need to be made because of this PR?
According to https://github.com/shopware/shopware/pull/1933 this PR will be BC breaking if it is enabled. As this is behind a toggle this shouldn't be a problem.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.