### PR TITLE
Normalized null type hints for ORM nullables

### DIFF
--- a/engine/Shopware/Models/Article/Article.php
+++ b/engine/Shopware/Models/Article/Article.php
@@ -47,12 +47,10 @@ class Article extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var \Shopware\Models\Tax\Tax
+     * @var \Shopware\Models\Tax\Tax|null
      *
      * @Assert\NotBlank()
      * @Assert\Valid()
-     *
-     * @var \Shopware\Models\Tax\Tax
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Tax\Tax")
      * @ORM\JoinColumn(name="taxID", referencedColumnName="id")
@@ -134,7 +132,7 @@ class Article extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var \Shopware\Models\Property\Group
+     * @var \Shopware\Models\Property\Group|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Property\Group", inversedBy="articles")
      * @ORM\JoinColumn(name="filtergroupID", referencedColumnName="id")
@@ -174,7 +172,7 @@ class Article extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var Supplier
+     * @var Supplier|null
      *
      * @Assert\Valid()
      *
@@ -198,7 +196,7 @@ class Article extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var Detail
+     * @var Detail|null
      *
      * @Assert\NotBlank()
      * @Assert\Valid()
@@ -245,7 +243,7 @@ class Article extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var \Shopware\Models\Price\Group
+     * @var \Shopware\Models\Price\Group|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Price\Group")
      * @ORM\JoinColumn(name="pricegroupID", referencedColumnName="id")
@@ -264,7 +262,7 @@ class Article extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductAttribute
+     * @var ProductAttribute|null
      *
      * @Assert\Valid()
      *
@@ -275,7 +273,7 @@ class Article extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var Configurator\Set
+     * @var Configurator\Set|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Article\Configurator\Set", inversedBy="articles", cascade={"persist"})
      * @ORM\JoinColumn(name="configurator_set_id", referencedColumnName="id")
@@ -325,42 +323,42 @@ class Article extends ModelEntity
     private $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="main_detail_id", type="integer", nullable=true)
      */
     private $mainDetailId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="supplierID", type="integer", nullable=true)
      */
     private $supplierId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="taxID", type="integer", nullable=true)
      */
     private $taxId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="pricegroupID", type="integer", nullable=true)
      */
     private $priceGroupId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="filtergroupID", type="integer", nullable=true)
      */
     private $filterGroupId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="configurator_set_id", type="integer", nullable=true)
      */
@@ -376,21 +374,21 @@ class Article extends ModelEntity
     private $name;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="description", type="text", nullable=true)
      */
     private $description;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="description_long", type="text", nullable=true)
      */
     private $descriptionLong;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @Assert\DateTime()
      *
@@ -420,14 +418,14 @@ class Article extends ModelEntity
     private $highlight = false;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="keywords", type="string", length=255, nullable=true)
      */
     private $keywords;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="metaTitle", type="string", length=255, nullable=true)
      */
@@ -470,7 +468,7 @@ class Article extends ModelEntity
     private $notification = false;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="template", type="string", length=255, nullable=true)
      */
@@ -484,14 +482,14 @@ class Article extends ModelEntity
     private $mode = 0;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="available_from", type="datetime", nullable=true)
      */
     private $availableFrom;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="available_to", type="datetime", nullable=true)
      */
@@ -567,7 +565,7 @@ class Article extends ModelEntity
     /**
      * Get description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -591,7 +589,7 @@ class Article extends ModelEntity
     /**
      * Get descriptionLong
      *
-     * @return string
+     * @return string|null
      */
     public function getDescriptionLong()
     {
@@ -619,7 +617,7 @@ class Article extends ModelEntity
     /**
      * Get date
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getAdded()
     {
@@ -715,7 +713,7 @@ class Article extends ModelEntity
     /**
      * Get keywords
      *
-     * @return string
+     * @return string|null
      */
     public function getKeywords()
     {
@@ -739,7 +737,7 @@ class Article extends ModelEntity
     /**
      * Get metaTitle
      *
-     * @return string
+     * @return string|null
      */
     public function getMetaTitle()
     {
@@ -849,7 +847,7 @@ class Article extends ModelEntity
     /**
      * Set template
      *
-     * @param string $template
+     * @param string|null $template
      *
      * @return Article
      */
@@ -863,7 +861,7 @@ class Article extends ModelEntity
     /**
      * Get template
      *
-     * @return string
+     * @return string|null
      */
     public function getTemplate()
     {
@@ -973,7 +971,7 @@ class Article extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Property\Group $propertyGroup
+     * @param \Shopware\Models\Property\Group|null $propertyGroup
      *
      * @return Article
      */
@@ -1025,7 +1023,7 @@ class Article extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Tax\Tax
+     * @return \Shopware\Models\Tax\Tax|null
      */
     public function getTax()
     {
@@ -1104,7 +1102,7 @@ class Article extends ModelEntity
      * OWNING SIDE
      * of the association between articles and supplier
      *
-     * @return Supplier
+     * @return Supplier|null
      */
     public function getSupplier()
     {
@@ -1112,7 +1110,7 @@ class Article extends ModelEntity
     }
 
     /**
-     * @param Supplier|array|null $supplier
+     * @param Supplier|array $supplier
      *
      * @return \Shopware\Components\Model\ModelEntity
      */
@@ -1165,7 +1163,7 @@ class Article extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Price\Group
+     * @return \Shopware\Models\Price\Group|null
      */
     public function getPriceGroup()
     {
@@ -1205,7 +1203,7 @@ class Article extends ModelEntity
     }
 
     /**
-     * @return ProductAttribute
+     * @return ProductAttribute|null
      */
     public function getAttribute()
     {
@@ -1245,7 +1243,7 @@ class Article extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getAvailableFrom()
     {
@@ -1253,7 +1251,7 @@ class Article extends ModelEntity
     }
 
     /**
-     * @param \DateTimeInterface $availableFrom
+     * @param \DateTimeInterface|null $availableFrom
      *
      * @return Article
      */
@@ -1265,7 +1263,7 @@ class Article extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getAvailableTo()
     {
@@ -1273,7 +1271,7 @@ class Article extends ModelEntity
     }
 
     /**
-     * @param \DateTimeInterface $availableTo
+     * @param \DateTimeInterface|null $availableTo
      *
      * @return Article
      */
@@ -1293,7 +1291,7 @@ class Article extends ModelEntity
     }
 
     /**
-     * @param Configurator\Set $configuratorSet
+     * @param Configurator\Set|null $configuratorSet
      *
      * @return Article
      */

--- a/engine/Shopware/Models/Article/Configurator/Dependency.php
+++ b/engine/Shopware/Models/Article/Configurator/Dependency.php
@@ -43,21 +43,21 @@ class Dependency extends ModelEntity
     private $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="configurator_set_id", type="integer", nullable=true)
      */
     private $configuratorSetId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parent_id", type="integer", nullable=true)
      */
     private $parentId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="child_id", type="integer", nullable=true)
      */
@@ -72,7 +72,7 @@ class Dependency extends ModelEntity
     private $parentOption;
 
     /**
-     * @var \Shopware\Models\Article\Configurator\Option
+     * @var \Shopware\Models\Article\Configurator\Option|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Article\Configurator\Option", inversedBy="dependencyChildren")
      * @ORM\JoinColumn(name="child_id", referencedColumnName="id")
@@ -80,7 +80,7 @@ class Dependency extends ModelEntity
     private $childOption;
 
     /**
-     * @var \Shopware\Models\Article\Configurator\Set
+     * @var \Shopware\Models\Article\Configurator\Set|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Article\Configurator\Set", inversedBy="dependencies")
      * @ORM\JoinColumn(name="configurator_set_id", referencedColumnName="id")
@@ -96,7 +96,7 @@ class Dependency extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Article\Configurator\Option
+     * @return \Shopware\Models\Article\Configurator\Option|null
      */
     public function getParentOption()
     {
@@ -112,7 +112,7 @@ class Dependency extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Article\Configurator\Option
+     * @return \Shopware\Models\Article\Configurator\Option|null
      */
     public function getChildOption()
     {
@@ -128,7 +128,7 @@ class Dependency extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Article\Configurator\Set
+     * @return \Shopware\Models\Article\Configurator\Set|null
      */
     public function getConfiguratorSet()
     {

--- a/engine/Shopware/Models/Article/Configurator/Group.php
+++ b/engine/Shopware/Models/Article/Configurator/Group.php
@@ -52,7 +52,7 @@ class Group extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ConfiguratorGroupAttribute
+     * @var ConfiguratorGroupAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ConfiguratorGroup", mappedBy="configuratorGroup", orphanRemoval=true, cascade={"persist"})
      */
@@ -75,7 +75,7 @@ class Group extends ModelEntity
     private $name;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="description", type="text", nullable=true)
      */
@@ -119,7 +119,7 @@ class Group extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -127,7 +127,7 @@ class Group extends ModelEntity
     }
 
     /**
-     * @param string $description
+     * @param string|null $description
      */
     public function setDescription($description)
     {
@@ -183,7 +183,7 @@ class Group extends ModelEntity
     }
 
     /**
-     * @return ConfiguratorGroupAttribute
+     * @return ConfiguratorGroupAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Article/Configurator/Option.php
+++ b/engine/Shopware/Models/Article/Configurator/Option.php
@@ -60,7 +60,7 @@ class Option extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ConfiguratorOptionAttribute
+     * @var ConfiguratorOptionAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ConfiguratorOption", mappedBy="configuratorOption", orphanRemoval=true, cascade={"persist"})
      */
@@ -76,7 +76,7 @@ class Option extends ModelEntity
     private $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="group_id", type="integer", nullable=true)
      */
@@ -97,7 +97,7 @@ class Option extends ModelEntity
     private $position;
 
     /**
-     * @var Group
+     * @var Group|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Article\Configurator\Group", inversedBy="options")
      * @ORM\JoinColumn(name="group_id", referencedColumnName="id")
@@ -119,7 +119,7 @@ class Option extends ModelEntity
     private $dependencyChildren;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="media_id", type="integer", nullable=true)
      */
@@ -172,7 +172,7 @@ class Option extends ModelEntity
     }
 
     /**
-     * @return Group
+     * @return Group|null
      */
     public function getGroup()
     {
@@ -220,7 +220,7 @@ class Option extends ModelEntity
     }
 
     /**
-     * @return ConfiguratorOptionAttribute
+     * @return ConfiguratorOptionAttribute|null
      */
     public function getAttribute()
     {
@@ -238,7 +238,7 @@ class Option extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMediaId()
     {
@@ -246,7 +246,7 @@ class Option extends ModelEntity
     }
 
     /**
-     * @param int $mediaId
+     * @param int|null $mediaId
      */
     public function setMediaId($mediaId)
     {

--- a/engine/Shopware/Models/Article/Configurator/PriceVariation.php
+++ b/engine/Shopware/Models/Article/Configurator/PriceVariation.php
@@ -58,7 +58,7 @@ class PriceVariation extends ModelEntity
     private $id;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="options", type="text", nullable=true)
      */
@@ -72,7 +72,7 @@ class PriceVariation extends ModelEntity
     private $variation;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="configurator_set_id", type="integer", nullable=true)
      */
@@ -103,7 +103,7 @@ class PriceVariation extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Article\Configurator\Set
+     * @return \Shopware\Models\Article\Configurator\Set|null
      */
     public function getConfiguratorSet()
     {
@@ -127,7 +127,7 @@ class PriceVariation extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getOptions()
     {

--- a/engine/Shopware/Models/Article/Configurator/Template/Price.php
+++ b/engine/Shopware/Models/Article/Configurator/Template/Price.php
@@ -49,7 +49,7 @@ class Price extends LazyFetchModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var TemplatePriceAttribute
+     * @var TemplatePriceAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\TemplatePrice", mappedBy="templatePrice", cascade={"persist"})
      */
@@ -85,7 +85,7 @@ class Price extends LazyFetchModelEntity
     private $from;
 
     /**
-     * @var int|string
+     * @var int|string|null
      *
      * @ORM\Column(name="`to`", type="string", nullable=true)
      */
@@ -281,7 +281,7 @@ class Price extends LazyFetchModelEntity
     }
 
     /**
-     * @return TemplatePriceAttribute
+     * @return TemplatePriceAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Article/Configurator/Template/Template.php
+++ b/engine/Shopware/Models/Article/Configurator/Template/Template.php
@@ -41,7 +41,7 @@ class Template extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var Product
+     * @var Product|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Article\Article", inversedBy="configuratorTemplate")
      * @ORM\JoinColumn(name="article_id", referencedColumnName="id")
@@ -60,7 +60,7 @@ class Template extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var TemplateAttribute
+     * @var TemplateAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Template", mappedBy="template", orphanRemoval=true, cascade={"persist"})
      */
@@ -69,7 +69,7 @@ class Template extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var Unit
+     * @var Unit|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Article\Unit", inversedBy="articles", cascade={"persist"})
      * @ORM\JoinColumn(name="unit_id", referencedColumnName="id")
@@ -86,14 +86,14 @@ class Template extends ModelEntity
     private $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="article_id", type="integer", nullable=false)
      */
     private $articleId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="unit_id", type="integer", nullable=true)
      */
@@ -110,14 +110,14 @@ class Template extends ModelEntity
     private $number = '';
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="suppliernumber", type="string", nullable=true)
      */
     private $supplierNumber;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="additionaltext", type="string", nullable=true)
      */
@@ -131,14 +131,14 @@ class Template extends ModelEntity
     private $active = false;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="instock", type="integer", nullable=true)
      */
     private $inStock;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="stockmin", type="integer", nullable=true)
      */
@@ -152,35 +152,35 @@ class Template extends ModelEntity
     private $lastStock;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="weight", type="decimal", nullable=true, precision=3)
      */
     private $weight;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="width", type="decimal", nullable=true, precision=3)
      */
     private $width;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="length", type="decimal", nullable=true, precision=3)
      */
     private $len;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="height", type="decimal", nullable=true, precision=3)
      */
     private $height;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="ean", type="string", nullable=true)
      */
@@ -201,42 +201,42 @@ class Template extends ModelEntity
     private $position = 0;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="minpurchase", type="integer", nullable=true)
      */
     private $minPurchase;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="purchasesteps", type="integer", nullable=true)
      */
     private $purchaseSteps;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="maxpurchase", type="integer", nullable=true)
      */
     private $maxPurchase;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="purchaseunit", type="decimal", nullable=true)
      */
     private $purchaseUnit;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="referenceunit", type="decimal", nullable=true)
      */
     private $referenceUnit;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="packunit", type="text", nullable=true)
      */
@@ -250,14 +250,14 @@ class Template extends ModelEntity
     private $shippingFree = false;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="releasedate", type="date", nullable=true)
      */
     private $releaseDate;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="shippingtime", type="string", length=11, nullable=true)
      */
@@ -308,7 +308,7 @@ class Template extends ModelEntity
     /**
      * Set supplierNumber
      *
-     * @param string $supplierNumber
+     * @param string|null $supplierNumber
      *
      * @return Template
      */
