### PR TITLE
Fix translation of product attributes via RestAPI

### DIFF
--- a/engine/Shopware/Components/Translation.php
+++ b/engine/Shopware/Components/Translation.php
@@ -24,6 +24,7 @@
 
 use Doctrine\DBAL\Connection;
 use Shopware\Bundle\AttributeBundle\Service\CrudService;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 
 /**
  * Shopware Translation Component
@@ -532,7 +533,15 @@ class Shopware_Components_Translation
         $columns = $schemaManager->listTableColumns('s_articles_translations');
         $columns = array_keys($columns);
 
+        $converter = new CamelCaseToSnakeCaseNameConverter();
+
         foreach ($data as $key => $value) {
+            if (strpos($key, '__attribute_') !== false) {
+                $columnname = str_replace('__attribute_', '', $key);
+                $columnname = $converter->normalize($columnname);
+                $data[$columnname] = $value;
+            }
+
             $column = strtolower($key);
             $column = str_replace(CrudService::EXT_JS_PREFIX, '', $column);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently the product attributes won't be translated correctly, since they are not saved in the s_articles_translation table. The issue is caused by a mix of camelCase and snake_case. The s_core_translations uses camelCase and the s_article_translations uses snake_case to identify the attribute.

### 2. What does this change do, exactly?
The foreach will add every attribute as snake_case to the array as well, otherwhise this check will fail: https://github.com/shopware/shopware/blob/cfcbcc820efefc3943280c2f9356da23c556f1b4/engine/Shopware/Components/Translation.php#L540

aasaasasasas vs aasa_asas_asas


### 3. Describe each step to reproduce the issue or behaviour.
Add a new attribute column like "aasa_asas_asas" to your product attributes as translatable and try to translate this attribute via RestAPI.

` $minimalTestArticle = [
        'name' => 'Test',
        'translations' => [
            3 => [
                'name' => 'Test-EN',
                '__attribute_aasaAsasAsas' => "sdgfdghdfghfgdhfghfgd",
                '__attribute_attr1' => 'testetst',
                'shopId' => 3,
            ]
        ]
    ];.`

attr1 will be saved correctly, the new attribute not.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-23584

### 5. Which documentation changes (if any) need to be made because of this PR?
Since the attributes are only added to the array as snake_case and not overwritten, this should not break anything. 

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.