### PR TITLE
FIX file definition path for console command sw:plugin:delete

### DIFF
--- a/engine/Shopware/Commands/PluginDeleteCommand.php
+++ b/engine/Shopware/Commands/PluginDeleteCommand.php
@@ -92,13 +92,8 @@ EOF
 
             return 1;
         }
-
-        $pluginPath = Shopware()->AppPath(implode('_', [
-            'Plugins',
-            $plugin->getSource(),
-            $plugin->getNamespace(),
-            $plugin->getName(),
-        ]));
+        
+        $pluginPath = $pluginManager->getPluginPath($pluginName);
 
         if ($plugin->getSource() === 'Default') {
             $message = "'Default' Plugins may not be deleted.";


### PR DESCRIPTION
### 1. Why is this change necessary?
This method works only with [legacy Plugin System](https://developers.shopware.com/developers-guide/legacy-plugin-system/)   and cannot return the correct path for plugins located in _"/custom/plugins/"_

Now it returns returns something like   _"/engine/Shopware/Plugins//ShopwarePlugins/SwagPluginName/"_ 
but not   _"/custom/plugins/SwagPluginName/"_ as was expected.
As a result, the command "_sw:plugin:delete_" cannot delete plugin files.

 
### 2. What does this change do, exactly?
Allows you to correctly determine the path to the plugins located in "/custom/plugins/" 


### 3. Describe each step to reproduce the issue or behaviour.
1. Try deleting any plugin located in  _"/custom/plugins/"_  using the console command
` ./bin/console  sw:plugin:delete   XxxPluginName`
2. Check the physical presence of the plugin files


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.