### PR TITLE
Update advanced menu click

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
@@ -181,12 +181,17 @@
          * @param {jQuery.Event} event
          */
         onClick: function (index, $el, event) {
-            var me = this;
+            var me = this,
+                menus = me.$el.find(me.opts.menuContainerSelector);
 
-            if (me._shouldPrevent || !$el.hasClass(me.opts.itemHoverClass)) {
+            var stop = $(menus[index]).has('ul').length && (me._shouldPrevent || !$el.hasClass(me.opts.itemHoverClass));
+
+            if (stop) {
                 event.preventDefault();
                 event.stopImmediatePropagation();
             }
+
+            $.publish('plugin/swAdvancedMenu/onClick', [ me, stop, index, $el, event ]);
         },
 
         /**


### PR DESCRIPTION
### 1. Why is this change necessary?

On a tablet device the menu does't open on first click.
If you have a sub menu, it make sense.
But without it should open directly.

### 2. What does this change do, exactly?

It fix it.

### 3. Describe each step to reproduce the issue or behaviour.

Step 1: Install Advanced Menu.
Step 2: Create some categories with sub entries or not.
Step 3: Open the shop with a tablet or if you don't have a tablet you can use the browser console with device toolbar.

You must click twice to open an upper navigation link.
With this change a navigation entry without a submenu will be open directly.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.