### PR TITLE
Show wrong opcache settings in system info

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -17,6 +17,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 * Added rich-snippets for `priceValidUntil` , `url`, `image` and  `gtin13`
 * Added new block `frontend_index_header_meta_tags_inner` to `frontend/index/header.tpl`
 * Added preselected checkbox option to 'Deactivate No Customer Account' in basic configuration
+* Added OPCache options `opcache.use_cwd` and `opcache.validate_root` to the system info's requirements tab.
 
 ### Changes
 

--- a/engine/Shopware/Components/Check/Requirements.php
+++ b/engine/Shopware/Components/Check/Requirements.php
@@ -73,6 +73,7 @@ class Requirements
             'checks' => [],
         ];
 
+        $checks = [];
         foreach ($this->runChecks() as $requirement) {
             $check = [];
             $check['name'] = (string) $requirement->name;
@@ -89,6 +90,12 @@ class Requirements
                 $check = $this->handleMaxCompatibleVersion($check);
             }
 
+            $checks[] = $check;
+        }
+
+        $checks = array_merge($checks, $this->checkOpcache());
+
+        foreach ($checks as $check) {
             if (!$check['check'] && $check['error']) {
                 $check['status'] = 'error';
                 $result['hasErrors'] = true;
@@ -247,6 +254,44 @@ class Requirements
         }
 
         return $v;
+    }
+
+    /**
+     * Checks the opcache configuration if the opcache exists.
+     */
+    private function checkOpcache()
+    {
+        if (!extension_loaded('Zend OPcache')) {
+            return [];
+        }
+
+        $useCwdOption = $this->compare('opcache.use_cwd', ini_get('opcache.use_cwd'), 1);
+        $opcacheRequirements = [[
+            'name' => 'opcache.use_cwd',
+            'group' => 'core',
+            'required' => 1,
+            'version' => ini_get('opcache.use_cwd'),
+            'result' => ini_get('opcache.use_cwd'),
+            'notice' => '',
+            'check' => $this->compare('opcache.use_cwd', ini_get('opcache.use_cwd'), 1),
+            'error' => '',
+        ]];
+
+        if (fileinode('/') > 2) {
+            $validateRootOption = $this->compare('opcache.validate_root', ini_get('opcache.validate_root'), 1);
+            $opcacheRequirements[] = [
+                'name' => 'opcache.validate_root',
+                'group' => 'core',
+                'required' => 1,
+                'version' => ini_get('opcache.validate_root'),
+                'result' => ini_get('opcache.validate_root'),
+                'notice' => '',
+                'check' => $this->compare('opcache.validate_root', ini_get('opcache.validate_root'), 1),
+                'error' => '',
+            ];
+        }
+
+        return $opcacheRequirements;
     }
 
     /**

--- a/recovery/install/src/Requirements.php
+++ b/recovery/install/src/Requirements.php
@@ -71,6 +71,7 @@ class Requirements
             'phpVersionNotSupported' => false,
         ];
 
+        $checks = [];
         foreach ($this->runChecks() as $requirement) {
             $check = [];
 
@@ -95,6 +96,12 @@ class Requirements
                 }
             }
 
+            $checks[] = $check;
+        }
+
+        $checks = array_merge($checks, $this->checkOpcache());
+
+        foreach ($checks as $check) {
             if (!$check['check'] && $check['error']) {
                 $check['status'] = 'error';
                 $result['hasErrors'] = true;
@@ -215,6 +222,44 @@ class Requirements
     private function checkModRewrite()
     {
         return isset($_SERVER['MOD_REWRITE']);
+    }
+
+    /**
+     * Checks the opcache configuration if the opcache exists.
+     */
+    private function checkOpcache()
+    {
+        if (!extension_loaded('Zend OPcache')) {
+            return [];
+        }
+
+        $useCwdOption = $this->compare('opcache.use_cwd', ini_get('opcache.use_cwd'), 1);
+        $opcacheRequirements = [[
+            'name' => 'opcache.use_cwd',
+            'group' => 'core',
+            'required' => 1,
+            'version' => ini_get('opcache.use_cwd'),
+            'result' => ini_get('opcache.use_cwd'),
+            'notice' => '',
+            'check' => $this->compare('opcache.use_cwd', ini_get('opcache.use_cwd'), 1),
+            'error' => '',
+        ]];
+
+        if (fileinode('/') > 2) {
+            $validateRootOption = $this->compare('opcache.validate_root', ini_get('opcache.validate_root'), 1);
+            $opcacheRequirements[] = [
+                'name' => 'opcache.validate_root',
+                'group' => 'core',
+                'required' => 1,
+                'version' => ini_get('opcache.validate_root'),
+                'result' => ini_get('opcache.validate_root'),
+                'notice' => '',
+                'check' => $this->compare('opcache.validate_root', ini_get('opcache.validate_root'), 1),
+                'error' => '',
+            ];
+        }
+
+        return $opcacheRequirements;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
If two Shopware shops are running on the same server, they might override each others model definition, if the OPCache module is not configured correctly. Depending on the definition, OPCache does not include the directory path in its caching which can lead to multiple files with the same name overriding each other. As a result, the shop will experience sporadic model definition errors which are hard to track down.

This pr will add the critical OPCache settings into the requirements tab if the OPCache module is enabled.

### 2. What does this change do, exactly?
This change adds the `opcache.use_cwd = 1` and the `opcache.validate_root = 1` settings into the requirements tab in case OPCache is used.

### 3. Describe each step to reproduce the issue or behaviour.
Configure OPCache incorrectly with `opcache.use_cwd = 0` and `opcache.validate_root = 0`. The requirements tab will now show if the correct settings are defined.

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
Add the options into the sysadmins guide: https://developers.shopware.com/sysadmins-guide/shopware-5-performance-for-sysadmins/#opcode-cache

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.