### PR TITLE
Prevent breaking change in snippet manager constructor

### DIFF
--- a/engine/Shopware/Components/Snippet/Manager.php
+++ b/engine/Shopware/Components/Snippet/Manager.php
@@ -75,7 +75,7 @@ class Shopware_Components_Snippet_Manager extends Enlight_Components_Snippet_Man
      */
     private $fallbackLocale;
 
-    public function __construct(ModelManager $modelManager, array $pluginDirectories, array $snippetConfig, $themeDir)
+    public function __construct(ModelManager $modelManager, array $pluginDirectories, array $snippetConfig, $themeDir = null)
     {
         $this->snippetConfig = $snippetConfig;
         $this->modelManager = $modelManager;
@@ -265,7 +265,7 @@ class Shopware_Components_Snippet_Manager extends Enlight_Components_Snippet_Man
     }
 
     /**
-     * @param string $themeDir
+     * @param string|null $themeDir
      *
      * @return string[]
      */
@@ -325,13 +325,17 @@ class Shopware_Components_Snippet_Manager extends Enlight_Components_Snippet_Man
     }
 
     /**
-     * @param string $themeDir
+     * @param string|null $themeDir
      *
      * @return array<string, string>
      */
     private function getThemeDirs($themeDir)
     {
         $configDir = [];
+
+        if ($themeDir === null) {
+            return $configDir;
+        }
 
         /** @var \DirectoryIterator $directory */
         foreach (new \DirectoryIterator(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

This change is required to prevent breaking plugin classes which `extends \Shopware_Components_Snippet_Manager`. We do this for example to provide localized API error messages (useful for app clients) or to provide localized user information messages during the initial installation of a plugin (i.e. when the plugin's snippets have not been imported yet).

### 2. What does this change do, exactly?

This change makes the `themeDir` constructor parameter optional.

### 3. Describe each step to reproduce the issue or behaviour.

Create a class which extends the snippet manager and call the parent constructor with only 3 parameters.

### 4. Please link to the relevant issues (if any).

n/a

### 5. Which documentation changes (if any) need to be made because of this PR?

n/a

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.