### PR TITLE
changed initial type according to other class properties

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/Struct/Product.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Struct/Product.php
@@ -82,7 +82,7 @@ class Product extends ListProduct
     /**
      * @var Group[]
      */
-    protected $fullConfiguration;
+    protected $fullConfiguration = [];
 
     /**
      * @var string[]


### PR DESCRIPTION
### 1. Why is this change necessary?
Under some circumstances index with bin/console sw:es:index:populate was not possible anymore. 

Uncaught TypeError: Argument 1 passed to Shopware\Bundle\ESIndexingBundle\Product\ProductListingVariationLoader::createSplitting() must be of the type array, null given

Full product configurations being null should not lead to the whole process aborting.

### 2. What does this change do, exactly?
It changes the initial type of the class property to the expected type. In that way not populated properties wont make the process crash.

### 3. Describe each step to reproduce the issue or behaviour.
There seemed to be articles having no valid variant-configuration. This may happen.

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.