### PR TITLE
Allow sorting the Plugins before initialization

### DIFF
--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -430,6 +430,17 @@ class Kernel implements HttpKernelInterface, TerminableInterface
             ksort($this->plugins);
         }
 
+        if (is_array($this->config['plugin_initialization']['sort'])) {
+            $pluginSortOrder = $this->config['plugin_initialization']['sort'];
+
+            uksort($this->plugins, function($pluginA, $pluginB) use ($pluginSortOrder){
+                $pluginA = intval($pluginSortOrder[$pluginA] ?? 0);
+                $pluginB = intval($pluginSortOrder[$pluginB] ?? 0);
+
+                return $pluginA > $pluginB;
+            });
+        }
+
         $this->activePlugins = $initializer->getActivePlugins();
 
         $this->pluginHash = $this->createPluginHash($this->plugins);


### PR DESCRIPTION
### 1. Why is this change necessary?
Sometimes it is necessary to set the sort order of the plugins manually.
For example if a plugin has snippets that you want to override, but the plugin is listed after your plugin.

All project relevant changes in Snippets for a customer will be stored in a "shop-customization" plugin.
After deployment, when the customization plugin has snippet updates, we execute the script to refresh the snippets from the plugin.

```
bin/console sw:snippets:to:db --include-plugins
```

Unfortunately the plugin with the original snippet texts is loaded before our customization plugin.
So it is not possible to update the snippets in a clean way without updating them manually in the database and skip this task during deployment.

example:

PluginList:
- FroshProfiler
- DemoPlugin
- ExampleCustomizations
- PaymentPlugin

Sorting by the alphabet will be default in Shopware 5.6.
So the sort order would be:

- DemoPlugin
- ExampleCustomizations
- FroshProfiler
- PaymentPlugin

In our example the Plugin `PaymentPlugin` has snippets that we want to override with the snippets in `ExampleCustomizations`.
With the Console Command it is not possible because of the wrong initialization order.

We could rename the Plugin `ExampleCustomization` to `ZZZExampleCustomization` to ensure that it is at the end of the list.
But in my opinion this is not an acceptable solution for the problem.

This may be my failed case. But there could be other cases where the same sort error occur.
Imagine you're trying to override a service before another service overrides it, it isn't working without tricks.

### 2. What does this change do, exactly?
It adds a Configuration option to add Sorting for the Plugins before initialization.

### 3. Describe each step to reproduce the issue or behaviour.
Starting from the example above:

config.php
```
return [
    ...
    'logger' => [
        'level' => Logger::DEBUG,
    ],
    'plugin_initialization' => [
        'sort' => [
            /**
             * By default all value starts with 0, so a higher value sets
             * it to the end of the list and a lower value to the top
             */
            'ExampleCustomization' => 10,
        ]
    ]
```

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
