### PR TITLE
Removes obsolete condition for currency factor

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -816,17 +816,13 @@ SQL;
         }
 
         // Including currency factor
+        $factor = 1;
         if ($this->sSYSTEM->sCurrency['factor'] && empty($voucherDetails['percental'])) {
             $factor = $this->sSYSTEM->sCurrency['factor'];
             $voucherDetails['value'] *= $factor;
-        } else {
-            $factor = 1;
         }
 
-        $basketValue = 0;
-        if ($factor !== 0) {
-            $basketValue = $amount['totalAmount'] / $factor;
-        }
+        $basketValue = $amount['totalAmount'] / $factor;
         // Check if the basket's value is above the voucher's
         if ($basketValue < $voucherDetails['minimumcharge']) {
             $snippet = $this->snippetManager->getNamespace('frontend/basket/internalMessages')->get(


### PR DESCRIPTION
### 1. Why is this change necessary?
It isn't. Just cleans up some obsolete code.

### 2. What does this change do, exactly?
Removes a condition that checks the variable `$factor` for `0`. But in [this condition](https://github.com/shopware/shopware/blob/5.5/engine/Shopware/Core/sBasket.php#L819) it is already checked and if it is `0` it falls back to `1`. Therefore it can never be `0` here.

### 3. Describe each step to reproduce the issue or behaviour.
None.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [x] I have written tests ~~and verified that they fail without my change~~
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.