### PR TITLE
Fix conversion of Resource to service id with CamelCase-Name

### DIFF
--- a/engine/Shopware/Components/Api/Manager.php
+++ b/engine/Shopware/Components/Api/Manager.php
@@ -25,6 +25,7 @@
 namespace Shopware\Components\Api;
 
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 
 /**
  * API Manger
@@ -45,7 +46,7 @@ class Manager
         $container = Shopware()->Container();
         try {
             /** @var Resource\Resource $resource */
-            $resource = $container->get('shopware.api.' . strtolower($name));
+            $resource = $container->get('shopware.api.' . (new CamelCaseToSnakeCaseNameConverter())->normalize($name));
         } catch (ServiceNotFoundException $e) {
             $name = ucfirst($name);
             $class = __NAMESPACE__ . '\\Resource\\' . $name;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Shopware\Components\Api\Manager::getResource('CustomerStream'); would fail to find the Service shopware.api.customer_stream

### 2. What does this change do, exactly?
Fix conversion of CustomerStream to customer_stream

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.