### PR TITLE
Fixes unknown `has` for HttpFoundation Request

### DIFF
--- a/engine/Shopware/Bundle/ControllerBundle/ArgumentResolver/RequestParameterResolver.php
+++ b/engine/Shopware/Bundle/ControllerBundle/ArgumentResolver/RequestParameterResolver.php
@@ -35,7 +35,7 @@ class RequestParameterResolver implements ArgumentValueResolverInterface
      */
     public function supports(Request $request, ArgumentMetadata $argument)
     {
-        return $request->has($argument->getName());
+        return $request->get($argument->getName()) !== null;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
The method `has` exists for individual ParameterBags, but not the Request as a whole.

### 2. What does this change do, exactly?
Looks for the argument in all parameter bags individually. Basically checking if the `get` method was able to provide *any* value. 

### 3. Describe each step to reproduce the issue or behaviour.
![screenshot-2019-03-06_16 13 16](https://user-images.githubusercontent.com/3962174/53891497-c803b100-402a-11e9-8eeb-b9b603c36e57.jpg)

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.