### PR TITLE
Make customergroup keys longer

### DIFF
--- a/_sql/migrations/1607-allow-longer-customergroup-keys.php
+++ b/_sql/migrations/1607-allow-longer-customergroup-keys.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration1607 extends Shopware\Components\Migrations\AbstractMigration
+{
+    /**
+     * @param string $modus
+     */
+    public function up($modus): void
+    {
+        $this->addSql("ALTER TABLE `s_core_customergroups` CHANGE `groupkey` `groupkey` VARCHAR(15);");
+        $this->addSql("ALTER TABLE `s_article_configurator_template_prices` CHANGE `customer_group_key` `customer_group_key` VARCHAR(15);");
+        $this->addSql("ALTER TABLE `s_articles_prices` CHANGE `pricegroup` `pricegroup` VARCHAR(15);");
+        $this->addSql("ALTER TABLE `s_campaigns_mailings` CHANGE `customergroup` `customergroup` VARCHAR(15);");
+    }
+}

--- a/engine/Shopware/Models/Article/Configurator/Template/Price.php
+++ b/engine/Shopware/Models/Article/Configurator/Template/Price.php
@@ -71,7 +71,7 @@ class Price extends LazyFetchModelEntity
 
     /**
      * @var string
-     * @ORM\Column(name="customer_group_key", type="string", length=30, nullable=false)
+     * @ORM\Column(name="customer_group_key", type="string", length=15, nullable=false)
      */
     private $customerGroupKey = '';
 

--- a/engine/Shopware/Models/Article/Price.php
+++ b/engine/Shopware/Models/Article/Price.php
@@ -93,7 +93,7 @@ class Price extends LazyFetchModelEntity
     /**
      * @var string
      *
-     * @ORM\Column(name="pricegroup", type="string", length=30, nullable=false)
+     * @ORM\Column(name="pricegroup", type="string", length=15, nullable=false)
      */
     private $customerGroupKey = '';
 

--- a/engine/Shopware/Models/Customer/Group.php
+++ b/engine/Shopware/Models/Customer/Group.php
@@ -92,7 +92,7 @@ class Group extends ModelEntity
      *
      * @var string
      *
-     * @ORM\Column(name="groupkey", type="string", length=5, nullable=false)
+     * @ORM\Column(name="groupkey", type="string", length=15, nullable=false)
      */
     private $key;
 

--- a/engine/Shopware/Models/Newsletter/Newsletter.php
+++ b/engine/Shopware/Models/Newsletter/Newsletter.php
@@ -175,7 +175,7 @@ class Newsletter extends ModelEntity
      *
      * @var string
      *
-     * @ORM\Column(name="customergroup", type="string", length=255, nullable=false)
+     * @ORM\Column(name="customergroup", type="string", length=15, nullable=false)
      */
     private $customerGroup = '';
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The customergroup model allows up to 5 chars while the customer model allows 15 characters for the customer group. The lower limit makes naming customer groups hard where you have several similar group names, eg. if you have companies as your customers where each company has their own customergroup. Having more space to use improves it a lot.

### 2. What does this change do, exactly?
Upping the customergroup model's limit to match the limit set in the customer model to 15 characters.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.