### PR TITLE
make queries in order repo more extendable

### DIFF
--- a/engine/Shopware/Models/Order/Document/Repository.php
+++ b/engine/Shopware/Models/Order/Document/Repository.php
@@ -43,9 +43,11 @@ class Repository extends ModelRepository
      * To determine the total number of records, use the following syntax:
      * Shopware()->Models()->getQueryCount($query);
      *
-     * @param int      $orderId
-     * @param int|null $limit
-     * @param int|null $offset
+     * @param int        $orderId
+     * @param array|null $filter
+     * @param array|null $orderBy
+     * @param int|null   $limit
+     * @param int|null   $offset
      *
      * @return \Doctrine\ORM\Query
      */


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Make some queries in the order repository more extendable.

I tried to extend the `getDocuments()` method by it's attributes. Unfortunately, that's only possible using a replace or after hook.

### 2. What does this change do, exactly?

- Splits the documents, payments and details query methods into two separate methods to make the query builder extendable
- Fix some doc blocks

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

Not aware of.

### 5. Which documentation changes (if any) need to be made because of this PR?

Not aware of.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.