### PR TITLE
Added missing type cast for ordernumbers

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -253,7 +253,7 @@ class sOrder
             ['subject' => $this]
         );
 
-        return $number;
+        return (string) $number;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Hooking into `sOrder::sSaveOrder` and reading the return value gives you different types depending on the fact whether there are ordernumber filters present or not.

### 2. What does this change do, exactly?
Adds a cast to match the return type declared in the phpdocs.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a subscriber:
```php
<?php declare (strict_types=1);
/// ...
    public static function getSubscribedEvents()
    {
        return [
            'sOrder::sSaveOrder::after' => 'onSaveOrder',
        ];
    }

    public function onSaveOrder(\Enlight_Hook_HookArgs $args)
    {
        /** @var string $ordernumber */
        $ordernumber = $args->getReturn();
        $this->processOrdernumber($ordernumber);
    }

    public function processOrdernumber(string $ordernumber)
    {
    }
```
2. This will break at calling `processOrdernumber` as the variable was not a string as the number incrementor returns an int
3. Have any `Shopware_Modules_Order_GetOrdernumber_FilterOrdernumber` subscriber that returns the number as string
4. Now the call `processOrdernumber` does not break

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Bonus

The quickfix is the following subscriber:
```php
<?php
// ...
    public static function getSubscribedEvents()
    {
        return [
            'Shopware_Modules_Order_GetOrdernumber_FilterOrdernumber' => 'makeOrdernumberOfTypeString',
        ];
    }

    public function makeOrdernumberOfTypeString(Enlight_Event_EventArgs $args)
    {
        return (string) $args->getReturn();
    }
```