### PR TITLE
Print correct path in success message

### DIFF
--- a/engine/Shopware/Commands/GenerateMigrationCommand.php
+++ b/engine/Shopware/Commands/GenerateMigrationCommand.php
@@ -65,7 +65,7 @@ class GenerateMigrationCommand extends ShopwareCommand
 
         $io = new SymfonyStyle($input, $output);
 
-        $io->success(sprintf('Generated file "%s/%s"', dirname($migrationDirectory), $fileName));
+        $io->success(sprintf('Generated file "%s/%s"', $migrationDirectory, $fileName));
     }
 
     private function findMigrationDirectory(?string $pluginName): ?string


### PR DESCRIPTION
### 1. Why is this change necessary?
Using the `bin/console sw:generate:migrations` command displays a different filepath than generated in reality.

### 2. What does this change do, exactly?
Removes an unnecessary `dirname` call.

### 3. Describe each step to reproduce the issue or behaviour.
1. `bin/console sw:ge:migr --plugin Foo bar`
2. See:
```
   [OK] Generated file                                                                                                    
      "/home/vagrant/www/shopware/custom/plugins/Foo/Resources/1-bar.php"     
```
3. `git status`
4. See:
```
On branch 5.6
Your branch is up-to-date with 'origin/5.6'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        custom/plugins/Foo/Resources/migrations/1-bar.php
```


#### Alternative Route
1. `bin/console sw:ge:migr bar`
2. See:
```
   [OK] Generated file                                                                                                    
      "/home/vagrant/www/shopware/_sql/1337-bar.php"     
```

3. `git status`
4. See:
```
On branch 5.6
Your branch is up-to-date with 'origin/5.6'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        _sql/migrations/1337-bar.php
```

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.