### PR TITLE
invalidate http cache on entity removal

### DIFF
--- a/_sql/migrations/1463-invalidate-http-cache-on-entity-removal-subscriber.php
+++ b/_sql/migrations/1463-invalidate-http-cache-on-entity-removal-subscriber.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+class Migrations_Migration1463 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+SET @plugin_id = (SELECT id FROM s_core_plugins WHERE name='HttpCache');
+INSERT IGNORE INTO `s_core_subscribes` (`subscribe`, `type`, `listener`, `pluginID`, `position`) VALUES ('Shopware\\Models\\Article\\Price::postRemove', 0, 'Shopware_Plugins_Core_HttpCache_Bootstrap::onPostPersist', @plugin_id, 0);
+INSERT IGNORE INTO `s_core_subscribes` (`subscribe`, `type`, `listener`, `pluginID`, `position`) VALUES ('Shopware\\Models\\Article\\Article::postRemove', 0, 'Shopware_Plugins_Core_HttpCache_Bootstrap::onPostPersist', @plugin_id, 0);
+INSERT IGNORE INTO `s_core_subscribes` (`subscribe`, `type`, `listener`, `pluginID`, `position`) VALUES ('Shopware\\Models\\Article\\Detail::postRemove', 0, 'Shopware_Plugins_Core_HttpCache_Bootstrap::onPostPersist', @plugin_id, 0);
+INSERT IGNORE INTO `s_core_subscribes` (`subscribe`, `type`, `listener`, `pluginID`, `position`) VALUES ('Shopware\\Models\\Category\\Category::postRemove', 0, 'Shopware_Plugins_Core_HttpCache_Bootstrap::onPostPersist', @plugin_id, 0);
+INSERT IGNORE INTO `s_core_subscribes` (`subscribe`, `type`, `listener`, `pluginID`, `position`) VALUES ('Shopware\\Models\\Banner\\Banner::postRemove', 0, 'Shopware_Plugins_Core_HttpCache_Bootstrap::onPostPersist', @plugin_id, 0);
+INSERT IGNORE INTO `s_core_subscribes` (`subscribe`, `type`, `listener`, `pluginID`, `position`) VALUES ('Shopware\\Models\\Blog\\Blog::postRemove', 0, 'Shopware_Plugins_Core_HttpCache_Bootstrap::onPostPersist', @plugin_id, 0);
+INSERT IGNORE INTO `s_core_subscribes` (`subscribe`, `type`, `listener`, `pluginID`, `position`) VALUES ('Shopware\\Models\\Emotion\\Emotion::postRemove', 0, 'Shopware_Plugins_Core_HttpCache_Bootstrap::onPostPersist', @plugin_id, 0);
+INSERT IGNORE INTO `s_core_subscribes` (`subscribe`, `type`, `listener`, `pluginID`, `position`) VALUES ('Shopware\\Models\\Site\\Site::postRemove', 0, 'Shopware_Plugins_Core_HttpCache_Bootstrap::onPostPersist', @plugin_id, 0);
+EOD;
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -124,27 +124,35 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
         $this->subscribeEvent('Shopware\Models\Article\Price::postUpdate', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Article\Price::postPersist', 'onPostPersist');
+        $this->subscribeEvent('Shopware\Models\Article\Price::postRemove', 'onPostPersist');
 
         $this->subscribeEvent('Shopware\Models\Article\Article::postUpdate', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Article\Article::postPersist', 'onPostPersist');
+        $this->subscribeEvent('Shopware\Models\Article\Article::postRemove', 'onPostPersist');
 
         $this->subscribeEvent('Shopware\Models\Article\Detail::postUpdate', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Article\Detail::postPersist', 'onPostPersist');
+        $this->subscribeEvent('Shopware\Models\Article\Detail::postRemove', 'onPostPersist');
 
         $this->subscribeEvent('Shopware\Models\Category\Category::postPersist', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Category\Category::postUpdate', 'onPostPersist');
+        $this->subscribeEvent('Shopware\Models\Category\Category::postRemove', 'onPostPersist');
 
         $this->subscribeEvent('Shopware\Models\Banner\Banner::postPersist', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Banner\Banner::postUpdate', 'onPostPersist');
+        $this->subscribeEvent('Shopware\Models\Banner\Banner::postRemove', 'onPostPersist');
 
         $this->subscribeEvent('Shopware\Models\Blog\Blog::postPersist', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Blog\Blog::postUpdate', 'onPostPersist');
+        $this->subscribeEvent('Shopware\Models\Blog\Blog::postRemove', 'onPostPersist');
 
         $this->subscribeEvent('Shopware\Models\Emotion\Emotion::postPersist', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Emotion\Emotion::postUpdate', 'onPostPersist');
+        $this->subscribeEvent('Shopware\Models\Emotion\Emotion::postRemove', 'onPostPersist');
 
         $this->subscribeEvent('Shopware\Models\Site\Site::postPersist', 'onPostPersist');
         $this->subscribeEvent('Shopware\Models\Site\Site::postUpdate', 'onPostPersist');
+        $this->subscribeEvent('Shopware\Models\Site\Site::postRemove', 'onPostPersist');
 
         $this->installForm();
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Page is still available in HTTP cache when entity got removed.

### 2. What does this change do, exactly?

Change removes affected pages from HTTP cache when an entity got deleted.

### 3. Describe each step to reproduce the issue or behaviour.

1. Activate HTTP cache
2. Open product page (copy link or leave tab open)
3. Enter backend in another tab
4. Delete corresponding produkt via backend
5. Refresh product page (maybe flush browser cache before)
6. Product page is still active and alive but assumend to be dead 💀 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.