### PR TITLE
Change s_order_basket.quantity and s_order_details.quantity to unsigned int

### DIFF
--- a/_sql/migrations/1457-change-quantity-to-unsinged-int.php
+++ b/_sql/migrations/1457-change-quantity-to-unsinged-int.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration1457 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('ALTER TABLE `s_order_basket` CHANGE `quantity` `quantity` INT(11) UNSIGNED;');
+        $this->addSql('ALTER TABLE `s_order_details` CHANGE `quantity` `quantity` INT(11) UNSIGNED;');
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
It could happen, for example from a plugin, that the quantity is inserted is negative. Afterwards the calculation of the shipping costs fail, with the following error:
![image](https://user-images.githubusercontent.com/6317761/53015162-a27f8080-344a-11e9-8db5-cf5e1394d782.png)
It is now very hard to reconstruct, which plugin or at what point the negative quantity was inserted. 

### 2. What does this change do, exactly?
Changes the database quantity fields to unsigned int, such that the error occurs when a plugin tries to set a negative quantity.

### 3. Describe each step to reproduce the issue or behaviour.
Easiest way would be to manually change the quantity in the database.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.