### PR TITLE
SW-23873 Fix manufacturer sorting

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -126,10 +126,10 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
         /** @var ShopContextInterface $context */
         $context = $this->get('shopware_storefront.context_service')->getShopContext();
 
-        /** @var \Shopware\Bundle\StoreFrontBundle\Service\CustomSortingServiceInterface $service */
-        $sortingService = $this->get('shopware_storefront.custom_sorting_service');
-
         if (!$this->Request()->getParam('sCategory')) {
+            /** @var \Shopware\Bundle\StoreFrontBundle\Service\CustomSortingServiceInterface $service */
+            $sortingService = $this->get('shopware_storefront.custom_sorting_service');
+
             $categoryId = $context->getShop()->getCategory()->getId();
 
             $this->Request()->setParam('sCategory', $categoryId);
@@ -140,6 +140,8 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
             $sortings = array_shift($sortings);
 
             $this->setDefaultSorting($sortings);
+
+            $this->view->assign('sortings', $sortings);
         }
 
         /** @var Criteria $criteria */


### PR DESCRIPTION
### 1. Why is this change necessary?
The sortings on the manufacturer page do not work.

### 2. What does this change do, exactly?
The $sortings are generated, but not passed to the view.

### 3. Describe each step to reproduce the issue or behaviour.
Create manufacturer page, try to sort the page.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-23873

### 5. Which documentation changes (if any) need to be made because of this PR?
/

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.