### PR TITLE
SW-17109 do not use uppercase values for product filter

### DIFF
--- a/themes/Backend/ExtJs/backend/article_list/resource/lexer.js
+++ b/themes/Backend/ExtJs/backend/article_list/resource/lexer.js
@@ -99,7 +99,7 @@ Ext.define('Lexer', {
             expectation,
             valid,
             finalCheck,
-            i, token, tokenType, tokenLength = tokens.length;
+            i, token, originalToken, tokenType, tokenLength = tokens.length;
 
         me.tokens = tokens;
         me.canceled = false;
@@ -128,6 +128,7 @@ Ext.define('Lexer', {
             if (me.canceled) {
                 return;
             }
+            originalToken = token;
             token = token.toUpperCase();
             tokenType = me.getTokenType(token);
 
@@ -170,7 +171,7 @@ Ext.define('Lexer', {
             }
 
 
-            me.addToAst(token, tokenType);
+            me.addToAst(token, originalToken, tokenType);
 
             if (me.inList && token == ')') {
                 me.inList = false;
@@ -248,8 +249,18 @@ Ext.define('Lexer', {
      * @param token
      * @param tokenType
      */
-    addToAst: function(token, tokenType) {
+    addToAst: function(token, originalToken, tokenType) {
         var me = this;
+
+        if (tokenType === 'values') {
+            /* 
+             * Do not use `token` which was usually generated from `originalToken.toUpperCase()`
+             * because the following is not always true and would make filtering certain values impossible:
+             * str.toUpperCase().toLowerCase() === str.toLowerCase()
+             * e.g. 'ß'.toUpperCase() == 'SS'
+             */
+            token = originalToken;
+        }
 
         this.astFlat.push({
             type: tokenType,


### PR DESCRIPTION
### 1. Why is this change necessary?
With the current implementation it is impossible to filter certain products by name.
Using `toUpperCase()` is not bijective 
```js
str.toUpperCase().toLowerCase() === str.toLowerCase() //might be false
```

This is an issue for chars like `ß` where `'ß'.toUppwerCase() == 'SS'` in most modern browsers.

For that reason the raw user input should be used as a filter.

### 2. What does this change do, exactly?
The Lexer will store the original input in the AST if the token is of type `values`.

### 3. Describe each step to reproduce the issue or behaviour.
Search for `ß` in the demo data. Articles like "Kicker Figuren Set, große Auswahl" will not be in the result set.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-17109

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.