### PR TITLE
Added missing attribute accessors on customer streams

### DIFF
--- a/engine/Shopware/Models/CustomerStream/CustomerStream.php
+++ b/engine/Shopware/Models/CustomerStream/CustomerStream.php
@@ -181,4 +181,22 @@ class CustomerStream extends ModelEntity
     {
         $this->static = $static;
     }
+
+    /**
+     * @return \Shopware\Models\Attribute\CustomerStream
+     */
+    public function getAttribute()
+    {
+        return $this->attribute;
+    }
+
+    /**
+     * @param \Shopware\Models\Attribute\CustomerStream|array|null $attribute
+     *
+     * @return \Shopware\Models\Attribute\CustomerStream
+     */
+    public function setAttribute($attribute)
+    {
+        return $this->setOneToOne($attribute, '\Shopware\Models\Attribute\CustomerStream', 'attribute', 'customerStream');
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
This is the only model missing the attribute accessors.

### 2. What does this change do, exactly?
Add a getter and a setter for the attribute property.

### 3. Describe each step to reproduce the issue or behaviour.
1. Use ORM
2. Use attributes
3. Try to use attributes on customer streams
4. Be confused
5. Check the database for this table
6. Check the model
7. Create a [PR](https://github.com/shopware/shopware/issues/2054)

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.