### PR TITLE
Added plugin specific logger service

### DIFF
--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -28,6 +28,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
 * Added better ExtJS file auto-loading. See [Improved ExtJS auto-loading](###Improved ExtJS auto-loading) for more details
 * Added configuration to show the voucher field on checkout confirm page
 * Added information text to detail page of category filter 
+* Added specific logger service for each plugin. See [Plugin specific logger](###Plugin specific logger) for more details  
 
 ### Changes
 
@@ -244,4 +245,20 @@ class MyPaymentController extends Controller {
         $this->redirect($redirectUrl);
     }
 }
+```
+
+### Plugin specific logger
+
+There is a new logger service for each plugin.
+The service id is a combination of the plugin's service prefix (lower camel case plugin name) and `.logger`.
+For example: when a plugin's name is `SwagPlugin` the specific logger can be accessed via `swag_plugin.logger`.
+This logger will now write into the logs directory using a rotating file pattern like the other logger services.
+The settings for the logger can be configured using the DI parameters `swag_plugin.logger.level`(defaults to shopware default logging level) and `swag_plugin.logger.max_files` (defaults to 14 like other shopware loggers).
+In this case the logger would write into a file like `var/log/swag_plugin_production-2019-03-06.log`.
+
+Support for easier log message writing is enabled:
+```php
+<?php
+
+$logger->fatal("An error is occured while requesting {module}/{controller}/{action}", $controller->Request()->getParams());
 ```

--- a/engine/Shopware/Components/DependencyInjection/Compiler/PluginLoggerCompilerPass.php
+++ b/engine/Shopware/Components/DependencyInjection/Compiler/PluginLoggerCompilerPass.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\DependencyInjection\Compiler;
+
+use Monolog\Handler\RotatingFileHandler;
+use Monolog\Processor\PsrLogMessageProcessor;
+use Shopware\Components\Logger;
+use Shopware\Components\Plugin;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @category Shopware
+ *
+ * @copyright Copyright (c) shopware AG (http://www.shopware.de)
+ */
+class PluginLoggerCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @var Plugin[]
+     */
+    private $plugins;
+
+    /**
+     * @param Plugin[] $plugins
+     */
+    public function __construct(array $plugins)
+    {
+        $this->plugins = $plugins;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($this->plugins as $plugin) {
+            $this->processPlugin($container, $plugin->getContainerPrefix());
+        }
+    }
+
+    protected function processPlugin(ContainerBuilder $container, string $servicePrefix): void
+    {
+        if (!$container->hasParameter($logLevel = $this->getParameterNameLogLevel($servicePrefix))) {
+            $container->setParameter($logLevel, $container->getParameter('shopware.logger.level'));
+        }
+
+        if (!$container->hasParameter($logMaxFiles = $this->getParameterNameLoggerMaxFiles($servicePrefix))) {
+            $container->setParameter($logMaxFiles, 14);
+        }
+
+        $container->setDefinition($this->getServiceIdLoggerHandler($servicePrefix), $this->createLoggerHandler($servicePrefix));
+        $container->setDefinition($this->getServiceIdLoggerFormatter($servicePrefix), $this->createLoggerFormatter());
+        $container->setDefinition($this->getServiceIdLogger($servicePrefix), $this->createLogger($servicePrefix));
+    }
+
+    protected function createLoggerHandler(string $servicePrefix): Definition
+    {
+        return (new Definition(RotatingFileHandler::class, [
+                sprintf('%%kernel.logs_dir%%/%s_%%kernel.environment%%.log', $servicePrefix),
+                sprintf('%%%s%%', $this->getParameterNameLoggerMaxFiles($servicePrefix)),
+                sprintf('%%%s%%', $this->getParameterNameLogLevel($servicePrefix)),
+            ]))
+            ->addMethodCall('pushProcessor', [new Reference('monolog.processor.uid')])
+            ->setPublic(false)
+        ;
+    }
+
+    protected function createLoggerFormatter(): Definition
+    {
+        return (new Definition(PsrLogMessageProcessor::class))
+            ->setPublic(false)
+        ;
+    }
+
+    protected function createLogger(string $servicePrefix): Definition
+    {
+        return (new Definition(Logger::class, [$servicePrefix]))
+            ->addMethodCall('pushHandler', [new Reference($this->getServiceIdLoggerHandler($servicePrefix))])
+            ->addMethodCall('pushProcessor', [new Reference($this->getServiceIdLoggerFormatter($servicePrefix))])
+        ;
+    }
+
+    protected function getServiceIdLogger(string $servicePrefix): string
+    {
+        return sprintf('%s.logger', $servicePrefix);
+    }
+
+    protected function getServiceIdLoggerFormatter(string $servicePrefix): string
+    {
+        return sprintf('%s.logger_formatter', $servicePrefix);
+    }
+
+    protected function getServiceIdLoggerHandler(string $servicePrefix): string
+    {
+        return sprintf('%s.logger_handler', $servicePrefix);
+    }
+
+    protected function getParameterNameLoggerMaxFiles(string $servicePrefix): string
+    {
+        return sprintf('%s.logger.max_files', $servicePrefix);
+    }
+
+    protected function getParameterNameLogLevel(string $servicePrefix): string
+    {
+        return sprintf('%s.logger.level', $servicePrefix);
+    }
+}

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -38,6 +38,7 @@ use Shopware\Components\DependencyInjection\Compiler\ConfigureApiResourcesPass;
 use Shopware\Components\DependencyInjection\Compiler\DoctrineEventSubscriberCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EventListenerCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EventSubscriberCompilerPass;
+use Shopware\Components\DependencyInjection\Compiler\PluginLoggerCompilerPass;
 use Shopware\Components\DependencyInjection\Container;
 use Shopware\Components\DependencyInjection\LegacyPhpDumper;
 use Shopware\Components\Plugin;
@@ -797,5 +798,6 @@ class Kernel implements HttpKernelInterface, TerminableInterface
         }
 
         $container->addCompilerPass(new RegisterControllerCompilerPass($activePlugins));
+        $container->addCompilerPass(new PluginLoggerCompilerPass($activePlugins));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
When writing a plugin that has to log a lot I always have to create an own logger service to collect all my logged data at one place without any other logged data.
Separate logged data by logging source makes it far easier to read logs.

### 2. What does this change do, exactly?
It adds a new service for each plugin with its own file pattern:
```
"var/log/{$pluginServicePrefix}_{$environment}-{$dateRotation}.log"
```

The service id is
```
"{$pluginServicePrefix}.logger"
```

### 3. Describe each step to reproduce the issue or behaviour.
1. Build something that works with huge payloads and logs processes on it.
2. Have to read the log files on that payload processing
3. Listen to Sir mix a lot
4. Copy your last logger definition from the other plugin where you had that issue before
5. Profit? Not really

### 4. Which documentation changes (if any) need to be made because of this PR?
There are new DI parameters and services that needs to be documented.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 6. Bonus
A bonus?
A BONUS!
![awesome bonus](http://www.reactiongifs.com/r/asm.gif)
Test this feature using the following plugin:
```php
<?php declare(strict_types=1);

namespace Pr2048;

use Enlight_Controller_Action;
use Enlight_Event_EventArgs;
use Shopware\Components\Logger;
use Shopware\Components\Plugin;

class Pr2048 extends Plugin
{
    public static function getSubscribedEvents()
    {
        return [
            'Enlight_Controller_Action_PreDispatch' => 'calledIt',
        ];
    }

    public function calledIt(Enlight_Event_EventArgs $args): void
    {
        /** @var Enlight_Controller_Action $subject */
        $subject = $args->get('subject');
        /** @var Logger $logger */
        $logger = $this->container->get('pr2048.logger');

        $message = sprintf(
            'Controller {%s}/{%s}::{%s} got requested',
            $subject->Request()->getModuleKey(),
            $subject->Request()->getControllerKey(),
            $subject->Request()->getActionKey()
        );
        $logger->info($message, [
            $subject->Request()->getModuleKey() => $subject->Request()->getModuleName(),
            $subject->Request()->getControllerKey() => $subject->Request()->getControllerName(),
            $subject->Request()->getActionKey() => $subject->Request()->getActionName(),
        ]);
    }
}
```
This generated the `var/log/pr2048_dev-2019-03-06.log` with the following content:
```
[2019-03-06 03:02:39] pr2048.INFO: Controller backend/index::index got requested {"module":"backend","controller":"index","action":"index"} {"uid":"568b161"}
[2019-03-06 03:02:39] pr2048.INFO: Controller backend/index::index got requested {"module":"backend","controller":"index","action":"index"} {"uid":"a877985"}
[2019-03-06 03:02:39] pr2048.INFO: Controller backend/index::auth got requested {"module":"backend","controller":"index","action":"auth"} {"uid":"a877985"}
[2019-03-06 03:02:40] pr2048.INFO: Controller backend/base::index got requested {"module":"backend","controller":"base","action":"index"} {"uid":"912d492"}
[2019-03-06 03:02:41] pr2048.INFO: Controller backend/CSRFToken::generate got requested {"module":"backend","controller":"CSRFToken","action":"generate"} {"uid":"62194b8"}
[2019-03-06 03:02:42] pr2048.INFO: Controller backend/Login::index got requested {"module":"backend","controller":"Login","action":"index"} {"uid":"9ddb2b6"}
[2019-03-06 03:02:42] pr2048.INFO: Controller backend/Login::load got requested {"module":"backend","controller":"Login","action":"load"} {"uid":"b747d6b"}
[2019-03-06 03:02:43] pr2048.INFO: Controller backend/Login::getLocales got requested {"module":"backend","controller":"Login","action":"getLocales"} {"uid":"71019bd"}
[2019-03-06 03:04:56] pr2048.INFO: Controller backend/index::index got requested {"module":"backend","controller":"index","action":"index"} {"uid":"1e11c86"}
[2019-03-06 03:04:56] pr2048.INFO: Controller backend/index::auth got requested {"module":"backend","controller":"index","action":"auth"} {"uid":"1e11c86"}
[2019-03-06 03:04:57] pr2048.INFO: Controller backend/CSRFToken::generate got requested {"module":"backend","controller":"CSRFToken","action":"generate"} {"uid":"74ea09f"}
[2019-03-06 03:04:58] pr2048.INFO: Controller backend/Login::getLocales got requested {"module":"backend","controller":"Login","action":"getLocales"} {"uid":"7895204"}
```

Proudly presented by
[![image](https://user-images.githubusercontent.com/1133593/53851934-83dbc680-3fc0-11e9-9141-52e9a4d079f5.png)](https://youtu.be/X53ZSxkQ3Ho)