### PR TITLE
Adds configuration to have the basket cleared on logout

### DIFF
--- a/_sql/migrations/1457-new-config-clear-basket-on-logout.php
+++ b/_sql/migrations/1457-new-config-clear-basket-on-logout.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration1457 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('INSERT INTO s_core_config_elements (form_id, name, value, label, description, type, required, position, scope, options) VALUES (147, "clearBasketAfterLogout", "b:1;", "Warenkorb beim Abmelden leeren", null, "boolean", 0, 0, 0, null);');
+        $this->addSql('INSERT INTO s_core_config_element_translations (element_id, locale_id, label, description) VALUES (LAST_INSERT_ID(), 2, "Clear basket after logout", null);');
+    }
+}

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -691,7 +691,9 @@ class sAdmin
 
     public function logout()
     {
-        $this->moduleManager->Basket()->clearBasket();
+        if ($this->config->get('clearBasketAfterLogout')) {
+            $this->moduleManager->Basket()->clearBasket();
+        }
 
         Shopware()->Session()->unsetAll();
         $this->regenerateSessionId();


### PR DESCRIPTION
### 1. Why is this change necessary?
you might not wish to clear the basket when a customer logs out.

### 2. What does this change do, exactly?
Adds a new configuration option under "Basic settings > Shopping cart / item details" to decide whether the basket should be cleared on logout or not. It is set to true per default to not break the existing behaviour.

### 3. Describe each step to reproduce the issue or behaviour.
1. Login as customer.
2. Put a product into your basket.
3. Logout.
4. Now the basket is cleared. The new configuration makes it possible to not have the basket cleared.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-13110

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.