### PR TITLE
Changed LIKE search for ordernumber to use the index on the table.

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Search.php
+++ b/engine/Shopware/Controllers/Frontend/Search.php
@@ -151,15 +151,16 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
             $products = array_column($products, 'articleID');
 
             if (empty($products)) {
+                $like_search = $search."%";
                 $sql = "
                     SELECT DISTINCT articleID
                     FROM s_articles_details
                     WHERE ordernumber = ?
-                    OR ? LIKE CONCAT(ordernumber, '%')
+                    OR ordernumber LIKE ?
                     GROUP BY articleID
                     LIMIT 2
                 ";
-                $products = $this->get('db')->fetchCol($sql, [$search, $search]);
+                $products = $this->get('db')->fetchCol($sql, [$search, $like_search]);
             }
         }
         if (!empty($products) && count($products) == 1) {


### PR DESCRIPTION
This dramatically decreases the search time and also corrects the placeholder
search of ordernumbers.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
It improves the search time for ordernumbers with LIKE operator


### 2. What does this change do, exactly?
Rewrites the SQL to improve search operation with LIKE. Also it fixes the search for parts of ordernumbers.

### 3. Describe each step to reproduce the issue or behaviour.
In very large shops (more than 2 Million articles) it took more than 6 seconds with original query. With rewritten SQL the search time drops down to 0.5 seconds.


### 4. Please link to the relevant issues (if any).

No issue yet opened, the fix was need ASAP as our customer was not very happy with the search time.

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.