### PR TITLE
Added Shopware_Command_Before_Run

### DIFF
--- a/engine/Shopware/Components/Console/Application.php
+++ b/engine/Shopware/Components/Console/Application.php
@@ -119,10 +119,20 @@ class Application extends BaseApplication
             $command->setContainer($this->kernel->getContainer());
         }
 
-        $exitCode = parent::doRunCommand($command, $input, $output);
-
         /** @var \Enlight_Event_EventManager $eventManager */
         $eventManager = $this->kernel->getContainer()->get('events');
+
+        $event = $eventManager->notifyUntil('Shopware_Command_Before_Run', [
+            'command' => $command,
+            'input' => $input,
+            'output' => $output,
+        ]);
+
+        if ($event) {
+            return (int) $event->getReturn();
+        }
+
+        $exitCode = parent::doRunCommand($command, $input, $output);
 
         $eventManager->notify('Shopware_Command_After_Run', [
            'exitCode' => $exitCode,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

As of today there exists a "Shopware_Command_After_Run" event but no ""Shopware_Command_Before_Run" event. As a consequence there is no way to hook into commands before they are run. This is a problem if for instance you need to obtain access to the input or output objects passed to the console command.

### 2. What does this change do, exactly?

Adds a new event "Shopware_Command_Before_Run" which is emitted just before a console command is run

### 3. Describe each step to reproduce the issue or behaviour.

At present, there is no event emitted before a console command is run.

### 4. Please link to the relevant issues (if any).

-

### 5. Which documentation changes (if any) need to be made because of this PR?

-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.