### PR TITLE
Allows using various attributes as a category path

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -1154,10 +1154,11 @@ class sExport
      * @param int      $articleID
      * @param string   $separator
      * @param int|null $categoryID
+     * @param string   $field
      *
      * @return string
      */
-    public function sGetArticleCategoryPath($articleID, $separator = ' > ', $categoryID = null)
+    public function sGetArticleCategoryPath($articleID, $separator = ' > ', $categoryID = null, $field = 'name')
     {
         if (empty($categoryID)) {
             $categoryID = $this->sSettings['categoryID'];
@@ -1168,7 +1169,7 @@ class sExport
         $breadcrumbs = [];
 
         foreach ($breadcrumb as $breadcrumbObj) {
-            $breadcrumbs[] = $breadcrumbObj['name'];
+            $breadcrumbs[] = $field === 'link' ? Shopware()->Modules()->Core()->sRewriteLink($breadcrumbObj[$field]) : $breadcrumbObj[$field];
         }
 
         return htmlspecialchars_decode(implode($separator, $breadcrumbs));


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Many integration systems require a unique category path identifier.  In this case, is "id" 
At the moment, we can only use the category name, but the name is not always unique, and it is not flexible.


An example of a system requiring a unique category path:  http://docs.relateddigital.com/display/KB/Uploading+Your+Product+Data



### 2. What does this change do, exactly?
This change allows you to use the following constructs in the feed configuration:

```xml
<item> 
    <category_name>{$sArticle.articleID|category:" > "}</category_name>
    <category_ids>{$sArticle.articleID|category:";":"":"id"}</category_ids>
    <category_links>{$sArticle.articleID|category:";":"":"link"}</category_links>
</item>
```

```xml
<item> 
    <category_name>SALE > Sub Sale</category_name>
    <category_ids>93;275</category_ids>
    <category_links>https://example.com/sale/;http://example.com/sale/sub-sale/</category_links>
</item>
```



### 3. Describe each step to reproduce the issue or behaviour.
none

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist 
- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.