### PR TITLE
Support single order detail update via API

### DIFF
--- a/tests/Functional/Components/Api/OrderTest.php
+++ b/tests/Functional/Components/Api/OrderTest.php
@@ -26,6 +26,7 @@ namespace Shopware\Tests\Functional\Components\Api;
 
 use Shopware\Components\Api\Resource\Order;
 use Shopware\Components\Api\Resource\Resource;
+use Shopware\Models\Order\Detail;
 
 class OrderTest extends TestCase
 {
@@ -629,6 +630,71 @@ class OrderTest extends TestCase
         $order = $this->resource->create($order);
 
         static::assertCount(2, $order->getDocuments());
+    }
+
+    public function testSingleOrderDetailUpdate()
+    {
+        // Get existing order with at least two order items
+        $orderId = intval(Shopware()->Db()
+            ->query('SELECT `orderID`, COUNT(1) `counter` FROM `s_order_details` GROUP BY `orderId` HAVING `counter` > 1 ORDER BY id DESC LIMIT 1')
+            ->fetchColumn()
+        );
+        $this->resource->setResultMode(Resource::HYDRATE_OBJECT);
+        $order = $this->resource->getOne($orderId);
+
+        /** @var Detail $firstDetail */
+        $firstDetail = $order->getDetails()->first();
+        $newShipped = $firstDetail->getShipped() + 1;
+        $orderCount = $order->getDetails()->count();
+
+        $order = $this->resource->update($order->getId(), [
+            'details' => [
+                [
+                    'id' => $firstDetail->getId(),
+                    'shipped' => $newShipped,
+                ],
+            ],
+            '__options_details' => [
+                'replace' => false,
+            ],
+        ]);
+
+        /** @var Detail|null $firstDetail */
+        $firstDetail = $order->getDetails()->filter(function (Detail $detail) use ($firstDetail): bool {
+            return $detail->getId() === $firstDetail->getId();
+        })->first();
+
+        static::assertEquals($orderCount, $order->getDetails()->count());
+        static::assertNotNull($firstDetail);
+        static::assertEquals($newShipped, $firstDetail->getShipped());
+    }
+
+    public function testSingleOrderDetailUpdateToDeleteOtherItems()
+    {
+        // Get existing order with at least two order items
+        $orderId = intval(Shopware()->Db()
+            ->query('SELECT `orderID`, COUNT(1) `counter` FROM `s_order_details` GROUP BY `orderId` HAVING `counter` > 1 ORDER BY id DESC LIMIT 1')
+            ->fetchColumn()
+        );
+        $this->resource->setResultMode(Resource::HYDRATE_OBJECT);
+        $order = $this->resource->getOne($orderId);
+
+        /** @var Detail $firstDetail */
+        $firstDetail = $order->getDetails()->first();
+
+        $order = $this->resource->update($order->getId(), [
+            'details' => [
+                ['id' => $firstDetail->getId()],
+            ],
+        ]);
+
+        /** @var Detail|null $firstDetail */
+        $firstDetail = $order->getDetails()->filter(function (Detail $detail) use ($firstDetail): bool {
+            return $detail->getId() === $firstDetail->getId();
+        })->first();
+
+        static::assertEquals(1, $order->getDetails()->count());
+        static::assertNotNull($firstDetail);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
If you want to update a single order detail's status via API you have to know all order details and send them over otherwise you will delete all those which you do not update in your API call.

### 2. What does this change do, exactly?
It always loads the existing details and only overrides them if given in the payload.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have an order with at least two order details.
2. Update this order via API with the following payload
```json
{
  "details": [{
    "id": 42,
    "status": 2
  }]
}
```
3. Every detail that has not the id 42 is now deleted as the foreign key to the order is lost on doctrine level and it deletes the orphans.

### 4. Which documentation changes (if any) need to be made because of this PR?
A hint to the order api documentation should be added.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.