### PR TITLE
hide non-sense informations in ConfigCache while Redis

### DIFF
--- a/engine/Library/Zend/Cache/Backend/Redis.php
+++ b/engine/Library/Zend/Cache/Backend/Redis.php
@@ -121,6 +121,16 @@ class Zend_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_
     }
 
     /**
+     * Gets the redis instance used by the cache.
+     *
+     * @return Redis|null
+     */
+    public function getRedis()
+    {
+        return $this->_redis;
+    }
+
+    /**
      * Returns status on if cache backend is connected to Redis
      *
      * @return bool true if cache backend is connected to Redis server

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -276,17 +276,29 @@ class CacheManager
      */
     public function getConfigCacheInfo()
     {
-        $cacheConfig = $this->container->getParameter('shopware.cache');
-        $dir = null;
+        $backendCache = $this->cache->getBackend();
 
-        if ($this->cache->getBackend() instanceof \Zend_Cache_Backend_Apcu) {
+        if ($backendCache instanceof \Zend_Cache_Backend_Apcu) {
             $info = [];
             $apcInfo = apcu_cache_info('user');
             $info['files'] = $apcInfo['num_entries'];
             $info['size'] = $this->encodeSize($apcInfo['mem_size']);
             $apcInfo = apcu_sma_info();
             $info['freeSpace'] = $this->encodeSize($apcInfo['avail_mem']);
+        } elseif ($backendCache instanceof \Zend_Cache_Backend_Redis) {
+            $info = [];
+
+            /**
+             * @var \Zend_Cache_Backend_Redis
+             * @var \Redis|null               $redis
+             */
+            $redis = $backendCache->getRedis();
+            $info['files'] = $redis->dbSize();
+            $info['size'] = $this->encodeSize($redis->info()['used_memory']);
         } else {
+            $cacheConfig = $this->container->getParameter('shopware.cache');
+            $dir = null;
+
             if (!empty($cacheConfig['backendOptions']['cache_dir'])) {
                 $dir = $cacheConfig['backendOptions']['cache_dir'];
             } elseif (!empty($cacheConfig['backendOptions']['slow_backend_options']['cache_dir'])) {
@@ -297,7 +309,7 @@ class CacheManager
 
         $info['name'] = 'Shopware configuration';
 
-        $backend = get_class($this->cache->getBackend());
+        $backend = get_class($backendCache);
         $backend = str_replace('Zend_Cache_Backend_', '', $backend);
 
         $info['backend'] = $backend;


### PR DESCRIPTION
### 1. Why is this change necessary?
When Redis is set, information of cacheDir will be shown.

### 2. What does this change do, exactly?
Show informations of redis 
![image](https://user-images.githubusercontent.com/135993/55229776-3698f080-521e-11e9-930d-9b2646a9b06c.png)

### 3. Describe each step to reproduce the issue or behaviour.
Set Redis, see Caches/Performance showing sizes of default CacheDir

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.