### PR TITLE
Order backend property list by property position

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -633,6 +633,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
 
         $builder = Shopware()->Models()->createQueryBuilder()
             ->from(\Shopware\Models\Property\Value::class, 'pv')
+            ->orderBy('pv.position', 'ASC')
             ->join('pv.articles', 'pa', 'with', 'pa.id = :articleId')
             ->setParameter('articleId', $productId)
             ->join('pv.option', 'po')


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
In the frontend properties are displayed in the order that is specified within Items -> Properties in the backend. I would expect the properties to be ordered the same way in the item's "Properties" tab, but instead those are ordered by creation date (or ID) of the original properties within Items -> Properties.

### 2. What does this change do, exactly?
It adds an `orderBy` statement to the query that loads an item's properties from the database. That way instead of the database infering the insert order as the result order, the `position` column is used.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a handful of property options for a group in Items -> Properties
2. Reorder these properties
3. Edit the properties of an item and select multiple options of the previously reordered ones
4. Save your changes
5. Observe that the order of properties within the preview changes based on the original creation order of the properties

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.