### PR TITLE
SW-22603 allow category filter in addition to sCategory base condition

### DIFF
--- a/engine/Shopware/Bundle/SearchBundle/CriteriaRequestHandler/CoreCriteriaRequestHandler.php
+++ b/engine/Shopware/Bundle/SearchBundle/CriteriaRequestHandler/CoreCriteriaRequestHandler.php
@@ -109,7 +109,8 @@ class CoreCriteriaRequestHandler implements CriteriaRequestHandlerInterface
             $criteria->addBaseCondition(
                 new CategoryCondition($ids)
             );
-        } elseif ($request->has('categoryFilter')) {
+        }
+        if ($request->has('categoryFilter')) {
             $ids = explode('|', $request->getParam('categoryFilter'));
 
             $criteria->addCondition(


### PR DESCRIPTION
This allows the user to filter for categories in product streams which uses categoryFilter to for filtering and sCategory for product stream selection

### 1. Why is this change necessary?
This fixes the issue described in https://issues.shopware.com/issues/SW-22603 where category filters are not applied in product streams.

### 2. What does this change do, exactly?
Criteria can now contain a base condition with a category and additional category conditions. 
A product stream request with category filters contains `sCategory` to identify the stream to be used and `categoryFilter` to do the actual filtering.
The category in `sCategory` is later replaced be the shops root category id and can therefor not be used to narrow the filter.

### 3. Describe each step to reproduce the issue or behaviour.
Create a stream, enable filters and render the stream with the cf parameter like this: http://shopware.ddev.local/cat/index/sCategory/76?p=1&o=1&n=12&cf=38

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-22603

### 5. Which documentation changes (if any) need to be made because of this PR?
- 

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.