### PR TITLE
Variant support for custom orderNumberRegex

### DIFF
--- a/themes/Backend/ExtJs/backend/article/view/variant/list.js
+++ b/themes/Backend/ExtJs/backend/article/view/variant/list.js
@@ -216,7 +216,7 @@ Ext.define('Shopware.apps.Article.view.variant.List', {
                    oldValue = e.record.get('inStock');
                }
 
-                if(e.field === 'details.number' &&  (!newValue || !newValue.match(/^[a-zA-Z0-9-_. ]+$/))) {
+                if(e.field === 'details.number' &&  (!newValue || !newValue.match({$orderNumberRegex}))) {
                     Shopware.Notification.createGrowlMessage(me.snippets.saved.errorTitle, me.snippets.saved.ordernumberNotMatch, me.snippets.growlMessage);
                     e.record.set('number', oldValue);
                     e.record.set('details.number', oldValue);


### PR DESCRIPTION
### 1. Why is this change necessary?

@soebbing has forget the regex in the variant listing in the backend.
So ordernumber still doesn't match, if the user has changed the regex in the config.

### 2. What does this change do, exactly?

Fix it

### 3. Describe each step to reproduce the issue or behaviour.

Change the regex in the config / open variant listing in the backend.

### 4. Please link to the relevant issues (if any).

Nope

### 5. Which documentation changes (if any) need to be made because of this PR?

Nope

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.