### PR TITLE
Use correct autoloader and config file when shopware is a composer dependency

### DIFF
--- a/tests/Functional/bootstrap.php
+++ b/tests/Functional/bootstrap.php
@@ -22,7 +22,27 @@
  * our trademarks remain entirely with us.
  */
 
-require __DIR__ . '/../../autoload.php';
+$searchDirectory = __DIR__;
+
+while (true) {
+    $newSearchDirectory = realpath($searchDirectory . DIRECTORY_SEPARATOR . '..');
+
+    if ($searchDirectory === false || strlen($searchDirectory) < 3 || $newSearchDirectory === $searchDirectory) {
+        throw new RuntimeException('No autoloader found');
+    }
+
+    $searchDirectory = $newSearchDirectory;
+
+    if (file_exists($autoloadFile = implode(DIRECTORY_SEPARATOR, [$searchDirectory, 'app', 'autoload.php']))) {
+        require $autoloadFile;
+        break;
+    }
+
+    if (file_exists($autoloadFile = implode(DIRECTORY_SEPARATOR, [$searchDirectory, 'vendor', 'autoload.php']))) {
+        require $autoloadFile;
+        break;
+    }
+}
 
 class TestKernel extends \Shopware\Kernel
 {
@@ -48,6 +68,12 @@ class TestKernel extends \Shopware\Kernel
 
     protected function getConfigPath()
     {
+        if (file_exists(__DIR__ . '/../../../../../app/config/config.php')) {
+            // shopware as composer dependency
+            return __DIR__ . '/../../../../../app/config/config.php';
+        }
+
+        // shopware standalone
         return __DIR__ . '/config.php';
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
When you write a plugin test in a composer-project environment like it is written in the [dev docs](https://developers.shopware.com/developers-guide/plugin-testing/) you can refer to the correct testing bootstrap file but it does not load the correct configuration file.

### 2. What does this change do, exactly?
If the special case of a composer project environment is detected it uses a different `autoload.php` and `config.php` file.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have a plugin in a composer project in `custom/project/FooBar`
2. Bootstrap tests
    ```php
    <?php
    // resides in custom/project/FooBar/Tests/Functional/Bootstrap.php
    ini_set('error_reporting', E_ALL);
    ini_set('display_errors', '1');
    ini_set('display_startup_errors', '1');

    require __DIR__ . '/../../../../../tests/Functional/bootstrap.php';
    ```
3. phpunit plugin folder
4. Cannot test as a wrong `autoload.php` is loaded
    ```
    Warning: require(/var/www/html/foobar/vendor/shopware/shopware/tests/Functional/autoload.php): failed to open stream: No such file or directory in /var/www/html/foobar/vendor/shopware/shopware/tests/Functional/bootstrap.php on line 30
    Fatal error: require(): Failed opening required '/var/www/html/foobar/vendor/shopware/shopware/tests/Functional/autoload.php' (include_path='/var/www/html/foobar/engine/Library:/var/www/html/foobar/vendor/shopware/shopware/engine/Library:.:/usr/share/php') in /var/www/html/foobar/vendor/shopware/shopware/tests/Functional/bootstrap.php on line 30
    ```
5. Amend bootstrap require path
6. phpunit plugin folder
7. Cannot test as a wrong `config.php` is loaded
    ```
    Fatal error:  Uncaught RuntimeException: Could not connect to database. Message from SQL Server: SQLSTATE[HY000] [2002] No such file or directory in /var/www/html/foobar/vendor/shopware/shopware/engine/Shopware/Components/DependencyInjection/Bridge/Db.php:78
    Stack trace:
    #0 /var/www/html/dynfoobaratics/vendor/shopware/shopware/engine/Shopware/Kernel.php(300): Shopware\Components\DependencyInjection\Bridge\Db::createPDO(Array)
    #1 /var/www/html/foobar/vendor/shopware/shopware/tests/Functional/bootstrap.php(41): Shopware\Kernel->boot()
    #2 /var/www/html/foobar/vendor/shopware/shopware/tests/Functional/bootstrap.php(67): TestKernel::start()
    #3 /var/www/html/foobar/custom/project/FooBar/Tests/Functional/Bootstrap.php(7): require('/var/www/html/f...')
    #4 /var/www/html/foobar/vendor/phpunit/phpunit/src/Util/Fileloader.php(64): include_once('/var/www/html/f...')
    #5 /var/www/html/foobar/vendor/phpunit/phpunit/src/Util/Fileloader.php(48): PHPUnit\Util\Fileloader::load('/var/www/html/f...')
    #6 /var/www/htm in /var/www/html/foobar/vendor/shopware/shopware/engine/Shopware/Components/DependencyInjection/Bridge/Db.php on line 78
    ```
8. Play some tetris on arcade machine to regain saneness

### 5. Which documentation changes (if any) need to be made because of this PR?
The dev docs should just have some paths to :clipboard: :ramen: from, depending on their test bootstrap location.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change 
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

> :ballot_box_with_check: I have written tests and verified that they fail without my change 
> :grin: it is THE test