### PR TITLE
SW-23605 | HttpCache beim ersten Aufruf fehlerhaft / Could not write …

### DIFF
--- a/engine/Shopware/Components/HttpCache/Store.php
+++ b/engine/Shopware/Components/HttpCache/Store.php
@@ -391,5 +391,7 @@ class Store extends BaseStore
         }
 
         @chmod($path, 0666 & ~umask());
+
+        return true;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Fatal error: Uncaught RuntimeException: Could not write cacheKey in engine/Shopware/Components/HttpCache/Store.php:206

### 2. What does this change do, exactly?
fix empty return value to be 'true' instead of empty

### 3. Describe each step to reproduce the issue or behaviour.
On initial visit of any URL when HttpCache is enabled.

### 4. Please link to the relevant issues (if any).
[SW-23605 | HttpCache beim ersten Aufruf fehlerhaft / Could not write cacheKey](https://issues.shopware.com/issues/SW-23605)

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.