### PR TITLE
Always fallback to DefaultFrom in Enlight_Components_Mail 

### DIFF
--- a/engine/Library/Enlight/Components/Mail.php
+++ b/engine/Library/Enlight/Components/Mail.php
@@ -205,6 +205,11 @@ class Enlight_Components_Mail extends Zend_Mail
             throw new \RuntimeException('Potential code injection in From header');
         }
 
+        // explicit nulling so fallback to parent::setFromToDefaultFrom() works
+        if (empty($email)) {
+            $email = null;
+        }
+
         $this->_fromName = $name;
 
         return parent::setFrom($email, $name);


### PR DESCRIPTION
### 1. Why is this change necessary?
If you send some mail with `Enlight_Components_Mail`, for example when changing the order state and sending out an update to your customer and you don't provide an sender, setting the `From` header to an empty string won't set the fallback default mail address.

### 2. What does this change do, exactly?
If the sender email address provided to `$mail->setFrom()` is an empty string fall back to `$address = null` to allow `Zend_Mail` to use `setFromToDefaultFrom()`.

### 3. Describe each step to reproduce the issue or behaviour.

1.  Go to an order
2. Change order state to cancelled
3. Send state change mail to customer
4. Customer gets mail but without a sender as it is an empty string (AFAIK there is no input for sender mail)
5. Now use this PR and go to step 1 and retry. Now shop's default mail address will be used.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.