### PR TITLE
Allow any attribute name in Risk Management

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -1911,7 +1911,6 @@ class sAdmin
         if (!empty($order['content'])) {
             $value = explode('|', $value);
             if (!empty($value[0]) && isset($value[1])) {
-                $number = (int) str_ireplace('attr', '', $value[0]);
 
                 $sql = "
                     SELECT s_articles_attributes.id
@@ -1923,7 +1922,7 @@ class sAdmin
                         OR (s_order_basket.articleID = s_articles_details.articleID AND s_articles_details.kind = 1)
                     )
                     AND s_articles_details.id = s_articles_attributes.articledetailsID
-                    AND s_articles_attributes.attr{$number} = ?
+                    AND s_articles_attributes.{$value[0]} = ?
                     LIMIT 1
                 ";
 
@@ -1953,7 +1952,6 @@ class sAdmin
         if (!empty($order['content'])) {
             $value = explode('|', $value);
             if (!empty($value[0]) && isset($value[1])) {
-                $number = (int) str_ireplace('attr', '', $value[0]);
 
                 $sql = "
                 SELECT s_articles_attributes.id
@@ -1966,7 +1964,7 @@ class sAdmin
                 OR (s_order_basket.articleID = s_articles_details.articleID AND s_articles_details.kind = 1)
                 )
                 AND s_articles_details.id = s_articles_attributes.articledetailsID
-                AND s_articles_attributes.attr{$number}!= ?
+                AND s_articles_attributes.{$value[0]}!= ?
                 LIMIT 1
                 ";
                 $checkProduct = $this->db->fetchOne(


### PR DESCRIPTION
### 1. Why is this change necessary?
Since 5.2 attributes can be added to database easily with any name.
Since today the risk management module only allows attributes with the old static naming like "attr{number}"

### 2. What does this change do, exactly?
It allows any kind of attribute name

### 3. Describe each step to reproduce the issue or behaviour.
Create an article attribute with any name and use it in the old format on attribute rules in risk management.

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.