### PR TITLE
Added option for template to hide rating symbols ⭐

### DIFF
--- a/themes/Frontend/Bare/frontend/_includes/rating.tpl
+++ b/themes/Frontend/Bare/frontend/_includes/rating.tpl
@@ -44,6 +44,11 @@
  *     Hide Label
  *     {include file="frontend/_includes/rating.tpl" points=$sArticle.sVoteAverage type="aggregated" label=false}
  *  ```
+ *
+ *  ```
+ *     Hide Symbols
+ *     {include file="frontend/_includes/rating.tpl" points=$sArticle.sVoteAverage type="aggregated" symbols=false}
+ *  ```
 
 
 {* Type *}
@@ -98,6 +103,14 @@
     {/if}
 {/block}
 
+{* Symbols *}
+{block name='frontend_rating_symbols'}
+    {$hasSymbols=true}
+    {if isset($symbols)}
+        {$hasSymbols=$symbols}
+    {/if}
+{/block}
+
 {* Star rating content *}
 {block name='frontend_rating_content'}
     <span class="product--rating"{if $hasMicroData} {$data}{/if}>
@@ -124,7 +137,7 @@
 
         {* Stars *}
         {block name='frontend_rating_content_stars'}
-            {if $points != 0}
+            {if $points != 0 && $hasSymbols}
                 {for $value=1 to 5}
                     {$cls = 'icon--star'}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It is [sometimes](#2065) possible to hide the label, but you cannot yet hide the symbols (in the default case :star:). Now you can.

### 2. What does this change do, exactly?
Adds a new optional parameter that defaults to `true` that impacts on display the symbols or not.

### 3. Which documentation changes (if any) need to be made because of this PR?
Is already part of the PR.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Bonus

Can be patched by adding this template:

```
{extends file="parent:frontend/_includes/rating.tpl"}

{block name="frontend_rating_content_stars"}
    {if !isset($symbols) || $symbols}
        {$smarty.block.parent}
    {/if}
{/block}
```
