### PR TITLE
assign filesize in product-downloads

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/DownloadGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/DownloadGateway.php
@@ -97,6 +97,7 @@ class DownloadGateway implements Gateway\DownloadGatewayInterface
 
         $query->from('s_articles_downloads', 'download')
             ->leftJoin('download', 's_articles_downloads_attributes', 'downloadAttribute', 'downloadAttribute.downloadID = download.id')
+            ->innerJoin('download', 's_media', 'media', 'media.path = download.filename')
             ->where('download.articleID IN (:ids)')
             ->setParameter(':ids', $ids, Connection::PARAM_INT_ARRAY);
 

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/FieldHelper.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/FieldHelper.php
@@ -485,7 +485,7 @@ class FieldHelper
             'download.articleID as __download_articleID',
             'download.description as __download_description',
             'download.filename as __download_filename',
-            'download.size as __download_size',
+            'media.file_size as __download_size',
         ];
 
         $fields = array_merge(

--- a/engine/Shopware/Models/Article/Download.php
+++ b/engine/Shopware/Models/Article/Download.php
@@ -86,6 +86,9 @@ class Download extends ModelEntity
     /**
      * @var float
      *
+     * @deprecated since 5.5.8 and will be removed in 5.7. Use media_service to get size
+     *
+     * @todo remove in 5.7
      * @ORM\Column(name="size", type="float", nullable=false)
      */
     private $size;
@@ -178,6 +181,10 @@ class Download extends ModelEntity
      * @param float $size
      *
      * @return Download
+     *
+     * @deprecated since 5.5.8 and will be removed in 5.7 without alternative
+     *
+     * @todo remove in 5.7
      */
     public function setSize($size)
     {
@@ -190,6 +197,10 @@ class Download extends ModelEntity
      * Get size
      *
      * @return float
+     *
+     * @deprecated since 5.5.8 and will be removed in 5.7. Use media_service to get size
+     *
+     * @todo remove in 5.7
      */
     public function getSize()
     {

--- a/themes/Backend/ExtJs/backend/article/model/download.js
+++ b/themes/Backend/ExtJs/backend/article/model/download.js
@@ -45,8 +45,7 @@ Ext.define('Shopware.apps.Article.model.Download', {
         { name: 'id', type: 'int' },
         { name: 'articleId', type: 'int' },
         { name: 'name', type: 'string' },
-        { name: 'file', type: 'string' },
-        { name: 'size', type: 'float' }
+        { name: 'file', type: 'string' }
     ]
 });
 //{/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
currently the size of downloads is 0. it won't be set by shopware. Maybe we could remove the field from database?!

### 2. What does this change do, exactly?
get filesize from mediaService

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-23682

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.