### PR TITLE
NTR - give extended feedback to user while add address

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.address-editor.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.address-editor.js
@@ -295,8 +295,11 @@
 
             $modal._$content.find('.address-editor--errors').removeClass('is--hidden');
 
-            $.each(errors, function(field) {
+            $.each(errors, function(field, feedback) {
                 $modal._$content.find('[name="' + fieldPrefix + '[' + field + ']"]').addClass('has--error');
+                if (feedback) {
+                    $modal._$content.find('.address-editor--errors .alert--content').append('<p>' + feedback + '</p>');
+                }
             });
         },
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If you create an additional Validator, f.e. for the zip code and city, and you give the user more specifically feedback, to what went wrong with the entered data, he can not see it (in the modal), like in the register view. f.e. to let him know, he need to enter an zip code only with 4 digits, because he selected Austria as the delivery country

### 2. What does this change do, exactly?
extend the error block with the additional message

### 3. Describe each step to reproduce the issue or behaviour.
We use our Plugin CoeAccountOrtPlz and set in the attributes of the country AT the length of the zip code to min and max 4 digits. Go to the checkout, and want to enter an new delivery address on the confirm page. After entering the wrong zip code and submit the form, you can only see, that you need to enter all fields (but they are all filled).
before / after: https://imgur.com/a/B6zFzYT

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.