### PR TITLE
Let parameter label for _include/rating.tpl have impact

### DIFF
--- a/themes/Frontend/Bare/frontend/_includes/rating.tpl
+++ b/themes/Frontend/Bare/frontend/_includes/rating.tpl
@@ -82,12 +82,8 @@
     {/if}
 {/block}
 
-{* Label *}
-{block name='frontend_rating_label'}
-    {if isset($label)}
-        {$hasLabel=$label}
-    {/if}
-{/block}
+{* Label - moved to frontend_rating_label_parameter *}
+{block name='frontend_rating_label'}{/block}
 
 {* Label depending on type *}
 {block name='frontend_rating_label_type'}
@@ -95,6 +91,13 @@
         {$hasLabel=true}
     {else}
         {$hasLabel=false}
+    {/if}
+{/block}
+
+{* Override label by parameter *}
+{block name='frontend_rating_label_parameter'}
+    {if isset($label)}
+        {$hasLabel=$label}
     {/if}
 {/block}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
There is an optional parameter called `label` for the template `frontend/_include/rating.tpl`. This is completely ignored and always overwritten by the given (or not given) type. If one reorder the blocks the type constraint only works as fallback and gives you back the power to hide an aggregated rating.

### 2. What does this change do, exactly?
Puts the block `frontend_rating_label` behind `frontend_rating_label_type` rather than in front like before.

### 3. Describe each step to reproduce the issue or behaviour.
1. Insert `{include file='frontend/_includes/rating.tpl' points=$sArticle.sVoteAverage.average type="aggregated" count=$sArticle.sVoteAverage.count label=false}` on a detail page
2. still get a label
3. :unamused: :anger: 

### 4. Which documentation changes (if any) need to be made because of this PR?
As this will break the previous behaviour there might have to be a hint in the UPGRADE.md. That is also the reason why I made the change against 5.6 and not 5.5.
This will change the behaviour of `frontend/listing/product-box/box-basic.tpl`@`frontend_listing_box_article_rating` in line 30. But this will work now as intended like the documentation in the `frontend/_include/rating.tpl` says. To hide a label just hide it:
```php
/**
 *     Hide Label
 *     {include file="frontend/_includes/rating.tpl" points=$sArticle.sVoteAverage type="aggregated" label=false}
 */
```

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.