### PR TITLE
Pulled method up into the interface

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/VariantHelper.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/VariantHelper.php
@@ -150,7 +150,7 @@ class VariantHelper implements VariantHelperInterface
     }
 
     /**
-     * @param QueryBuilder $query
+     * {@inheritdoc}
      */
     public function joinVariants(QueryBuilder $query)
     {

--- a/engine/Shopware/Bundle/SearchBundleDBAL/VariantHelperInterface.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/VariantHelperInterface.php
@@ -50,4 +50,9 @@ interface VariantHelperInterface
      * @param Criteria             $criteria
      */
     public function joinPrices(QueryBuilder $query, ShopContextInterface $context, Criteria $criteria);
+
+    /**
+     * @param QueryBuilder $query
+     */
+    public function joinVariants(QueryBuilder $query);
 }


### PR DESCRIPTION
You cannot simply decorate VariantHelper as the [ImmediateDeliveryFacetHandler](https://github.com/shopware/shopware/blob/24affc52190ed03dd1cf5b8f90d14a8945b5c5c1/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/ImmediateDeliveryFacetHandler.php#L105) expects a specific implementation of it.

### 1. Why is this change necessary?
To decorate VariantHelper

### 2. What does this change do, exactly?
Extend the interface to contain a public function that is already in the current implementation

### 3. Describe each step to reproduce the issue or behaviour.
1. Try to decorate VariantHelper
2. Open a listing
3. :bomb: 

### 4. Which documentation changes (if any) need to be made because of this PR?
This should be part of the UPGRADE-XX.md as this changes an interface.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.