### PR TITLE
converting to lowercase locale undependend in es backend indexer

### DIFF
--- a/engine/Shopware/Bundle/EsBackendBundle/EsBackendIndexer.php
+++ b/engine/Shopware/Bundle/EsBackendBundle/EsBackendIndexer.php
@@ -108,7 +108,7 @@ class EsBackendIndexer
                 }
 
                 if (is_string($value)) {
-                    $value = strtolower($value);
+                    $value = mb_strtolower($value);
                 }
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Because the locale settings of the Shop Administrator is unknown, strings should be converted independently of the locale. I received a lot of errors while importing products with a lot of german strings into elasticsearch.

### 2. What does this change do, exactly?
It converts strings to lowercase not by locale settings, but by the Unicode character properties.

### 3. Describe each step to reproduce the issue or behaviour.
```
echo strtolower('Trikothose Kids weiß Saison 16/17');
#can produce in some case of locale settings, something like this: 'trikothose kids wei? saison 16/17'

echo mb_strtolower('Trikothose Kids weiß Saison 16/17')
#expected is: 'trikothose kids weiß saison 16/17'
```

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.