### PR TITLE
Adds support for third party authentication adapters

### DIFF
--- a/engine/Shopware/Components/Auth.php
+++ b/engine/Shopware/Components/Auth.php
@@ -125,7 +125,6 @@ class Shopware_Components_Auth extends Enlight_Components_Auth
     /**
      * Do a authentication approve with a defined adapter
      *
-     *
      * @return Zend_Auth_Result
      */
     public function authenticate(Zend_Auth_Adapter_Interface $adapter = null)
@@ -134,17 +133,7 @@ class Shopware_Components_Auth extends Enlight_Components_Auth
             $adapter = $this->_baseAdapter;
         }
 
-        $result = parent::authenticate($adapter);
-
-        // If authentication with the current adapter was succeeded, read user data from default adapter (database)
-        if ($result->isValid() && method_exists($this->getAdapter(0), 'getResultRowObject')) {
-            $user = $this->getAdapter(0)->getResultRowObject();
-            $this->getStorage()->write($user);
-        } else {
-            $this->getStorage()->clear();
-        }
-
-        return $result;
+        return parent::authenticate($adapter);
     }
 
     /**

--- a/tests/Functional/Components/AuthTest.php
+++ b/tests/Functional/Components/AuthTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+use Shopware\Components\Password\Encoder\PasswordEncoderInterface;
+
+class Shopware_Tests_Components_AuthTest extends Enlight_Components_Test_TestCase
+{
+    /**
+     * @var Enlight_Components_Db_Adapter_Pdo_Mysql
+     */
+    private $db;
+
+    /**
+     * @var Shopware_Components_Auth
+     */
+    private $auth;
+
+    /**
+     * @var PasswordEncoderInterface
+     */
+    private $encoder;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->db = Shopware()->Db();
+        $this->db->beginTransaction();
+
+        $this->auth = Shopware_Components_Auth::getInstance();
+
+        /** @var \Shopware\Components\Password\Manager $passworEncoderRegistry */
+        $passworEncoderRegistry = Shopware()->Container()->get('PasswordEncoder');
+        $defaultEncoderName = $passworEncoderRegistry->getDefaultPasswordEncoderName();
+        $this->encoder = $passworEncoderRegistry->getEncoderByName($defaultEncoderName);
+    }
+
+    protected function tearDown()
+    {
+        $this->db->rollBack();
+
+        parent::tearDown();
+    }
+
+    public function testAuthenticateWithPassedAdapter()
+    {
+        // Create adapter
+        $adapter = new Shopware_Components_Auth_Adapter_Default();
+
+        // Prepare backend user
+        $username = 'testUser' . uniqid(rand());
+        $password = 'correctPassword';
+        $this->createAdminUser($username, $password);
+
+        // Authenticate with wrong password; should fail
+        $adapter->setIdentity($username);
+        $adapter->setCredential($password . 'GoneWrong');
+        static::assertFalse($this->auth->authenticate($adapter)->isValid());
+
+        // Authenticate with correct password; should succeed
+        $adapter->setIdentity($username);
+        $adapter->setCredential($password);
+        static::assertTrue($this->auth->authenticate($adapter)->isValid());
+        $user = $this->auth->getStorage()->read();
+        static::assertInstanceOf('stdClass', $user);
+        static::assertEquals($username, $user->username);
+    }
+
+    public function testAuthenticateWithSetAdapter()
+    {
+        // Create adapter
+        $adapter = new Shopware_Components_Auth_Adapter_Default();
+
+        // Set adapter, so we don't have to pass it to authenticate method
+        $this->auth->setBaseAdapter($adapter);
+        $this->auth->addAdapter($adapter);
+
+        // Prepare backend user
+        $username = 'testUser' . uniqid(rand());
+        $password = 'correctPassword';
+        $this->createAdminUser($username, $password);
+
+        // Authenticate with wrong password; should fail
+        $adapter->setIdentity($username);
+        $adapter->setCredential($password . 'GoneWrong');
+        static::assertFalse($this->auth->authenticate()->isValid());
+
+        // Authenticate with correct password; should succeed
+        $adapter->setIdentity($username);
+        $adapter->setCredential($password);
+        static::assertTrue($this->auth->authenticate()->isValid());
+        $user = $this->auth->getStorage()->read();
+        static::assertInstanceOf('stdClass', $user);
+        static::assertEquals($username, $user->username);
+    }
+
+    protected function createAdminUser($username, $password)
+    {
+        $name = uniqid(rand());
+        $email = $name . '@shopware.com';
+        $password = $this->encoder->encodePassword($password);
+
+        $this->db->insert('s_core_auth', [
+            'roleID' => 1,
+            'username' => $username,
+            'password' => $password,
+            'encoder' => $this->encoder->getName(),
+            'localeID' => 1,
+            'name' => $name,
+            'email' => $email,
+            'active' => true,
+            'failedlogins' => 0,
+            'lockedUntil' => (new DateTime('1970-01-01'))->format('Y-m-d H:i:s'),
+        ]);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
If a plugin wants to add an authentication adapter, it would have no effect. This is because when iterating over all given adapters and trying to authenticate the user with them, the routine will always use the first adapter in the set of adapters.

### 2. What does this change do, exactly?
This change will use the actual adapter of the current iteration instead of always using the first one.

### 3. Describe each step to reproduce the issue or behaviour.
1. Try to add an authentication adapter.
2. Wonder why it does not work.
3. Find out, you never had a chance to begin with.
4. Rage for a few minutes. (optional)
5. Replace the default adapter entirely.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
Maybe one could add a tutorial in the documentation on how to add a custom authentication adapter.

### 6. Checklist

- [x] I have written tests ~~and verified that they fail without my change~~
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.