### PR TITLE
add missing GTINs

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/content/header.tpl
+++ b/themes/Frontend/Bare/frontend/detail/content/header.tpl
@@ -19,7 +19,16 @@
 
                     {block name="frontend_detail_index_data_ean"}
                         {if $sArticle.ean}
-                            <meta itemprop="gtin13" content="{$sArticle.ean}"/>
+                            {$sArticle.ean = $sArticle.ean|trim}
+                            {if $sArticle.ean|strlen == 13}
+                                <meta itemprop="gtin13" content="{$sArticle.ean}"/>
+                            {elseif $sArticle.ean|strlen == 8}
+                                <meta itemprop="gtin8" content="{$sArticle.ean}"/>
+                            {elseif $sArticle.ean|strlen == 12}
+                                <meta itemprop="gtin12" content="{$sArticle.ean}"/>
+                            {elseif $sArticle.ean|strlen == 14}
+                                <meta itemprop="gtin14" content="{$sArticle.ean}"/>
+                            {/if}
                         {/if}
                     {/block}
 


### PR DESCRIPTION
### 1. Why is this change necessary?

GTIN13 shouldn't be forced.
https://www.barcode.graphics/education-gtin-data-structures/

### 2. What does this change do, exactly?
Check length of string and select matching GTIN. GTIN13 at first, cause it should be common.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.