### PR TITLE
Fix Logger mode

### DIFF
--- a/engine/Shopware/Components/HttpCache/CacheWarmer.php
+++ b/engine/Shopware/Components/HttpCache/CacheWarmer.php
@@ -136,7 +136,7 @@ class CacheWarmer
                 'error' => function (ErrorEvent $e) use ($shopId, $events) {
                     $events->notify('Shopware_Components_CacheWarmer_ErrorOccured');
                     if ($e->getResponse() !== null && $e->getResponse()->getStatusCode() === 404) {
-                        $this->logger->notice(
+                        $this->logger->error(
                             'Warm up http-cache error with shopId ' . $shopId . ' ' . $e->getException()->getMessage()
                         );
                     } else {


### PR DESCRIPTION
### 1. Why is this change necessary?
The backend shows a notification about warmup error and says it has been logged. But 404 errors won't be logged in default, cause of Monolog min level (default error).

### 2. What does this change do, exactly?
Changed logger level from notice to error

### 3. Describe each step to reproduce the issue or behaviour.
Warmup 404 pages, there is currently no entry in log

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.