### PR TITLE
Also consider links when collecting media which should not be removed

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/GarbageCollector.php
+++ b/engine/Shopware/Bundle/MediaBundle/GarbageCollector.php
@@ -125,7 +125,7 @@ class GarbageCollector
             LEFT JOIN s_media_album a
             ON m.albumID = a.id
             SET albumID=-13
-            WHERE a.garbage_collectable = 1 
+            WHERE a.garbage_collectable = 1
             AND u.id IS NULL
         ';
         $this->connection->exec($sql);
@@ -223,6 +223,8 @@ class GarbageCollector
             preg_match_all("/{{1}media[\s+]?path=[\"'](?'mediaTag'\S*)[\"']}{1}/mi", $value, $mediaMatches);
             // Src tag matches
             preg_match_all("/<?img[^<]*src=[\"'](?'srcTag'[^{]*?)[\"'][^>]*\/?>?/mi", $value, $srcMatches);
+            // Link matches
+            preg_match_all("/<?a[^<]*href=[\"'](?'hrefTag'[^{]*?)[\"'][^>]*\/?>?/mi", $value, $hrefMatches);
 
             if ($mediaMatches['mediaTag']) {
                 foreach ($mediaMatches['mediaTag'] as $match) {
@@ -235,6 +237,17 @@ class GarbageCollector
                 foreach ($srcMatches['srcTag'] as $match) {
                     $match = $this->mediaService->normalize($match);
                     $this->addMediaByPath($match);
+                }
+            }
+
+            if ($hrefMatches['hrefTag']) {
+                foreach ($hrefMatches['hrefTag'] as $match) {
+                    $match = $this->mediaService->normalize($match);
+
+                    // Only add normalized media links and not arbitrary links
+                    if (strpos($match, 'media/') === 0) {
+                        $this->addMediaByPath($match);
+                    }
                 }
             }
         }

--- a/tests/Unit/Bundle/MediaBundle/GarbageCollectorTest.php
+++ b/tests/Unit/Bundle/MediaBundle/GarbageCollectorTest.php
@@ -39,11 +39,13 @@ class GarbageCollectorTest extends TestCase
 
         $propertyValue = $queueProperty->getValue($garbageCollector);
 
-        $this->assertCount(9, $propertyValue['path']);
+        $this->assertCount(11, $propertyValue['path']);
 
         $this->assertArraySubset([
             'media/image/foo.png',
             'media/image/bar.png',
+            'media/pdf/foo.pdf',
+            'media/pdf/bar.pdf',
             'media/image/foo2.png',
             'media/image/bar2.png',
             'media/image/foo3.png',
@@ -117,8 +119,11 @@ class QueryBuilderMock
                 'Minions ipsum quis consequat belloo! <img src="{media path=\'media/image/foo.png\'}" />Et quis. Bee do bee do bee do dolore adipisicing minim.',
                 // Src Tag
                 'Bacon ipsum dolor amet t-bone brisket prosciutto <img src="media/image/bar.png" /> biltong rump drumstick pancetta andouille salami jerky beef ribs ball tip.',
+                // Href Link Tag
+                'Minions ipsum quis consequat belloo! <a href="{media path=\'media/pdf/foo.pdf\'}" >Et quis</a>. <a href="media/pdf/bar.pdf">Bee do</a> bee do bee do dolore adipisicing minim.',
                 // Should not match
                 'Lorem ipsum dolor sit amet <img src="{file link=\'media/image/foobar.png\'" />',
+                'Minions ipsum quis consequat belloo! <a href="{file link=\'media/pdf/foo1.pdf\'}" >Et quis</a>. <a href="https://example.com">Bee do</a> bee do bee do <a href="foo/bar/media/pdf/foobar.pdf">dolore</a> adipisicing minim.',
                 // Multiple matches
                 'Minions ipsum quis consequat belloo! <img src="{media path=\'media/image/foo2.png\'}" />Et quis. <img src="media/image/bar2.png"/> Bee do bee do bee do dolore adipisicing minim.',
                 // data-src match


### PR DESCRIPTION
### 1. Why is this change necessary?
When adding for example a PDF via the media manager in a shop page, not an image is created but a link to that file. 
When now running the media garbage collector, this file gets removed even though it is used in a shop page.

### 2. What does this change do, exactly?
Also consider links such that the media garbage collector does not remove these media.

### 3. Describe each step to reproduce the issue or behaviour.
See **1**

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.