### PR TITLE
Enable defining pdo options in config

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Db.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Db.php
@@ -54,7 +54,8 @@ class Db
             $conn = new \PDO(
                 'mysql:' . $connectionString,
                 $dbConfig['username'],
-                $password
+                $password,
+                $dbConfig['pdoOptions']
             );
 
             $conn->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -138,6 +138,7 @@ return array_replace_recursive([
         'host' => 'localhost',
         'charset' => 'utf8mb4',
         'adapter' => 'pdo_mysql',
+        'pdoOptions' => null,
     ],
     'es' => [
         'prefix' => 'sw_shop',


### PR DESCRIPTION
### 1. Why is this change necessary?

Definiting connection options for pdo is needed, to enable tls encrypted connection to the mysql database. In many cloud environments (like Microsoft Azure) it is recommended to encrypt the traffic between the app server and the database if the Database is managed by the hoster / cloud admins.

Otherwise the traffic is not protected again MITM-Attacks.

Additionally, shop owners can use this options to add additional pdo options that are not related to this.

### 2. What does this change do, exactly?

Passing options from config to the PDO connection.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?

https://developers.shopware.com/developers-guide/shopware-config should be updated with the new config option.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change -> I don't know, how to test this. Any ideas? If I modify the db settings in the tests, other tests could fail because of this changes. I don't think, that this change is risky in any way, because it just passes some parameters to the PDO object initialization
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.