### PR TITLE
Console bash completion feature is back for shopware 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,8 @@
         "fig/link-util": "1.0.0",
         "league/flysystem": "1.0.46",
         "league/flysystem-aws-s3-v3": "1.0.19",
-        "superbalist/flysystem-google-storage": "6.0.0"
+        "superbalist/flysystem-google-storage": "6.0.0",
+        "stecman/symfony-console-completion": "^0.10.0"
     },
     "suggest": {
         "ext-apcu": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04deb54a1992aae98da9f53607eda735",
+    "content-hash": "ef3d38291810b8f6c22774b777207ceb",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1630,12 +1630,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "801d776b4e4c9fce294d800974266c616bb2ce40"
+                "reference": "b5fbb742af122b565925987e65c08957739976a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/801d776b4e4c9fce294d800974266c616bb2ce40",
-                "reference": "801d776b4e4c9fce294d800974266c616bb2ce40",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/b5fbb742af122b565925987e65c08957739976a7",
+                "reference": "b5fbb742af122b565925987e65c08957739976a7",
                 "shasum": ""
             },
             "require": {
@@ -3535,6 +3535,51 @@
                 "pdf"
             ],
             "time": "2017-05-11T14:25:49+00:00"
+        },
+        {
+            "name": "stecman/symfony-console-completion",
+            "version": "0.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stecman/symfony-console-completion.git",
+                "reference": "bc095febf00aa42ace233b344d4561071d7c912b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stecman/symfony-console-completion/zipball/bc095febf00aa42ace233b344d4561071d7c912b",
+                "reference": "bc095febf00aa42ace233b344d4561071d7c912b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2",
+                "symfony/console": "~2.3 || ~3.0 || ~4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.36 || ~5.7 || ~6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stecman\\Component\\Symfony\\Console\\BashCompletion\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stephen Holdaway",
+                    "email": "stephen@stecman.co.nz"
+                }
+            ],
+            "description": "Automatic BASH completion for Symfony Console Component based applications.",
+            "time": "2019-04-26T12:14:26+00:00"
         },
         {
             "name": "superbalist/flysystem-google-storage",

--- a/engine/Shopware/Bundle/MediaBundle/Commands/ImageMigrateCommand.php
+++ b/engine/Shopware/Bundle/MediaBundle/Commands/ImageMigrateCommand.php
@@ -25,12 +25,34 @@
 namespace Shopware\Bundle\MediaBundle\Commands;
 
 use Shopware\Commands\ShopwareCommand;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ImageMigrateCommand extends ShopwareCommand
+class ImageMigrateCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if (in_array($optionName, ['from', 'to'])) {
+            return array_keys($this->getContainer()->getParameter('shopware.cdn.adapters'));
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Bundle/MediaBundle/Commands/MediaOptimizeCommand.php
+++ b/engine/Shopware/Bundle/MediaBundle/Commands/MediaOptimizeCommand.php
@@ -31,6 +31,9 @@ use Shopware\Bundle\MediaBundle\MediaServiceInterface;
 use Shopware\Bundle\MediaBundle\Optimizer\OptimizerInterface;
 use Shopware\Bundle\MediaBundle\OptimizerServiceInterface;
 use Shopware\Commands\ShopwareCommand;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\ShellPathCompletion;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -42,8 +45,29 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 /**
  * This command allows to optimize all media files at once by executing the relevant optimization commands available.
  */
-class MediaOptimizeCommand extends ShopwareCommand
+class MediaOptimizeCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'path') {
+            // TODO set path for shell completion. Hint: the exit code gets checked in the generated completion bash script
+            exit(ShellPathCompletion::PATH_COMPLETION_EXIT_CODE);
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/CronRunCommand.php
+++ b/engine/Shopware/Commands/CronRunCommand.php
@@ -26,13 +26,40 @@ namespace Shopware\Commands;
 
 use Enlight_Components_Cron_Job;
 use Enlight_Components_Cron_Manager;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CronRunCommand extends ShopwareCommand
+class CronRunCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'cronjob') {
+            /** @var Enlight_Components_Cron_Manager $manager */
+            $manager = $this->container->get('cron');
+
+            return array_map(function (Enlight_Components_Cron_Job $job) {
+                return $job->getAction();
+            }, $manager->getAllJobs());
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/DatabaseSetupCommand.php
+++ b/engine/Shopware/Commands/DatabaseSetupCommand.php
@@ -26,12 +26,14 @@ namespace Shopware\Commands;
 
 use Shopware\Components\Install\Database;
 use Shopware\Components\Migrations\Manager;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class DatabaseSetupCommand extends ShopwareCommand
+class DatabaseSetupCommand extends ShopwareCommand implements CompletionAwareInterface
 {
     private $validSteps = [
         'drop',
@@ -41,6 +43,26 @@ class DatabaseSetupCommand extends ShopwareCommand
         'importDemodata',
         'setupShop',
     ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'steps') {
+            return $this->validSteps;
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
 
     /**
      * {@inheritdoc}

--- a/engine/Shopware/Commands/MigrationsMigrateCommand.php
+++ b/engine/Shopware/Commands/MigrationsMigrateCommand.php
@@ -24,13 +24,44 @@
 
 namespace Shopware\Commands;
 
+use ReflectionClass;
+use Shopware\Components\Migrations\AbstractMigration;
 use Shopware\Components\Migrations\Manager;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MigrationsMigrateCommand extends ShopwareCommand
+class MigrationsMigrateCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'mode') {
+            $meta = new ReflectionClass(AbstractMigration::class);
+            $constants = $meta->getConstants();
+            $modeConstantKeys = array_filter(array_keys($constants), function ($constantKey) {
+                return strpos($constantKey, 'MODUS_') === 0;
+            });
+            $modeConstantPseudoValues = array_pad([], count($modeConstantKeys), 0);
+
+            return array_intersect_key($constants, array_combine($modeConstantKeys, $modeConstantPseudoValues));
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/PluginActivateCommand.php
+++ b/engine/Shopware/Commands/PluginActivateCommand.php
@@ -25,12 +25,46 @@
 namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Components\Model\ModelRepository;
+use Shopware\Models\Plugin\Plugin;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PluginActivateCommand extends PluginCommand
+class PluginActivateCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'plugin') {
+            /** @var ModelRepository $repository */
+            $repository = $this->getContainer()->get('models')->getRepository(Plugin::class);
+            $queryBuilder = $repository->createQueryBuilder('plugin');
+            $result = $queryBuilder->andWhere($queryBuilder->expr()->eq('plugin.capabilityEnable', 'true'))
+                ->andWhere($queryBuilder->expr()->neq('plugin.active', 'true'))
+                ->andWhere($queryBuilder->expr()->isNotNull('plugin.installed'))
+                ->select(['plugin.name'])
+                ->getQuery()
+                ->getArrayResult();
+
+            return array_column($result, 'name');
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/PluginConfigListCommand.php
+++ b/engine/Shopware/Commands/PluginConfigListCommand.php
@@ -27,14 +27,40 @@ namespace Shopware\Commands;
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Shop\Shop;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class PluginConfigListCommand extends ShopwareCommand
+class PluginConfigListCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'shop') {
+            return $this->completeShopIds($context->getCurrentWord());
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'plugin') {
+            return $this->queryPluginNames($context->getCurrentWord());
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/PluginConfigSetCommand.php
+++ b/engine/Shopware/Commands/PluginConfigSetCommand.php
@@ -26,15 +26,98 @@ namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
 use Shopware\Components\Model\ModelManager;
+use Shopware\Components\Model\ModelRepository;
+use Shopware\Models\Plugin\Plugin;
+use Shopware\Models\Shop\Repository;
 use Shopware\Models\Shop\Shop;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class PluginConfigSetCommand extends ShopwareCommand
+class PluginConfigSetCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'shop') {
+            return $this->completeShopIds($context->getCurrentWord());
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'plugin') {
+            /** @var ModelRepository $repository */
+            $repository = $this->getContainer()->get('models')->getRepository(Plugin::class);
+            $queryBuilder = $repository->createQueryBuilder('plugin');
+            $result = $queryBuilder->andWhere($queryBuilder->expr()->eq('plugin.capabilityEnable', 'true'))
+                ->select(['plugin.name'])
+                ->getQuery()
+                ->getArrayResult();
+
+            return array_column($result, 'name');
+        } elseif ($argumentName === 'key') {
+            $pluginName = $context->getWordAtIndex($context->getWordIndex() - 1);
+            /** @var InstallerService $pluginManager */
+            $pluginManager = $this->container->get('shopware_plugininstaller.plugin_manager');
+            try {
+                $plugin = $pluginManager->getPluginByName($pluginName);
+            } catch (\Exception $e) {
+                return [];
+            }
+
+            /** @var Repository $shopRepository */
+            $shopRepository = $this->getContainer()->get('models')->getRepository(Shop::class);
+
+            $shops = $shopRepository->findAll();
+
+            /** @var string[] $result */
+            $result = [];
+
+            foreach ($shops as $shop) {
+                $configKeys = array_keys($pluginManager->getPluginConfig($plugin, $shop));
+
+                if (empty($result)) {
+                    $result = $configKeys;
+                } else {
+                    $result = array_intersect($result, $configKeys);
+                }
+            }
+
+            return $result;
+        } elseif ($argumentName === 'value') {
+            if (stripos('true', $context->getCurrentWord()) === 0) {
+                return ['true'];
+            }
+
+            if (stripos('false', $context->getCurrentWord()) === 0) {
+                return ['false'];
+            }
+
+            if (stripos('null', $context->getCurrentWord()) === 0) {
+                return ['null'];
+            }
+
+            if (strpos($context->getCurrentWord(), '[') === 0 &&
+                stripos($context->getCurrentWord(), ']') === false) {
+                return ["{$context->getCurrentWord()}]"];
+            }
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/PluginDeactivateCommand.php
+++ b/engine/Shopware/Commands/PluginDeactivateCommand.php
@@ -25,12 +25,46 @@
 namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Components\Model\ModelRepository;
+use Shopware\Models\Plugin\Plugin;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PluginDeactivateCommand extends PluginCommand
+class PluginDeactivateCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'plugin') {
+            /** @var ModelRepository $repository */
+            $repository = $this->getContainer()->get('models')->getRepository(Plugin::class);
+            $queryBuilder = $repository->createQueryBuilder('plugin');
+            $result = $queryBuilder->andWhere($queryBuilder->expr()->eq('plugin.capabilityEnable', 'true'))
+                ->andWhere($queryBuilder->expr()->eq('plugin.active', 'true'))
+                ->andWhere($queryBuilder->expr()->isNotNull('plugin.installed'))
+                ->select(['plugin.name'])
+                ->getQuery()
+                ->getArrayResult();
+
+            return array_column($result, 'name');
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/PluginInstallCommand.php
+++ b/engine/Shopware/Commands/PluginInstallCommand.php
@@ -25,13 +25,46 @@
 namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Components\Model\ModelRepository;
+use Shopware\Models\Plugin\Plugin;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PluginInstallCommand extends PluginCommand
+class PluginInstallCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'plugin') {
+            /** @var ModelRepository $repository */
+            $repository = $this->getContainer()->get('models')->getRepository(Plugin::class);
+            $queryBuilder = $repository->createQueryBuilder('plugin');
+            $result = $queryBuilder->andWhere($queryBuilder->expr()->eq('plugin.capabilityInstall', 'true'))
+                ->andWhere($queryBuilder->expr()->isNull('plugin.installed'))
+                ->select(['plugin.name'])
+                ->getQuery()
+                ->getArrayResult();
+
+            return array_column($result, 'name');
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/PluginListCommand.php
+++ b/engine/Shopware/Commands/PluginListCommand.php
@@ -26,13 +26,50 @@ namespace Shopware\Commands;
 
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Plugin\Plugin;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PluginListCommand extends ShopwareCommand
+class PluginListCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'filter') {
+            return [
+                'activate',
+                'inactive',
+            ];
+        }
+
+        if ($optionName === 'namespace') {
+            $namespaces = [
+                'core',
+                'frontend',
+                'backend',
+                'ShopwarePlugins',
+                'ProjectPlugins',
+            ];
+
+            return array_diff($namespaces, array_intersect($namespaces, $context->getWords()));
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/PluginReinstallCommand.php
+++ b/engine/Shopware/Commands/PluginReinstallCommand.php
@@ -25,13 +25,35 @@
 namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PluginReinstallCommand extends PluginCommand
+class PluginReinstallCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'plugin') {
+            return $this->queryPluginNames($context->getCurrentWord());
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/PluginUninstallCommand.php
+++ b/engine/Shopware/Commands/PluginUninstallCommand.php
@@ -25,13 +25,46 @@
 namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Components\Model\ModelRepository;
+use Shopware\Models\Plugin\Plugin;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PluginUninstallCommand extends PluginCommand
+class PluginUninstallCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'plugin') {
+            /** @var ModelRepository $repository */
+            $repository = $this->getContainer()->get('models')->getRepository(Plugin::class);
+            $queryBuilder = $repository->createQueryBuilder('plugin');
+            $result = $queryBuilder->andWhere($queryBuilder->expr()->eq('plugin.capabilityEnable', 'true'))
+                ->andWhere($queryBuilder->expr()->isNotNull('plugin.installed'))
+                ->select(['plugin.name'])
+                ->getQuery()
+                ->getArrayResult();
+
+            return array_column($result, 'name');
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/PluginUpdateCommand.php
+++ b/engine/Shopware/Commands/PluginUpdateCommand.php
@@ -26,13 +26,35 @@ namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
 use Shopware\Components\Model\ModelManager;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PluginUpdateCommand extends PluginCommand
+class PluginUpdateCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'plugin') {
+            return $this->queryPluginNames($context->getCurrentWord());
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/SettingsLabelsFindMissingCommand.php
+++ b/engine/Shopware/Commands/SettingsLabelsFindMissingCommand.php
@@ -25,13 +25,39 @@
 namespace Shopware\Commands;
 
 use Shopware\Models\Shop\Locale;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SettingsLabelsFindMissingCommand extends ShopwareCommand
+class SettingsLabelsFindMissingCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'target') {
+            return $this->completeDirectoriesInDirectory($this->container->get('application')->DocPath());
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'locale') {
+            return $this->completeInstalledLocaleKeys($context->getCurrentWord());
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/SnippetsRemoveCommand.php
+++ b/engine/Shopware/Commands/SnippetsRemoveCommand.php
@@ -24,12 +24,34 @@
 
 namespace Shopware\Commands;
 
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SnippetsRemoveCommand extends ShopwareCommand
+class SnippetsRemoveCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'folder') {
+            return $this->completeDirectoriesInDirectory($this->container->getParameter('kernel.root_dir'));
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/SnippetsToDbCommand.php
+++ b/engine/Shopware/Commands/SnippetsToDbCommand.php
@@ -27,12 +27,34 @@ namespace Shopware\Commands;
 use Shopware\Components\Snippet\DatabaseHandler;
 use Shopware\Kernel;
 use Shopware\Models\Plugin\Plugin;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SnippetsToDbCommand extends ShopwareCommand
+class SnippetsToDbCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'source') {
+            return $this->completeInDirectory($this->container->getParameter('kernel.root_dir'));
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/SnippetsToIniCommand.php
+++ b/engine/Shopware/Commands/SnippetsToIniCommand.php
@@ -24,13 +24,39 @@
 
 namespace Shopware\Commands;
 
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SnippetsToIniCommand extends ShopwareCommand
+class SnippetsToIniCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'target') {
+            return $this->completeDirectoriesInDirectory();
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'locale') {
+            return $this->completeInstalledLocaleKeys($context->getCurrentWord());
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/SnippetsToSqlCommand.php
+++ b/engine/Shopware/Commands/SnippetsToSqlCommand.php
@@ -26,13 +26,39 @@ namespace Shopware\Commands;
 
 use Shopware\Components\Snippet\QueryHandler;
 use Shopware\Models\Plugin\Plugin;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SnippetsToSqlCommand extends ShopwareCommand
+class SnippetsToSqlCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'update') {
+            return ['true', 'false'];
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'file') {
+            return $this->completeInDirectory();
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/SnippetsValidateCommand.php
+++ b/engine/Shopware/Commands/SnippetsValidateCommand.php
@@ -25,12 +25,34 @@
 namespace Shopware\Commands;
 
 use Shopware\Components\Snippet\SnippetValidator;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SnippetsValidateCommand extends ShopwareCommand
+class SnippetsValidateCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'folder') {
+            return $this->completeInDirectory();
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/StoreCommand.php
+++ b/engine/Shopware/Commands/StoreCommand.php
@@ -24,7 +24,9 @@
 
 namespace Shopware\Commands;
 
+use Shopware\Bundle\PluginInstallerBundle\Service\AccountManagerService;
 use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
+use Shopware\Components\HttpClient\HttpClientInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -101,7 +103,7 @@ abstract class StoreCommand extends ShopwareCommand
     {
         $version = $input->getOption('shopware-version');
         if (empty($version)) {
-            $version = $this->container->getParameter('shopware.release.version');
+            $version = $this->getInstalledShopwareVersion();
         }
 
         return $version;
@@ -176,5 +178,55 @@ abstract class StoreCommand extends ShopwareCommand
         }
 
         return $hostname;
+    }
+
+    /**
+     * @param string $input
+     *
+     * @return string[]
+     */
+    protected function completeLicensedDomain($input)
+    {
+        /* @var AccountManagerService $accountManagerService */
+        try {
+            $accountManagerService = $this->container->get('shopware_plugininstaller.account_manager_service');
+        } catch (\Exception $e) {
+            return [];
+        }
+
+        // TODO is it useful to query for other shop hosts?
+        return [
+            $accountManagerService->getDomain(),
+        ];
+    }
+
+    /**
+     * @param string $input
+     *
+     * @return string[]
+     */
+    protected function completeShopwareVersions($input)
+    {
+        try {
+            /** @var HttpClientInterface $guzzle */
+            $guzzle = $this->container->get('http_client');
+            $response = $guzzle->get('https://api.shopware.com/pluginstatics/softwareVersions');
+        } catch (\Exception $e) {
+            return [];
+        }
+
+        $data = json_decode($response->getBody(), true);
+
+        return array_column(array_filter($data, function (array $softwareVersion) {
+            return $softwareVersion['selectable'];
+        }), 'name');
+    }
+
+    /**
+     * @return string
+     */
+    protected function getInstalledShopwareVersion()
+    {
+        return $this->container->getParameter('shopware.release.version');
     }
 }

--- a/engine/Shopware/Commands/StoreDownloadCommand.php
+++ b/engine/Shopware/Commands/StoreDownloadCommand.php
@@ -35,18 +35,59 @@ use Shopware\Bundle\PluginInstallerBundle\Struct\AccessTokenStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\LicenceStruct;
 use Shopware\Bundle\PluginInstallerBundle\Struct\PluginStruct;
 use Shopware\Models\Plugin\Plugin;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class StoreDownloadCommand extends StoreCommand
+class StoreDownloadCommand extends StoreCommand implements CompletionAwareInterface
 {
     /**
      * @var SymfonyStyle
      */
     private $io;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'domain') {
+            return $this->completeLicensedDomain($context->getCurrentWord());
+        }
+
+        if ($optionName === 'shopware-version') {
+            return $this->completeShopwareVersions($context->getCurrentWord());
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'technical-name') {
+            if (!is_null($token = $this->getAuthenticationFromArguments($context->getWords()))) {
+                $context = new LicenceRequest(null, $this->getVersionFromArguments($context->getWords()), $this->getDomainFromArguments($context->getWords()), $token);
+
+                /** @var PluginStoreService $pluginStoreService */
+                $pluginStoreService = $this->container->get(
+                    'shopware_plugininstaller.plugin_service_store_production'
+                );
+
+                return array_map(function (LicenceStruct $licence) {
+                    return $licence->getTechnicalName();
+                }, $pluginStoreService->getLicences($context));
+            }
+        }
+
+        return [];
+    }
 
     /**
      * {@inheritdoc}
@@ -281,7 +322,7 @@ class StoreDownloadCommand extends StoreCommand
     {
         $version = $this->input->getOption('shopware-version');
         if (empty($version)) {
-            $version = $this->container->getParameter('shopware.release.version');
+            $version = $this->getInstalledShopwareVersion();
         }
 
         return $version;
@@ -393,5 +434,57 @@ class StoreDownloadCommand extends StoreCommand
         $context = new PluginsByTechnicalNameRequest('', $version, [$technicalName]);
 
         return $service->getPlugin($context);
+    }
+
+    /**
+     * @param string[] $arguments
+     *
+     * @return string
+     */
+    private function getDomainFromArguments(array $arguments)
+    {
+        $domain = ($domainKey = array_search('--domain', $arguments)) === false ? '' : $arguments[$domainKey + 1];
+
+        if (empty($domain)) {
+            $domain = $this->container->get('shopware_plugininstaller.account_manager_service')->getDomain();
+        }
+
+        return $domain;
+    }
+
+    /**
+     * @param string[] $arguments
+     *
+     * @return string
+     */
+    private function getVersionFromArguments(array $arguments)
+    {
+        $version = ($versionKey = array_search('--shopware-version', $arguments)) === false ? '' : $arguments[$versionKey + 1];
+        if (empty($version)) {
+            $version = $this->getInstalledShopwareVersion();
+        }
+
+        return $version;
+    }
+
+    /**
+     * @param string[] $arguments
+     *
+     * @return AccessTokenStruct|null
+     */
+    private function getAuthenticationFromArguments(array $arguments)
+    {
+        $username = ($usernameKey = array_search('--username', $arguments)) === false ? '' : $arguments[$usernameKey + 1];
+        $password = ($passwordKey = array_search('--password', $arguments)) === false ? '' : $arguments[$passwordKey + 1];
+
+        try {
+            /** @var StoreClient $storeClient */
+            $storeClient = $this->container->get('shopware_plugininstaller.store_client');
+
+            return $storeClient->getAccessToken($username, $password);
+        } catch (\Exception $e) {
+        }
+
+        return null;
     }
 }

