### PR TITLE
Fix wrong permissions for cache folders/files

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Cache.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Cache.php
@@ -51,6 +51,14 @@ class Cache
     {
         $backendOptions['release'] = $release;
 
+        if(isset($backendOptions['hashed_directory_perm'])) {
+            $backendOptions['hashed_directory_perm'] = decoct($backendOptions['hashed_directory_perm']);
+        }
+
+        if(isset($backendOptions['cache_file_perm'])) {
+            $backendOptions['cache_file_perm'] = decoct($backendOptions['cache_file_perm']);
+        }
+
         $backend = $this->createBackend($backend, $backendOptions);
         $cacheCore = $this->createCacheCore($frontendOptions);
 

--- a/engine/Shopware/Components/DependencyInjection/Bridge/Cache.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Cache.php
@@ -51,11 +51,11 @@ class Cache
     {
         $backendOptions['release'] = $release;
 
-        if(isset($backendOptions['hashed_directory_perm'])) {
+        if (isset($backendOptions['hashed_directory_perm'])) {
             $backendOptions['hashed_directory_perm'] = decoct($backendOptions['hashed_directory_perm']);
         }
 
-        if(isset($backendOptions['cache_file_perm'])) {
+        if (isset($backendOptions['cache_file_perm'])) {
             $backendOptions['cache_file_perm'] = decoct($backendOptions['cache_file_perm']);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The default permission configuration for cache folders/files will result in wrong file permissions.

"0777 & ~umask()" will return an decimal permission value. (e.g. with umask 0002 this will return 509).

This values will be injected into the "Zend_Cache_Backend_File" Component which will call "octdec" on "hashed_directory_perm" and "cache_file_perm" in the constructor. Because these values are already decimals this will return wrong permission values and these will be set during cache creation.

### 2. What does this change do, exactly?
This change will convert the decimal results back to octal numbers before injecting them into the "Zend_Cache_Backend_File" Component.

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
/

### 5. Which documentation changes (if any) need to be made because of this PR?
/

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.