### PR TITLE
NTR - prevent google bots from index sites that are disallowed in the robots.txt

### DIFF
--- a/engine/Shopware/Controllers/Widgets/Campaign.php
+++ b/engine/Shopware/Controllers/Widgets/Campaign.php
@@ -25,6 +25,14 @@
 class Shopware_Controllers_Widgets_Campaign extends Shopware_Controllers_Widgets_Emotion
 {
     /**
+     * Pre dispatch method
+     */
+    public function preDispatch()
+    {
+        $this->Response()->setHeader('x-robots', 'noindex');
+    }
+
+    /**
      * The getEmotion method for the emotion landing page
      *
      * @param \Shopware\Models\Emotion\Repository $repository

--- a/engine/Shopware/Controllers/Widgets/Captcha.php
+++ b/engine/Shopware/Controllers/Widgets/Captcha.php
@@ -29,6 +29,14 @@ use Shopware\Components\Captcha\Exception\CaptchaNotFoundException;
  */
 class Shopware_Controllers_Widgets_Captcha extends Enlight_Controller_Action
 {
+    /**
+     * Pre dispatch method
+     */
+    public function preDispatch()
+    {
+        $this->Response()->setHeader('x-robots', 'noindex');
+    }
+
     public function refreshCaptchaAction()
     {
         $this->Front()->Plugins()->ViewRenderer()->setNoRender();

--- a/engine/Shopware/Controllers/Widgets/Checkout.php
+++ b/engine/Shopware/Controllers/Widgets/Checkout.php
@@ -46,6 +46,7 @@ class Shopware_Controllers_Widgets_Checkout extends Enlight_Controller_Action
     {
         $this->module = Shopware()->Modules()->Basket();
         $this->session = Shopware()->Session();
+        $this->Response()->setHeader('x-robots', 'noindex');
     }
 
     public function infoAction()

--- a/engine/Shopware/Controllers/Widgets/Compare.php
+++ b/engine/Shopware/Controllers/Widgets/Compare.php
@@ -27,6 +27,14 @@
  */
 class Shopware_Controllers_Widgets_Compare extends Enlight_Controller_Action
 {
+    /**
+     * Pre dispatch method
+     */
+    public function preDispatch()
+    {
+        $this->Response()->setHeader('x-robots', 'noindex');
+    }
+
     public function indexAction()
     {
         $this->View()->assign('sComparisons', Shopware()->Modules()->Articles()->sGetComparisons());

--- a/engine/Shopware/Controllers/Widgets/Error.php
+++ b/engine/Shopware/Controllers/Widgets/Error.php
@@ -24,6 +24,14 @@
 
 class Shopware_Controllers_Widgets_Error extends Shopware_Controllers_Frontend_Error
 {
+    /**
+     * Pre dispatch method
+     */
+    public function preDispatch()
+    {
+        $this->Response()->setHeader('x-robots', 'noindex');
+    }
+
     public function serviceAction()
     {
         $this->Response()->setHttpResponseCode(503);

--- a/engine/Shopware/Controllers/Widgets/Index.php
+++ b/engine/Shopware/Controllers/Widgets/Index.php
@@ -32,6 +32,8 @@ class Shopware_Controllers_Widgets_Index extends Enlight_Controller_Action
      */
     public function preDispatch()
     {
+        $this->Response()->setHeader('x-robots', 'noindex');
+
         if ($this->Request()->getActionName() === 'refreshStatistic') {
             $this->Front()->Plugins()->ViewRenderer()->setNoRender();
         }

--- a/engine/Shopware/Controllers/Widgets/Listing.php
+++ b/engine/Shopware/Controllers/Widgets/Listing.php
@@ -34,6 +34,14 @@ use Shopware\Components\Compatibility\LegacyStructConverter;
 class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
 {
     /**
+     * Pre dispatch method
+     */
+    public function preDispatch()
+    {
+        $this->Response()->setHeader('x-robots', 'noindex');
+    }
+
+    /**
      * Product navigation as json string
      */
     public function productNavigationAction()

--- a/engine/Shopware/Controllers/Widgets/Recommendation.php
+++ b/engine/Shopware/Controllers/Widgets/Recommendation.php
@@ -36,6 +36,14 @@ class Shopware_Controllers_Widgets_Recommendation extends Enlight_Controller_Act
     /** @var sMarketing */
     protected $marketingModule;
 
+    /**
+     * Pre dispatch method
+     */
+    public function preDispatch()
+    {
+        $this->Response()->setHeader('x-robots', 'noindex');
+    }
+
     public function init()
     {
         $this->config = Shopware()->Config();


### PR DESCRIPTION
### 1. Why is this change necessary?
Google bot put ajax urls into the index

### 2. What does this change do, exactly?
Set Header X-Robots to noindex in the widget controllers that are disallowed by robots.txt

### 3. Describe each step to reproduce the issue or behaviour.
let google crawl your site and you will see that f.e. refreshStatistic and widgets/listing/getCategory/categoryId/XX will be indexed

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.