### PR TITLE
Prevents broken event listeners from being registered

### DIFF
--- a/_sql/migrations/1463-remove-uncallable-event-listeners.php
+++ b/_sql/migrations/1463-remove-uncallable-event-listeners.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration1463 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $uncallableListeners = [
+            'Shopware_Plugins_Backend_Menu_Bootstrap::onInitResourceMenu',
+            'Shopware_Plugins_Core_Router_Bootstrap::onFilterAssemble',
+            'Shopware_Plugins_Core_Router_Bootstrap::onFilterUrl',
+            'Shopware_Plugins_Core_Router_Bootstrap::onAssemble',
+            'Shopware_Plugins_Backend_Check_Bootstrap::onGetControllerPathBackend',
+            'Shopware_Plugins_Core_MarketingAggregate_Bootstrap::initTopSeller',
+        ];
+
+        $sql = 'DELETE FROM s_core_subscribes WHERE listener = "%s";';
+
+        foreach ($uncallableListeners as $uncallableListener) {
+            $this->addSql(sprintf($sql, $uncallableListener));
+        }
+    }
+}

--- a/engine/Library/Enlight/Event/EventManager.php
+++ b/engine/Library/Enlight/Event/EventManager.php
@@ -24,6 +24,8 @@
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Enlight\Event\SubscriberInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * The Enlight_Event_EventManager stores all event listeners.
@@ -50,6 +52,26 @@ class Enlight_Event_EventManager extends Enlight_Class
      *                              registerListener(Enlight_Event_Handler $handler) function.
      */
     protected $listeners = [];
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Enlight_Event_EventManager constructor.
+     * @param LoggerInterface $logger
+     */
+    public function __construct()
+    {
+        $this->logger = new NullLogger();
+        parent::__construct();
+    }
+
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
 
     /**
      * Returns all event listeners of the Enlight_Event_EventManager
@@ -98,6 +120,27 @@ class Enlight_Event_EventManager extends Enlight_Class
      */
     public function registerListener(Enlight_Event_Handler $handler)
     {
+        if (!$handler->isCallable()) {
+            $handlerInfo = $handler->toArray();
+
+            if (is_array($handlerInfo['listener'])) {
+                if (is_object($handlerInfo['listener'][0])) {
+                    $handlerInfo['listener'][0] = get_class($handlerInfo['listener'][0]);
+                }
+
+                $handlerInfo['listener'] = implode('::', $handlerInfo['listener']);
+            }
+
+            $this->logger->error(sprintf(
+                'The event listener "%s::%s" for the event "%s" cannot be registered because it is not callable.',
+                $handlerInfo['plugin'],
+                $handlerInfo['listener'],
+                $handlerInfo['name']
+            ));
+
+            return $this;
+        }
+
         $eventName = strtolower($handler->getName());
 
         if (!isset($this->listeners[$eventName])) {

--- a/engine/Library/Enlight/Event/Handler.php
+++ b/engine/Library/Enlight/Event/Handler.php
@@ -96,6 +96,13 @@ abstract class Enlight_Event_Handler
     abstract public function getListener();
 
     /**
+     * Checks if the event listener is callable.
+     *
+     * @return bool
+     */
+    abstract public function isCallable();
+
+    /**
      * Executes the event handler with the Enlight_Event_EventArgs.
      * @param   Enlight_Event_EventArgs $args
      * @return  mixed

--- a/engine/Library/Enlight/Event/Handler/Default.php
+++ b/engine/Library/Enlight/Event/Handler/Default.php
@@ -82,6 +82,16 @@ class Enlight_Event_Handler_Default extends Enlight_Event_Handler
     }
 
     /**
+     * Checks if the event listener is callable.
+     *
+     * @return bool
+     */
+    public function isCallable()
+    {
+        return is_callable($this->getListener());
+    }
+
+    /**
      * Executes the listener with the given Enlight_Event_EventArgs.
      * @param   Enlight_Event_EventArgs $args
      * @return  mixed

--- a/engine/Library/Enlight/Event/Handler/Plugin.php
+++ b/engine/Library/Enlight/Event/Handler/Plugin.php
@@ -121,6 +121,16 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
     }
 
     /**
+     * Checks if the event listener is callable.
+     *
+     * @return bool
+     */
+    public function isCallable()
+    {
+        return method_exists($this->Plugin(), $this->getListener());
+    }
+
+    /**
      * Setter method for the internal namespace property.
      * @param   Enlight_Plugin_Namespace $namespace
      * @return  Enlight_Event_Handler_Plugin

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -199,6 +199,9 @@
         <service id="shopware.event_manager" alias="events" />
         <service id="events" class="Shopware\Components\ContainerAwareEventManager">
             <argument type="service" id="service_container"/>
+            <call method="setLogger">
+                <argument type="service" id="corelogger"/>
+            </call>
         </service>
 
         <service id="shopware.hook_manager" alias="Hooks" />

--- a/tests/Unit/Components/Event/EventManagerTest.php
+++ b/tests/Unit/Components/Event/EventManagerTest.php
@@ -303,6 +303,7 @@ class EventManagerTest extends TestCase
         static::assertCount(1, $this->eventManager->getListeners('eventName1'));
         static::assertCount(1, $this->eventManager->getListeners('eventName2'));
         static::assertCount(3, $this->eventManager->getListeners('eventName3'));
+        static::assertCount(0, $this->eventManager->getListeners('eventName4'));
 
         $listeners = $this->eventManager->getListeners('eventName3');
         $listener = $listeners[5];
@@ -354,6 +355,31 @@ class EventSubsciberTest implements SubscriberInterface
                 ['callback3_1'],
                 ['callback3_2'],
             ],
+            'eventName4' => 'brokenCallback',
         ];
+    }
+
+    public function callback0()
+    {
+    }
+
+    public function callback1()
+    {
+    }
+
+    public function callback2()
+    {
+    }
+
+    public function callback3_0()
+    {
+    }
+
+    public function callback3_1()
+    {
+    }
+
+    public function callback3_2()
+    {
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
When a plugin registers an event listener, it creates a database entry with a callback for that listener. If this callback will later be not callable anymore and the listened event is triggered, it will result in a fatal error. For some reason this only seems to affect the cli. A listener could become not callable if e.g. the plugin is removed from the system without using the plugin manager to uninstall it.

### 2. What does this change do, exactly?
Before the event listeners are registered, it will now be checked if they are callable. If they are not, they are not registered in the event manager. So now, the error will not be triggered anymore.

### 3. Describe each step to reproduce the issue or behaviour.
1. Install e.g. [SwagImportExport](https://github.com/shopwareLabs/SwagImportExport) and activate it.
2. Go to the plugin directory and remove SwagImportExport.
3. Try to execute a command in the cli, e.g. `sw:cache:clear`.


### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

PS: While working on this, I discovered, that there are several event listeners in the default Shopware database, that are not callable. But since the listened events seem to not exist anymore, they do not actually matter.