### PR TITLE
Allow any attribute name in Risk Management

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -1910,36 +1910,43 @@ class sAdmin
     {
         if (!empty($order['content'])) {
             $value = explode('|', $value);
-            if (!empty($value[0]) && isset($value[1])) {
-                $number = (int) str_ireplace('attr', '', $value[0]);
 
+            $crudService = Shopware()->Container()->get('shopware_attribute.crud_service');
+            $columnData = $crudService->get('s_articles_attributes', $value[0]);
+
+            if ($columnData === null && is_numeric($value[0])) {
+                $columnData = $crudService->get('s_articles_attributes', 'attr' . $value[0]);
+                $value[0] = 'attr' . $value[0];
+            }
+
+            if ($columnData !== null && !empty($value[0]) && isset($value[1])) {
                 $sqlProductOrderNumber = $this->connection->createQueryBuilder()
-                   ->select(['s_articles_attributes.id'])
-                   ->from('s_order_basket, s_articles_attributes, s_articles_details')
-                   ->where('s_order_basket.sessionID = :sessionID')
-                   ->andWhere('s_order_basket.modus = 0')
-                   ->andWhere('s_order_basket.ordernumber = s_articles_details.ordernumber')
-                   ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
-                   ->andWhere('s_articles_attributes.attr' . $number . ' = :attrValue')
-                   ->setParameters([
-                       'attrValue' => $value[1],
-                       'sessionID' => $this->session->offsetGet('sessionId'),
-                   ])
-                   ->execute()->fetch(\PDO::FETCH_ASSOC);
+                    ->select(['s_articles_attributes.id'])
+                    ->from('s_order_basket, s_articles_attributes, s_articles_details')
+                    ->where('s_order_basket.sessionID = :sessionID')
+                    ->andWhere('s_order_basket.modus = 0')
+                    ->andWhere('s_order_basket.ordernumber = s_articles_details.ordernumber')
+                    ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
+                    ->andWhere('s_articles_attributes.' . $value[0] . ' = :attrValue')
+                    ->setParameters([
+                        'attrValue' => $value[1],
+                        'sessionID' => $this->session->offsetGet('sessionId'),
+                    ])
+                    ->execute()->fetch(\PDO::FETCH_ASSOC);
 
                 $sqlProductId = $this->connection->createQueryBuilder()
-                  ->select(['s_articles_attributes.id'])
-                  ->from('s_order_basket, s_articles_attributes, s_articles_details')
-                  ->where('s_order_basket.sessionID = :sessionID')
-                  ->andWhere('s_order_basket.modus = 0')
-                  ->andWhere('s_order_basket.articleID = s_articles_details.articleID AND s_articles_details.kind = 1')
-                  ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
-                  ->andWhere('s_articles_attributes.attr' . $number . ' = :attrValue')
-                  ->setParameters([
-                      'attrValue' => $value[1],
-                      'sessionID' => $this->session->offsetGet('sessionId'),
-                  ])
-                  ->execute()->fetch(\PDO::FETCH_ASSOC);
+                    ->select(['s_articles_attributes.id'])
+                    ->from('s_order_basket, s_articles_attributes, s_articles_details')
+                    ->where('s_order_basket.sessionID = :sessionID')
+                    ->andWhere('s_order_basket.modus = 0')
+                    ->andWhere('s_order_basket.articleID = s_articles_details.articleID AND s_articles_details.kind = 1')
+                    ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
+                    ->andWhere('s_articles_attributes.' . $value[0] . ' = :attrValue')
+                    ->setParameters([
+                        'attrValue' => $value[1],
+                        'sessionID' => $this->session->offsetGet('sessionId'),
+                    ])
+                    ->execute()->fetch(\PDO::FETCH_ASSOC);
 
                 return (bool) $sqlProductOrderNumber || (bool) $sqlProductId;
             }
@@ -1961,36 +1968,43 @@ class sAdmin
     {
         if (!empty($order['content'])) {
             $value = explode('|', $value);
-            if (!empty($value[0]) && isset($value[1])) {
-                $number = (int) str_ireplace('attr', '', $value[0]);
 
+            $crudService = Shopware()->Container()->get('shopware_attribute.crud_service');
+            $columnData = $crudService->get('s_articles_attributes', $value[0]);
+
+            if ($columnData === null && is_numeric($value[0])) {
+                $columnData = $crudService->get('s_articles_attributes', 'attr' . $value[0]);
+                $value[0] = 'attr' . $value[0];
+            }
+
+            if ($columnData !== null && !empty($value[0]) && isset($value[1])) {
                 $sqlProductOrderNumber = $this->connection->createQueryBuilder()
-                   ->select(['s_articles_attributes.id'])
-                   ->from('s_order_basket, s_articles_attributes, s_articles_details')
-                   ->where('s_order_basket.sessionID = :sessionID')
-                   ->andWhere('s_order_basket.modus = 0')
-                   ->andWhere('s_order_basket.ordernumber = s_articles_details.ordernumber')
-                   ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
-                   ->andWhere('s_articles_attributes.attr' . $number . ' != :attrValue')
-                   ->setParameters([
-                       'attrValue' => $value[1],
-                       'sessionID' => $this->session->offsetGet('sessionId'),
-                   ])
-                   ->execute()->fetch(\PDO::FETCH_ASSOC);
+                    ->select(['s_articles_attributes.id'])
+                    ->from('s_order_basket, s_articles_attributes, s_articles_details')
+                    ->where('s_order_basket.sessionID = :sessionID')
+                    ->andWhere('s_order_basket.modus = 0')
+                    ->andWhere('s_order_basket.ordernumber = s_articles_details.ordernumber')
+                    ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
+                    ->andWhere('s_articles_attributes.' . $value[0] . ' != :attrValue')
+                    ->setParameters([
+                        'attrValue' => $value[1],
+                        'sessionID' => $this->session->offsetGet('sessionId'),
+                    ])
+                    ->execute()->fetch(\PDO::FETCH_ASSOC);
 
                 $sqlProductId = $this->connection->createQueryBuilder()
-                  ->select(['s_articles_attributes.id'])
-                  ->from('s_order_basket, s_articles_attributes, s_articles_details')
-                  ->where('s_order_basket.sessionID = :sessionID')
-                  ->andWhere('s_order_basket.modus = 0')
-                  ->andWhere('s_order_basket.articleID = s_articles_details.articleID AND s_articles_details.kind = 1')
-                  ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
-                  ->andWhere('s_articles_attributes.attr' . $number . ' != :attrValue')
-                  ->setParameters([
-                      'attrValue' => $value[1],
-                      'sessionID' => $this->session->offsetGet('sessionId'),
-                  ])
-                  ->execute()->fetch(\PDO::FETCH_ASSOC);
+                    ->select(['s_articles_attributes.id'])
+                    ->from('s_order_basket, s_articles_attributes, s_articles_details')
+                    ->where('s_order_basket.sessionID = :sessionID')
+                    ->andWhere('s_order_basket.modus = 0')
+                    ->andWhere('s_order_basket.articleID = s_articles_details.articleID AND s_articles_details.kind = 1')
+                    ->andWhere('s_articles_details.id = s_articles_attributes.articledetailsID')
+                    ->andWhere('s_articles_attributes.' . $value[0] . ' != :attrValue')
+                    ->setParameters([
+                        'attrValue' => $value[1],
+                        'sessionID' => $this->session->offsetGet('sessionId'),
+                    ])
+                    ->execute()->fetch(\PDO::FETCH_ASSOC);
 
                 return (bool) $sqlProductOrderNumber || (bool) $sqlProductId;
             }
@@ -2948,7 +2962,7 @@ class sAdmin
             LEFT JOIN s_user_addresses as ub
                 ON ub.user_id = u.id
                 AND ub.id = :billingAddressId
-              
+
             LEFT JOIN s_user_addresses as us
                 ON us.user_id = u.id
                 AND us.id = :shippingAddressId
@@ -4364,7 +4378,7 @@ SQL;
         $dbal = Shopware()->Container()->get('dbal_connection');
 
         return (int) $dbal->fetchColumn('
-            SELECT default_billing_address_id 
+            SELECT default_billing_address_id
             FROM s_user WHERE id = :id
             ',
             ['id' => $this->session->offsetGet('sUserId')]
@@ -4385,7 +4399,7 @@ SQL;
         $dbal = Shopware()->Container()->get('dbal_connection');
 
         return (int) $dbal->fetchColumn('
-            SELECT default_shipping_address_id 
+            SELECT default_shipping_address_id
             FROM s_user WHERE id = :id
             ',
             ['id' => $this->session->offsetGet('sUserId')]


### PR DESCRIPTION
### 1. Why is this change necessary?
Since 5.2 attributes can be added to database easily with any name.
Since today the risk management module only allows attributes with the old static naming like "attr{number}"

### 2. What does this change do, exactly?
It allows any kind of attribute name

### 3. Describe each step to reproduce the issue or behaviour.
Create an article attribute with any name and use it in the old format on attribute rules in risk management.

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.