### PR TITLE
allow custom attributes in document templates

### DIFF
--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -386,11 +386,21 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
      */
     public function getPositions()
     {
+        // Workaround to fetch all attribute columns without shadowing id columns from other tables
+        $attributeColumns = 'at.attr1, at.attr2, at.attr3, at.attr4, at.attr5,
+                             at.attr6, at.attr7, at.attr8, at.attr9, at.attr10,
+                             at.attr11, at.attr12, at.attr13, at.attr14,
+                             at.attr15, at.attr16, at.attr17, at.attr18,
+                             at.attr19, at.attr20';
+        $attributeColumnNames = Shopware()->Db()->fetchRow('SELECT * FROM s_articles_attributes LIMIT 1');
+        if (!empty($attributeColumnNames)) {
+            unset($attributeColumnNames['id'], $attributeColumnNames['articleID'], $attributeColumnNames['articledetailsID']);
+            $attributeColumns = 'at.' . implode(', at.', array_keys($attributeColumnNames));
+        }
+
         $this->_positions = new ArrayObject(Shopware()->Db()->fetchAll('
-        SELECT
-            od.*, a.taxID as articleTaxID,
-            at.attr1, at.attr2, at.attr3, at.attr4, at.attr5, at.attr6, at.attr7, at.attr8, at.attr9, at.attr10,
-            at.attr11, at.attr12, at.attr13, at.attr14, at.attr15, at.attr16, at.attr17, at.attr18, at.attr19, at.attr20
+        SELECT od.*, a.taxID as articleTaxID,
+        ' . $attributeColumns . '
         FROM  s_order_details od
 
         LEFT JOIN s_articles_details d


### PR DESCRIPTION
### 1. Why is this change necessary?
This change is necessary to use custom attributes in any document templates

### 2. What does this change do, exactly?
With this change the function getPositions selects all columns of s_articles_attributes including custom shop-specific attributes instead of only at.attr1 - at.attr20. 

### 3. Describe each step to reproduce the issue or behaviour.
If custom article attributes are added, they cannot be used in document templates.
With this change all attributes that worked before still work and custom ones can be used too.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.