### PR TITLE
Corrected translation of order status processing string

### DIFF
--- a/snippets/backend/static/position_status.ini
+++ b/snippets/backend/static/position_status.ini
@@ -1,7 +1,7 @@
 [en_GB]
 cancelled = "Cancelled"
 completed = "Completed"
-in_process = "In process"
+in_process = "In progress"
 open = "Open"
 
 [de_DE]


### PR DESCRIPTION
### 1. Why is this change necessary?
Improved English language used in the order list based on end user customer feedback.

### 2. What does this change do, exactly?
Changes one of the order status strings.

"In Process" doesn't make sense, suspect it should be "In progress" for orders being processed?

### 3. Describe each step to reproduce the issue or behaviour.
Check the order status drop down options
