### PR TITLE
sw:plugin:install Activate plugin although it is already installed

### DIFF
--- a/engine/Shopware/Commands/PluginInstallCommand.php
+++ b/engine/Shopware/Commands/PluginInstallCommand.php
@@ -81,14 +81,14 @@ EOF
             return 1;
         }
 
+        $installationContext = null;
+
         if ($plugin->getInstalled()) {
             $output->writeln(sprintf('The plugin %s is already installed.', $pluginName));
-
-            return 1;
+        } else {
+            $installationContext = $pluginManager->installPlugin($plugin);
+            $output->writeln(sprintf('Plugin %s has been installed successfully.', $pluginName));
         }
-
-        $installationContext = $pluginManager->installPlugin($plugin);
-        $output->writeln(sprintf('Plugin %s has been installed successfully.', $pluginName));
 
         $activationContext = null;
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When you run `sw:plugin:install --activate ...` and the plugin is already installed it won't get activated.

### 2. What does this change do, exactly?
Don't stop after checking the installation state of the plugin and continue with optional activation.

### 3. Describe each step to reproduce the issue or behaviour.
1. `sw:plugin:install ...`
2. Wait and forget you installed it (optional)
3. `sw:plugin:install --activate ...`
4. Use things from the freshly installed and activated plugin
5. Wait wat? :confused: 
6. Why is my service not loaded?
7. Random coworker: did you activate your plugin and clear the cache?
    Me: Sure I did, see :point_right: `sw:plugin:list | grep ...`
    Random coworker: no you did not lawl

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.