### PR TITLE
Fix conversion of Resource to service id with CamelCase-Name

### DIFF
--- a/engine/Shopware/Components/Api/Manager.php
+++ b/engine/Shopware/Components/Api/Manager.php
@@ -26,6 +26,7 @@ namespace Shopware\Components\Api;
 
 use Shopware\Components\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 
 /**
  * API Manger
@@ -46,7 +47,12 @@ class Manager
         $container = Shopware()->Container();
         try {
             /** @var Resource\Resource $resource */
-            $resource = $container->get('shopware.api.' . strtolower($name));
+            $serviceId = 'shopware.api.' . (new CamelCaseToSnakeCaseNameConverter())->normalize($name);
+            if ($container->has($serviceId)) {
+                $resource = $container->get($serviceId);
+            } else {
+                $resource = $container->get('shopware.api.' . strtolower($name));
+            }
         } catch (ServiceNotFoundException $e) {
             $name = ucfirst($name);
             $class = __NAMESPACE__ . '\\Resource\\' . $name;

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -612,18 +612,18 @@
         <service id="shopware.api.category" class="Shopware\Components\Api\Resource\Category" shared="false" />
         <service id="shopware.api.country" class="Shopware\Components\Api\Resource\Country" shared="false" />
         <service id="shopware.api.customer" class="Shopware\Components\Api\Resource\Customer" shared="false" />
-        <service id="shopware.api.customergroup" class="Shopware\Components\Api\Resource\CustomerGroup" shared="false" />
+        <service id="shopware.api.customer_group" class="Shopware\Components\Api\Resource\CustomerGroup" shared="false" />
         <service id="shopware.api.manufacturer" class="Shopware\Components\Api\Resource\Manufacturer" shared="false" />
         <service id="shopware.api.media" class="Shopware\Components\Api\Resource\Media" shared="false" />
         <service id="shopware.api.order" class="Shopware\Components\Api\Resource\Order" shared="false" />
-        <service id="shopware.api.propertygroup" class="Shopware\Components\Api\Resource\PropertyGroup" shared="false" />
+        <service id="shopware.api.property_group" class="Shopware\Components\Api\Resource\PropertyGroup" shared="false" />
         <service id="shopware.api.shop" class="Shopware\Components\Api\Resource\Shop" shared="false" />
         <service id="shopware.api.translation" class="Shopware\Components\Api\Resource\Translation" shared="false">
             <argument type="service" id="translation" />
         </service>
         <service id="shopware.api.variant" class="Shopware\Components\Api\Resource\Variant" shared="false" />
 
-        <service id="shopware.api.emotionpreset" class="Shopware\Components\Api\Resource\EmotionPreset" shared="false">
+        <service id="shopware.api.emotion_preset" class="Shopware\Components\Api\Resource\EmotionPreset" shared="false">
             <argument type="service" id="dbal_connection" />
             <argument type="service" id="models" />
             <argument type="service" id="shopware.slug" />
@@ -641,7 +641,19 @@
         </service>
 
         <!-- Necessary because of implementation in \Shopware\Components\Api\Manager::getResource() -->
-        <service id="shopware.api.customerstream" alias="shopware.api.customer_stream" />
+        <service id="shopware.api.customerstream" alias="shopware.api.customer_stream" >
+            <deprecated>use shopware.api.customer_stream instead</deprecated>
+        </service>
+        <service id="shopware.api.customergroup" alias="shopware.api.customer_group" >
+            <deprecated>use shopware.api.customer_group instead</deprecated>
+        </service>
+        <service id="shopware.api.propertygroup" alias="shopware.api.property_group" >
+            <deprecated>use shopware.api.property_group instead</deprecated>
+        </service>
+        <service id="shopware.api.emotionpreset" alias="shopware.api.emotion_preset" >
+            <deprecated>use shopware.api.emotion_preset instead</deprecated>
+        </service>
+
 
         <service id="shopware.emotion.emotion_presetdata_transformer" class="Shopware\Components\Emotion\Preset\EmotionToPresetDataTransformer">
             <argument type="service" id="models" />


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Shopware\Components\Api\Manager::getResource('CustomerStream'); would fail to find the Service shopware.api.customer_stream

### 2. What does this change do, exactly?
Fix conversion of CustomerStream to customer_stream

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.


This PR is an updated version of https://github.com/shopware/shopware/pull/2010 for 5.5-branch