### PR TITLE
Fixed SearchIndexer to not delete keywords unintentionally

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/SearchIndexer.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/SearchIndexer.php
@@ -284,7 +284,7 @@ class SearchIndexer implements SearchIndexerInterface
             $sql_join
 
             GROUP BY keywordID, fieldID
-            HAVING COUNT(*) > (SELECT COUNT(*)*0.9 FROM `s_articles`)
+            HAVING COUNT(*) > (SELECT COUNT(*)*0.9 FROM `s_articles_details`)
         ";
 
         $collectToDelete = $this->connection->fetchAll($sql);

--- a/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/SearchIndexer.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/SearchIndexer.php
@@ -37,7 +37,7 @@ class SearchIndexer implements SearchIndexerInterface
     /**
      * Percent of matches to delete search index keywords
      *
-     * @type float
+     * @var float
      */
     const INDEX_DELETE_THRESHOLD = 0.9;
 
@@ -88,7 +88,7 @@ class SearchIndexer implements SearchIndexerInterface
             return;
         }
 
-        $interval = (int)$this->config->get('cacheSearch');
+        $interval = (int) $this->config->get('cacheSearch');
 
         if (empty($interval) || $interval < 360) {
             $interval = 86400;
@@ -191,7 +191,7 @@ class SearchIndexer implements SearchIndexerInterface
                     foreach ($fields as $fieldID => $field) {
                         $field_keywords = [$row[$field['fieldName']]];
 
-                        if (!(bool)$field['doNotSplit']) {
+                        if (!(bool) $field['doNotSplit']) {
                             // Split string from column into keywords
                             $field_keywords = $this->termHelper->splitTerm($row[$field['fieldName']]);
                         }

--- a/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/SearchIndexer.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/SearchIndexer.php
@@ -128,8 +128,8 @@ class SearchIndexer implements SearchIndexerInterface
 
         $this->setNextUpdateTimestamp();
 
-        // Truncate search index table
-        $this->connection->executeUpdate('TRUNCATE TABLE `s_search_index`');
+        // Truncate search index table (using DELETE to avoid committing database transactions in tests)
+        $this->connection->executeUpdate('DELETE FROM `s_search_index`');
 
         // Get a list of all tables and columns in this tables that should be processed by search
         /**

--- a/tests/Functional/Bundle/SearchBundleDBAL/SearchIndexerTest.php
+++ b/tests/Functional/Bundle/SearchBundleDBAL/SearchIndexerTest.php
@@ -1,4 +1,26 @@
 <?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
 
 namespace Shopware\Tests\Functional\Bundle\SearchBundleDBAL;
 
@@ -52,5 +74,4 @@ class SearchIndexerTest extends Enlight_Components_Test_Controller_TestCase
         // The 4 "example..." keywords + all "foo" (5) and "bar" (6) keywords
         static::assertCount(15, $index);
     }
-
 }

--- a/tests/Functional/Bundle/SearchBundleDBAL/SearchIndexerTest.php
+++ b/tests/Functional/Bundle/SearchBundleDBAL/SearchIndexerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Shopware\Tests\Functional\Bundle\SearchBundleDBAL;
+
+use Enlight_Components_Test_Controller_TestCase;
+
+class SearchIndexerTest extends Enlight_Components_Test_Controller_TestCase
+{
+    public function setUp()
+    {
+        Shopware()->Models()->getConnection()->beginTransaction();
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        Shopware()->Models()->getConnection()->rollBack();
+        parent::tearDown();
+    }
+
+    /**
+     * Tests building the search index.
+     * Example data is loaded and search index is populated with these values (see data.sql).
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function testSearchIndexer()
+    {
+        $connection = Shopware()->Models()->getConnection();
+
+        // Load example content
+        $connection->exec(file_get_contents(__DIR__ . '/fixtures/data.sql'));
+
+        // Build search index with populated values
+        Shopware()->Container()->get('shopware_searchdbal.search_indexer')->build();
+
+        // If keyword/index cleanup wouldn't work, we'd have 10 keywords indexed overall:
+        // - testarticle (10 matches) / examplearticle (1 match)
+        // - testcategory (10 matches) / examplecategory (1 match)
+        // - testsupplier (10 matches) / examplesupplier (1 match)
+        // - testordernumber (10 matches) / exampleordernumber (1 match)
+        // - foo (5 matches) / bar (6 matches)
+
+        // As keywords matching on more than 90% of the referenced table should be deleted, all keywords beginning with "test" should've disappeared.
+        // "foo" and "bar" should both be retained, as they match on less than 90% of translations.
+
+        $keywords = array_column($connection->fetchAll('SELECT * FROM s_search_keywords'), 'keyword');
+        $index = $connection->fetchAll('SELECT * FROM s_search_index');
+
+        static::assertEquals($keywords, ['examplearticle', 'examplecategory', 'examplesupplier', 'exampleordernumber', 'foo', 'bar']);
+
+        // The 4 "example..." keywords + all "foo" (5) and "bar" (6) keywords
+        static::assertCount(15, $index);
+    }
+
+}

--- a/tests/Functional/Bundle/SearchBundleDBAL/fixtures/data.sql
+++ b/tests/Functional/Bundle/SearchBundleDBAL/fixtures/data.sql
@@ -1,0 +1,109 @@
+/* Test content for SearchIndexerTest */
+
+/* Clear tables */
+DELETE FROM s_articles;
+DELETE FROM s_articles_details;
+DELETE FROM s_articles_categories;
+DELETE FROM s_articles_supplier;
+DELETE FROM s_articles_translations;
+DELETE FROM s_categories;
+DELETE FROM s_search_keywords;
+DELETE FROM s_search_fields;
+
+/* Set search index config */
+INSERT INTO `s_search_fields` (`id`, `name`, `relevance`, `field`, `tableID`, `do_not_split`)
+VALUES
+	(1,'Kategorie-Überschrift',70,'description',2,0),
+	(2,'Artikel-Name',400,'name',1,0),
+	(3,'Artikel-Bestellnummer',50,'ordernumber',4,0),
+	(4,'Hersteller-Name',45,'name',3,0),
+	(5,'Artikel-Name Übersetzung',50,'name',5,0);
+
+/* Insert some test suppliers */
+INSERT INTO `s_articles_supplier` (`id`, `name`, `img`, `link`, `description`, `meta_title`, `meta_description`, `meta_keywords`, `changed`)
+VALUES
+	(1, 'Testsupplier 1', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00'),
+	(2, 'Testsupplier 2', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00'),
+	(3, 'Testsupplier 3', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00'),
+	(4, 'Testsupplier 4', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00'),
+	(5, 'Testsupplier 5', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00'),
+	(6, 'Testsupplier 6', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00'),
+	(7, 'Testsupplier 7', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00'),
+	(8, 'Testsupplier 8', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00'),
+	(9, 'Testsupplier 9', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00'),
+	(10, 'Testsupplier 10', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00'),
+	(11, 'Examplesupplier', '', '', '', NULL, NULL, NULL, '2019-01-01 00:00:00');
+
+/* Insert some test articles */
+INSERT INTO `s_articles` (`id`, `supplierID`, `name`, `description`, `description_long`, `shippingtime`, `datum`, `active`, `taxID`, `pseudosales`, `topseller`, `metaTitle`, `keywords`, `changetime`, `pricegroupID`, `pricegroupActive`, `filtergroupID`, `laststock`, `crossbundlelook`, `notification`, `template`, `mode`, `main_detail_id`, `available_from`, `available_to`, `configurator_set_id`)
+VALUES
+	(1, 1, 'Testarticle 1', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL),
+	(2, 2, 'Testarticle 2', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL),
+	(3, 3, 'Testarticle 3', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL),
+	(4, 4, 'Testarticle 4', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL),
+	(5, 5, 'Testarticle 5', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL),
+	(6, 6, 'Testarticle 6', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL),
+	(7, 7, 'Testarticle 7', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL),
+	(8, 8, 'Testarticle 8', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL),
+	(9, 9, 'Testarticle 9', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL),
+	(10, 10, 'Testarticle 10', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL),
+	(11, 11, 'Examplearticle', NULL, NULL, NULL, NULL, 1, NULL, 0, 0, NULL, NULL, '2019-01-01 00:00:00', NULL, 0, NULL, 0, 0, 0, '', 0, NULL, NULL, NULL, NULL);
+
+/* Insert some test article details */
+INSERT INTO `s_articles_details` (`id`, `articleID`, `ordernumber`, `suppliernumber`, `kind`, `additionaltext`, `sales`, `active`, `instock`, `stockmin`, `laststock`, `weight`, `position`, `width`, `height`, `length`, `ean`, `unitID`, `purchasesteps`, `maxpurchase`, `minpurchase`, `purchaseunit`, `referenceunit`, `packunit`, `releasedate`, `shippingfree`, `shippingtime`, `purchaseprice`)
+VALUES
+	(1, 1, 'testordernumber-1', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0),
+	(2, 2, 'testordernumber-2', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0),
+	(3, 3, 'testordernumber-3', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0),
+	(4, 4, 'testordernumber-4', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0),
+	(5, 5, 'testordernumber-5', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0),
+	(6, 6, 'testordernumber-6', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0),
+	(7, 7, 'testordernumber-7', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0),
+	(8, 8, 'testordernumber-8', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0),
+	(9, 9, 'testordernumber-9', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0),
+	(10, 10, 'testordernumber-10', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0),
+	(11, 11, 'exampleordernumber-11', NULL, 0, NULL, 0, 1, 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, 0, NULL, 0);
+
+/* Insert some test translations */
+INSERT INTO `s_articles_translations` (`id`, `articleID`, `languageID`, `name`, `keywords`, `description`, `description_long`, `description_clear`, `shippingtime`)
+VALUES
+	(1, 1, 2, 'Foo', '', '', '', '', ''),
+	(2, 2, 2, 'Foo', '', '', '', '', ''),
+	(3, 3, 2, 'Foo', '', '', '', '', ''),
+	(4, 4, 2, 'Foo', '', '', '', '', ''),
+	(5, 5, 2, 'Foo', '', '', '', '', ''),
+	(6, 6, 2, 'Bar', '', '', '', '', ''),
+	(7, 7, 2, 'Bar', '', '', '', '', ''),
+	(8, 8, 2, 'Bar', '', '', '', '', ''),
+	(9, 9, 2, 'Bar', '', '', '', '', ''),
+	(10, 10, 2, 'Bar', '', '', '', '', ''),
+	(11, 11, 2, 'Bar', '', '', '', '', '');
+
+/* Insert some test categories and link them to the article */
+INSERT INTO `s_categories` (`id`, `parent`, `path`, `description`, `position`, `left`, `right`, `level`, `added`, `changed`, `metakeywords`, `metadescription`, `cmsheadline`, `cmstext`, `template`, `active`, `blog`, `external`, `hidefilter`, `hidetop`, `mediaID`, `product_box_layout`, `meta_title`, `stream_id`, `hide_sortings`, `sorting_ids`, `facet_ids`, `external_target`, `shops`)
+VALUES
+	(1, NULL, NULL, 'Testcategory 1', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL),
+	(2, NULL, NULL, 'Testcategory 2', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL),
+	(3, NULL, NULL, 'Testcategory 3', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL),
+	(4, NULL, NULL, 'Testcategory 4', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL),
+	(5, NULL, NULL, 'Testcategory 5', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL),
+	(6, NULL, NULL, 'Testcategory 6', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL),
+	(7, NULL, NULL, 'Testcategory 7', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL),
+	(8, NULL, NULL, 'Testcategory 8', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL),
+	(9, NULL, NULL, 'Testcategory 9', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL),
+	(10, NULL, NULL, 'Testcategory 10', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL),
+	(11, NULL, NULL, 'Examplecategory', 0, 0, 0, 0, '2019-01-01 00:00:00', '2019-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, 0, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, '', NULL);
+
+INSERT INTO `s_articles_categories` (`id`, `articleID`, `categoryID`)
+VALUES
+	(1, 1, 1),
+	(2, 2, 2),
+	(3, 3, 3),
+	(4, 4, 4),
+	(5, 5, 5),
+	(6, 6, 6),
+	(7, 7, 7),
+	(8, 8, 8),
+	(9, 9, 9),
+	(10, 10, 10),
+	(11, 11, 11);


### PR DESCRIPTION
### 1. Why is this change necessary?
For shops with few articles, but many variants, keywords would be deleted unintentionally. Had a case with a client, where there were only a few articles, but highly configurable. Search for special keywords always failed, until I found this issue.

### 2. What does this change do, exactly?
While populating the search index, keywords are deleted if they match on more than 90% of the number of articles (SQL COUNT s_articles). But when you do heavy use of variants, s_articles_details count would be preferable over s_articles, as potentially it could be much higher.

### 3. Describe each step to reproduce the issue or behaviour.
See 2.

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist
* [ ]  I have written tests and verified that they fail without my change
* [x]  I have squashed any insignificant commits
* [ ]  This change has comments for package types, values, functions, and non-obvious lines of code
* [x]  I have read the contribution requirements and fulfil them.

