### PR TITLE
update userId in notes on login and NotePostDispatch

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -3216,9 +3216,10 @@ class sAdmin implements \Enlight_Hook
             $newHash = $this->passwordEncoder->reencodePassword($plaintext, $hash, $encoderName);
         }
 
+        $userId = (int) $getUser['id'];
+
         if (!empty($newHash) && $newHash !== $hash) {
             $hash = $newHash;
-            $userId = (int) $getUser['id'];
             $this->db->update(
                 's_user',
                 [
@@ -3229,9 +3230,23 @@ class sAdmin implements \Enlight_Hook
             );
         }
 
+        // Update note userID
+        $uniqueId = $this->front->Request()->getCookie('sUniqueID');
+        if (!empty($uniqueId)) {
+            $this->connection->executeQuery(
+                'UPDATE s_order_notes SET userID = :userId, sUniqueID = NULL WHERE sUniqueID = :uniqueId AND userID = 0',
+                [
+                    'userId' => $userId,
+                    'uniqueId' => $uniqueId,
+                ]
+            );
+            //destroy cookie
+            $this->front->Response()->setCookie('sUniqueID');
+        }
+
         $this->session->offsetSet('sUserMail', $email);
         $this->session->offsetSet('sUserPassword', $hash);
-        $this->session->offsetSet('sUserId', $getUser['id']);
+        $this->session->offsetSet('sUserId', $userId);
 
         if (!$this->sCheckUser()) {
             return;


### PR DESCRIPTION
### 1. Why is this change necessary?
With https://github.com/shopware/shopware/commit/bf254f2b1a080bc8014860efd413d0092d069a66 notes without userId will be deleted. Unless the userId will not be updated, the Clearing will unwanted delete to many notes. We have to update userID, so used notes won't be deleted.

### 2. What does this change do, exactly?
add updateUserID ~~in NotePostDispatch and~~ on Login

### 3. Describe each step to reproduce the issue or behaviour.
- don't login in Shop (on default you'll check you're not loggedin in checkout latest :-) )
- add product to note
- login
- you will your note, but...
- (without this change) userId will stay 0, so it will be deleted
- (with this change) userId was updated to yours, so it won't be deleted

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/pull/1628

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.