### PR TITLE
Update email regex

### DIFF
--- a/engine/Shopware/Components/Validator/EmailValidator.php
+++ b/engine/Shopware/Components/Validator/EmailValidator.php
@@ -40,6 +40,6 @@ class EmailValidator implements EmailValidatorInterface
     {
         // Proposed regex by the w3c for the input[type="email"]
         // see https://www.w3.org/TR/html5/sec-forms.html#valid-e-mail-address
-        return (bool) preg_match('/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/', $emailAddress);
+        return (bool) preg_match('/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/', $emailAddress);
     }
 }

--- a/engine/Shopware/Components/Validator/EmailValidator.php
+++ b/engine/Shopware/Components/Validator/EmailValidator.php
@@ -38,8 +38,8 @@ class EmailValidator implements EmailValidatorInterface
      */
     public function isValid($emailAddress)
     {
-        // Inspired by the regex used in symfony/validator
-        // See: https://github.com/symfony/validator/blob/dae70b74fe173461395cfd61a5c5245e05e511f5/Constraints/EmailValidator.php#L72
-        return (bool) preg_match('/^\S+\@\S+\.\S+$/', $emailAddress);
+        // Proposed regex by the w3c for the input[type="email"]
+        // see https://www.w3.org/TR/html5/sec-forms.html#valid-e-mail-address
+        return (bool) preg_match('/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/', $emailAddress);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The old regex allowed for invalid email-addresses to be entered

### 2. What does this change do, exactly?
The new regex validates emails like the `<input type="email">` does. The regex is actually proposed by the w3c as an implementation for this (https://www.w3.org/TR/html5/sec-forms.html#valid-e-mail-address)

### 3. Describe each step to reproduce the issue or behaviour.
Enter "test@-.com" as your e-mail-address in the register form. The address will be accepted by shopware even though it's not a valid address. Use a text-input, not type="email" for this or the browser throws an error because the input actually validates this correctly (which does not mean, shopware should simply accept it)

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [-] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [-] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.