### PR TITLE
use createdDateTime on listing media in backend

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/MediaReplaceService.php
+++ b/engine/Shopware/Bundle/MediaBundle/MediaReplaceService.php
@@ -96,6 +96,7 @@ class MediaReplaceService implements MediaReplaceServiceInterface
 
         $media->setExtension($this->getExtension($file));
         $media->setFileSize(filesize($file->getRealPath()));
+        $media->setCreated(new \DateTime());
 
         if ($media->getType() === Media::TYPE_IMAGE) {
             $imageSize = getimagesize($file->getRealPath());

--- a/themes/Backend/ExtJs/backend/media_manager/view/media/grid.js
+++ b/themes/Backend/ExtJs/backend/media_manager/view/media/grid.js
@@ -182,8 +182,9 @@ Ext.define('Shopware.apps.MediaManager.view.media.Grid', {
     previewRenderer: function(value, tdStyle, record) {
         var me = this,
             type = record.get('type').toLowerCase(),
-            value = value + '?' + new Date().getTime(),
             result;
+
+        value += '?' + record.data.created.getTime();
 
         switch(type) {
            case 'video':

--- a/themes/Backend/ExtJs/backend/media_manager/view/replace/row.js
+++ b/themes/Backend/ExtJs/backend/media_manager/view/replace/row.js
@@ -204,7 +204,7 @@ Ext.define('Shopware.apps.MediaManager.view.replace.Row', {
         var me = this;
 
         if (data && !data.isRaw) {
-            data.thumbnail += '?' + new Date().getTime();
+            data.thumbnail += '?' + data.created.getTime();
         }
 
         return Ext.create('Ext.container.Container', {


### PR DESCRIPTION
### 1. Why is this change necessary?
Due to reduce load and caching increasing

### 2. What does this change do, exactly?
- Use createdDateTime of media in listing instead of CurrentDateTime
- Update createdDate on media when replacing

### 3. Describe each step to reproduce the issue or behaviour.
Open media manager and switch media manager, see Querystring of images chaning all the time

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.