### PR TITLE
Refreshes plugin manager before install and update plugin commands

### DIFF
--- a/engine/Shopware/Commands/PluginInstallCommand.php
+++ b/engine/Shopware/Commands/PluginInstallCommand.php
@@ -53,6 +53,12 @@ class PluginInstallCommand extends PluginCommand
                 InputOption::VALUE_NONE,
                 'Activate plugin after intallation.'
             )
+            ->addOption(
+                'no-refresh',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not refresh plugin list.'
+            )
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> installs a plugin.
 EOF
@@ -66,6 +72,10 @@ EOF
     {
         /** @var InstallerService $pluginManager */
         $pluginManager = $this->container->get('shopware_plugininstaller.plugin_manager');
+        if (!$input->getOption('no-refresh')) {
+            $pluginManager->refreshPluginList();
+            $output->writeln('Successfully refreshed');
+        }
         $pluginName = $input->getArgument('plugin');
 
         try {

--- a/engine/Shopware/Commands/PluginReinstallCommand.php
+++ b/engine/Shopware/Commands/PluginReinstallCommand.php
@@ -53,6 +53,12 @@ class PluginReinstallCommand extends PluginCommand
                 InputOption::VALUE_NONE,
                 'if supplied plugin data will be removed'
             )
+            ->addOption(
+                'no-refresh',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not refresh plugin list.'
+            )
         ;
     }
 
@@ -63,6 +69,10 @@ class PluginReinstallCommand extends PluginCommand
     {
         /** @var InstallerService $pluginManager */
         $pluginManager = $this->container->get('shopware_plugininstaller.plugin_manager');
+        if (!$input->getOption('no-refresh')) {
+            $pluginManager->refreshPluginList();
+            $output->writeln('Successfully refreshed');
+        }
         $pluginName = $input->getArgument('plugin');
 
         try {

--- a/engine/Shopware/Commands/PluginUpdateCommand.php
+++ b/engine/Shopware/Commands/PluginUpdateCommand.php
@@ -54,6 +54,12 @@ class PluginUpdateCommand extends PluginCommand
                 InputOption::VALUE_REQUIRED,
                 'Batch update several plugins. Possible values are all, inactive, active, installed, uninstalled'
             )
+            ->addOption(
+                'no-refresh',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not refresh plugin list.'
+            )
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> updates a plugin.
 EOF
@@ -67,6 +73,10 @@ EOF
     {
         /** @var InstallerService $pluginManager */
         $pluginManager = $this->container->get('shopware_plugininstaller.plugin_manager');
+        if (!$input->getOption('no-refresh')) {
+            $pluginManager->refreshPluginList();
+            $output->writeln('Successfully refreshed');
+        }
 
         $pluginNames = $input->getArgument('plugin');
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Because I always forget to do it when I want to use `sw:plugin:update`.

### 2. What does this change do, exactly?
Refreshes the plugins before `sw:plugin:install`, `sw:plugin:reinstall` and `sw:plugin:update` commands.

### 3. Describe each step to reproduce the issue or behaviour.
1. Run `sw:plugin:update` without running `sw:plugin:refresh` first.
2. Wonder why nothing happens.
3. Remember that you must first run `sw:plugin:refresh`.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
The commands `sw:plugin:install`, `sw:plugin:reinstall` and `sw:plugin:update` now feature a new option called `no-refresh`. If it exists, the plugin list will not be refreshed.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.