### PR TITLE
[user-scalable="no"] wird nicht mehr benötigt

### DIFF
--- a/themes/Frontend/Bare/frontend/index/header.tpl
+++ b/themes/Frontend/Bare/frontend/index/header.tpl
@@ -40,7 +40,7 @@
     {/block}
 
     {block name='frontend_index_header_meta_tags_mobile'}
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-title" content="{if $theme.appleWebAppTitle != ""}{$theme.appleWebAppTitle|escapeHtml}{else}{{config name=sShopname}|escapeHtml}{/if}">
         <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
Nach den aktuellen Audits von Lighthouse wird [user-scalable="no"] nicht mehr bewertet und soll entfernt werden, wir haben dies einmal getestet und es funktioniert alles noch wie gehabt und google meckert nicht mehr.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
According to Lighthouse, Google no longer needs this parameter.

### 2. What does this change do, exactly?

It removes a meanwhile unnecessary parameter for the viewport.

### 3. Describe each step to reproduce the issue or behaviour.
Carry out an audit in the Lighthouse, then look at the error under use.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.