### PR TITLE
Check plugin validation before activation

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInstaller.php
@@ -247,9 +247,10 @@ class PluginInstaller
      */
     public function activatePlugin(Plugin $plugin)
     {
-        $context = new ActivateContext($plugin, $this->release->getVersion(), $plugin->getVersion());
-
         $bootstrap = $this->getPluginByName($plugin->getName());
+        $this->requirementValidator->validate($bootstrap->getPath() . '/plugin.xml', $this->release->getVersion());
+
+        $context = new ActivateContext($plugin, $this->release->getVersion(), $plugin->getVersion());
 
         $this->events->notify(PluginEvent::PRE_ACTIVATE, new PrePluginActivateEvent($context, $bootstrap));
 


### PR DESCRIPTION
### 1. Why is this change necessary?
There is no check on plugin activation if the conditions, especially `requiredPlugins`, are still met. 

### 2. What does this change do, exactly?
Assert plugin conditions.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have 2 Plugins where one is dependent on the other one.
2. Install both but don't activate yet.
3. Uninstall the base plugin
4. Activate dependent plugin

If the dependent plugin decorates a symfony service of the parent plugin you are completely f**k'd as now all calls try to instantiate the non existent service and therefore crash.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.