--- a/engine/Shopware/Commands/StoreListCommand.php
+++ b/engine/Shopware/Commands/StoreListCommand.php
@@ -26,12 +26,38 @@ namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Context\LicenceRequest;
 use Shopware\Bundle\PluginInstallerBundle\Struct\LicenceStruct;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class StoreListCommand extends StoreCommand
+class StoreListCommand extends StoreCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'domain') {
+            return $this->completeLicensedDomain($context->getCurrentWord());
+        }
+
+        if ($optionName === 'shopware-version') {
+            return $this->completeShopwareVersions($context->getCurrentWord());
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/StoreListUpdatesCommand.php
+++ b/engine/Shopware/Commands/StoreListUpdatesCommand.php
@@ -26,12 +26,34 @@ namespace Shopware\Commands;
 
 use Shopware\Bundle\PluginInstallerBundle\Context\UpdateListingRequest;
 use Shopware\Bundle\PluginInstallerBundle\Struct\UpdateResultStruct;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class StoreListUpdatesCommand extends StoreCommand
+class StoreListUpdatesCommand extends StoreCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'shopware-version') {
+            return $this->completeShopwareVersions($context->getCurrentWord());
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/StreamIndexPopulateCommand.php
+++ b/engine/Shopware/Commands/StreamIndexPopulateCommand.php
@@ -26,13 +26,49 @@ namespace Shopware\Commands;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\AbstractQuery;
+use Shopware\Components\Model\ModelRepository;
 use Shopware\Models\CustomerStream\CustomerStream;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class StreamIndexPopulateCommand extends ShopwareCommand
+class StreamIndexPopulateCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'streamId') {
+            /** @var ModelRepository $customerStreamRepository */
+            $customerStreamRepository = $this->getContainer()->get('models')->getRepository(CustomerStream::class);
+            $queryBuilder = $customerStreamRepository->createQueryBuilder('stream');
+
+            if (is_numeric($context->getCurrentWord())) {
+                $queryBuilder->andWhere($queryBuilder->expr()->like('stream.id', ':id'))
+                    ->setParameter('id', addcslashes($context->getCurrentWord(), '%_') . '%');
+            }
+
+            $result = $queryBuilder->select(['stream.id'])
+                ->getQuery()
+                ->getArrayResult();
+
+            return array_column($result, 'id');
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/ThemeCacheGenerateCommand.php
+++ b/engine/Shopware/Commands/ThemeCacheGenerateCommand.php
@@ -29,12 +29,37 @@ use Shopware\Components\CacheManager;
 use Shopware\Components\Theme\Compiler;
 use Shopware\Models\Shop\Repository;
 use Shopware\Models\Shop\Shop;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ThemeCacheGenerateCommand extends ShopwareCommand
+class ThemeCacheGenerateCommand extends ShopwareCommand implements CompletionAwareInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'shopId') {
+            $shopIdKeys = array_map(function ($key) { return $key + 1; }, array_keys($context->getWords(), '--shopId'));
+            $selectedShopIds = array_intersect_key($context->getWords(), array_combine($shopIdKeys, array_pad([], count($shopIdKeys), 0)));
+
+            return array_diff($this->completeShopIds($context->getCurrentWord()), array_map('intval', $selectedShopIds));
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/engine/Shopware/Commands/ThumbnailGenerateCommand.php
+++ b/engine/Shopware/Commands/ThumbnailGenerateCommand.php
@@ -24,12 +24,16 @@
 
 namespace Shopware\Commands;
 
+use Doctrine\ORM\Query\Expr\Join;
 use Exception;
 use Shopware\Components\Model\ModelManager;
+use Shopware\Components\Model\ModelRepository;
 use Shopware\Components\Thumbnail\Manager;
 use Shopware\Models\Media\Album;
 use Shopware\Models\Media\Media;
 use Shopware\Models\Media\Repository;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -41,7 +45,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * This class is used as a command to generate thumbnails from media albums.
  * If no album is defined, thumbnails from all album medias are created.
  */
-class ThumbnailGenerateCommand extends ShopwareCommand
+class ThumbnailGenerateCommand extends ShopwareCommand implements CompletionAwareInterface
 {
     /**
      * @var OutputInterface
@@ -62,6 +66,41 @@ class ThumbnailGenerateCommand extends ShopwareCommand
      * @var Manager
      */
     private $generator;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'albumid') {
+            /** @var ModelRepository $albumRepository */
+            $albumRepository = $this->getContainer()->get('models')->getRepository(Album::class);
+
+            $queryBuilder = $albumRepository->createQueryBuilder('alb')
+                ->innerJoin('alb.settings', 'settings', Join::WITH, 'settings.createThumbnails = 1');
+
+            if (is_numeric($context->getCurrentWord())) {
+                $queryBuilder->andWhere($queryBuilder->expr()->like('alb.id', ':id'))
+                    ->setParameter('id', addcslashes($context->getCurrentWord(), '%_') . '%');
+            }
+
+            $result = $queryBuilder->select(['alb.id'])
+                ->getQuery()
+                ->getArrayResult();
+
+            return array_column($result, 'id');
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
 
     /**
      * {@inheritdoc}

--- a/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
+++ b/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
@@ -29,13 +29,16 @@ use Shopware\Components\HttpCache\UrlProvider\UrlProviderInterface;
 use Shopware\Components\HttpCache\UrlProviderFactoryInterface;
 use Shopware\Components\Routing\Context;
 use Shopware\Models\Shop\Shop;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class WarmUpHttpCacheCommand extends ShopwareCommand
+class WarmUpHttpCacheCommand extends ShopwareCommand implements CompletionAwareInterface
 {
     private $errorMessage = false;
 
@@ -45,6 +48,26 @@ class WarmUpHttpCacheCommand extends ShopwareCommand
      * @var string[]
      */
     private $defaultProviderNames = ['blog', 'category', 'emotion', 'manufacturer', 'product', 'productwithcategory', 'productwithnumber', 'static', 'variantswitch'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'shopId') {
+            return $this->completeShopIds($context->getCurrentWord());
+        }
+
+        return [];
+    }
 
     /**
      * {@inheritdoc}

--- a/engine/Shopware/Components/DependencyInjection/Compiler/ConfigureContainerAwareCommands.php
+++ b/engine/Shopware/Components/DependencyInjection/Compiler/ConfigureContainerAwareCommands.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\DependencyInjection\Compiler;
+
+use Shopware\Components\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ConfigureContainerAwareCommands implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach (array_keys($container->findTaggedServiceIds('console.command')) as $id) {
+            try {
+                $definition = $container->getDefinition($id);
+            } catch (ServiceNotFoundException $exception) {
+                // Might be an alias, we don't want to register those
+                continue;
+            }
+
+            if (is_a($definition->getClass(), ContainerAwareInterface::class, true)) {
+                $definition->addMethodCall('setContainer', [new Reference('service_container')]);
+            }
+        }
+    }
+}

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -981,5 +981,9 @@
         <service id="shopware.components.robots_txt_generator" class="Shopware\Components\RobotsTxtGenerator">
             <argument type="service" id="router"/>
         </service>
+
+        <service id="shopware.console.completion_command" class="Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand">
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -34,6 +34,7 @@ use Shopware\Bundle\FormBundle\DependencyInjection\CompilerPass\FormPass;
 use Shopware\Bundle\PluginInstallerBundle\Service\PluginInitializer;
 use Shopware\Components\ConfigLoader;
 use Shopware\Components\DependencyInjection\Compiler\ConfigureApiResourcesPass;
+use Shopware\Components\DependencyInjection\Compiler\ConfigureContainerAwareCommands;
 use Shopware\Components\DependencyInjection\Compiler\DoctrineEventSubscriberCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EventListenerCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EventSubscriberCompilerPass;
@@ -617,6 +618,7 @@ class Kernel implements HttpKernelInterface, TerminableInterface
         $container->addCompilerPass(new AddConsoleCommandPass());
         $container->addCompilerPass(new MatcherCompilerPass());
         $container->addCompilerPass(new ConfigureApiResourcesPass());
+        $container->addCompilerPass(new ConfigureContainerAwareCommands());
         $container->addCompilerPass(new ControllerCompilerPass());
         $container->addCompilerPass(new RegisterControllerArgumentLocatorsPass('argument_resolver.service', 'shopware.controller'));
 


### PR DESCRIPTION
### 1. Why is this change necessary?
For easier usability of console commands.

Did you ever cloned a category tree and did not know what category ids you have?
You wanted to configure a plugin via commandline and rage be upset when you had to copy/rewrite every single config key?

As this is a reworked pull request that timed out previously I refer to that one https://github.com/shopware/shopware/pull/1488 . I suggest you reading the original pull request to get a deeper understanding.

### 2. What does this change do, exactly?
Implements for all core/shipped bundle commands the CompletionAwareInterface

### 3. Describe each step to reproduce the issue or behaviour.
Press tab to complete your shopware console commands. It just does not work.

### 4. Which documentation changes (if any) need to be made because of this PR?
You can add this feature to the documentation.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.