@@ -322,7 +322,7 @@ class Template extends ModelEntity
     /**
      * Get supplierNumber
      *
-     * @return string
+     * @return string|null
      */
     public function getSupplierNumber()
     {
@@ -330,7 +330,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @param string $additionalText
+     * @param string|null $additionalText
      *
      * @return Template
      */
@@ -344,7 +344,7 @@ class Template extends ModelEntity
     /**
      * Get additionalText
      *
-     * @return string
+     * @return string|null
      */
     public function getAdditionalText()
     {
@@ -378,7 +378,7 @@ class Template extends ModelEntity
     /**
      * Set inStock
      *
-     * @param int $inStock
+     * @param int|null $inStock
      *
      * @return Template
      */
@@ -392,7 +392,7 @@ class Template extends ModelEntity
     /**
      * Get inStock
      *
-     * @return int
+     * @return int|null
      */
     public function getInStock()
     {
@@ -402,7 +402,7 @@ class Template extends ModelEntity
     /**
      * Set stockMin
      *
-     * @param int $stockMin
+     * @param int|null $stockMin
      *
      * @return Template
      */
@@ -416,7 +416,7 @@ class Template extends ModelEntity
     /**
      * Get stockMin
      *
-     * @return int
+     * @return int|null
      */
     public function getStockMin()
     {
@@ -446,7 +446,7 @@ class Template extends ModelEntity
     /**
      * Set weight
      *
-     * @param float $weight
+     * @param float|null $weight
      *
      * @return Template
      */
@@ -460,7 +460,7 @@ class Template extends ModelEntity
     /**
      * Get weight
      *
-     * @return float
+     * @return float|null
      */
     public function getWeight()
     {
@@ -492,7 +492,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @return Product
+     * @return Product|null
      */
     public function getArticle()
     {
@@ -500,7 +500,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @param Product $article
+     * @param Product|null $article
      *
      * @return Template
      */
@@ -548,7 +548,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getWidth()
     {
@@ -556,7 +556,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @param float $width
+     * @param float|null $width
      */
     public function setWidth($width)
     {
@@ -564,7 +564,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getLen()
     {
@@ -572,7 +572,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @param float $length
+     * @param float|null $length
      */
     public function setLen($length)
     {
@@ -580,7 +580,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getHeight()
     {
@@ -588,7 +588,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @param float $height
+     * @param float|null $height
      */
     public function setHeight($height)
     {
@@ -596,7 +596,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getEan()
     {
@@ -604,7 +604,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @param string $ean
+     * @param string|null $ean
      */
     public function setEan($ean)
     {
@@ -638,7 +638,7 @@ class Template extends ModelEntity
     /**
      * Set shipping time
      *
-     * @param string $shippingTime
+     * @param string|null $shippingTime
      *
      * @return Template
      */
@@ -652,7 +652,7 @@ class Template extends ModelEntity
     /**
      * Get shipping time
      *
-     * @return string
+     * @return string|null
      */
     public function getShippingTime()
     {
@@ -704,7 +704,7 @@ class Template extends ModelEntity
     /**
      * Get releaseDate
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getReleaseDate()
     {
@@ -714,7 +714,7 @@ class Template extends ModelEntity
     /**
      * Set minPurchase
      *
-     * @param int $minPurchase
+     * @param int|null $minPurchase
      *
      * @return Template
      */
@@ -728,7 +728,7 @@ class Template extends ModelEntity
     /**
      * Get minPurchase
      *
-     * @return int
+     * @return int|null
      */
     public function getMinPurchase()
     {
@@ -738,7 +738,7 @@ class Template extends ModelEntity
     /**
      * Set purchaseSteps
      *
-     * @param int $purchaseSteps
+     * @param int|null $purchaseSteps
      *
      * @return Template
      */
@@ -752,7 +752,7 @@ class Template extends ModelEntity
     /**
      * Get purchaseSteps
      *
-     * @return int
+     * @return int|null
      */
     public function getPurchaseSteps()
     {
@@ -762,7 +762,7 @@ class Template extends ModelEntity
     /**
      * Set maxPurchase
      *
-     * @param int $maxPurchase
+     * @param int|null $maxPurchase
      *
      * @return Template
      */
@@ -776,7 +776,7 @@ class Template extends ModelEntity
     /**
      * Get maxPurchase
      *
-     * @return int
+     * @return int|null
      */
     public function getMaxPurchase()
     {
@@ -786,7 +786,7 @@ class Template extends ModelEntity
     /**
      * Set purchaseUnit
      *
-     * @param float $purchaseUnit
+     * @param float|null $purchaseUnit
      *
      * @return Template
      */
@@ -800,7 +800,7 @@ class Template extends ModelEntity
     /**
      * Get purchaseUnit
      *
-     * @return float
+     * @return float|null
      */
     public function getPurchaseUnit()
     {
@@ -810,7 +810,7 @@ class Template extends ModelEntity
     /**
      * Set referenceUnit
      *
-     * @param float $referenceUnit
+     * @param float|null $referenceUnit
      *
      * @return Template
      */
@@ -824,7 +824,7 @@ class Template extends ModelEntity
     /**
      * Get referenceUnit
      *
-     * @return float
+     * @return float|null
      */
     public function getReferenceUnit()
     {
@@ -834,7 +834,7 @@ class Template extends ModelEntity
     /**
      * Set packUnit
      *
-     * @param string $packUnit
+     * @param string|null $packUnit
      *
      * @return Template
      */
@@ -848,7 +848,7 @@ class Template extends ModelEntity
     /**
      * Get packUnit
      *
-     * @return string
+     * @return string|null
      */
     public function getPackUnit()
     {
@@ -859,7 +859,7 @@ class Template extends ModelEntity
      * OWNING SIDE
      * of the association between articles and unit
      *
-     * @return Unit
+     * @return Unit|null
      */
     public function getUnit()
     {
@@ -867,7 +867,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @param Unit|array|null $unit
+     * @param Unit|array $unit
      *
      * @return Template
      */

--- a/engine/Shopware/Models/Article/Detail.php
+++ b/engine/Shopware/Models/Article/Detail.php
@@ -60,7 +60,7 @@ class Detail extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductAttribute
+     * @var ProductAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Article", mappedBy="articleDetail", orphanRemoval=true, cascade={"persist"})
      */
@@ -138,7 +138,7 @@ class Detail extends ModelEntity
     private $articleId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="unitID", type="integer", nullable=true)
      */
@@ -155,7 +155,7 @@ class Detail extends ModelEntity
     private $number = '';
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="suppliernumber", type="string", nullable=true)
      */
@@ -169,7 +169,7 @@ class Detail extends ModelEntity
     private $kind = 2;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="additionaltext", type="string", nullable=true)
      */
@@ -190,7 +190,7 @@ class Detail extends ModelEntity
     private $inStock = 0;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="stockmin", type="integer", nullable=true)
      */
@@ -204,35 +204,35 @@ class Detail extends ModelEntity
     private $lastStock;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="weight", type="decimal", nullable=true, precision=3)
      */
     private $weight;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="width", type="decimal", nullable=true, precision=3)
      */
     private $width;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="length", type="decimal", nullable=true, precision=3)
      */
     private $len;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="height", type="decimal", nullable=true, precision=3)
      */
     private $height;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="ean", type="string", nullable=true)
      */
@@ -260,35 +260,35 @@ class Detail extends ModelEntity
     private $minPurchase = 1;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="purchasesteps", type="integer", nullable=true)
      */
     private $purchaseSteps;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="maxpurchase", type="integer", nullable=true)
      */
     private $maxPurchase;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="purchaseunit", type="decimal", nullable=true)
      */
     private $purchaseUnit;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="referenceunit", type="decimal", nullable=true)
      */
     private $referenceUnit;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="packunit", type="text", nullable=true)
      */
@@ -302,14 +302,14 @@ class Detail extends ModelEntity
     private $shippingFree = false;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="releasedate", type="date", nullable=true)
      */
     private $releaseDate;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="shippingtime", type="string", length=11, nullable=true)
      */
@@ -363,7 +363,7 @@ class Detail extends ModelEntity
     /**
      * Set supplierNumber
      *
-     * @param string $supplierNumber
+     * @param string|null $supplierNumber
      *
      * @return Detail
      */
@@ -377,7 +377,7 @@ class Detail extends ModelEntity
     /**
      * Get supplierNumber
      *
-     * @return string
+     * @return string|null
      */
     public function getSupplierNumber()
     {
@@ -411,7 +411,7 @@ class Detail extends ModelEntity
     /**
      * Set additionalText
      *
-     * @param string $additionalText
+     * @param string|null $additionalText
      *
      * @return Detail
      */
@@ -425,7 +425,7 @@ class Detail extends ModelEntity
     /**
      * Get additionalText
      *
-     * @return string
+     * @return string|null
      */
     public function getAdditionalText()
     {
@@ -483,7 +483,7 @@ class Detail extends ModelEntity
     /**
      * Set stockMin
      *
-     * @param int $stockMin
+     * @param int|null $stockMin
      *
      * @return Detail
      */
@@ -497,7 +497,7 @@ class Detail extends ModelEntity
     /**
      * Get stockMin
      *
-     * @return int
+     * @return int|null
      */
     public function getStockMin()
     {
@@ -531,7 +531,7 @@ class Detail extends ModelEntity
     /**
      * Set weight
      *
-     * @param float $weight
+     * @param float|null $weight
      *
      * @return Detail
      */
@@ -545,7 +545,7 @@ class Detail extends ModelEntity
     /**
      * Get weight
      *
-     * @return float
+     * @return float|null
      */
     public function getWeight()
     {
@@ -639,7 +639,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getWidth()
     {
@@ -647,7 +647,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @param float $width
+     * @param float|null $width
      */
     public function setWidth($width)
     {
@@ -655,7 +655,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getLen()
     {
@@ -663,7 +663,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @param float $length
+     * @param float|null $length
      */
     public function setLen($length)
     {
@@ -671,7 +671,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getHeight()
     {
@@ -679,7 +679,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @param float $height
+     * @param float|null $height
      */
     public function setHeight($height)
     {
@@ -687,7 +687,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getEan()
     {
@@ -695,7 +695,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @param string $ean
+     * @param string|null $ean
      */
     public function setEan($ean)
     {
@@ -729,7 +729,7 @@ class Detail extends ModelEntity
     /**
      * Set shipping time
      *
-     * @param string $shippingTime
+     * @param string|null $shippingTime
      *
      * @return Detail
      */
@@ -743,7 +743,7 @@ class Detail extends ModelEntity
     /**
      * Get shipping time
      *
-     * @return string
+     * @return string|null
      */
     public function getShippingTime()
     {
@@ -795,7 +795,7 @@ class Detail extends ModelEntity
     /**
      * Get releaseDate
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getReleaseDate()
     {
@@ -833,7 +833,7 @@ class Detail extends ModelEntity
     /**
      * Set purchaseSteps
      *
-     * @param int $purchaseSteps
+     * @param int|null $purchaseSteps
      *
      * @return Detail
      */
@@ -847,7 +847,7 @@ class Detail extends ModelEntity
     /**
      * Get purchaseSteps
      *
-     * @return int
+     * @return int|null
      */
     public function getPurchaseSteps()
     {
@@ -857,7 +857,7 @@ class Detail extends ModelEntity
     /**
      * Set maxPurchase
      *
-     * @param int $maxPurchase
+     * @param int|null $maxPurchase
      *
      * @return Detail
      */
@@ -871,7 +871,7 @@ class Detail extends ModelEntity
     /**
      * Get maxPurchase
      *
-     * @return int
+     * @return int|null
      */
     public function getMaxPurchase()
     {
@@ -881,7 +881,7 @@ class Detail extends ModelEntity
     /**
      * Set purchaseUnit
      *
-     * @param float $purchaseUnit
+     * @param float|null $purchaseUnit
      *
      * @return Detail
      */
@@ -895,7 +895,7 @@ class Detail extends ModelEntity
     /**
      * Get purchaseUnit
      *
-     * @return float
+     * @return float|null
      */
     public function getPurchaseUnit()
     {
@@ -905,7 +905,7 @@ class Detail extends ModelEntity
     /**
      * Set referenceUnit
      *
-     * @param float $referenceUnit
+     * @param float|null $referenceUnit
      *
      * @return Detail
      */
@@ -919,7 +919,7 @@ class Detail extends ModelEntity
     /**
      * Get referenceUnit
      *
-     * @return float
+     * @return float|null
      */
     public function getReferenceUnit()
     {
@@ -929,7 +929,7 @@ class Detail extends ModelEntity
     /**
      * Set packUnit
      *
-     * @param string $packUnit
+     * @param string|null $packUnit
      *
      * @return Detail
      */
@@ -943,7 +943,7 @@ class Detail extends ModelEntity
     /**
      * Get packUnit
      *
-     * @return string
+     * @return string|null
      */
     public function getPackUnit()
     {
@@ -954,7 +954,7 @@ class Detail extends ModelEntity
      * OWNING SIDE
      * of the association between articles and unit
      *
-     * @return Unit
+     * @return Unit|null
      */
     public function getUnit()
     {

--- a/engine/Shopware/Models/Article/Download.php
+++ b/engine/Shopware/Models/Article/Download.php
@@ -47,7 +47,7 @@ class Download extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductDownloadAttribute
+     * @var ProductDownloadAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ArticleDownload", mappedBy="articleDownload", cascade={"persist"})
      */
@@ -209,7 +209,7 @@ class Download extends ModelEntity
     }
 
     /**
-     * @return ProductDownloadAttribute
+     * @return ProductDownloadAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Article/Element.php
+++ b/engine/Shopware/Models/Article/Element.php
@@ -59,21 +59,21 @@ class Element extends ModelEntity
     private $type;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="`default`", type="string", nullable=true)
      */
     private $default;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="store", type="string", nullable=true)
      */
     private $store;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="label", type="string", nullable=true)
      */
@@ -87,7 +87,7 @@ class Element extends ModelEntity
     private $required = false;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="help", type="string", nullable=true)
      */
@@ -155,7 +155,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDefault()
     {
@@ -163,7 +163,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @param string $default
+     * @param string|null $default
      */
     public function setDefault($default)
     {
@@ -171,7 +171,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getStore()
     {
@@ -179,7 +179,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @param string $store
+     * @param string|null $store
      */
     public function setStore($store)
     {
@@ -187,7 +187,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLabel()
     {
@@ -219,7 +219,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getHelp()
     {
@@ -227,7 +227,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @param string $help
+     * @param string|null $help
      */
     public function setHelp($help)
     {

--- a/engine/Shopware/Models/Article/Esd.php
+++ b/engine/Shopware/Models/Article/Esd.php
@@ -39,7 +39,7 @@ class Esd extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductEsdAttribute
+     * @var ProductEsdAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ArticleEsd", mappedBy="articleEsd", cascade={"persist"})
      */
@@ -98,7 +98,7 @@ class Esd extends ModelEntity
     private $articleDetailId;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="file", type="string", length=255, nullable=true)
      */
@@ -126,7 +126,7 @@ class Esd extends ModelEntity
     private $maxdownloads = 0;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="datum", type="datetime", nullable=true)
      */
@@ -138,7 +138,7 @@ class Esd extends ModelEntity
     }
 
     /**
-     * @return ProductEsdAttribute
+     * @return ProductEsdAttribute|null
      */
     public function getAttribute()
     {
@@ -228,7 +228,7 @@ class Esd extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getDate()
     {
@@ -244,7 +244,7 @@ class Esd extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFile()
     {

--- a/engine/Shopware/Models/Article/EsdSerial.php
+++ b/engine/Shopware/Models/Article/EsdSerial.php
@@ -62,7 +62,7 @@ class EsdSerial extends ModelEntity
     private $id;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="serialnumber", type="string", length=255, nullable=true)
      */
@@ -103,7 +103,7 @@ class EsdSerial extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getSerialnumber()
     {

--- a/engine/Shopware/Models/Article/Image.php
+++ b/engine/Shopware/Models/Article/Image.php
@@ -50,7 +50,7 @@ class Image extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductImageAttribute
+     * @var ProductImageAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ArticleImage", mappedBy="articleImage", orphanRemoval=true, cascade={"persist"})
      */
@@ -81,7 +81,7 @@ class Image extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var \Shopware\Models\Media\Media
+     * @var \Shopware\Models\Media\Media|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Media\Media", inversedBy="articles")
      * @ORM\JoinColumn(name="media_id", referencedColumnName="id")
@@ -98,14 +98,14 @@ class Image extends ModelEntity
     private $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="articleID", type="integer", nullable=true)
      */
     private $articleId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="article_detail_id", type="integer", nullable=true)
      */
@@ -119,7 +119,7 @@ class Image extends ModelEntity
     private $description = '';
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="img", type="string", length=100, nullable=true)
      */
@@ -168,14 +168,14 @@ class Image extends ModelEntity
     private $extension = '';
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parent_id", type="integer", nullable=true)
      */
     private $parentId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="media_id", type="integer", nullable=true)
      */
@@ -184,7 +184,7 @@ class Image extends ModelEntity
     /**
      * The parent image
      *
-     * @var Image
+     * @var Image|null
      *
      * @ORM\ManyToOne(targetEntity="Image", inversedBy="children", cascade={"persist"})
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id")
@@ -282,7 +282,7 @@ class Image extends ModelEntity
     }
 
     /**
-     * @param string $path
+     * @param string|null $path
      */
     public function setPath($path)
     {
@@ -290,7 +290,7 @@ class Image extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPath()
     {
@@ -346,7 +346,7 @@ class Image extends ModelEntity
     }
 
     /**
-     * @return Article
+     * @return Article|null
      */
     public function getArticle()
     {
@@ -362,7 +362,7 @@ class Image extends ModelEntity
     }
 
     /**
-     * @return ProductImageAttribute
+     * @return ProductImageAttribute|null
      */
     public function getAttribute()
     {
@@ -414,7 +414,7 @@ class Image extends ModelEntity
     }
 
     /**
-     * @return Image
+     * @return Image|null
      */
     public function getParent()
     {
@@ -422,7 +422,7 @@ class Image extends ModelEntity
     }
 
     /**
-     * @param Image $parent
+     * @param Image|null $parent
      */
     public function setParent($parent)
     {
@@ -430,7 +430,7 @@ class Image extends ModelEntity
     }
 
     /**
-     * @return Detail
+     * @return Detail|null
      */
     public function getArticleDetail()
     {
@@ -446,7 +446,7 @@ class Image extends ModelEntity
     }
 
     /**
-     * @return Media
+     * @return Media|null
      */
     public function getMedia()
     {

--- a/engine/Shopware/Models/Article/Link.php
+++ b/engine/Shopware/Models/Article/Link.php
@@ -48,7 +48,7 @@ class Link extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductLinkAttribute
+     * @var ProductLinkAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ArticleLink", mappedBy="articleLink", cascade={"persist"})
      */
@@ -203,7 +203,7 @@ class Link extends ModelEntity
     }
 
     /**
-     * @return ProductLinkAttribute
+     * @return ProductLinkAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Article/Notification.php
+++ b/engine/Shopware/Models/Article/Notification.php
@@ -64,7 +64,7 @@ class Notification extends LazyFetchModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductNotificationAttribute
+     * @var ProductNotificationAttribute|null
      *
      * @Assert\Valid()
      *
@@ -226,7 +226,7 @@ class Notification extends LazyFetchModelEntity
     }
 
     /**
-     * @return ProductNotificationAttribute
+     * @return ProductNotificationAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Article/Price.php
+++ b/engine/Shopware/Models/Article/Price.php
@@ -53,7 +53,7 @@ class Price extends LazyFetchModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductPriceAttribute
+     * @var ProductPriceAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ArticlePrice", orphanRemoval=true, mappedBy="articlePrice", cascade={"persist"})
      */
@@ -107,7 +107,7 @@ class Price extends LazyFetchModelEntity
     private $from = 1;
 
     /**
-     * @var int|string
+     * @var int|string|null
      *
      * @ORM\Column(name="`to`", type="string", nullable=true)
      */
@@ -151,7 +151,7 @@ class Price extends LazyFetchModelEntity
     }
 
     /**
-     * @param Article|array|null $article
+     * @param Article|array $article
      *
      * @return Price
      */
@@ -347,7 +347,7 @@ class Price extends LazyFetchModelEntity
     }
 
     /**
-     * @return ProductPriceAttribute
+     * @return ProductPriceAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Article/Supplier.php
+++ b/engine/Shopware/Models/Article/Supplier.php
@@ -54,7 +54,7 @@ class Supplier extends ModelEntity
     /**
      * Title for the page - SEO metadata
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="meta_title", type="string", nullable=true)
      */
@@ -63,7 +63,7 @@ class Supplier extends ModelEntity
     /**
      * Description for the page - SEO metadata
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="meta_description", type="string", nullable=true)
      */
@@ -72,7 +72,7 @@ class Supplier extends ModelEntity
     /**
      * Meta keywords for the page - SEO metadata
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="meta_keywords", type="string", nullable=true)
      */
@@ -92,7 +92,7 @@ class Supplier extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductSupplierAttribute
+     * @var ProductSupplierAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ArticleSupplier", mappedBy="articleSupplier", cascade={"persist"})
      */
@@ -139,7 +139,7 @@ class Supplier extends ModelEntity
     /**
      * Description text which can be used e.g. for a special supplier page
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="description", type="text", nullable=true)
      */
@@ -255,7 +255,7 @@ class Supplier extends ModelEntity
     /**
      * Returns suppliers description. This description may contains HTML Code.
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -265,7 +265,7 @@ class Supplier extends ModelEntity
     /**
      * Sets the description of the supplier. This description may contains HTML codes.
      *
-     * @param string $description
+     * @param string|null $description
      *
      * @return Supplier
      */
@@ -301,7 +301,7 @@ class Supplier extends ModelEntity
     }
 
     /**
-     * @return ProductSupplierAttribute
+     * @return ProductSupplierAttribute|null
      */
     public function getAttribute()
     {
@@ -319,7 +319,7 @@ class Supplier extends ModelEntity
     }
 
     /**
-     * @param string $metaTitle
+     * @param string|null $metaTitle
      */
     public function setMetaTitle($metaTitle)
     {
@@ -327,7 +327,7 @@ class Supplier extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getMetaTitle()
     {
@@ -335,7 +335,7 @@ class Supplier extends ModelEntity
     }
 
     /**
-     * @param string $metaDescription
+     * @param string|null $metaDescription
      */
     public function setMetaDescription($metaDescription)
     {
@@ -343,7 +343,7 @@ class Supplier extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getMetaDescription()
     {
@@ -351,7 +351,7 @@ class Supplier extends ModelEntity
     }
 
     /**
-     * @param string $metaKeywords
+     * @param string|null $metaKeywords
      */
     public function setMetaKeywords($metaKeywords)
     {
@@ -359,7 +359,7 @@ class Supplier extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getMetaKeywords()
     {

--- a/engine/Shopware/Models/Article/Vote.php
+++ b/engine/Shopware/Models/Article/Vote.php
@@ -75,7 +75,7 @@ class Vote extends ModelEntity
     private $articleId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="shop_id", type="integer", nullable=true)
      */
@@ -138,7 +138,7 @@ class Vote extends ModelEntity
     private $answer;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="answer_date", type="datetime", nullable=true)
      */
@@ -352,7 +352,7 @@ class Vote extends ModelEntity
     /**
      * Sets the datum of the answer
      *
-     * @param \DateTimeInterface|string $answer_date
+     * @param \DateTimeInterface|string|null $answer_date
      *
      * @return Vote
      */
@@ -369,7 +369,7 @@ class Vote extends ModelEntity
     /**
      * Gets the datum of the answer
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getAnswerDate()
     {
@@ -388,7 +388,7 @@ class Vote extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Article\Article|array|null $article
+     * @param \Shopware\Models\Article\Article|array $article
      *
      * @return \Shopware\Models\Article\Vote
      */

--- a/engine/Shopware/Models/Attribute/Configuration.php
+++ b/engine/Shopware/Models/Attribute/Configuration.php
@@ -64,7 +64,7 @@ class Configuration extends ModelEntity
     private $columnType;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="default_value", type="string", nullable=true)
      */
@@ -78,21 +78,21 @@ class Configuration extends ModelEntity
     private $entity;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="label", type="string", nullable=true)
      */
     private $label;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="help_text", type="string", nullable=true)
      */
     private $helpText;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="support_text", type="string", nullable=true)
      */
@@ -127,7 +127,7 @@ class Configuration extends ModelEntity
     private $position = 0;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="array_store", type="text", nullable=true)
      */
@@ -190,7 +190,7 @@ class Configuration extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLabel()
     {
@@ -206,7 +206,7 @@ class Configuration extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getHelpText()
     {
@@ -222,7 +222,7 @@ class Configuration extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getSupportText()
     {
@@ -318,7 +318,7 @@ class Configuration extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getArrayStore()
     {
@@ -326,7 +326,7 @@ class Configuration extends ModelEntity
     }
 
     /**
-     * @param string $arrayStore
+     * @param string|null $arrayStore
      */
     public function setArrayStore($arrayStore)
     {
@@ -334,7 +334,7 @@ class Configuration extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDefaultValue()
     {
@@ -342,7 +342,7 @@ class Configuration extends ModelEntity
     }
 
     /**
-     * @param string $defaultValue
+     * @param string|null $defaultValue
      */
     public function setDefaultValue($defaultValue)
     {

--- a/engine/Shopware/Models/Banner/Banner.php
+++ b/engine/Shopware/Models/Banner/Banner.php
@@ -60,7 +60,7 @@ class Banner extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var BannerAttribute
+     * @var BannerAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Banner", mappedBy="banner", cascade={"persist"})
      */
@@ -394,7 +394,7 @@ class Banner extends ModelEntity
     }
 
     /**
-     * @return BannerAttribute
+     * @return BannerAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Benchmark/BenchmarkConfig.php
+++ b/engine/Shopware/Models/Benchmark/BenchmarkConfig.php
@@ -110,7 +110,7 @@ class BenchmarkConfig extends ModelEntity
     /**
      * The most recent date to figure out which orders have been updated since they have last been transmitted
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="last_updated_orders_date", type="datetime", nullable=true)
      */
@@ -146,7 +146,7 @@ class BenchmarkConfig extends ModelEntity
     /**
      * The latest token provided by the server
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="response_token", type="string", length=200, nullable=true)
      */
@@ -171,7 +171,7 @@ class BenchmarkConfig extends ModelEntity
     /**
      * Flag which defines if the current shop is locked for transmitting data.
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="locked", type="datetime", nullable=true)
      */
@@ -302,14 +302,17 @@ class BenchmarkConfig extends ModelEntity
     }
 
     /**#
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getLastUpdatedOrdersDate()
     {
         return $this->lastUpdatedOrdersDate;
     }
 
-    public function setLastUpdatedOrdersDate(\DateTimeInterface $lastUpdatedOrdersDate)
+    /**
+     * @param \DateTimeInterface|null $lastUpdatedOrdersDate
+     */
+    public function setLastUpdatedOrdersDate($lastUpdatedOrdersDate)
     {
         $this->lastUpdatedOrdersDate = $lastUpdatedOrdersDate;
     }
@@ -363,7 +366,7 @@ class BenchmarkConfig extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getToken()
     {
@@ -371,7 +374,7 @@ class BenchmarkConfig extends ModelEntity
     }
 
     /**
-     * @param string $token
+     * @param string|null $token
      */
     public function setToken($token)
     {
@@ -418,7 +421,10 @@ class BenchmarkConfig extends ModelEntity
         return $this->locked;
     }
 
-    public function setLocked(\DateTimeInterface $locked)
+    /**
+     * @param \DateTimeInterface|null $locked
+     */
+    public function setLocked($locked)
     {
         $this->locked = $locked;
     }

--- a/engine/Shopware/Models/Blog/Blog.php
+++ b/engine/Shopware/Models/Blog/Blog.php
@@ -68,7 +68,7 @@ class Blog extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\Blog
+     * @var \Shopware\Models\Attribute\Blog|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Blog", mappedBy="blog", cascade={"persist"})
      */
@@ -100,7 +100,7 @@ class Blog extends ModelEntity
     private $title;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="author_id", type="integer", nullable=true)
      */
@@ -130,7 +130,7 @@ class Blog extends ModelEntity
     private $description;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="views", type="integer", nullable=true)
      */
@@ -144,7 +144,7 @@ class Blog extends ModelEntity
     private $displayDate;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="category_id", type="integer", nullable=true)
      */
@@ -166,21 +166,21 @@ class Blog extends ModelEntity
     private $template;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="meta_keywords", type="string", nullable=true)
      */
     private $metaKeyWords;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="meta_description", type="string", nullable=true)
      */
     private $metaDescription;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="meta_title", type="string", nullable=true)
      */
@@ -189,7 +189,7 @@ class Blog extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\User\User
+     * @var \Shopware\Models\User\User|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\User\User", inversedBy="blog")
      * @ORM\JoinColumn(name="author_id", referencedColumnName="id")
@@ -313,7 +313,7 @@ class Blog extends ModelEntity
     /**
      * Get Views
      *
-     * @return int
+     * @return int|null
      */
     public function getViews()
     {
@@ -323,7 +323,7 @@ class Blog extends ModelEntity
     /**
      * Set Views
      *
-     * @param int $views
+     * @param int|null $views
      */
     public function setViews($views)
     {
@@ -356,7 +356,7 @@ class Blog extends ModelEntity
     /**
      * Get CategoryId
      *
-     * @return int
+     * @return int|null
      */
     public function getCategoryId()
     {
@@ -458,7 +458,7 @@ class Blog extends ModelEntity
     /**
      * Set the metaKeyWords
      *
-     * @return string
+     * @return string|null
      */
     public function getMetaKeyWords()
     {
@@ -468,7 +468,7 @@ class Blog extends ModelEntity
     /**
      * Get the metaKeyWords
      *
-     * @param string $metaKeyWords
+     * @param string|null $metaKeyWords
      */
     public function setMetaKeyWords($metaKeyWords)
     {
@@ -478,7 +478,7 @@ class Blog extends ModelEntity
     /**
      * Get the metaDescription
      *
-     * @return string
+     * @return string|null
      */
     public function getMetaDescription()
     {
@@ -488,7 +488,7 @@ class Blog extends ModelEntity
     /**
      * Set the metaDescription
      *
-     * @param string $metaDescription
+     * @param string|null $metaDescription
      */
     public function setMetaDescription($metaDescription)
     {
@@ -498,7 +498,7 @@ class Blog extends ModelEntity
     /**
      * Returns the Attributes
      *
-     * @return \Shopware\Models\Attribute\Blog
+     * @return \Shopware\Models\Attribute\Blog|null
      */
     public function getAttribute()
     {
@@ -538,7 +538,7 @@ class Blog extends ModelEntity
     /**
      * Returns the author
      *
-     * @return \Shopware\Models\User\User
+     * @return \Shopware\Models\User\User|null
      */
     public function getAuthor()
     {
@@ -548,7 +548,7 @@ class Blog extends ModelEntity
     /**
      * Sets the author
      *
-     * @param \Shopware\Models\User\User $author
+     * @param \Shopware\Models\User\User|null $author
      */
     public function setAuthor($author)
     {
@@ -558,7 +558,7 @@ class Blog extends ModelEntity
     /**
      * Set the metaTitle
      *
-     * @param string $metaTitle
+     * @param string|null $metaTitle
      */
     public function setMetaTitle($metaTitle)
     {
@@ -568,7 +568,7 @@ class Blog extends ModelEntity
     /**
      * Returns the metaTitle
      *
-     * @return string
+     * @return string|null
      */
     public function getMetaTitle()
     {

--- a/engine/Shopware/Models/Blog/Comment.php
+++ b/engine/Shopware/Models/Blog/Comment.php
@@ -103,7 +103,7 @@ class Comment extends ModelEntity
     private $points;
 
     /**
-     * @var \Shopware\Models\Shop\Shop
+     * @var \Shopware\Models\Shop\Shop|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Shop\Shop")
      * @ORM\JoinColumn(name="shop_id", referencedColumnName="id")
@@ -111,7 +111,7 @@ class Comment extends ModelEntity
     private $shop;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="shop_id", type="integer", nullable=true)
      */
@@ -307,7 +307,7 @@ class Comment extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Shop\Shop|null $shop
+     * @param \Shopware\Models\Shop\Shop $shop
      */
     public function setShop($shop)
     {
@@ -315,7 +315,7 @@ class Comment extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getShopId()
     {

--- a/engine/Shopware/Models/Blog/Tag.php
+++ b/engine/Shopware/Models/Blog/Tag.php
@@ -38,7 +38,7 @@ class Tag extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var \Shopware\Models\Blog\Blog
+     * @var \Shopware\Models\Blog\Blog|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Blog\Blog", inversedBy="tags")
      * @ORM\JoinColumn(name="blog_id", referencedColumnName="id")
@@ -55,7 +55,7 @@ class Tag extends ModelEntity
     private $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="blog_id", type="integer", nullable=true)
      */
@@ -99,7 +99,7 @@ class Tag extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Blog\Blog
+     * @return \Shopware\Models\Blog\Blog|null
      */
     public function getBlog()
     {

--- a/engine/Shopware/Models/Category/Category.php
+++ b/engine/Shopware/Models/Category/Category.php
@@ -60,7 +60,7 @@ class Category extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\Category
+     * @var \Shopware\Models\Attribute\Category|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Category", mappedBy="category", cascade={"persist"})
      */
@@ -84,7 +84,7 @@ class Category extends ModelEntity
     /**
      * OWNING SIDE
      *
-     * @var \Shopware\Models\Media\Media
+     * @var \Shopware\Models\Media\Media|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Media\Media")
      * @ORM\JoinColumn(name="mediaID", referencedColumnName="id")
@@ -92,7 +92,7 @@ class Category extends ModelEntity
     protected $media;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="sorting_ids", type="string", nullable=true)
      */
@@ -106,7 +106,7 @@ class Category extends ModelEntity
     protected $hideSortings = false;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="facet_ids", type="string", nullable=true)
      */
@@ -133,21 +133,21 @@ class Category extends ModelEntity
     /**
      * The id of the parent category
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parent", type="integer", nullable=true)
      */
     private $parentId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="stream_id", type="integer", nullable=true)
      */
     private $streamId;
 
     /**
-     * @var ProductStream
+     * @var ProductStream|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\ProductStream\ProductStream")
      * @ORM\JoinColumn(name="stream_id", referencedColumnName="id")
@@ -159,7 +159,7 @@ class Category extends ModelEntity
      *
      * OWNING SIDE
      *
-     * @var Category
+     * @var Category|null
      *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children", cascade={"persist"})
      * @ORM\JoinColumn(name="parent", nullable=true, referencedColumnName="id", onDelete="SET NULL")
@@ -178,7 +178,7 @@ class Category extends ModelEntity
     /**
      * Integer value on which the return values are ordered (asc)
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="position", type="integer", nullable=true)
      */
@@ -187,7 +187,7 @@ class Category extends ModelEntity
     /**
      * SEO friendly title which is displayed in the HTML page.
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="meta_title", type="text", nullable=true)
      */
@@ -196,7 +196,7 @@ class Category extends ModelEntity
     /**
      * Keeps the meta keywords which are displayed in the HTML page.
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="metakeywords", type="text", nullable=true)
      */
@@ -205,7 +205,7 @@ class Category extends ModelEntity
     /**
      * Keeps the meta description which is displayed in the HTML page.
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="metadescription", type="text", nullable=true)
      */
@@ -216,7 +216,7 @@ class Category extends ModelEntity
      *
      * Max chars: 255
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="cmsheadline", type="string", length=255, nullable=true)
      */
@@ -225,7 +225,7 @@ class Category extends ModelEntity
     /**
      * Keeps the CMS Text for this category
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="cmstext", type="text", nullable=true)
      */
@@ -243,14 +243,14 @@ class Category extends ModelEntity
     /**
      * If this field is set the category page will uses this template
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="template", type="string", length=255, nullable=true)
      */
     private $template;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="product_box_layout", type="string", length=50, nullable=true)
      */
@@ -273,7 +273,7 @@ class Category extends ModelEntity
     /**
      * Is this category based outside from the shop?
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="external", type="string", length=255, nullable=true)
      */
@@ -361,7 +361,7 @@ class Category extends ModelEntity
     private $added;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="mediaID", type="integer", nullable=true)
      */
@@ -414,7 +414,7 @@ class Category extends ModelEntity
     /**
      * Get parent id
      *
-     * @return int
+     * @return int|null
      */
     public function getParentId()
     {
@@ -424,7 +424,6 @@ class Category extends ModelEntity
     /**
      * Sets the id of the parent category
      *
-     * @param Category $parent
      *
      * @return Category
      */
@@ -536,7 +535,7 @@ class Category extends ModelEntity
     /**
      * Returns position
      *
-     * @return int
+     * @return int|null
      */
     public function getPosition()
     {
@@ -584,7 +583,7 @@ class Category extends ModelEntity
     /**
      * Set the meta keywords.
      *
-     * @param string $metaKeywords
+     * @param string|null $metaKeywords
      *
      * @return Category
      */
@@ -602,7 +601,7 @@ class Category extends ModelEntity
     /**
      * Returns the meta keywords
      *
-     * @return string
+     * @return string|null
      */
     public function getMetaKeywords()
     {
@@ -612,7 +611,7 @@ class Category extends ModelEntity
     /**
      * Sets the  meta description text.
      *
-     * @param string $metaDescription
+     * @param string|null $metaDescription
      *
      * @return Category
      */
@@ -626,7 +625,7 @@ class Category extends ModelEntity
     /**
      * Gets the meta description text.
      *
-     * @return string
+     * @return string|null
      */
     public function getMetaDescription()
     {
@@ -650,7 +649,7 @@ class Category extends ModelEntity
     /**
      * Gets the CMS headline
      *
-     * @return string
+     * @return string|null
      */
     public function getCmsHeadline()
     {
@@ -674,7 +673,7 @@ class Category extends ModelEntity
     /**
      * Gets CMS text
      *
-     * @return string
+     * @return string|null
      */
     public function getCmsText()
     {
@@ -684,7 +683,7 @@ class Category extends ModelEntity
     /**
      * Set template
      *
-     * @param string $template
+     * @param string|null $template
      *
      * @return Category
      */
@@ -698,7 +697,7 @@ class Category extends ModelEntity
     /**
      * Get template
      *
-     * @return string
+     * @return string|null
      */
     public function getTemplate()
     {
@@ -766,7 +765,7 @@ class Category extends ModelEntity
     /**
      * Gets the flag if this category is linked to an external source
      *
-     * @return string
+     * @return string|null
      */
     public function getExternal()
     {
@@ -876,7 +875,7 @@ class Category extends ModelEntity
     /**
      * Returns the Attributes
      *
-     * @return \Shopware\Models\Attribute\Category
+     * @return \Shopware\Models\Attribute\Category|null
      */
     public function getAttribute()
     {
@@ -922,7 +921,7 @@ class Category extends ModelEntity
     /**
      * Returns the Media model
      *
-     * @return \Shopware\Models\Media\Media
+     * @return \Shopware\Models\Media\Media|null
      */
     public function getMedia()
     {
@@ -932,7 +931,7 @@ class Category extends ModelEntity
     /**
      * Sets the Media model
      *
-     * @param \Shopware\Models\Media\Media $media
+     * @param \Shopware\Models\Media\Media|null $media
      *
      * @return Category
      */
@@ -996,7 +995,7 @@ class Category extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getProductBoxLayout()
     {
@@ -1004,7 +1003,7 @@ class Category extends ModelEntity
     }
 
     /**
-     * @param string $productBoxLayout
+     * @param string|null $productBoxLayout
      *
      * @return Category
      */
@@ -1016,7 +1015,7 @@ class Category extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getMetaTitle()
     {
@@ -1024,7 +1023,7 @@ class Category extends ModelEntity
     }
 
     /**
-     * @param string $metaTitle
+     * @param string|null $metaTitle
      */
     public function setMetaTitle($metaTitle)
     {
@@ -1032,23 +1031,20 @@ class Category extends ModelEntity
     }
 
     /**
-     * @return ProductStream
+     * @return ProductStream|null
      */
     public function getStream()
     {
         return $this->stream;
     }
 
-    /**
-     * @param ProductStream $stream
-     */
     public function setStream(ProductStream $stream = null)
     {
         $this->stream = $stream;
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMediaId()
     {
@@ -1056,7 +1052,7 @@ class Category extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getSortingIds()
     {
@@ -1064,7 +1060,7 @@ class Category extends ModelEntity
     }
 
     /**
-     * @param string $sortingIds
+     * @param string|null $sortingIds
      */
     public function setSortingIds($sortingIds)
     {
@@ -1088,7 +1084,7 @@ class Category extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFacetIds()
     {
@@ -1096,7 +1092,7 @@ class Category extends ModelEntity
     }
 
     /**
-     * @param string $facetIds
+     * @param string|null $facetIds
      */
     public function setFacetIds($facetIds)
     {

--- a/engine/Shopware/Models/CommentConfirm/CommentConfirm.php
+++ b/engine/Shopware/Models/CommentConfirm/CommentConfirm.php
@@ -52,7 +52,7 @@ class CommentConfirm extends ModelEntity
     private $creationDate;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="type", type="string", length=255, nullable=true)
      */
@@ -159,7 +159,7 @@ class CommentConfirm extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getType()
     {

--- a/engine/Shopware/Models/Config/Element.php
+++ b/engine/Shopware/Models/Config/Element.php
@@ -63,28 +63,28 @@ class Element extends ModelEntity
     private $name;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="value", type="object", nullable=true)
      */
     private $value;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="description", type="string", nullable=true)
      */
     private $description;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="label", type="string", nullable=true)
      */
     private $label;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="type", type="string", nullable=true)
      */
@@ -185,6 +185,8 @@ class Element extends ModelEntity
     /**
      * Set value
      *
+     * @param mixed|null $value
+     *
      * @return Element
      */
     public function setValue($value)
@@ -196,6 +198,8 @@ class Element extends ModelEntity
 
     /**
      * Get value
+     *
+     * @return mixed|null
      */
     public function getValue()
     {
@@ -205,7 +209,7 @@ class Element extends ModelEntity
     /**
      * Set description
      *
-     * @param string $description
+     * @param string|null $description
      *
      * @return Element
      */
@@ -219,7 +223,7 @@ class Element extends ModelEntity
     /**
      * Get description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -243,7 +247,7 @@ class Element extends ModelEntity
     /**
      * Get label
      *
-     * @return string
+     * @return string|null
      */
     public function getLabel()
     {
@@ -361,7 +365,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getType()
     {

--- a/engine/Shopware/Models/Config/ElementTranslation.php
+++ b/engine/Shopware/Models/Config/ElementTranslation.php
@@ -61,14 +61,14 @@ class ElementTranslation extends ModelEntity
     private $id;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="description", type="string", nullable=true)
      */
     private $description = null;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="label", type="string", nullable=true)
      */
@@ -101,7 +101,7 @@ class ElementTranslation extends ModelEntity
     /**
      * Set description
      *
-     * @param string $description
+     * @param string|null $description
      *
      * @return ElementTranslation
      */
@@ -115,7 +115,7 @@ class ElementTranslation extends ModelEntity
     /**
      * Get description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -139,7 +139,7 @@ class ElementTranslation extends ModelEntity
     /**
      * Get label
      *
-     * @return string
+     * @return string|null
      */
     public function getLabel()
     {

--- a/engine/Shopware/Models/Config/Form.php
+++ b/engine/Shopware/Models/Config/Form.php
@@ -61,14 +61,14 @@ class Form extends ModelEntity
     private $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parent_id", type="integer", nullable=true)
      */
     private $parentId;
 
     /**
-     * @var Form
+     * @var Form|null
      *
      * @ORM\ManyToOne(targetEntity="Form", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", nullable=true, referencedColumnName="id", onDelete="SET NULL")
@@ -83,7 +83,7 @@ class Form extends ModelEntity
     private $name;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="label", type="string", nullable=true)
      */
@@ -179,7 +179,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLabel()
     {
@@ -338,7 +338,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @return Form
+     * @return Form|null
      */
     public function getParent()
     {
@@ -346,7 +346,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @param Form $parent
+     * @param Form|null $parent
      */
     public function setParent($parent)
     {

--- a/engine/Shopware/Models/Config/FormTranslation.php
+++ b/engine/Shopware/Models/Config/FormTranslation.php
@@ -61,14 +61,14 @@ class FormTranslation extends ModelEntity
     private $id;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="label", type="string", nullable=true)
      */
     private $label;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="description", type="string", nullable=true)
      */
@@ -111,7 +111,7 @@ class FormTranslation extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLabel()
     {
@@ -121,7 +121,7 @@ class FormTranslation extends ModelEntity
     /**
      * Set description
      *
-     * @param string $description
+     * @param string|null $description
      *
      * @return FormTranslation
      */
@@ -135,7 +135,7 @@ class FormTranslation extends ModelEntity
     /**
      * Get description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {

--- a/engine/Shopware/Models/Config/Value.php
+++ b/engine/Shopware/Models/Config/Value.php
@@ -67,7 +67,7 @@ class Value extends ModelEntity
     private $shopId;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="value", type="object", nullable=true)
      */
@@ -134,6 +134,7 @@ class Value extends ModelEntity
     /**
      * Set value
      *
+     *
      * @return Value
      */
     public function setValue($value)
@@ -145,6 +146,8 @@ class Value extends ModelEntity
 
     /**
      * Get value
+     *
+     * @return mixed|null
      */
     public function getValue()
     {

--- a/engine/Shopware/Models/Country/Area.php
+++ b/engine/Shopware/Models/Country/Area.php
@@ -54,14 +54,14 @@ class Area extends ModelEntity
     private $id;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="name", type="string", length=255, nullable=true)
      */
     private $name = null;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="active", type="integer", nullable=true)
      */
@@ -94,7 +94,7 @@ class Area extends ModelEntity
     /**
      * Get name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -118,7 +118,7 @@ class Area extends ModelEntity
     /**
      * Get active
      *
-     * @return int
+     * @return int|null
      */
     public function getActive()
     {

--- a/engine/Shopware/Models/Country/Country.php
+++ b/engine/Shopware/Models/Country/Country.php
@@ -74,7 +74,7 @@ class Country extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var CountryAttribute
+     * @var CountryAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Country", mappedBy="country", orphanRemoval=true, cascade={"persist"})
      */
@@ -455,7 +455,7 @@ class Country extends ModelEntity
     }
 
     /**
-     * @return CountryAttribute
+     * @return CountryAttribute|null
      */
     public function getAttribute()
     {
@@ -502,7 +502,7 @@ class Country extends ModelEntity
     }
 
     /**
-     * @param Area|array|null $area
+     * @param Area|array $area
      *
      * @return Country
      */

--- a/engine/Shopware/Models/Country/State.php
+++ b/engine/Shopware/Models/Country/State.php
@@ -49,7 +49,7 @@ class State extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var CountryStateAttribute
+     * @var CountryStateAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\CountryState", mappedBy="countryState", orphanRemoval=true, cascade={"persist"})
      */
@@ -65,35 +65,35 @@ class State extends ModelEntity
     private $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="countryID", type="integer", nullable=true)
      */
     private $countryId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="position", type="integer", nullable=true)
      */
     private $position;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="name", type="string", length=255, nullable=true)
      */
     private $name;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="shortcode", type="string", length=255, nullable=true)
      */
     private $shortCode;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="active", type="integer", nullable=true)
      */
@@ -126,7 +126,7 @@ class State extends ModelEntity
     /**
      * Get name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -150,7 +150,7 @@ class State extends ModelEntity
     /**
      * Get shortCode
      *
-     * @return string
+     * @return string|null
      */
     public function getShortCode()
     {
@@ -174,7 +174,7 @@ class State extends ModelEntity
     /**
      * Get active
      *
-     * @return int
+     * @return int|null
      */
     public function getActive()
     {
@@ -182,7 +182,7 @@ class State extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getPosition()
     {
@@ -201,7 +201,7 @@ class State extends ModelEntity
      * OWNING SIDE
      * of the association between states and country
      *
-     * @return Country
+     * @return Country|null
      */
     public function getCountry()
     {
@@ -209,7 +209,7 @@ class State extends ModelEntity
     }
 
     /**
-     * @param Country|array|null $country
+     * @param Country|array $country
      *
      * @return State
      */
@@ -221,7 +221,7 @@ class State extends ModelEntity
     }
 
     /**
-     * @return CountryStateAttribute
+     * @return CountryStateAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Customer/Address.php
+++ b/engine/Shopware/Models/Customer/Address.php
@@ -81,7 +81,7 @@ class Address extends ModelEntity
     /**
      * Contains the name of the address address company
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="company", type="string", length=255, nullable=true)
      */
@@ -90,7 +90,7 @@ class Address extends ModelEntity
     /**
      * Contains the department name of the address address company
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="department", type="string", length=35, nullable=true)
      */
@@ -115,7 +115,7 @@ class Address extends ModelEntity
     protected $firstname;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="title", type="string", length=100, nullable=true)
      */
@@ -160,7 +160,7 @@ class Address extends ModelEntity
     /**
      * Contains the phone number of the address
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="phone", type="string", length=40, nullable=true)
      */
@@ -169,7 +169,7 @@ class Address extends ModelEntity
     /**
      * Contains the vat id of the address
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="ustid", type="string", length=50, nullable=true)
      */
@@ -178,7 +178,7 @@ class Address extends ModelEntity
     /**
      * Contains the additional address line data
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="additional_address_line1", type="string", length=255, nullable=true)
      */
@@ -187,7 +187,7 @@ class Address extends ModelEntity
     /**
      * Contains the additional address line data 2
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="additional_address_line2", type="string", length=255, nullable=true)
      */
@@ -205,7 +205,7 @@ class Address extends ModelEntity
     /**
      * Contains the id of the state.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="state_id", type="integer", nullable=true)
      */
@@ -226,7 +226,7 @@ class Address extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var CustomerAddressAttribute
+     * @var CustomerAddressAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\CustomerAddress", mappedBy="customerAddress", orphanRemoval=true, cascade={"persist"})
      */
@@ -241,7 +241,7 @@ class Address extends ModelEntity
     protected $country;
 
     /**
-     * @var State
+     * @var State|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Country\State")
      * @ORM\JoinColumn(name="state_id", referencedColumnName="id")
@@ -266,7 +266,7 @@ class Address extends ModelEntity
     /**
      * Setter function for the company column property
      *
-     * @param string $company
+     * @param string|null $company
      */
     public function setCompany($company)
     {
@@ -276,7 +276,7 @@ class Address extends ModelEntity
     /**
      * Getter function for the company column property.
      *
-     * @return string
+     * @return string|null
      */
     public function getCompany()
     {
@@ -286,7 +286,7 @@ class Address extends ModelEntity
     /**
      * Setter function for the department column property.
      *
-     * @param string $department
+     * @param string|null $department
      */
     public function setDepartment($department)
     {
@@ -296,7 +296,7 @@ class Address extends ModelEntity
     /**
      * Getter function for the department column property.
      *
-     * @return string
+     * @return string|null
      */
     public function getDepartment()
     {
@@ -426,7 +426,7 @@ class Address extends ModelEntity
     /**
      * Setter function for the phone column property.
      *
-     * @param string $phone
+     * @param string|null $phone
      */
     public function setPhone($phone)
     {
@@ -436,7 +436,7 @@ class Address extends ModelEntity
     /**
      * Getter function for the phone column property.
      *
-     * @return string
+     * @return string|null
      */
     public function getPhone()
     {
@@ -447,7 +447,7 @@ class Address extends ModelEntity
      * Setter function for the vatId column property.
      * The vatId will be saved in the ustId table field.
      *
-     * @param string $vatId
+     * @param string|null $vatId
      */
     public function setVatId($vatId)
     {
@@ -458,7 +458,7 @@ class Address extends ModelEntity
      * Getter function for the vatId column property.
      * The vatId is saved in the ustId table field.
      *
-     * @return string
+     * @return string|null
      */
     public function getVatId()
     {
@@ -499,7 +499,7 @@ class Address extends ModelEntity
     /**
      * Setter function for the setAdditionalAddressLine1 column property.
      *
-     * @param string $additionalAddressLine1
+     * @param string|null $additionalAddressLine1
      */
     public function setAdditionalAddressLine1($additionalAddressLine1)
     {
@@ -509,7 +509,7 @@ class Address extends ModelEntity
     /**
      * Getter function for the getAdditionalAddressLine1 column property.
      *
-     * @return string
+     * @return string|null
      */
     public function getAdditionalAddressLine1()
     {
@@ -519,7 +519,7 @@ class Address extends ModelEntity
     /**
      * Setter function for the setAdditionalAddressLine2 column property.
      *
-     * @param string $additionalAddressLine2
+     * @param string|null $additionalAddressLine2
      */
     public function setAdditionalAddressLine2($additionalAddressLine2)
     {
@@ -529,7 +529,7 @@ class Address extends ModelEntity
     /**
      * Getter function for the getAdditionalAddressLine2 column property.
      *
-     * @return string
+     * @return string|null
      */
     public function getAdditionalAddressLine2()
     {
@@ -579,7 +579,7 @@ class Address extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getTitle()
     {
@@ -587,7 +587,7 @@ class Address extends ModelEntity
     }
 
     /**
-     * @param string $title
+     * @param string|null $title
      */
     public function setTitle($title)
     {

--- a/engine/Shopware/Models/Customer/Customer.php
+++ b/engine/Shopware/Models/Customer/Customer.php
@@ -76,7 +76,7 @@ class Customer extends LazyFetchModelEntity
     /**
      * Contains the unique customer number
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="customernumber", type="string", length=30, nullable=true)
      */
@@ -118,7 +118,7 @@ class Customer extends LazyFetchModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var CustomerAttribute
+     * @var CustomerAttribute|null
      *
      * @Assert\Valid()
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Customer", mappedBy="customer", orphanRemoval=true, cascade={"persist"})
@@ -130,7 +130,7 @@ class Customer extends LazyFetchModelEntity
      * The price group property represents the owning side for the association between customer and customer price group.
      * The association is joined over the pricegroup id field and the pricegroupID field of the customer.
      *
-     * @var PriceGroup
+     * @var PriceGroup|null
      *
      * @ORM\ManyToOne(targetEntity="\Shopware\Models\Customer\PriceGroup", inversedBy="customers")
      * @ORM\JoinColumn(name="pricegroupID", referencedColumnName="id")
@@ -237,7 +237,7 @@ class Customer extends LazyFetchModelEntity
     /**
      * Id of the price group, which the customer is assigned
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="pricegroupID", type="integer", nullable=true)
      */
@@ -423,7 +423,7 @@ class Customer extends LazyFetchModelEntity
     /**
      * Contains the time, since the customer is logged into a session.
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="lockedUntil", type="datetime", nullable=true)
      */
@@ -462,7 +462,7 @@ class Customer extends LazyFetchModelEntity
     private $lastname;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="birthday", type="date", nullable=true)
      */
@@ -476,14 +476,14 @@ class Customer extends LazyFetchModelEntity
     private $doubleOptinRegister;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="doubleOptinEmailSentDate", type="datetime", nullable=true)
      */
     private $doubleOptinEmailSentDate;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="doubleOptinConfirmDate", type="datetime", nullable=true)
      */
@@ -927,7 +927,7 @@ class Customer extends LazyFetchModelEntity
      * Setter function for the lockedUntil column property, which contains the time since the customer is logged into a session.
      * Expects a \DateTimeInterface object or a time string which will be converted to a \DateTime object.
      *
-     * @param string|\DateTimeInterface $lockedUntil
+     * @param string|\DateTimeInterface|null $lockedUntil
      *
      * @return Customer
      */
@@ -944,7 +944,7 @@ class Customer extends LazyFetchModelEntity
     /**
      * Getter function for the lockedUntil column property, which contains the time since the customer is logged into a session.
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getLockedUntil()
     {
@@ -994,7 +994,7 @@ class Customer extends LazyFetchModelEntity
     }
 
     /**
-     * @return CustomerAttribute
+     * @return CustomerAttribute|null
      */
     public function getAttribute()
     {
@@ -1097,7 +1097,7 @@ class Customer extends LazyFetchModelEntity
      * the Customer.group property (OWNING SIDE) and the Group.customers (INVERSE SIDE) property.
      * The group data is joined over the s_core_customergroup.id field.
      *
-     * @param Group|array|null $group
+     * @param Group|array $group
      *
      * @return Customer
      */
@@ -1123,7 +1123,7 @@ class Customer extends LazyFetchModelEntity
     }
 
     /**
-     * @return PriceGroup
+     * @return PriceGroup|null
      */
     public function getPriceGroup()
     {
@@ -1131,7 +1131,7 @@ class Customer extends LazyFetchModelEntity
     }
 
     /**
-     * @param PriceGroup $priceGroup
+     * @param PriceGroup|null $priceGroup
      */
     public function setPriceGroup($priceGroup)
     {
@@ -1313,7 +1313,7 @@ class Customer extends LazyFetchModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBirthday()
     {
@@ -1349,7 +1349,7 @@ class Customer extends LazyFetchModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getNumber()
     {
@@ -1357,7 +1357,7 @@ class Customer extends LazyFetchModelEntity
     }
 
     /**
-     * @param string $number
+     * @param string|null $number
      */
     public function setNumber($number)
     {
@@ -1413,7 +1413,7 @@ class Customer extends LazyFetchModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getDoubleOptinEmailSentDate()
     {
@@ -1421,7 +1421,7 @@ class Customer extends LazyFetchModelEntity
     }
 
     /**
-     * @param \DateTimeInterface $doubleOptinEmailSentDate
+     * @param \DateTimeInterface|null $doubleOptinEmailSentDate
      */
     public function setDoubleOptinEmailSentDate($doubleOptinEmailSentDate)
     {

--- a/engine/Shopware/Models/Customer/Group.php
+++ b/engine/Shopware/Models/Customer/Group.php
@@ -60,7 +60,7 @@ class Group extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var CustomerGroup
+     * @var CustomerGroup|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\CustomerGroup", mappedBy="customerGroup", orphanRemoval=true, cascade={"persist"})
      */
@@ -410,7 +410,7 @@ class Group extends ModelEntity
     }
 
     /**
-     * @return CustomerGroup
+     * @return CustomerGroup|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Customer/PaymentData.php
+++ b/engine/Shopware/Models/Customer/PaymentData.php
@@ -65,49 +65,49 @@ class PaymentData extends ModelEntity
     protected $customer;
 
     /**
-     * @var bool
+     * @var bool|null
      *
      * @ORM\Column(name="use_billing_data", type="boolean", nullable=true)
      */
     protected $useBillingData;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="bankname", type="string", length=255, nullable=true)
      */
     protected $bankName;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="bic", type="string", length=50, nullable=true)
      */
     protected $bic;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="iban", type="string", length=50, nullable=true)
      */
     protected $iban;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="account_number", type="string", length=50, nullable=true)
      */
     protected $accountNumber;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="bank_code", type="string", length=50, nullable=true)
      */
     protected $bankCode;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="account_holder", type="string", length=50, nullable=true)
      */
@@ -153,7 +153,7 @@ class PaymentData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBankName()
     {
@@ -169,7 +169,7 @@ class PaymentData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBic()
     {
@@ -217,7 +217,7 @@ class PaymentData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getIban()
     {
@@ -249,7 +249,7 @@ class PaymentData extends ModelEntity
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
     public function getUseBillingData()
     {
@@ -265,7 +265,7 @@ class PaymentData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getAccountHolder()
     {
@@ -281,7 +281,7 @@ class PaymentData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getAccountNumber()
     {
@@ -297,7 +297,7 @@ class PaymentData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBankCode()
     {

--- a/engine/Shopware/Models/CustomerStream/CustomerStream.php
+++ b/engine/Shopware/Models/CustomerStream/CustomerStream.php
@@ -38,7 +38,7 @@ class CustomerStream extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var CustomerStreamAttribute
+     * @var CustomerStreamAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\CustomerStream", mappedBy="customerStream", orphanRemoval=true, cascade={"persist"})
      */
@@ -70,7 +70,7 @@ class CustomerStream extends ModelEntity
     private $description;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="conditions", type="string", nullable=true)
      */
@@ -84,7 +84,7 @@ class CustomerStream extends ModelEntity
     private $static = false;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @Assert\DateTime()
      *

--- a/engine/Shopware/Models/Dispatch/Dispatch.php
+++ b/engine/Shopware/Models/Dispatch/Dispatch.php
@@ -63,7 +63,7 @@ class Dispatch extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\Dispatch
+     * @var \Shopware\Models\Attribute\Dispatch|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Dispatch", mappedBy="dispatch", orphanRemoval=true, cascade={"persist"})
      */
@@ -180,7 +180,7 @@ class Dispatch extends ModelEntity
     /**
      * Defines the value after the shipping fee will be dropped.
      *
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="shippingfree", type="decimal", nullable=true)
      */
@@ -189,7 +189,7 @@ class Dispatch extends ModelEntity
     /**
      * Id of the sub shop used for this dispatch
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="multishopID", type="integer", nullable=true)
      */
@@ -199,7 +199,7 @@ class Dispatch extends ModelEntity
      * The dispatch can be restricted to a given user group ID. If non ID is given
      * there will be no restriction to a user group.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="customergroupID", type="integer", nullable=true)
      */
@@ -222,7 +222,7 @@ class Dispatch extends ModelEntity
      * If the dispatch type should only be available during a given time frame, the start time can be selected here.
      * The time is given as an Integer in seconds.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="bind_time_from", type="integer", nullable=true)
      */
@@ -232,7 +232,7 @@ class Dispatch extends ModelEntity
      * If the dispatch type should only be available during a given time frame, the end time can be selected here.
      * The time is given as an Integer in seconds.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="bind_time_to", type="integer", nullable=true)
      */
@@ -245,7 +245,7 @@ class Dispatch extends ModelEntity
      *  - 1 == Order quantity
      *  - 2 == Order quantity + minimum stock
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="bind_instock", type="integer", nullable=true)
      */
@@ -254,7 +254,7 @@ class Dispatch extends ModelEntity
     /**
      * Just use this dispatch if there are sales articles in the shopping cart.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="bind_laststock", type="integer", nullable=false)
      */
@@ -264,7 +264,7 @@ class Dispatch extends ModelEntity
      * This dispatch is just available between specific weekdays.
      * The beginning of the weekdays is defined here
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="bind_weekday_from", type="integer", nullable=true)
      */
@@ -274,7 +274,7 @@ class Dispatch extends ModelEntity
      * This dispatch is just available between specific weekdays.
      * The ending of the weekdays is defined here
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="bind_weekday_to", type="integer", nullable=true)
      */
@@ -284,7 +284,7 @@ class Dispatch extends ModelEntity
      * This dispatch is only available if the weight of the shopping cart is between this start point and and the end point.
      * The start point is defined here.
      *
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="bind_weight_from", type="decimal", nullable=true)
      */
@@ -294,7 +294,7 @@ class Dispatch extends ModelEntity
      * This dispatch is only available if the weight of the shopping cart is between a start point and and this end point.
      * The end point is defined here.
      *
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="bind_weight_to", type="decimal", nullable=true)
      */
@@ -304,7 +304,7 @@ class Dispatch extends ModelEntity
      * This dispatch is only available from this price to the end price.
      * The start price is defined here.
      *
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="bind_price_from", type="decimal", nullable=true)
      */
@@ -314,7 +314,7 @@ class Dispatch extends ModelEntity
      * This dispatch is only available from a price to this end price.
      * The end price is defined here.
      *
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="bind_price_to", type="decimal", nullable=true)
      */
@@ -323,7 +323,7 @@ class Dispatch extends ModelEntity
     /**
      * Defines a SQL Query used to calculate the dispatch prices
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="bind_sql", type="text", nullable=true)
      */
@@ -332,7 +332,7 @@ class Dispatch extends ModelEntity
     /**
      * Link to the delivery tracking system.
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="status_link", type="text", nullable=true)
      */
@@ -341,7 +341,7 @@ class Dispatch extends ModelEntity
     /**
      * Defines a SQL Query used to calculate the dispatch prices
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="calculation_sql", type="text", nullable=true)
      */
@@ -640,7 +640,7 @@ class Dispatch extends ModelEntity
     /**
      * Set shippingFree
      *
-     * @param float $shippingFree
+     * @param float|null $shippingFree
      *
      * @return Dispatch
      */
@@ -654,7 +654,7 @@ class Dispatch extends ModelEntity
     /**
      * Get shippingFree
      *
-     * @return float
+     * @return float|null
      */
     public function getShippingFree()
     {
@@ -664,7 +664,7 @@ class Dispatch extends ModelEntity
     /**
      * Set multiShopId
      *
-     * @param int $multiShopId
+     * @param int|null $multiShopId
      *
      * @return Dispatch
      */
@@ -678,7 +678,7 @@ class Dispatch extends ModelEntity
     /**
      * Get multiShopId
      *
-     * @return int
+     * @return int|null
      */
     public function getMultiShopId()
     {
@@ -688,7 +688,7 @@ class Dispatch extends ModelEntity
     /**
      * Set customerGroupId
      *
-     * @param int $customerGroupId
+     * @param int|null $customerGroupId
      *
      * @return Dispatch
      */
@@ -702,7 +702,7 @@ class Dispatch extends ModelEntity
     /**
      * Get customerGroupId
      *
-     * @return int
+     * @return int|null
      */
     public function getCustomerGroupId()
     {
@@ -736,7 +736,7 @@ class Dispatch extends ModelEntity
     /**
      * Set bindTimeFrom
      *
-     * @param int $bindTimeFrom
+     * @param int|null $bindTimeFrom
      *
      * @return Dispatch
      */
@@ -750,7 +750,7 @@ class Dispatch extends ModelEntity
     /**
      * Get bindTimeFrom
      *
-     * @return int
+     * @return int|null
      */
     public function getBindTimeFrom()
     {
@@ -760,7 +760,7 @@ class Dispatch extends ModelEntity
     /**
      * Set bindTimeTo
      *
-     * @param int $bindTimeTo
+     * @param int|null $bindTimeTo
      *
      * @return Dispatch
      */
@@ -774,7 +774,7 @@ class Dispatch extends ModelEntity
     /**
      * Get bindTimeTo
      *
-     * @return int
+     * @return int|null
      */
     public function getBindTimeTo()
     {
@@ -784,7 +784,7 @@ class Dispatch extends ModelEntity
     /**
      * Set bindInStock
      *
-     * @param int $bindInStock
+     * @param int|null $bindInStock
      *
      * @return Dispatch
      */
@@ -798,7 +798,7 @@ class Dispatch extends ModelEntity
     /**
      * Get bindInStock
      *
-     * @return int
+     * @return int|null
      */
     public function getBindInStock()
     {
@@ -832,7 +832,7 @@ class Dispatch extends ModelEntity
     /**
      * Set bindWeekdayFrom
      *
-     * @param int $bindWeekdayFrom
+     * @param int|null $bindWeekdayFrom
      *
      * @return Dispatch
      */
@@ -846,7 +846,7 @@ class Dispatch extends ModelEntity
     /**
      * Get bindWeekdayFrom
      *
-     * @return int
+     * @return int|null
      */
     public function getBindWeekdayFrom()
     {
@@ -856,7 +856,7 @@ class Dispatch extends ModelEntity
     /**
      * Set bindWeekdayTo
      *
-     * @param int $bindWeekdayTo
+     * @param int|null $bindWeekdayTo
      *
      * @return Dispatch
      */
@@ -870,7 +870,7 @@ class Dispatch extends ModelEntity
     /**
      * Get bindWeekdayTo
      *
-     * @return int
+     * @return int|null
      */
     public function getBindWeekdayTo()
     {
@@ -880,7 +880,7 @@ class Dispatch extends ModelEntity
     /**
      * Set bindWeightFrom
      *
-     * @param float $bindWeightFrom
+     * @param float|null $bindWeightFrom
      *
      * @return Dispatch
      */
@@ -894,7 +894,7 @@ class Dispatch extends ModelEntity
     /**
      * Get bindWeightFrom
      *
-     * @return float
+     * @return float|null
      */
     public function getBindWeightFrom()
     {
@@ -904,7 +904,7 @@ class Dispatch extends ModelEntity
     /**
      * Set bindWeightTo
      *
-     * @param float $bindWeightTo
+     * @param float|null $bindWeightTo
      *
      * @return Dispatch
      */
@@ -918,7 +918,7 @@ class Dispatch extends ModelEntity
     /**
      * Get bindWeightTo
      *
-     * @return float
+     * @return float|null
      */
     public function getBindWeightTo()
     {
@@ -928,7 +928,7 @@ class Dispatch extends ModelEntity
     /**
      * Set bindPriceFrom
      *
-     * @param float $bindPriceFrom
+     * @param float|null $bindPriceFrom
      *
      * @return Dispatch
      */
@@ -942,7 +942,7 @@ class Dispatch extends ModelEntity
     /**
      * Get bindPriceFrom
      *
-     * @return float
+     * @return float|null
      */
     public function getBindPriceFrom()
     {
@@ -952,7 +952,7 @@ class Dispatch extends ModelEntity
     /**
      * Set bindPriceTo
      *
-     * @param float $bindPriceTo
+     * @param float|null $bindPriceTo
      *
      * @return Dispatch
      */
@@ -966,7 +966,7 @@ class Dispatch extends ModelEntity
     /**
      * Get bindPriceTo
      *
-     * @return float
+     * @return float|null
      */
     public function getBindPriceTo()
     {
@@ -976,7 +976,7 @@ class Dispatch extends ModelEntity
     /**
      * Set bindSql
      *
-     * @param string $bindSql
+     * @param string|null $bindSql
      *
      * @return Dispatch
      */
@@ -990,7 +990,7 @@ class Dispatch extends ModelEntity
     /**
      * Get bindSql
      *
-     * @return string
+     * @return string|null
      */
     public function getBindSql()
     {
@@ -1014,7 +1014,7 @@ class Dispatch extends ModelEntity
     /**
      * Get statusLink
      *
-     * @return string
+     * @return string|null
      */
     public function getStatusLink()
     {
@@ -1024,7 +1024,7 @@ class Dispatch extends ModelEntity
     /**
      * Set calculationSql
      *
-     * @param string $calculationSql
+     * @param string|null $calculationSql
      *
      * @return Dispatch
      */
@@ -1038,7 +1038,7 @@ class Dispatch extends ModelEntity
     /**
      * Get calculationSql
      *
-     * @return string
+     * @return string|null
      */
     public function getCalculationSql()
     {
@@ -1160,7 +1160,7 @@ class Dispatch extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Attribute\Dispatch
+     * @return \Shopware\Models\Attribute\Dispatch|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Dispatch/ShippingCost.php
+++ b/engine/Shopware/Models/Dispatch/ShippingCost.php
@@ -198,7 +198,7 @@ class ShippingCost extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Dispatch\Dispatch|array|null $dispatch
+     * @param \Shopware\Models\Dispatch\Dispatch|array $dispatch
      */
     public function setDispatch($dispatch)
     {

--- a/engine/Shopware/Models/Document/Document.php
+++ b/engine/Shopware/Models/Document/Document.php
@@ -61,7 +61,7 @@ class Document extends ModelEntity
      * An internal key, which can be used to identify a document type independently
      * from its id or name, because these values may have been changed by the user.
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="`key`", type="string", nullable=true, unique=true)
      */
@@ -191,7 +191,7 @@ class Document extends ModelEntity
     /**
      * Gets the document's unique key
      *
-     * @return string
+     * @return string|null
      */
     public function getKey()
     {

--- a/engine/Shopware/Models/Emotion/Data.php
+++ b/engine/Shopware/Models/Emotion/Data.php
@@ -115,7 +115,7 @@ class Data extends ModelEntity
     private $fieldId;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="value", type="text", nullable=true)
      */
@@ -194,7 +194,7 @@ class Data extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getValue()
     {

--- a/engine/Shopware/Models/Emotion/Element.php
+++ b/engine/Shopware/Models/Emotion/Element.php
@@ -153,7 +153,7 @@ class Element extends ModelEntity
     /**
      * Defines a custom user CSS class for every element.
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="css_class", type="string", length=255, nullable=true)
      */
@@ -269,7 +269,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @param string $cssClass
+     * @param string|null $cssClass
      */
     public function setCssClass($cssClass)
     {
@@ -277,7 +277,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCssClass()
     {

--- a/engine/Shopware/Models/Emotion/Emotion.php
+++ b/engine/Shopware/Models/Emotion/Emotion.php
@@ -90,7 +90,7 @@ class Emotion extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\Emotion
+     * @var \Shopware\Models\Attribute\Emotion|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Emotion", mappedBy="emotion", orphanRemoval=true, cascade={"persist"})
      */
@@ -104,14 +104,14 @@ class Emotion extends ModelEntity
     protected $showListing;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="template_id", type="integer", nullable=true)
      */
     protected $templateId = null;
 
     /**
-     * @var Template
+     * @var Template|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Emotion\Template", inversedBy="emotions")
      * @ORM\JoinColumn(name="template_id", referencedColumnName="id")
@@ -130,7 +130,7 @@ class Emotion extends ModelEntity
     private $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parent_id", type="integer", nullable=true)
      */
@@ -172,7 +172,7 @@ class Emotion extends ModelEntity
     private $position = 1;
 
     /**
-     * @var int
+     * @var string|null
      *
      * @ORM\Column(name="device", type="string", length=255, nullable=true)
      */
@@ -189,7 +189,7 @@ class Emotion extends ModelEntity
      * With the $validFrom and $validTo property you can define
      * a date range in which the emotion will be displayed.
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="valid_from", type="datetime", nullable=true)
      */
@@ -227,7 +227,7 @@ class Emotion extends ModelEntity
      * With the $validFrom and $validTo property you can define
      * a date range in which the emotion will be displayed.
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="valid_to", type="datetime", nullable=true)
      */
@@ -314,21 +314,21 @@ class Emotion extends ModelEntity
     private $mode;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="preview_id", type="integer", nullable=true)
      */
     private $previewId;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="preview_secret", type="string", nullable=true)
      */
     private $previewSecret;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="customer_stream_ids", type="string", nullable=true)
      */
@@ -423,7 +423,7 @@ class Emotion extends ModelEntity
     /**
      * Create date of the emotion.
      *
-     * @param \DateTimeInterface|string|null $createDate
+     * @param \DateTimeInterface|string $createDate
      */
     public function setCreateDate($createDate = 'now')
     {
@@ -463,7 +463,7 @@ class Emotion extends ModelEntity
      * With the $validFrom and $validTo property you can define
      * a date range in which the emotion will be displayed.
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getValidFrom()
     {
@@ -489,7 +489,7 @@ class Emotion extends ModelEntity
      * With the $validFrom and $validTo property you can define
      * a date range in which the emotion will be displayed.
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getValidTo()
     {
@@ -531,7 +531,7 @@ class Emotion extends ModelEntity
     }
 
     /**
-     * @param \DateTimeInterface|string|null $modified
+     * @param \DateTimeInterface|string $modified
      */
     public function setModified($modified)
     {
@@ -716,7 +716,7 @@ class Emotion extends ModelEntity
     }
 
     /**
-     * @return Template
+     * @return Template|null
      */
     public function getTemplate()
     {
@@ -732,7 +732,7 @@ class Emotion extends ModelEntity
     }
 
     /**
-     * @param int $device
+     * @param string $device
      */
     public function setDevice($device)
     {
@@ -740,7 +740,7 @@ class Emotion extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return string|null
      */
     public function getDevice()
     {
@@ -876,7 +876,7 @@ class Emotion extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getParentId()
     {
@@ -884,7 +884,7 @@ class Emotion extends ModelEntity
     }
 
     /**
-     * @param int $parentId
+     * @param int|null $parentId
      */
     public function setParentId($parentId)
     {
@@ -892,7 +892,7 @@ class Emotion extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getPreviewId()
     {
@@ -900,7 +900,7 @@ class Emotion extends ModelEntity
     }
 
     /**
-     * @param int $previewId
+     * @param int|null $previewId
      */
     public function setPreviewId($previewId)
     {
@@ -908,7 +908,7 @@ class Emotion extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPreviewSecret()
     {
@@ -916,7 +916,7 @@ class Emotion extends ModelEntity
     }
 
     /**
-     * @param string $previewSecret
+     * @param string|null $previewSecret
      */
     public function setPreviewSecret($previewSecret)
     {
@@ -939,11 +939,17 @@ class Emotion extends ModelEntity
         $this->replacement = $replacement;
     }
 
+    /**
+     * @return string|null
+     */
     public function getCustomerStreamIds()
     {
         return $this->customerStreamIds;
     }
 
+    /**
+     * @param string|null $customerStreamIds
+     */
     public function setCustomerStreamIds($customerStreamIds)
     {
         $this->customerStreamIds = $customerStreamIds;

--- a/engine/Shopware/Models/Emotion/Library/Component.php
+++ b/engine/Shopware/Models/Emotion/Library/Component.php
@@ -40,7 +40,7 @@ use Shopware\Models\Plugin\Plugin;
 class Component extends ModelEntity
 {
     /**
-     * @var Plugin
+     * @var Plugin|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Plugin\Plugin", inversedBy="emotionComponents")
      * @ORM\JoinColumn(name="pluginID", referencedColumnName="id")
@@ -83,7 +83,7 @@ class Component extends ModelEntity
     private $name;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="convert_function", type="string", length=255, nullable=true)
      */
@@ -129,7 +129,7 @@ class Component extends ModelEntity
     /**
      * Contains the plugin id which added this component to the library
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="pluginID", type="integer", nullable=true)
      */
@@ -269,7 +269,7 @@ class Component extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getPluginId()
     {
@@ -277,7 +277,7 @@ class Component extends ModelEntity
     }
 
     /**
-     * @param int $pluginId
+     * @param int|null $pluginId
      */
     public function setPluginId($pluginId)
     {
@@ -301,7 +301,7 @@ class Component extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getConvertFunction()
     {
@@ -309,7 +309,7 @@ class Component extends ModelEntity
     }
 
     /**
-     * @param string $convertFunction
+     * @param string|null $convertFunction
      */
     public function setConvertFunction($convertFunction)
     {
@@ -317,7 +317,7 @@ class Component extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Plugin\Plugin
+     * @return \Shopware\Models\Plugin\Plugin|null
      */
     public function getPlugin()
     {
@@ -325,7 +325,7 @@ class Component extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Plugin\Plugin $plugin
+     * @param \Shopware\Models\Plugin\Plugin|null $plugin
      */
     public function setPlugin($plugin)
     {

--- a/engine/Shopware/Models/Emotion/Preset.php
+++ b/engine/Shopware/Models/Emotion/Preset.php
@@ -98,7 +98,7 @@ class Preset extends ModelEntity
     /**
      * Contains the thumbnail path
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="thumbnail", type="text", nullable=true)
      */
@@ -107,7 +107,7 @@ class Preset extends ModelEntity
     /**
      * Contains the preview image path
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="preview", type="text", nullable=true)
      */
@@ -232,7 +232,7 @@ class Preset extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getThumbnail()
     {
@@ -240,7 +240,7 @@ class Preset extends ModelEntity
     }
 
     /**
-     * @param string $thumbnail
+     * @param string|null $thumbnail
      */
     public function setThumbnail($thumbnail)
     {
@@ -248,7 +248,7 @@ class Preset extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPreview()
     {
@@ -256,7 +256,7 @@ class Preset extends ModelEntity
     }
 
     /**
-     * @param string $preview
+     * @param string|null $preview
      */
     public function setPreview($preview)
     {

--- a/engine/Shopware/Models/Form/Field.php
+++ b/engine/Shopware/Models/Form/Field.php
@@ -89,7 +89,7 @@ class Field extends ModelEntity
     /**
      * Addition note to display
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="note", type="string", length=255, nullable=true)
      */
@@ -273,7 +273,7 @@ class Field extends ModelEntity
     /**
      * Get note of field
      *
-     * @return string
+     * @return string|null
      */
     public function getNote()
     {

--- a/engine/Shopware/Models/Form/Form.php
+++ b/engine/Shopware/Models/Form/Form.php
@@ -64,7 +64,7 @@ class Form extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\Form
+     * @var \Shopware\Models\Attribute\Form|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Form", mappedBy="form", orphanRemoval=true, cascade={"persist"})
      */
@@ -143,21 +143,21 @@ class Form extends ModelEntity
     private $isocode = 'de';
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="meta_title", type="string", length=255, nullable=true)
      */
     private $metaTitle = '';
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="meta_keywords", type="string", length=255, nullable=true)
      */
     private $metaKeywords = '';
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="meta_description", type="text", nullable=true)
      */
@@ -450,7 +450,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @param string $metaTitle
+     * @param string|null $metaTitle
      */
     public function setMetaTitle($metaTitle)
     {
@@ -458,7 +458,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getMetaTitle()
     {
@@ -466,7 +466,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @param string $metaDescription
+     * @param string|null $metaDescription
      */
     public function setMetaDescription($metaDescription)
     {
@@ -474,7 +474,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getMetaDescription()
     {
@@ -482,7 +482,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @param string $metaKeywords
+     * @param string|null $metaKeywords
      */
     public function setMetaKeywords($metaKeywords)
     {
@@ -490,7 +490,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getMetaKeywords()
     {
@@ -498,7 +498,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Attribute\Form
+     * @return \Shopware\Models\Attribute\Form|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Mail/Attachment.php
+++ b/engine/Shopware/Models/Mail/Attachment.php
@@ -51,7 +51,7 @@ class Attachment extends File
     /**
      * The role property is the owning side of the association between attachment and shop.
      *
-     * @var \Shopware\Models\Shop\Shop
+     * @var \Shopware\Models\Shop\Shop|null
      *
      * @ORM\ManyToOne(targetEntity="\Shopware\Models\Shop\Shop")
      * @ORM\JoinColumn(name="shopID", referencedColumnName="id", nullable=true)
@@ -93,7 +93,7 @@ class Attachment extends File
     }
 
     /**
-     * @return \Shopware\Models\Shop\Shop
+     * @return \Shopware\Models\Shop\Shop|null
      */
     public function getShop()
     {
@@ -112,7 +112,10 @@ class Attachment extends File
         return null;
     }
 
-    public function setShop(\Shopware\Models\Shop\Shop $shop)
+    /**
+     * @param \Shopware\Models\Shop\Shop|null $shop
+     */
+    public function setShop($shop)
     {
         $this->shop = $shop;
     }

--- a/engine/Shopware/Models/Mail/Mail.php
+++ b/engine/Shopware/Models/Mail/Mail.php
@@ -80,7 +80,7 @@ class Mail extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\Mail
+     * @var \Shopware\Models\Attribute\Mail|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Mail", mappedBy="mail", orphanRemoval=true, cascade={"persist"})
      */
@@ -147,7 +147,7 @@ class Mail extends ModelEntity
     private $isHtml = false;
 
     /**
-     * @var bool
+     * @var bool|null
      *
      * @ORM\Column(name="dirty", type="boolean", nullable=true)
      */
@@ -583,7 +583,7 @@ class Mail extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Attribute\Mail
+     * @return \Shopware\Models\Attribute\Mail|null
      */
     public function getAttribute()
     {
@@ -601,7 +601,7 @@ class Mail extends ModelEntity
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
     public function isDirty()
     {

--- a/engine/Shopware/Models/Media/Album.php
+++ b/engine/Shopware/Models/Media/Album.php
@@ -102,7 +102,7 @@ class Album extends ModelEntity
     /**
      * Id of the parent album
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parentID", type="integer", nullable=true)
      */

--- a/engine/Shopware/Models/Media/Media.php
+++ b/engine/Shopware/Models/Media/Media.php
@@ -99,7 +99,7 @@ class Media extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var MediaAttribute
+     * @var MediaAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Media", mappedBy="media", orphanRemoval=true, cascade={"persist"})
      */
@@ -239,7 +239,7 @@ class Media extends ModelEntity
     /**
      * Width of the file in px if it's an image
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="width", type="integer", nullable=true)
      */
@@ -248,7 +248,7 @@ class Media extends ModelEntity
     /**
      * Height of the file in px if it's an image
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="height", type="integer", nullable=true)
      */
@@ -939,7 +939,7 @@ class Media extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getWidth()
     {
@@ -947,7 +947,7 @@ class Media extends ModelEntity
     }
 
     /**
-     * @param int $width
+     * @param int|null $width
      */
     public function setWidth($width)
     {
@@ -955,7 +955,7 @@ class Media extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getHeight()
     {
@@ -963,7 +963,7 @@ class Media extends ModelEntity
     }
 
     /**
-     * @param int $height
+     * @param int|null $height
      */
     public function setHeight($height)
     {
@@ -981,7 +981,7 @@ class Media extends ModelEntity
     }
 
     /**
-     * @return MediaAttribute
+     * @return MediaAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Menu/Menu.php
+++ b/engine/Shopware/Models/Menu/Menu.php
@@ -44,7 +44,7 @@ class Menu extends ModelEntity
     public $label;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="onclick", type="string", length=255, nullable=true)
      */
@@ -58,28 +58,28 @@ class Menu extends ModelEntity
     public $class;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="controller", type="string", length=255, nullable=true)
      */
     public $controller;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="action", type="string", length=255, nullable=true)
      */
     public $action;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="shortcut", type="string", length=255, nullable=true)
      */
     public $shortcut;
 
     /**
-     * @var \Shopware\Models\Plugin\Plugin
+     * @var \Shopware\Models\Plugin\Plugin|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Plugin\Plugin", inversedBy="menuItems")
      * @ORM\JoinColumn(name="pluginID", referencedColumnName="id")
@@ -110,21 +110,21 @@ class Menu extends ModelEntity
     private $active = true;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="pluginID", type="integer", nullable=true)
      */
     private $pluginId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parent", type="integer", nullable=true)
      */
     private $parentId;
 
     /**
-     * @var Menu
+     * @var Menu|null
      *
      * @ORM\ManyToOne(targetEntity="Menu", inversedBy="children", cascade={"persist"})
      * @ORM\JoinColumn(name="parent", nullable=true, referencedColumnName="id", onDelete="SET NULL")
@@ -169,7 +169,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getOnclick()
     {
@@ -177,7 +177,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @param string $onclick
+     * @param string|null $onclick
      */
     public function setOnclick($onclick)
     {
@@ -233,7 +233,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getPluginId()
     {
@@ -241,7 +241,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @param int $pluginId
+     * @param int|null $pluginId
      */
     public function setPluginId($pluginId)
     {
@@ -249,7 +249,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getController()
     {
@@ -257,7 +257,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @param string $controller
+     * @param string|null $controller
      */
     public function setController($controller)
     {
@@ -265,7 +265,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getAction()
     {
@@ -273,7 +273,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @param string $action
+     * @param string|null $action
      */
     public function setAction($action)
     {
@@ -281,7 +281,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getShortcut()
     {
@@ -289,7 +289,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @param string $shortcut
+     * @param string|null $shortcut
      */
     public function setShortcut($shortcut)
     {
@@ -297,16 +297,13 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @return Menu
+     * @return Menu|null
      */
     public function getParent()
     {
         return $this->parent;
     }
 
-    /**
-     * @param Menu $parent
-     */
     public function setParent(Menu $parent = null)
     {
         // Parent may be null when this menu item should be a main menu item
@@ -349,7 +346,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Plugin\Plugin
+     * @return \Shopware\Models\Plugin\Plugin|null
      */
     public function getPlugin()
     {
@@ -357,7 +354,7 @@ class Menu extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Plugin\Plugin $plugin
+     * @param \Shopware\Models\Plugin\Plugin|null $plugin
      */
     public function setPlugin($plugin)
     {

--- a/engine/Shopware/Models/Newsletter/Address.php
+++ b/engine/Shopware/Models/Newsletter/Address.php
@@ -52,7 +52,7 @@ class Address extends LazyFetchModelEntity
      * The group property is the owning side of the association between group and newsletter group
      * The association is joined over the address groupId and the group's id
      *
-     * @var \Shopware\Models\Newsletter\Group
+     * @var \Shopware\Models\Newsletter\Group|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Newsletter\Group")
      * @ORM\JoinColumn(name="groupID", referencedColumnName="id")
@@ -82,7 +82,7 @@ class Address extends LazyFetchModelEntity
     /**
      * ID of the newsletter-group this mail address belongs to
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="groupID", type="integer", length=11, nullable=true)
      */
@@ -130,7 +130,7 @@ class Address extends LazyFetchModelEntity
     /**
      * The Double-Opt-In registration date
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="added", type="datetime", nullable=true)
      */
@@ -139,7 +139,7 @@ class Address extends LazyFetchModelEntity
     /**
      * The Double-Opt-In confirmation date
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="double_optin_confirmed", type="datetime", nullable=true)
      */
@@ -246,7 +246,7 @@ class Address extends LazyFetchModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Newsletter\Group $newsletterGroup
+     * @param \Shopware\Models\Newsletter\Group|null $newsletterGroup
      *
      * @return Address
      */
@@ -258,7 +258,7 @@ class Address extends LazyFetchModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Newsletter\Group
+     * @return \Shopware\Models\Newsletter\Group|null
      */
     public function getNewsletterGroup()
     {
@@ -266,7 +266,7 @@ class Address extends LazyFetchModelEntity
     }
 
     /**
-     * @param int $groupId
+     * @param int|null $groupId
      */
     public function setGroupId($groupId)
     {
@@ -274,7 +274,7 @@ class Address extends LazyFetchModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getGroupId()
     {
@@ -293,7 +293,7 @@ class Address extends LazyFetchModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getAdded()
     {
@@ -309,7 +309,7 @@ class Address extends LazyFetchModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getDoubleOptinConfirmed()
     {
@@ -317,7 +317,7 @@ class Address extends LazyFetchModelEntity
     }
 
     /**
-     * @param \DateTimeInterface $doubleOptinConfirmed
+     * @param \DateTimeInterface|null $doubleOptinConfirmed
      */
     public function setDoubleOptinConfirmed($doubleOptinConfirmed)
     {

--- a/engine/Shopware/Models/Newsletter/ContactData.php
+++ b/engine/Shopware/Models/Newsletter/ContactData.php
@@ -54,49 +54,49 @@ class ContactData extends ModelEntity
     protected $groupId;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="salutation", type="string", nullable=true)
      */
     protected $salutation;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="title", type="string", nullable=true)
      */
     protected $title;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="firstname", type="string", nullable=true)
      */
     protected $firstName;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="lastname", type="string", nullable=true)
      */
     protected $lastName;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="street", type="string", length=255, nullable=true)
      */
     protected $street;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="zipcode", type="string", nullable=true)
      */
     protected $zipCode;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="city", type="string", nullable=true)
      */
@@ -117,7 +117,7 @@ class ContactData extends ModelEntity
     protected $doubleOptinConfirmed;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="deleted", type="datetime", nullable=true)
      */
@@ -159,7 +159,7 @@ class ContactData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCity()
     {
@@ -167,7 +167,7 @@ class ContactData extends ModelEntity
     }
 
     /**
-     * @param \DateTimeInterface $deleted
+     * @param \DateTimeInterface|null $deleted
      */
     public function setDeleted($deleted)
     {
@@ -175,7 +175,7 @@ class ContactData extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getDeleted()
     {
@@ -207,7 +207,7 @@ class ContactData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFirstName()
     {
@@ -247,7 +247,7 @@ class ContactData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLastName()
     {
@@ -263,7 +263,7 @@ class ContactData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getSalutation()
     {
@@ -279,7 +279,7 @@ class ContactData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getStreet()
     {
@@ -287,7 +287,7 @@ class ContactData extends ModelEntity
     }
 
     /**
-     * @param string $title
+     * @param string|null $title
      */
     public function setTitle($title)
     {
@@ -295,7 +295,7 @@ class ContactData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getTitle()
     {
@@ -311,7 +311,7 @@ class ContactData extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getZipCode()
     {

--- a/engine/Shopware/Models/Newsletter/Container.php
+++ b/engine/Shopware/Models/Newsletter/Container.php
@@ -88,7 +88,7 @@ class Container extends ModelEntity
      * OWNING SIDE
      * Owning side of the newsletter-container association
      *
-     * @var \Shopware\Models\Newsletter\Newsletter
+     * @var \Shopware\Models\Newsletter\Newsletter|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Newsletter\Newsletter", inversedBy="containers")
      * @ORM\JoinColumn(name="promotionID", referencedColumnName="id")
@@ -109,7 +109,7 @@ class Container extends ModelEntity
     /**
      * Newsletter ID
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="promotionID", type="integer", length=11, nullable=true)
      */
@@ -214,7 +214,7 @@ class Container extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Newsletter\Newsletter
+     * @return \Shopware\Models\Newsletter\Newsletter|null
      */
     public function getNewsletter()
     {

--- a/engine/Shopware/Models/Newsletter/ContainerType/Article.php
+++ b/engine/Shopware/Models/Newsletter/ContainerType/Article.php
@@ -39,7 +39,7 @@ class Article extends LazyFetchModelEntity
      * OWNING SIDE
      * Owning side of relation between container type 'article' and parent container
      *
-     * @var \Shopware\Models\Newsletter\Container
+     * @var \Shopware\Models\Newsletter\Container|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Newsletter\Container", inversedBy="articles")
      * @ORM\JoinColumn(name="parentID", referencedColumnName="id")
@@ -71,7 +71,7 @@ class Article extends LazyFetchModelEntity
     /**
      * ID of the container this model belongs to
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parentID", type="integer", length=11, nullable=true)
      */
@@ -132,7 +132,7 @@ class Article extends LazyFetchModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Newsletter\Container
+     * @return \Shopware\Models\Newsletter\Container|null
      */
     public function getContainer()
     {

--- a/engine/Shopware/Models/Newsletter/ContainerType/Banner.php
+++ b/engine/Shopware/Models/Newsletter/ContainerType/Banner.php
@@ -39,7 +39,7 @@ class Banner extends ModelEntity
      * OWNING SIDE
      * Owning side of relation between container type 'article' and parent container
      *
-     * @var \Shopware\Models\Newsletter\Container
+     * @var \Shopware\Models\Newsletter\Container|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Newsletter\Container", inversedBy="banner")
      * @ORM\JoinColumn(name="parentID", referencedColumnName="id")
@@ -60,7 +60,7 @@ class Banner extends ModelEntity
     /**
      * ID of the container this model belongs to
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parentID", type="integer", length=11, nullable=true)
      */
@@ -174,7 +174,7 @@ class Banner extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Newsletter\Container
+     * @return \Shopware\Models\Newsletter\Container|null
      */
     public function getContainer()
     {

--- a/engine/Shopware/Models/Newsletter/ContainerType/Link.php
+++ b/engine/Shopware/Models/Newsletter/ContainerType/Link.php
@@ -39,7 +39,7 @@ class Link extends ModelEntity
      * OWNING SIDE
      * Owning side of relation between container type 'article' and parent container
      *
-     * @var \Shopware\Models\Newsletter\Container
+     * @var \Shopware\Models\Newsletter\Container|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Newsletter\Container", inversedBy="links")
      * @ORM\JoinColumn(name="parentID", referencedColumnName="id")
@@ -60,7 +60,7 @@ class Link extends ModelEntity
     /**
      * ID of the container this model belongs to
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parentID", type="integer", length=11, nullable=true)
      */
@@ -174,7 +174,7 @@ class Link extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Newsletter\Container
+     * @return \Shopware\Models\Newsletter\Container|null
      */
     public function getContainer()
     {

--- a/engine/Shopware/Models/Newsletter/ContainerType/Text.php
+++ b/engine/Shopware/Models/Newsletter/ContainerType/Text.php
@@ -39,7 +39,7 @@ class Text extends ModelEntity
      * OWNING SIDE
      * Owning side of relation between container type 'text' and parent container
      *
-     * @var \Shopware\Models\Newsletter\Container
+     * @var \Shopware\Models\Newsletter\Container|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Newsletter\Container", inversedBy="text")
      * @ORM\JoinColumn(name="parentID", referencedColumnName="id")
@@ -60,7 +60,7 @@ class Text extends ModelEntity
     /**
      * ID of the container this model belongs to
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parentID", type="integer", length=11, nullable=true)
      */
@@ -132,7 +132,7 @@ class Text extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Newsletter\Container
+     * @return \Shopware\Models\Newsletter\Container|null
      */
     public function getContainer()
     {

--- a/engine/Shopware/Models/Newsletter/Newsletter.php
+++ b/engine/Shopware/Models/Newsletter/Newsletter.php
@@ -61,7 +61,7 @@ class Newsletter extends ModelEntity
     /**
      * Date of the newsletter
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="datum", type="date", nullable=true)
      */
@@ -137,7 +137,7 @@ class Newsletter extends ModelEntity
     private $status = 0;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="locked", type="datetime", nullable=true)
      */
@@ -191,7 +191,7 @@ class Newsletter extends ModelEntity
     /**
      * Should the mail delivered in future?
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="timed_delivery", type="datetime", nullable=true)
      */
@@ -214,7 +214,7 @@ class Newsletter extends ModelEntity
     }
 
     /**
-     * @param \DateTimeInterface $date
+     * @param \DateTimeInterface|null $date
      */
     public function setDate($date)
     {
@@ -222,7 +222,7 @@ class Newsletter extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getDate()
     {
@@ -294,7 +294,7 @@ class Newsletter extends ModelEntity
     }
 
     /**
-     * @param \DateTimeInterface $locked
+     * @param \DateTimeInterface|null $locked
      */
     public function setLocked($locked)
     {
@@ -302,7 +302,7 @@ class Newsletter extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getLocked()
     {
@@ -504,7 +504,7 @@ class Newsletter extends ModelEntity
     }
 
     /**
-     * @param \DateTimeInterface $timedDelivery
+     * @param \DateTimeInterface|null $timedDelivery
      */
     public function setTimedDelivery($timedDelivery)
     {

--- a/engine/Shopware/Models/Order/Basket.php
+++ b/engine/Shopware/Models/Order/Basket.php
@@ -35,21 +35,21 @@ use Shopware\Models\Attribute\OrderBasket as OrderBasketAttribute;
 class Basket extends ModelEntity
 {
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="userID", type="integer", nullable=true)
      */
     protected $customerId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="articleID", type="integer", nullable=true)
      */
     protected $articleId;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="ordernumber", type="string", length=255, nullable=true)
      */
@@ -88,7 +88,7 @@ class Basket extends ModelEntity
     private $sessionId;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="partnerID", type="string", length=45, nullable=true)
      */
@@ -301,7 +301,7 @@ class Basket extends ModelEntity
     }
 
     /**
-     * @param string $partnerId
+     * @param string|null $partnerId
      */
     public function setPartnerId($partnerId)
     {
@@ -309,7 +309,7 @@ class Basket extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPartnerId()
     {
@@ -429,7 +429,7 @@ class Basket extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getOrderNumber()
     {
@@ -453,7 +453,7 @@ class Basket extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getArticleId()
     {
@@ -469,7 +469,7 @@ class Basket extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getCustomerId()
     {

--- a/engine/Shopware/Models/Order/Billing.php
+++ b/engine/Shopware/Models/Order/Billing.php
@@ -60,7 +60,7 @@ class Billing extends ModelEntity
     use AttributeCleanerTrait;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="title", type="string", length=100, nullable=true)
      */
@@ -69,7 +69,7 @@ class Billing extends ModelEntity
     /**
      * Contains the additional address line data
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="additional_address_line1", type="string", length=255, nullable=true)
      */
@@ -78,7 +78,7 @@ class Billing extends ModelEntity
     /**
      * Contains the additional address line data 2
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="additional_address_line2", type="string", length=255, nullable=true)
      */
@@ -87,7 +87,7 @@ class Billing extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var OrderBillingAttribute
+     * @var OrderBillingAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\OrderBilling", mappedBy="orderBilling", orphanRemoval=true, cascade={"persist"})
      */
@@ -119,7 +119,7 @@ class Billing extends ModelEntity
      * If of the associated customer. Used as foreign key for the
      * customer - billing association.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="userID", type="integer", nullable=true)
      */
@@ -137,7 +137,7 @@ class Billing extends ModelEntity
     /**
      * Contains the id of the state. Used for billing - state association.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="stateID", type="integer", nullable=true)
      */
@@ -173,7 +173,7 @@ class Billing extends ModelEntity
     /**
      * Contains the unique customer number
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="customernumber", type="string", length=30, nullable=true)
      */
@@ -236,7 +236,7 @@ class Billing extends ModelEntity
     /**
      * Contains the vat id of the billing address
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="ustid", type="string", length=50, nullable=true)
      */
@@ -246,7 +246,7 @@ class Billing extends ModelEntity
      * The customer property is the owning side of the association between customer and billing.
      * The association is joined over the billing userID and the customer id
      *
-     * @var \Shopware\Models\Customer\Customer
+     * @var \Shopware\Models\Customer\Customer|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Customer\Customer")
      * @ORM\JoinColumn(name="userID", referencedColumnName="id")
@@ -273,7 +273,7 @@ class Billing extends ModelEntity
     private $country;
 
     /**
-     * @var \Shopware\Models\Country\State
+     * @var \Shopware\Models\Country\State|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Country\State")
      * @ORM\JoinColumn(name="stateID", referencedColumnName="id")
@@ -365,7 +365,7 @@ class Billing extends ModelEntity
     /**
      * Setter function for the customer number column property.
      *
-     * @param string $number
+     * @param string|null $number
      *
      * @return Billing
      */
@@ -379,7 +379,7 @@ class Billing extends ModelEntity
     /**
      * Getter function for the customer number column property.
      *
-     * @return string
+     * @return string|null
      */
     public function getNumber()
     {
@@ -534,7 +534,7 @@ class Billing extends ModelEntity
      * Setter function for the vatId column property.
      * The vatId will be saved in the ustId table field.
      *
-     * @param string $vatId
+     * @param string|null $vatId
      *
      * @return Billing
      */
@@ -549,7 +549,7 @@ class Billing extends ModelEntity
      * Getter function for the vatId column property.
      * The vatId is saved in the ustId table field.
      *
-     * @return string
+     * @return string|null
      */
     public function getVatId()
     {
@@ -562,7 +562,7 @@ class Billing extends ModelEntity
      * the Customer.billing property (INVERSE SIDE) and the Billing.customer (OWNING SIDE) property.
      * The customer data is joined over the s_user.id field.
      *
-     * @return \Shopware\Models\Customer\Customer
+     * @return \Shopware\Models\Customer\Customer|null
      */
     public function getCustomer()
     {
@@ -631,7 +631,7 @@ class Billing extends ModelEntity
     /**
      * Getter for the state association
      *
-     * @return \Shopware\Models\Country\State
+     * @return \Shopware\Models\Country\State|null
      */
     public function getState()
     {
@@ -639,7 +639,7 @@ class Billing extends ModelEntity
     }
 
     /**
-     * @return OrderBillingAttribute
+     * @return OrderBillingAttribute|null
      */
     public function getAttribute()
     {
@@ -659,7 +659,7 @@ class Billing extends ModelEntity
     /**
      * Setter function for the setAdditionalAddressLine2 column property.
      *
-     * @param string $additionalAddressLine2
+     * @param string|null $additionalAddressLine2
      */
     public function setAdditionalAddressLine2($additionalAddressLine2)
     {
@@ -669,7 +669,7 @@ class Billing extends ModelEntity
     /**
      * Getter function for the getAdditionalAddressLine2 column property.
      *
-     * @return string
+     * @return string|null
      */
     public function getAdditionalAddressLine2()
     {
@@ -679,7 +679,7 @@ class Billing extends ModelEntity
     /**
      * Setter function for the setAdditionalAddressLine1 column property.
      *
-     * @param string $additionalAddressLine1
+     * @param string|null $additionalAddressLine1
      */
     public function setAdditionalAddressLine1($additionalAddressLine1)
     {
@@ -689,7 +689,7 @@ class Billing extends ModelEntity
     /**
      * Getter function for the getAdditionalAddressLine1 column property.
      *
-     * @return string
+     * @return string|null
      */
     public function getAdditionalAddressLine1()
     {
@@ -727,7 +727,7 @@ class Billing extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getTitle()
     {
@@ -735,7 +735,7 @@ class Billing extends ModelEntity
     }
 
     /**
-     * @param string $title
+     * @param string|null $title
      */
     public function setTitle($title)
     {

--- a/engine/Shopware/Models/Order/Detail.php
+++ b/engine/Shopware/Models/Order/Detail.php
@@ -80,7 +80,7 @@ class Detail extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\OrderDetail
+     * @var \Shopware\Models\Attribute\OrderDetail|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\OrderDetail", mappedBy="orderDetail", orphanRemoval=true, cascade={"persist"})
      */
@@ -159,7 +159,7 @@ class Detail extends ModelEntity
     private $articleDetailID;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="ordernumber", type="string", length=255, nullable=true)
      */
@@ -216,7 +216,7 @@ class Detail extends ModelEntity
     private $shippedGroup = 0;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="releasedate", type="date", nullable=true)
      */
@@ -244,21 +244,21 @@ class Detail extends ModelEntity
     private $config = '';
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="ean", type="string", length=255, nullable=true)
      */
     private $ean;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="unit", type="string", length=255, nullable=true)
      */
     private $unit;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="pack_unit", type="string", length=255, nullable=true)
      */
@@ -291,7 +291,7 @@ class Detail extends ModelEntity
     /**
      * Get number
      *
-     * @return string
+     * @return string|null
      */
     public function getNumber()
     {
@@ -458,7 +458,7 @@ class Detail extends ModelEntity
     /**
      * Set releaseDate
      *
-     * @param \DateTimeInterface $releaseDate
+     * @param \DateTimeInterface|null $releaseDate
      *
      * @return Detail
      */
@@ -472,7 +472,7 @@ class Detail extends ModelEntity
     /**
      * Get releaseDate
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getReleaseDate()
     {
@@ -729,7 +729,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Attribute\OrderDetail
+     * @return \Shopware\Models\Attribute\OrderDetail|null
      */
     public function getAttribute()
     {
@@ -795,7 +795,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @param string $ean
+     * @param string|null $ean
      */
     public function setEan($ean)
     {
@@ -803,7 +803,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getEan()
     {
@@ -811,7 +811,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @param string $unit
+     * @param string|null $unit
      */
     public function setUnit($unit)
     {
@@ -819,7 +819,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getUnit()
     {
@@ -827,7 +827,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @param string $packUnit
+     * @param string|null $packUnit
      */
     public function setPackUnit($packUnit)
     {
@@ -835,7 +835,7 @@ class Detail extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPackUnit()
     {

--- a/engine/Shopware/Models/Order/Document/Document.php
+++ b/engine/Shopware/Models/Order/Document/Document.php
@@ -70,7 +70,7 @@ if ($documentIdConversion->isDocumentIdUpperCase()) {
          *
          * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Document", mappedBy="document", orphanRemoval=true, cascade={"persist"})
          *
-         * @var \Shopware\Models\Attribute\Document
+         * @var \Shopware\Models\Attribute\Document|null
          */
         protected $attribute;
 
@@ -351,7 +351,7 @@ if ($documentIdConversion->isDocumentIdUpperCase()) {
         }
 
         /**
-         * @return \Shopware\Models\Attribute\Document
+         * @return \Shopware\Models\Attribute\Document|null
          */
         public function getAttribute()
         {
@@ -390,7 +390,7 @@ if ($documentIdConversion->isDocumentIdUpperCase()) {
         /**
          * INVERSE SIDE
          *
-         * @var \Shopware\Models\Attribute\Document
+         * @var \Shopware\Models\Attribute\Document|null
          *
          * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Document", mappedBy="document", orphanRemoval=true, cascade={"persist"})
          */
@@ -673,7 +673,7 @@ if ($documentIdConversion->isDocumentIdUpperCase()) {
         }
 
         /**
-         * @return \Shopware\Models\Attribute\Document
+         * @return \Shopware\Models\Attribute\Document|null
          */
         public function getAttribute()
         {

--- a/engine/Shopware/Models/Order/Esd.php
+++ b/engine/Shopware/Models/Order/Esd.php
@@ -82,7 +82,7 @@ class Esd extends ModelEntity
     private $id;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="datum", type="datetime", nullable=true)
      */
@@ -129,7 +129,7 @@ class Esd extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getDate()
     {

--- a/engine/Shopware/Models/Order/History.php
+++ b/engine/Shopware/Models/Order/History.php
@@ -86,7 +86,7 @@ class History extends ModelEntity
      * The $userId property contains the unique user id of the user which changed the order status.
      * Used for the $user association property.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="userID", type="integer", nullable=true)
      */
@@ -96,7 +96,7 @@ class History extends ModelEntity
      * The $previousOrderStatusId property contains the id of the previous order status of the order.
      * Used for the $previousOrderStatus association property.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="previous_order_status_id", type="integer", nullable=true)
      */
@@ -106,7 +106,7 @@ class History extends ModelEntity
      * The $orderStatusId property contains the id of the current order status of the order.
      * Used for the $orderStatus association property.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="order_status_id", type="integer", nullable=true)
      */
@@ -116,7 +116,7 @@ class History extends ModelEntity
      * The $previousPaymentStatusId property contains the id of the previous payment status of the order.
      * Used for the $previousPaymentStatus association property.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="previous_payment_status_id", type="integer", nullable=true)
      */
@@ -126,7 +126,7 @@ class History extends ModelEntity
      * The $paymentStatusId property contains the id of the current payment status of the order.
      * Used for the $paymentStatus association property.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="payment_status_id", type="integer", nullable=true)
      */
@@ -160,7 +160,7 @@ class History extends ModelEntity
      * user model. This association is an uni-directional association. That means that the user model
      * don't know anything about the order status history.
      *
-     * @var \Shopware\Models\User\User
+     * @var \Shopware\Models\User\User|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\User\User")
      * @ORM\JoinColumn(name="userID", referencedColumnName="id")
@@ -173,7 +173,7 @@ class History extends ModelEntity
      * previous order status model. This association is an uni-directional association. That means that the order
      * status model don't know anything about the order status history.
      *
-     * @var \Shopware\Models\Order\Status
+     * @var \Shopware\Models\Order\Status|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Order\Status")
      * @ORM\JoinColumn(name="previous_order_status_id", referencedColumnName="id")
@@ -186,7 +186,7 @@ class History extends ModelEntity
      * current order status model. This association is an uni-directional association. That means that the order
      * status model don't know anything about the order status history.
      *
-     * @var \Shopware\Models\Order\Status
+     * @var \Shopware\Models\Order\Status|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Order\Status")
      * @ORM\JoinColumn(name="order_status_id", referencedColumnName="id")
@@ -199,7 +199,7 @@ class History extends ModelEntity
      * previous payment status model. This association is an uni-directional association. That means that the payment
      * status model don't know anything about the order status history.
      *
-     * @var \Shopware\Models\Order\Status
+     * @var \Shopware\Models\Order\Status|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Order\Status")
      * @ORM\JoinColumn(name="previous_payment_status_id", referencedColumnName="id")
@@ -212,7 +212,7 @@ class History extends ModelEntity
      * current payment status model. This association is an uni-directional association. That means that the payment
      * status model don't know anything about the order status history.
      *
-     * @var \Shopware\Models\Order\Status
+     * @var \Shopware\Models\Order\Status|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Order\Status")
      * @ORM\JoinColumn(name="payment_status_id", referencedColumnName="id")
@@ -265,7 +265,7 @@ class History extends ModelEntity
      * user model. This association is an uni-directional association. That means that the user model
      * don't know anything about the order status history.
      *
-     * @return \Shopware\Models\User\User
+     * @return \Shopware\Models\User\User|null
      */
     public function getUser()
     {
@@ -355,7 +355,7 @@ class History extends ModelEntity
      * current order status model. This association is an uni-directional association. That means that the order
      * status model don't know anything about the order status history.
      *
-     * @return \Shopware\Models\Order\Status
+     * @return \Shopware\Models\Order\Status|null
      */
     public function getOrderStatus()
     {
@@ -387,7 +387,7 @@ class History extends ModelEntity
      * current payment status model. This association is an uni-directional association. That means that the payment
      * status model don't know anything about the order status history.
      *
-     * @return \Shopware\Models\Order\Status
+     * @return \Shopware\Models\Order\Status|null
      */
     public function getPaymentStatus()
     {
@@ -419,7 +419,7 @@ class History extends ModelEntity
      * previous order status model. This association is an uni-directional association. That means that the order
      * status model don't know anything about the order status history.
      *
-     * @return \Shopware\Models\Order\Status
+     * @return \Shopware\Models\Order\Status|null
      */
     public function getPreviousOrderStatus()
     {
@@ -451,7 +451,7 @@ class History extends ModelEntity
      * previous payment status model. This association is an uni-directional association. That means that the payment
      * status model don't know anything about the order status history.
      *
-     * @return \Shopware\Models\Order\Status
+     * @return \Shopware\Models\Order\Status|null
      */
     public function getPreviousPaymentStatus()
     {

--- a/engine/Shopware/Models/Order/Order.php
+++ b/engine/Shopware/Models/Order/Order.php
@@ -95,7 +95,7 @@ class Order extends ModelEntity
     protected $payment;
 
     /**
-     * @var \Shopware\Models\Dispatch\Dispatch
+     * @var \Shopware\Models\Dispatch\Dispatch|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Dispatch\Dispatch")
      * @ORM\JoinColumn(name="dispatchID", referencedColumnName="id")
@@ -128,7 +128,7 @@ class Order extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\Order
+     * @var \Shopware\Models\Attribute\Order|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Order", mappedBy="order", orphanRemoval=true, cascade={"persist"})
      */
@@ -241,7 +241,7 @@ class Order extends ModelEntity
     /**
      * Contains the alphanumeric order number. If the
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="ordernumber", type="string", length=255, nullable=true)
      */
@@ -276,7 +276,7 @@ class Order extends ModelEntity
     private $paymentId;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="dispatchID", type="integer", nullable=true)
      */
@@ -333,7 +333,7 @@ class Order extends ModelEntity
     private $invoiceShippingNet;
 
     /**
-     * @var float
+     * @var float|null
      *
      * @ORM\Column(name="invoice_shipping_tax_rate", type="decimal", nullable=true)
      */
@@ -407,7 +407,7 @@ class Order extends ModelEntity
     private $referer;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="cleareddate", type="datetime", nullable=true)
      */
@@ -458,14 +458,14 @@ class Order extends ModelEntity
     private $currencyFactor;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="remote_addr", type="string", length=255, nullable=true)
      */
     private $remoteAddress;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="deviceType", type="string", length=50, nullable=true)
      */
@@ -521,7 +521,7 @@ class Order extends ModelEntity
     /**
      * Get number
      *
-     * @return string
+     * @return string|null
      */
     public function getNumber()
     {
@@ -625,7 +625,7 @@ class Order extends ModelEntity
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getInvoiceShippingTaxRate()
     {
@@ -633,7 +633,7 @@ class Order extends ModelEntity
     }
 
     /**
-     * @param float $invoiceShippingTaxRate
+     * @param float|null $invoiceShippingTaxRate
      */
     public function setInvoiceShippingTaxRate($invoiceShippingTaxRate)
     {
@@ -862,7 +862,7 @@ class Order extends ModelEntity
     /**
      * Set clearedDate
      *
-     * @param \DateTimeInterface|string $clearedDate
+     * @param \DateTimeInterface|string|null $clearedDate
      *
      * @return Order
      */
@@ -879,7 +879,7 @@ class Order extends ModelEntity
     /**
      * Get clearedDate
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getClearedDate()
     {
@@ -999,7 +999,7 @@ class Order extends ModelEntity
     /**
      * Get remoteAddress
      *
-     * @return string
+     * @return string|null
      */
     public function getRemoteAddress()
     {
@@ -1039,7 +1039,7 @@ class Order extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Dispatch\Dispatch
+     * @return \Shopware\Models\Dispatch\Dispatch|null
      */
     public function getDispatch()
     {
@@ -1111,7 +1111,7 @@ class Order extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Order\Shipping|null $shipping
+     * @param \Shopware\Models\Order\Shipping $shipping
      *
      * @return Order
      */
@@ -1129,7 +1129,7 @@ class Order extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Order\Billing|null $billing
+     * @param \Shopware\Models\Order\Billing $billing
      *
      * @return Order
      */
@@ -1217,7 +1217,7 @@ class Order extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Attribute\Order
+     * @return \Shopware\Models\Attribute\Order|null
      */
     public function getAttribute()
     {
@@ -1317,7 +1317,7 @@ class Order extends ModelEntity
     }
 
     /**
-     * @param string $deviceType
+     * @param string|null $deviceType
      */
     public function setDeviceType($deviceType)
     {
@@ -1325,7 +1325,7 @@ class Order extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDeviceType()
     {

--- a/engine/Shopware/Models/Order/Shipping.php
+++ b/engine/Shopware/Models/Order/Shipping.php
@@ -61,7 +61,7 @@ class Shipping extends ModelEntity
     use AttributeCleanerTrait;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="title", type="string", length=100, nullable=true)
      */
@@ -70,7 +70,7 @@ class Shipping extends ModelEntity
     /**
      * Contains the additional address line data
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="additional_address_line1", type="string", length=255, nullable=true)
      */
@@ -79,7 +79,7 @@ class Shipping extends ModelEntity
     /**
      * Contains the additional address line data 2
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="additional_address_line2", type="string", length=255, nullable=true)
      */
@@ -89,7 +89,7 @@ class Shipping extends ModelEntity
      * The customer property is the owning side of the association between customer and shipping.
      * The association is joined over the shipping userID and the customer id
      *
-     * @var \Shopware\Models\Customer\Customer
+     * @var \Shopware\Models\Customer\Customer|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Customer\Customer")
      * @ORM\JoinColumn(name="userID", referencedColumnName="id")
@@ -118,7 +118,7 @@ class Shipping extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var OrderShippingAttribute
+     * @var OrderShippingAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\OrderShipping", mappedBy="orderShipping", orphanRemoval=true, cascade={"persist"})
      */
@@ -158,7 +158,7 @@ class Shipping extends ModelEntity
     /**
      * Contains the id of the state. Used for billing - state association.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="stateID", type="integer", nullable=true)
      */
@@ -168,7 +168,7 @@ class Shipping extends ModelEntity
      * If of the associated customer. Used as foreign key for the
      * customer - shipping association.
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="userID", type="integer", nullable=true)
      */
@@ -256,7 +256,7 @@ class Shipping extends ModelEntity
     private $phone = '';
 
     /**
-     * @var State
+     * @var State|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Country\State")
      * @ORM\JoinColumn(name="stateID", referencedColumnName="id")
@@ -495,7 +495,7 @@ class Shipping extends ModelEntity
      * the Customer.shipping property (INVERSE SIDE) and the Shipping.customer (OWNING SIDE) property.
      * The customer data is joined over the s_user.id field.
      *
-     * @return \Shopware\Models\Customer\Customer
+     * @return \Shopware\Models\Customer\Customer|null
      */
     public function getCustomer()
     {
@@ -568,7 +568,7 @@ class Shipping extends ModelEntity
     }
 
     /**
-     * @return OrderShippingAttribute
+     * @return OrderShippingAttribute|null
      */
     public function getAttribute()
     {
@@ -598,7 +598,7 @@ class Shipping extends ModelEntity
     /**
      * Getter function for the getAdditionalAddressLine2 column property.
      *
-     * @return string
+     * @return string|null
      */
     public function getAdditionalAddressLine2()
     {
@@ -618,7 +618,7 @@ class Shipping extends ModelEntity
     /**
      * Getter function for the getAdditionalAddressLine1 column property.
      *
-     * @return string
+     * @return string|null
      */
     public function getAdditionalAddressLine1()
     {
@@ -653,7 +653,7 @@ class Shipping extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getTitle()
     {

--- a/engine/Shopware/Models/Order/Status.php
+++ b/engine/Shopware/Models/Order/Status.php
@@ -244,7 +244,7 @@ class Status extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Mail\Mail|array|null $mail
+     * @param \Shopware\Models\Mail\Mail|array $mail
      *
      * @return Status
      */

--- a/engine/Shopware/Models/Partner/Partner.php
+++ b/engine/Shopware/Models/Partner/Partner.php
@@ -46,7 +46,7 @@ class Partner extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\Partner
+     * @var \Shopware\Models\Attribute\Partner|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Partner", mappedBy="partner", orphanRemoval=true, cascade={"persist"})
      */
@@ -181,7 +181,7 @@ class Partner extends ModelEntity
     private $active = 0;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="userID", type="integer", nullable=true)
      */
@@ -230,7 +230,7 @@ class Partner extends ModelEntity
     }
 
     /**
-     * @param \DateTimeInterface|string|null $date
+     * @param \DateTimeInterface|string $date
      *
      * @return Partner
      */
@@ -584,7 +584,7 @@ class Partner extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getCustomerId()
     {
@@ -600,7 +600,7 @@ class Partner extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Attribute\Partner
+     * @return \Shopware\Models\Attribute\Partner|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Payment/Payment.php
+++ b/engine/Shopware/Models/Payment/Payment.php
@@ -68,7 +68,7 @@ class Payment extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var PaymentAttribute
+     * @var PaymentAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Payment", mappedBy="payment", orphanRemoval=true, cascade={"persist"})
      */
@@ -218,21 +218,21 @@ class Payment extends ModelEntity
     private $hideProspect = 0;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="action", type="string", length=255, nullable=true)
      */
     private $action;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="pluginID", type="integer", nullable=true)
      */
     private $pluginId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="source", type="integer", nullable=true)
      */
@@ -658,7 +658,7 @@ class Payment extends ModelEntity
     /**
      * Sets the action of a payment
      *
-     * @param string $action
+     * @param string|null $action
      *
      * @return Payment
      */
@@ -672,7 +672,7 @@ class Payment extends ModelEntity
     /**
      * Gets the action of a payment
      *
-     * @return string
+     * @return string|null
      */
     public function getAction()
     {
@@ -798,7 +798,7 @@ class Payment extends ModelEntity
     }
 
     /**
-     * @return PaymentAttribute
+     * @return PaymentAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Payment/PaymentInstance.php
+++ b/engine/Shopware/Models/Payment/PaymentInstance.php
@@ -73,77 +73,77 @@ class PaymentInstance extends ModelEntity
     protected $customer;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="firstname", type="string", length=255, nullable=true)
      */
     protected $firstName;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="lastname", type="string", length=255, nullable=true)
      */
     protected $lastName;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="address", type="string", length=255, nullable=true)
      */
     protected $address;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="zipcode", type="string", length=15, nullable=true)
      */
     protected $zipCode;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="city", type="string", length=50, nullable=true)
      */
     protected $city;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="bank_name", type="string", length=255, nullable=true)
      */
     protected $bankName;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="bank_code", type="string", length=255, nullable=true)
      */
     protected $bankCode;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="account_number", type="string", length=50, nullable=true)
      */
     protected $accountNumber;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="account_holder", type="string", length=255, nullable=true)
      */
     protected $accountHolder;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="bic", type="string", length=50, nullable=true)
      */
     protected $bic;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="iban", type="string", length=50, nullable=true)
      */
@@ -196,7 +196,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getAddress()
     {
@@ -212,7 +212,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBankName()
     {
@@ -228,7 +228,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBic()
     {
@@ -244,7 +244,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCity()
     {
@@ -292,7 +292,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFirstName()
     {
@@ -308,7 +308,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getIban()
     {
@@ -324,7 +324,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLastName()
     {
@@ -372,7 +372,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getZipCode()
     {
@@ -404,7 +404,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getAccountHolder()
     {
@@ -420,7 +420,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getAccountNumber()
     {
@@ -436,7 +436,7 @@ class PaymentInstance extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBankCode()
     {

--- a/engine/Shopware/Models/Plugin/License.php
+++ b/engine/Shopware/Models/Plugin/License.php
@@ -98,42 +98,42 @@ class License extends ModelEntity
     private $source;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="added", type="date", nullable=true)
      */
     private $added;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="creation", type="date", nullable=true)
      */
     private $creation;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="expiration", type="date", nullable=true)
      */
     private $expiration;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="active", type="integer", nullable=true)
      */
     private $active;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="plugin_id", type="integer", nullable=true)
      */
     private $pluginId;
 
     /**
-     * @var \Shopware\Models\Plugin\Plugin
+     * @var \Shopware\Models\Plugin\Plugin|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Plugin\Plugin", inversedBy="licenses")
      * @ORM\JoinColumn(name="plugin_id", referencedColumnName="id")
@@ -157,7 +157,7 @@ class License extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getActive()
     {
@@ -173,7 +173,7 @@ class License extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getAdded()
     {
@@ -189,7 +189,7 @@ class License extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getCreation()
     {
@@ -205,7 +205,7 @@ class License extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getExpiration()
     {
@@ -293,7 +293,7 @@ class License extends ModelEntity
     }
 
     /**
-     * @param Plugin $plugin
+     * @param Plugin|null $plugin
      */
     public function setPlugin($plugin)
     {
@@ -301,7 +301,7 @@ class License extends ModelEntity
     }
 
     /**
-     * @return Plugin
+     * @return Plugin|null
      */
     public function getPlugin()
     {

--- a/engine/Shopware/Models/Plugin/Plugin.php
+++ b/engine/Shopware/Models/Plugin/Plugin.php
@@ -104,35 +104,35 @@ class Plugin extends ModelEntity
     private $added;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="installation_date", type="datetime", nullable=true)
      */
     private $installed;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="update_date", type="datetime", nullable=true)
      */
     private $updated;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="refresh_date", type="datetime", nullable=true)
      */
     private $refreshed;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="author", type="string", nullable=true)
      */
     private $author;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="copyright", type="string", nullable=true)
      */
@@ -441,7 +441,7 @@ class Plugin extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getUpdated()
     {
@@ -449,7 +449,7 @@ class Plugin extends ModelEntity
     }
 
     /**
-     * @param \DateTimeInterface $updated
+     * @param \DateTimeInterface|null $updated
      */
     public function setUpdated($updated)
     {
@@ -457,7 +457,7 @@ class Plugin extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getAuthor()
     {
@@ -465,7 +465,7 @@ class Plugin extends ModelEntity
     }
 
     /**
-     * @param string $author
+     * @param string|null $author
      */
     public function setAuthor($author)
     {
@@ -473,7 +473,7 @@ class Plugin extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCopyright()
     {
@@ -481,7 +481,7 @@ class Plugin extends ModelEntity
     }
 
     /**
-     * @param string $copyright
+     * @param string|null $copyright
      */
     public function setCopyright($copyright)
     {

--- a/engine/Shopware/Models/Price/Discount.php
+++ b/engine/Shopware/Models/Price/Discount.php
@@ -45,7 +45,7 @@ class Discount extends ModelEntity
     private $id;
 
     /**
-     * @var \Shopware\Models\Price\Group
+     * @var \Shopware\Models\Price\Group|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Price\Group", inversedBy="discounts")
      * @ORM\JoinColumn(name="groupID", referencedColumnName="id")
@@ -53,7 +53,7 @@ class Discount extends ModelEntity
     private $group;
 
     /**
-     * @var \Shopware\Models\Customer\Group
+     * @var \Shopware\Models\Customer\Group|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Customer\Group")
      * @ORM\JoinColumn(name="customergroupID", referencedColumnName="id")
@@ -75,14 +75,14 @@ class Discount extends ModelEntity
     private $start;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="customergroupID", type="integer", nullable=true)
      */
     private $customerGroupId = null;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="groupID", type="integer", nullable=true)
      */
@@ -115,7 +115,7 @@ class Discount extends ModelEntity
     /**
      * Get group
      *
-     * @return Group
+     * @return Group|null
      */
     public function getGroup()
     {
@@ -139,7 +139,7 @@ class Discount extends ModelEntity
     /**
      * Get customerGroup
      *
-     * @return \Shopware\Models\Customer\Group
+     * @return \Shopware\Models\Customer\Group|null
      */
     public function getCustomerGroup()
     {
@@ -195,7 +195,7 @@ class Discount extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getCustomerGroupId()
     {

--- a/engine/Shopware/Models/ProductFeed/ProductFeed.php
+++ b/engine/Shopware/Models/ProductFeed/ProductFeed.php
@@ -50,7 +50,7 @@ class ProductFeed extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductFeedAttribute
+     * @var ProductFeedAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ProductFeed", mappedBy="productFeed", orphanRemoval=true, cascade={"persist"})
      */
@@ -150,35 +150,35 @@ class ProductFeed extends ModelEntity
     private $encodingId = 1;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="categoryID", type="integer", nullable=true)
      */
     private $categoryId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="currencyID", type="integer", nullable=true)
      */
     private $currencyId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="customergroupID", type="integer", nullable=true)
      */
     private $customerGroupId;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="partnerID", type="string", length=255, nullable=true)
      */
     private $partnerId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="languageID", type="integer", nullable=true)
      */
@@ -255,14 +255,14 @@ class ProductFeed extends ModelEntity
     private $countFilter;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="multishopID", type="integer", nullable=true)
      */
     private $shopId;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="cache_refreshed", type="datetime", nullable=true)
      */
@@ -618,7 +618,7 @@ class ProductFeed extends ModelEntity
     /**
      * Set categoryId
      *
-     * @param int $categoryId
+     * @param int|null $categoryId
      *
      * @return ProductFeed
      */
@@ -632,7 +632,7 @@ class ProductFeed extends ModelEntity
     /**
      * Get categoryId
      *
-     * @return int
+     * @return int|null
      */
     public function getCategoryId()
     {
@@ -656,7 +656,7 @@ class ProductFeed extends ModelEntity
     /**
      * Get currencyId
      *
-     * @return int
+     * @return int|null
      */
     public function getCurrencyId()
     {
@@ -680,7 +680,7 @@ class ProductFeed extends ModelEntity
     /**
      * Get customerGroupId
      *
-     * @return int
+     * @return int|null
      */
     public function getCustomerGroupId()
     {
@@ -704,7 +704,7 @@ class ProductFeed extends ModelEntity
     /**
      * Get partnerId
      *
-     * @return string
+     * @return string|null
      */
     public function getPartnerId()
     {
@@ -714,7 +714,7 @@ class ProductFeed extends ModelEntity
     /**
      * Set languageId
      *
-     * @param int $languageId
+     * @param int|null $languageId
      *
      * @return ProductFeed
      */
@@ -728,7 +728,7 @@ class ProductFeed extends ModelEntity
     /**
      * Get languageId
      *
-     * @return int
+     * @return int|null
      */
     public function getLanguageId()
     {
@@ -992,7 +992,7 @@ class ProductFeed extends ModelEntity
     /**
      * Get shopId
      *
-     * @return int
+     * @return int|null
      */
     public function getShopId()
     {
@@ -1076,7 +1076,7 @@ class ProductFeed extends ModelEntity
     }
 
     /**
-     * @return ProductFeedAttribute
+     * @return ProductFeedAttribute|null
      */
     public function getAttribute()
     {
@@ -1096,7 +1096,7 @@ class ProductFeed extends ModelEntity
     /**
      * Set cache refreshed datetime
      *
-     * @param \DateTimeInterface|string $cacheRefreshed
+     * @param \DateTimeInterface|string|null $cacheRefreshed
      *
      * @return ProductFeed
      */
@@ -1113,7 +1113,7 @@ class ProductFeed extends ModelEntity
     /**
      * Get cache refreshed datetime
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getCacheRefreshed()
     {

--- a/engine/Shopware/Models/ProductStream/ProductStream.php
+++ b/engine/Shopware/Models/ProductStream/ProductStream.php
@@ -37,7 +37,7 @@ class ProductStream extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var ProductStreamAttribute
+     * @var ProductStreamAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\ProductStream", mappedBy="productStream", orphanRemoval=true, cascade={"persist"})
      */
@@ -83,14 +83,14 @@ class ProductStream extends ModelEntity
     private $sorting;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="conditions", type="string", nullable=true)
      */
-    private $conditions = true;
+    private $conditions;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="sorting_id", type="integer", nullable=true)
      */
@@ -137,7 +137,7 @@ class ProductStream extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getConditions()
     {
@@ -187,7 +187,7 @@ class ProductStream extends ModelEntity
     }
 
     /**
-     * @return ProductStreamAttribute
+     * @return ProductStreamAttribute|null
      */
     public function getAttribute()
     {
@@ -205,7 +205,7 @@ class ProductStream extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getSortingId()
     {

--- a/engine/Shopware/Models/Property/Group.php
+++ b/engine/Shopware/Models/Property/Group.php
@@ -41,7 +41,7 @@ class Group extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var PropertyGroupAttribute
+     * @var PropertyGroupAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\PropertyGroup", mappedBy="propertyGroup", orphanRemoval=true, cascade={"persist"})
      */
@@ -280,7 +280,7 @@ class Group extends ModelEntity
     }
 
     /**
-     * @return PropertyGroupAttribute
+     * @return PropertyGroupAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Property/Option.php
+++ b/engine/Shopware/Models/Property/Option.php
@@ -47,7 +47,7 @@ class Option extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var PropertyOptionAttribute
+     * @var PropertyOptionAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\PropertyOption", mappedBy="propertyOption", orphanRemoval=true, cascade={"persist"})
      */
@@ -189,7 +189,7 @@ class Option extends ModelEntity
     }
 
     /**
-     * @return PropertyOptionAttribute
+     * @return PropertyOptionAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Property/Relation.php
+++ b/engine/Shopware/Models/Property/Relation.php
@@ -47,7 +47,7 @@ class Relation extends ModelEntity
     /**
      * The resource property is the owning side of the association between relation and group.
      *
-     * @var \Shopware\Models\Property\Group
+     * @var \Shopware\Models\Property\Group|null
      * @ORM\ManyToOne(targetEntity="\Shopware\Models\Property\Group", inversedBy="relations")
      * @ORM\JoinColumn(name="groupID", referencedColumnName="id", nullable=true)
      */
@@ -56,14 +56,14 @@ class Relation extends ModelEntity
     /**
      * @ORM\Column(name="groupID", type="integer", nullable=true)
      *
-     * @var int
+     * @var int|null
      */
     private $groupId;
 
     /**
      * The resource property is the owning side of the association between relation and option.
      *
-     * @var \Shopware\Models\Property\Option
+     * @var \Shopware\Models\Property\Option|null
      * @ORM\ManyToOne(targetEntity="\Shopware\Models\Property\Option", inversedBy="relations")
      * @ORM\JoinColumn(name="optionID", referencedColumnName="id", nullable=true)
      */
@@ -72,7 +72,7 @@ class Relation extends ModelEntity
     /**
      * @ORM\Column(name="optionID", type="integer", nullable=true)
      *
-     * @var int
+     * @var int|null
      */
     private $optionId;
 
@@ -102,7 +102,7 @@ class Relation extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Property\Option
+     * @return \Shopware\Models\Property\Option|null
      */
     public function getOption()
     {
@@ -118,7 +118,7 @@ class Relation extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Property\Group
+     * @return \Shopware\Models\Property\Group|null
      */
     public function getGroup()
     {

--- a/engine/Shopware/Models/Property/Value.php
+++ b/engine/Shopware/Models/Property/Value.php
@@ -41,7 +41,7 @@ class Value extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var PropertyValueAttribute
+     * @var PropertyValueAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\PropertyValue", mappedBy="propertyValue", orphanRemoval=true, cascade={"persist"})
      */
@@ -101,14 +101,14 @@ class Value extends ModelEntity
     private $articles;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="media_id", type="integer", nullable=true)
      */
     private $mediaId;
 
     /**
-     * @var Media
+     * @var Media|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Media\Media", inversedBy="properties")
      * @ORM\JoinColumn(name="media_id", referencedColumnName="id")
@@ -200,7 +200,7 @@ class Value extends ModelEntity
     }
 
     /**
-     * @return Media
+     * @return Media|null
      */
     public function getMedia()
     {
@@ -208,7 +208,7 @@ class Value extends ModelEntity
     }
 
     /**
-     * @param Media $media
+     * @param Media|null $media
      */
     public function setMedia($media)
     {
@@ -216,7 +216,7 @@ class Value extends ModelEntity
     }
 
     /**
-     * @return PropertyValueAttribute
+     * @return PropertyValueAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Search/CustomFacet.php
+++ b/engine/Shopware/Models/Search/CustomFacet.php
@@ -41,7 +41,7 @@ class CustomFacet extends ModelEntity
     protected $name;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="unique_key", nullable=true)
      */
@@ -196,7 +196,7 @@ class CustomFacet extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getUniqueKey()
     {

--- a/engine/Shopware/Models/Search/CustomSorting.php
+++ b/engine/Shopware/Models/Search/CustomSorting.php
@@ -62,7 +62,7 @@ class CustomSorting extends ModelEntity
     protected $position;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(nullable=true)
      */
@@ -118,7 +118,7 @@ class CustomSorting extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getSortings()
     {

--- a/engine/Shopware/Models/Shop/Shop.php
+++ b/engine/Shopware/Models/Shop/Shop.php
@@ -46,14 +46,14 @@ class Shop extends ModelEntity
     protected $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="main_id", type="integer", nullable=true)
      */
     protected $mainId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="category_id", type="integer", nullable=true)
      */
@@ -74,7 +74,7 @@ class Shop extends ModelEntity
     protected $name;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="title", type="string", length=255, nullable=true)
      */
@@ -88,21 +88,21 @@ class Shop extends ModelEntity
     protected $position = 0;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="host", type="string", length=255, nullable=true)
      */
     protected $host;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="base_path", type="string", length=255, nullable=true)
      */
     protected $basePath;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="base_url", type="string", length=255, nullable=true)
      */
@@ -123,14 +123,14 @@ class Shop extends ModelEntity
     protected $secure = false;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="template_id", type="integer", nullable=true)
      */
     protected $templateId;
 
     /**
-     * @var Template
+     * @var Template|null
      *
      * @ORM\ManyToOne(targetEntity="Template", inversedBy="shops")
      * @ORM\JoinColumn(name="template_id", referencedColumnName="id")
@@ -232,7 +232,7 @@ class Shop extends ModelEntity
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Shop", mappedBy="shop", orphanRemoval=true, cascade={"persist"})
      *
-     * @var \Shopware\Models\Attribute\Shop
+     * @var \Shopware\Models\Attribute\Shop|null
      */
     protected $attribute;
 
@@ -270,7 +270,7 @@ class Shop extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getTitle()
     {
@@ -278,7 +278,7 @@ class Shop extends ModelEntity
     }
 
     /**
-     * @param string $title
+     * @param string|null $title
      */
     public function setTitle($title)
     {
@@ -302,7 +302,7 @@ class Shop extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getHost()
     {
@@ -310,7 +310,7 @@ class Shop extends ModelEntity
     }
 
     /**
-     * @param string $host
+     * @param string|null $host
      */
     public function setHost($host)
     {
@@ -318,7 +318,7 @@ class Shop extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBasePath()
     {
@@ -326,7 +326,7 @@ class Shop extends ModelEntity
     }
 
     /**
-     * @param string $basePath
+     * @param string|null $basePath
      */
     public function setBasePath($basePath)
     {
@@ -334,7 +334,7 @@ class Shop extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBaseUrl()
     {
@@ -342,7 +342,7 @@ class Shop extends ModelEntity
     }
 
     /**
-     * @param string $baseUrl
+     * @param string|null $baseUrl
      */
     public function setBaseUrl($baseUrl)
     {
@@ -374,7 +374,7 @@ class Shop extends ModelEntity
     }
 
     /**
-     * @param Template $template
+     * @param Template|null $template
      */
     public function setTemplate($template)
     {
@@ -606,7 +606,7 @@ class Shop extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Attribute\Shop
+     * @return \Shopware\Models\Attribute\Shop|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Shop/Template.php
+++ b/engine/Shopware/Models/Shop/Template.php
@@ -39,7 +39,7 @@ use Shopware\Models\Shop\TemplateConfig\Set;
 class Template extends ModelEntity
 {
     /**
-     * @var \Shopware\Models\Shop\Template
+     * @var \Shopware\Models\Shop\Template|null
      *
      * @ORM\ManyToOne(targetEntity="\Shopware\Models\Shop\Template")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id")
@@ -131,7 +131,7 @@ class Template extends ModelEntity
     /**
      * Author of the template
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="author", type="string", length=255, nullable=true)
      */
@@ -140,7 +140,7 @@ class Template extends ModelEntity
     /**
      * License of the template e.G. BSD / MIT / GPL
      *
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="license", type="string", length=255, nullable=true)
      */
@@ -181,14 +181,14 @@ class Template extends ModelEntity
     private $version = 1;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="plugin_id", type="integer", nullable=true)
      */
     private $pluginId;
 
     /**
-     * @var \Shopware\Models\Plugin\Plugin
+     * @var \Shopware\Models\Plugin\Plugin|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Plugin\Plugin", inversedBy="templates")
      * @ORM\JoinColumn(name="plugin_id", referencedColumnName="id")
@@ -196,7 +196,7 @@ class Template extends ModelEntity
     private $plugin;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parent_id", type="integer", nullable=true)
      */
@@ -253,7 +253,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getAuthor()
     {
@@ -313,7 +313,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLicense()
     {
@@ -409,7 +409,7 @@ class Template extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Plugin\Plugin $plugin
+     * @param \Shopware\Models\Plugin\Plugin|null $plugin
      */
     public function setPlugin($plugin)
     {

--- a/engine/Shopware/Models/Shop/TemplateConfig/Element.php
+++ b/engine/Shopware/Models/Shop/TemplateConfig/Element.php
@@ -84,21 +84,21 @@ class Element extends ModelEntity
     protected $defaultValue;
 
     /**
-     * @var array
+     * @var array|null
      *
      * @ORM\Column(name="selection", type="array", nullable=true)
      */
     protected $selection = null;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="field_label", type="string", nullable=true)
      */
     protected $fieldLabel = null;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="support_text", type="string", nullable=true)
      */
@@ -194,7 +194,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @param string $supportText
+     * @param string|null $supportText
      */
     public function setSupportText($supportText)
     {
@@ -202,7 +202,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getSupportText()
     {
@@ -266,7 +266,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFieldLabel()
     {
@@ -342,7 +342,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @return array
+     * @return array|null
      */
     public function getSelection()
     {
@@ -350,7 +350,7 @@ class Element extends ModelEntity
     }
 
     /**
-     * @param array $selection
+     * @param array|null $selection
      */
     public function setSelection($selection)
     {

--- a/engine/Shopware/Models/Shop/TemplateConfig/Layout.php
+++ b/engine/Shopware/Models/Shop/TemplateConfig/Layout.php
@@ -67,14 +67,14 @@ class Layout extends ModelEntity
     protected $template;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parent_id", type="integer", nullable=true)
      */
     protected $parentId;
 
     /**
-     * @var Layout
+     * @var Layout|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Shop\TemplateConfig\Layout", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", nullable=true, referencedColumnName="id")
@@ -150,7 +150,7 @@ class Layout extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Shop\TemplateConfig\Layout $parent
+     * @param \Shopware\Models\Shop\TemplateConfig\Layout|null $parent
      */
     public function setParent($parent)
     {
@@ -158,7 +158,7 @@ class Layout extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Shop\TemplateConfig\Layout
+     * @return \Shopware\Models\Shop\TemplateConfig\Layout|null
      */
     public function getParent()
     {
@@ -166,7 +166,7 @@ class Layout extends ModelEntity
     }
 
     /**
-     * @param int $parentId
+     * @param int|null $parentId
      */
     public function setParentId($parentId)
     {
@@ -174,7 +174,7 @@ class Layout extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getParentId()
     {

--- a/engine/Shopware/Models/Site/Group.php
+++ b/engine/Shopware/Models/Site/Group.php
@@ -68,7 +68,7 @@ class Group extends ModelEntity
     private $active = true;
 
     /**
-     * @var \Shopware\Models\Site\Group
+     * @var \Shopware\Models\Site\Group|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Site\Group")
      * @ORM\JoinColumn(name="mapping_id", nullable=true, referencedColumnName="id")

--- a/engine/Shopware/Models/Site/Site.php
+++ b/engine/Shopware/Models/Site/Site.php
@@ -41,7 +41,7 @@ class Site extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var SiteAttribute
+     * @var SiteAttribute|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Site", mappedBy="site", orphanRemoval=true, cascade={"persist"})
      */
@@ -193,7 +193,7 @@ class Site extends ModelEntity
     /**
      * The parent category
      *
-     * @var Site
+     * @var Site|null
      *
      * @ORM\ManyToOne(targetEntity="Site", inversedBy="children")
      * @ORM\JoinColumn(name="parentID", referencedColumnName="id")
@@ -201,7 +201,7 @@ class Site extends ModelEntity
     private $parent;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parentID", type="integer", nullable=true)
      */
@@ -479,7 +479,7 @@ class Site extends ModelEntity
     }
 
     /**
-     * @return Site
+     * @return Site|null
      */
     public function getParent()
     {
@@ -487,7 +487,7 @@ class Site extends ModelEntity
     }
 
     /**
-     * @param Site $parent
+     * @param Site|null $parent
      *
      * @return Site
      */
@@ -519,7 +519,7 @@ class Site extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getParentId()
     {
@@ -539,7 +539,7 @@ class Site extends ModelEntity
     }
 
     /**
-     * @return SiteAttribute
+     * @return SiteAttribute|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Tax/Rule.php
+++ b/engine/Shopware/Models/Tax/Rule.php
@@ -77,21 +77,21 @@ class Rule extends ModelEntity
     private $active = false;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="areaID", type="integer", nullable=true)
      */
     private $areaId = null;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="countryID", type="integer", nullable=true)
      */
     private $countryId = null;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="stateID", type="integer", nullable=true)
      */
@@ -115,7 +115,7 @@ class Rule extends ModelEntity
      * The area property is the owning side of the association between tax rule and area.
      * The association is joined over the tax rule areaID field and the id field of the area.
      *
-     * @var \Shopware\Models\Country\Area
+     * @var \Shopware\Models\Country\Area|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Country\Area")
      * @ORM\JoinColumn(name="areaID", referencedColumnName="id")
@@ -126,7 +126,7 @@ class Rule extends ModelEntity
      * The country property is the owning side of the association between tax rule and country.
      * The association is joined over the tax rule countryID field and the id field of the country.
      *
-     * @var \Shopware\Models\Country\Country
+     * @var \Shopware\Models\Country\Country|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Country\Country")
      * @ORM\JoinColumn(name="countryID", referencedColumnName="id")
@@ -205,7 +205,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Country\Area $area
+     * @param \Shopware\Models\Country\Area|null $area
      */
     public function setArea($area)
     {
@@ -213,7 +213,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Country\Area
+     * @return \Shopware\Models\Country\Area|null
      */
     public function getArea()
     {
@@ -221,7 +221,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @param int $areaId
+     * @param int|null $areaId
      */
     public function setAreaId($areaId)
     {
@@ -229,7 +229,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getAreaId()
     {
@@ -237,7 +237,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Country\Country $country
+     * @param \Shopware\Models\Country\Country|null $country
      */
     public function setCountry($country)
     {
@@ -245,7 +245,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Country\Country
+     * @return \Shopware\Models\Country\Country|null
      */
     public function getCountry()
     {
@@ -253,7 +253,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @param int $countryId
+     * @param int|null $countryId
      */
     public function setCountryId($countryId)
     {
@@ -261,7 +261,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getCountryId()
     {
@@ -301,7 +301,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Country\State $state
+     * @param \Shopware\Models\Country\State|null $state
      */
     public function setState($state)
     {
@@ -309,7 +309,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Country\State
+     * @return \Shopware\Models\Country\State|null
      */
     public function getState()
     {
@@ -317,7 +317,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @param int $stateId
+     * @param int|null $stateId
      */
     public function setStateId($stateId)
     {
@@ -325,7 +325,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getStateId()
     {

--- a/engine/Shopware/Models/Tracking/ArticleImpression.php
+++ b/engine/Shopware/Models/Tracking/ArticleImpression.php
@@ -90,7 +90,7 @@ class ArticleImpression extends ModelEntity
     private $impressions;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="deviceType", type="string", length=50, nullable=true)
      */
@@ -101,7 +101,7 @@ class ArticleImpression extends ModelEntity
      * @param int                     $shopId
      * @param \DateTimeInterface|null $date
      * @param int                     $impressions
-     * @param string                  $deviceType
+     * @param string|null             $deviceType
      */
     public function __construct($articleId, $shopId, $date = null, $impressions = 1, $deviceType = null)
     {
@@ -218,7 +218,7 @@ class ArticleImpression extends ModelEntity
     }
 
     /**
-     * @param string $deviceType
+     * @param string|null $deviceType
      */
     public function setDeviceType($deviceType)
     {
@@ -226,7 +226,7 @@ class ArticleImpression extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDeviceType()
     {

--- a/engine/Shopware/Models/Tracking/Banner.php
+++ b/engine/Shopware/Models/Tracking/Banner.php
@@ -72,7 +72,7 @@ class Banner extends ModelEntity
     /**
      * ID of the banner which should be tracked
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="bannerID", type="integer", nullable=true)
      */
@@ -81,7 +81,7 @@ class Banner extends ModelEntity
     /**
      * Accumulated number of clicks
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="clicks", type="integer", nullable=true)
      */
@@ -90,7 +90,7 @@ class Banner extends ModelEntity
     /**
      * Accumulated number of views
      *
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="views", type="integer", nullable=true)
      */
@@ -136,7 +136,7 @@ class Banner extends ModelEntity
     /**
      * Returns the ID of the banner which should be tracked.
      *
-     * @return int
+     * @return int|null
      */
     public function getBannerId()
     {
@@ -160,7 +160,7 @@ class Banner extends ModelEntity
     /**
      * Returns the amount of clicks on a particular banner.
      *
-     * @return int
+     * @return int|null
      */
     public function getClicks()
     {
@@ -170,7 +170,7 @@ class Banner extends ModelEntity
     /**
      * Sets the numbers of clicks this banner received
      *
-     * @param int $clicks
+     * @param int|null $clicks
      *
      * @return Banner
      */
@@ -184,7 +184,7 @@ class Banner extends ModelEntity
     /**
      * Return the number of times a banner has been shown
      *
-     * @return int
+     * @return int|null
      */
     public function getViews()
     {
@@ -194,7 +194,7 @@ class Banner extends ModelEntity
     /**
      * Sets the number of times the banner has been displayed.
      *
-     * @param int $views
+     * @param int|null $views
      *
      * @return Banner
      */

--- a/engine/Shopware/Models/User/Resource.php
+++ b/engine/Shopware/Models/User/Resource.php
@@ -64,7 +64,7 @@ class Resource extends ModelEntity implements \Zend_Acl_Resource_Interface
     private $name;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="pluginID", type="integer", nullable=true)
      */
@@ -125,7 +125,7 @@ class Resource extends ModelEntity implements \Zend_Acl_Resource_Interface
     /**
      * Getter function for the pluginId property
      *
-     * @return int
+     * @return int|null
      */
     public function getPluginId()
     {

--- a/engine/Shopware/Models/User/Role.php
+++ b/engine/Shopware/Models/User/Role.php
@@ -58,7 +58,7 @@ class Role extends ModelEntity implements \Zend_Acl_Role_Interface
     private $id;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="parentID", type="integer", nullable=true)
      */
@@ -162,7 +162,7 @@ class Role extends ModelEntity implements \Zend_Acl_Role_Interface
     /**
      * Set parentId
      *
-     * @param int $parentId
+     * @param int|null $parentId
      *
      * @return Role
      */
@@ -176,7 +176,7 @@ class Role extends ModelEntity implements \Zend_Acl_Role_Interface
     /**
      * Get parentId
      *
-     * @return int
+     * @return int|null
      */
     public function getParentId()
     {
@@ -382,7 +382,7 @@ class Role extends ModelEntity implements \Zend_Acl_Role_Interface
      * contains the inherited parent role. The association is defined over
      * the Role.id property and the Role.parentId property.
      *
-     * @return \Shopware\Models\User\Role
+     * @return \Shopware\Models\User\Role|null
      */
     public function getParent()
     {
@@ -395,7 +395,7 @@ class Role extends ModelEntity implements \Zend_Acl_Role_Interface
      * contains the inherited parent role. The association is defined over
      * the Role.id property and the Role.parentId property.
      *
-     * @param \Shopware\Models\User\Role $parent
+     * @param \Shopware\Models\User\Role|null $parent
      */
     public function setParent($parent)
     {

--- a/engine/Shopware/Models/User/Rule.php
+++ b/engine/Shopware/Models/User/Rule.php
@@ -58,7 +58,7 @@ class Rule extends ModelEntity
     /**
      * The resource property is the owning side of the association between rule and permission.
      *
-     * @var \Shopware\Models\User\Resource
+     * @var \Shopware\Models\User\Resource|null
      *
      * @ORM\ManyToOne(targetEntity="\Shopware\Models\User\Resource", fetch="EAGER")
      * @ORM\JoinColumn(name="resourceID", referencedColumnName="id", nullable=true)
@@ -68,7 +68,7 @@ class Rule extends ModelEntity
     /**
      * The privilege property is the owning side of the association between rule and permission.
      *
-     * @var \Shopware\Models\User\Privilege
+     * @var \Shopware\Models\User\Privilege|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\User\Privilege", fetch="EAGER")
      * @ORM\JoinColumn(name="privilegeID", referencedColumnName="id", nullable=true)
@@ -78,21 +78,21 @@ class Rule extends ModelEntity
     /**
      * @ORM\Column(name="privilegeID", type="integer", nullable=true)
      *
-     * @var int
+     * @var int|null
      */
     private $privilegeId;
 
     /**
      * @ORM\Column(name="roleID", type="integer", nullable=true)
      *
-     * @var int
+     * @var int|null
      */
     private $roleId;
 
     /**
      * @ORM\Column(name="resourceID", type="integer", nullable=true)
      *
-     * @var int
+     * @var int|null
      */
     private $resourceId;
 
@@ -130,7 +130,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getPrivilegeId()
     {
@@ -138,7 +138,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @param int $privilegeId
+     * @param int|null $privilegeId
      */
     public function setPrivilegeId($privilegeId)
     {
@@ -146,7 +146,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getRoleId()
     {
@@ -162,7 +162,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getResourceId()
     {
@@ -170,7 +170,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @param int $resourceId
+     * @param int|null $resourceId
      */
     public function setResourceId($resourceId)
     {
@@ -186,7 +186,7 @@ class Rule extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\User\Resource $resource
+     * @param \Shopware\Models\User\Resource|null $resource
      */
     public function setResource($resource)
     {

--- a/engine/Shopware/Models/User/User.php
+++ b/engine/Shopware/Models/User/User.php
@@ -50,7 +50,7 @@ class User extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\User
+     * @var \Shopware\Models\Attribute\User|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\User", mappedBy="user", orphanRemoval=true, cascade={"persist"})
      */
@@ -109,7 +109,7 @@ class User extends ModelEntity
     private $encoder;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="apiKey", type="string", length=40, nullable=true)
      */
@@ -259,7 +259,7 @@ class User extends ModelEntity
     /**
      * Set API-Key
      *
-     * @param string $apiKey
+     * @param string|null $apiKey
      *
      * @return User
      */
@@ -277,7 +277,7 @@ class User extends ModelEntity
     /**
      * Get API-Key
      *
-     * @return string
+     * @return string|null
      */
     public function getApiKey()
     {
@@ -575,7 +575,7 @@ class User extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Attribute\User
+     * @return \Shopware\Models\Attribute\User|null
      */
     public function getAttribute()
     {

--- a/engine/Shopware/Models/Voucher/Code.php
+++ b/engine/Shopware/Models/Voucher/Code.php
@@ -52,7 +52,7 @@ class Code extends ModelEntity
     private $voucherId;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="userID", type="integer", nullable=true)
      */
@@ -81,7 +81,7 @@ class Code extends ModelEntity
     private $voucher;
 
     /**
-     * @var \Shopware\Models\Voucher\Voucher
+     * @var \Shopware\Models\Customer\Customer|null
      *
      * @ORM\OneToOne(targetEntity="\Shopware\Models\Customer\Customer")
      * @ORM\JoinColumn(name="userID", referencedColumnName="id")
@@ -125,7 +125,7 @@ class Code extends ModelEntity
     /**
      * Set customerId
      *
-     * @param int $customerId
+     * @param int|null $customerId
      *
      * @return Code
      */
@@ -139,7 +139,7 @@ class Code extends ModelEntity
     /**
      * Get customerId
      *
-     * @return int
+     * @return int|null
      */
     public function getCustomerId()
     {
@@ -217,7 +217,7 @@ class Code extends ModelEntity
     /**
      * get Customer
      *
-     * @return \Shopware\Models\Voucher\Voucher
+     * @return \Shopware\Models\Customer\Customer|null
      */
     public function getCustomer()
     {
@@ -227,7 +227,7 @@ class Code extends ModelEntity
     /**
      * set Customer
      *
-     * @param \Shopware\Models\Voucher\Voucher $user
+     * @param \Shopware\Models\Customer\Customer|null $user
      */
     public function setCustomer($user)
     {

--- a/engine/Shopware/Models/Voucher/Voucher.php
+++ b/engine/Shopware/Models/Voucher/Voucher.php
@@ -47,7 +47,7 @@ class Voucher extends ModelEntity
     /**
      * INVERSE SIDE
      *
-     * @var \Shopware\Models\Attribute\Voucher
+     * @var \Shopware\Models\Attribute\Voucher|null
      *
      * @ORM\OneToOne(targetEntity="Shopware\Models\Attribute\Voucher", mappedBy="voucher", orphanRemoval=true, cascade={"persist"})
      */
@@ -105,21 +105,21 @@ class Voucher extends ModelEntity
     private $shippingFree;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="bindtosupplier", type="integer", nullable=true)
      */
     private $bindToSupplier;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="valid_from", type="date", nullable=true)
      */
     private $validFrom;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="valid_to", type="date", nullable=true)
      */
@@ -154,7 +154,7 @@ class Voucher extends ModelEntity
     private $numOrder;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="customergroup", type="integer", nullable=true)
      */
@@ -175,7 +175,7 @@ class Voucher extends ModelEntity
     private $strict;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="subshopID", type="integer", nullable=true)
      */
@@ -189,7 +189,7 @@ class Voucher extends ModelEntity
     private $taxConfig;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="customer_stream_ids", type="text", nullable=true)
      */
@@ -352,7 +352,7 @@ class Voucher extends ModelEntity
     /**
      * Setter Method to set the bindToSupplier field from the Model
      *
-     * @param int $bindToSupplier
+     * @param int|null $bindToSupplier
      *
      * @return Voucher
      */
@@ -366,7 +366,7 @@ class Voucher extends ModelEntity
     /**
      * Getter Method to get the bindToSupplier field from the Model
      *
-     * @return int
+     * @return int|null
      */
     public function getBindToSupplier()
     {
@@ -376,7 +376,7 @@ class Voucher extends ModelEntity
     /**
      * Setter Method to set the validFrom field from the Model
      *
-     * @param \DateTimeInterface|string $validFrom
+     * @param \DateTimeInterface|string|null $validFrom
      *
      * @return Voucher
      */
@@ -393,7 +393,7 @@ class Voucher extends ModelEntity
     /**
      * Getter Method to get the ValidFrom field from the Model
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getValidFrom()
     {
@@ -403,7 +403,7 @@ class Voucher extends ModelEntity
     /**
      * Setter Method to set the validTo field from the Model
      *
-     * @param \DateTimeInterface|string $validTo
+     * @param \DateTimeInterface|string|null $validTo
      *
      * @return Voucher
      */
@@ -420,7 +420,7 @@ class Voucher extends ModelEntity
     /**
      * Getter Method to get the ValidTo field from the Model
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getValidTo()
     {
@@ -526,7 +526,7 @@ class Voucher extends ModelEntity
     /**
      * Setter Method to set the customerGroup field from the Model
      *
-     * @param int $customerGroup
+     * @param int|null $customerGroup
      *
      * @return Voucher
      */
@@ -540,7 +540,7 @@ class Voucher extends ModelEntity
     /**
      * Getter Method to get the customerGroup field from the Model
      *
-     * @return int
+     * @return int|null
      */
     public function getCustomerGroup()
     {
@@ -598,7 +598,7 @@ class Voucher extends ModelEntity
     /**
      * Setter Method to set the shopId field from the Model
      *
-     * @param int $shopId
+     * @param int|null $shopId
      *
      * @return Voucher
      */
@@ -612,7 +612,7 @@ class Voucher extends ModelEntity
     /**
      * Getter Method to get the shopId field from the Model
      *
-     * @return int
+     * @return int|null
      */
     public function getShopId()
     {
@@ -662,7 +662,7 @@ class Voucher extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Attribute\Voucher
+     * @return \Shopware\Models\Attribute\Voucher|null
      */
     public function getAttribute()
     {
@@ -680,7 +680,7 @@ class Voucher extends ModelEntity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCustomerStreamIds()
     {
@@ -688,7 +688,7 @@ class Voucher extends ModelEntity
     }
 
     /**
-     * @param string $customerStreamIds
+     * @param string|null $customerStreamIds
      */
     public function setCustomerStreamIds($customerStreamIds)
     {

--- a/engine/Shopware/Models/Widget/View.php
+++ b/engine/Shopware/Models/Widget/View.php
@@ -51,7 +51,7 @@ class View extends ModelEntity
     private $widget;
 
     /**
-     * @var \Shopware\Models\User\User
+     * @var \Shopware\Models\User\User|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\User\User")
      * @ORM\JoinColumn(name="auth_id", referencedColumnName="id")
@@ -59,7 +59,7 @@ class View extends ModelEntity
     private $auth;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="auth_id", type="integer", nullable=true)
      */
@@ -111,7 +111,7 @@ class View extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\User\User
+     * @return \Shopware\Models\User\User|null
      */
     public function getAuth()
     {
@@ -158,6 +158,9 @@ class View extends ModelEntity
         $this->position = $position;
     }
 
+    /**
+     * @return int|null
+     */
     public function getAuthId()
     {
         return $this->authId;

--- a/engine/Shopware/Models/Widget/Widget.php
+++ b/engine/Shopware/Models/Widget/Widget.php
@@ -57,14 +57,14 @@ class Widget extends ModelEntity
     private $views;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="plugin_id", type="integer", nullable=true)
      */
     private $pluginId;
 
     /**
-     * @var \Shopware\Models\Plugin\Plugin
+     * @var \Shopware\Models\Plugin\Plugin|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Plugin\Plugin", inversedBy="widgets")
      * @ORM\JoinColumn(name="plugin_id", referencedColumnName="id")
@@ -112,7 +112,7 @@ class Widget extends ModelEntity
     }
 
     /**
-     * @param \Shopware\Models\Plugin\Plugin $plugin
+     * @param \Shopware\Models\Plugin\Plugin|null $plugin
      */
     public function setPlugin($plugin)
     {
@@ -120,7 +120,7 @@ class Widget extends ModelEntity
     }
 
     /**
-     * @return \Shopware\Models\Plugin\Plugin
+     * @return \Shopware\Models\Plugin\Plugin|null
      */
     public function getPlugin()
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
I used the ORM via API resources for exporting orders. Reading data from the billing and shipping address properties failed because the phpdoc typehints said: you will get strings. I expected empty strings on empty inputs. I got null. It is ok to be null if you have a look at the Doctrine ORM hints and on the database, but the accessor methods do barely know.

### 2. What does this change do, exactly?
Added `|null` to a lot of phpdoc typehints. AND one completely wrong phpdoc typehint in the voucher-model at the customer property/accessors.

### 3. Describe each step to reproduce the issue or behaviour.
Use the ORM and have expectations given by (phpdoc) typehints.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.