### PR TITLE
add http cache warming for site in modal box/xhr request

### DIFF
--- a/engine/Shopware/Components/HttpCache/UrlProvider/StaticProvider.php
+++ b/engine/Shopware/Components/HttpCache/UrlProvider/StaticProvider.php
@@ -79,23 +79,12 @@ class StaticProvider implements UrlProviderInterface
         }
 
         return $this->router->generateList(
-            array_filter(array_map(
-                function ($custom) {
-                    if (empty($custom['link']) || !$this->isShopwareLink($custom['link'])) {
-                        return ['sViewport' => 'custom', 'sCustom' => $custom['id']];
-                    }
-                    $parts = parse_url($custom['link']);
-                    parse_str($parts['query'], $query);
-
-                    if (isset($query['sViewport,registerFC'])) {
-                        unset($query['sViewport,registerFC']);
-                        $query['sViewport'] = 'registerFC';
-                    }
-
-                    return $query;
-                },
-                $result
-            )),
+            array_filter(
+                array_merge(
+                    array_map([$this, 'createRequestParameters'], $result),
+                    array_map([$this, 'createXhrRequestParameters'], $result)
+                )
+            ),
             $context
         );
     }
@@ -105,11 +94,20 @@ class StaticProvider implements UrlProviderInterface
      */
     public function getCount(Context $context)
     {
-        return (int) $this->getBaseQuery()
+        $countSites = (int) $this->getBaseQuery()
             ->addSelect(['COUNT(id)'])
             ->setParameter(':shop', $context->getShopId())
             ->execute()
             ->fetchColumn();
+
+        $countSitesForXhr = (int) $this->getBaseQuery()
+            ->addSelect(['COUNT(id)'])
+            ->setParameter(':shop', $context->getShopId())
+            ->andWhere('link IS NULL OR or link = ""')
+            ->execute()
+            ->fetchColumn();
+
+        return $countSites + $countSitesForXhr;
     }
 
     /**
@@ -131,5 +129,33 @@ class StaticProvider implements UrlProviderInterface
     private function isShopwareLink($link)
     {
         return strpos($link, 'shopware.php') !== false;
+    }
+
+    private function createRequestParameters(array $custom): array
+    {
+        if (empty($custom['link']) || !$this->isShopwareLink($custom['link'])) {
+            return ['sViewport' => 'custom', 'sCustom' => $custom['id']];
+        }
+        $parts = parse_url($custom['link']);
+        parse_str($parts['query'], $query);
+
+        if (isset($query['sViewport,registerFC'])) {
+            unset($query['sViewport,registerFC']);
+            $query['sViewport'] = 'registerFC';
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return array|null
+     */
+    private function createXhrRequestParameters(array $custom)
+    {
+        if (empty($custom['link'])) {
+            return ['sViewport' => 'custom', 'sCustom' => $custom['id'], 'isXHR' => 1];
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
New PR for #2098. This time with correct code styling.
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Shop sites in modal boxes are not taken into account for HTTP cache warm up, currently.

### 2. What does this change do, exactly?

PR changes the static site URL provider for cache warming and adds the shop site URL with 'isXHR' GET parameter.

### 3. Describe each step to reproduce the issue or behaviour.

1. Warm up HTTP cache for shop sites
2. Enabled http cache debug option in config.php
```
    'httpcache' => [
        'debug' => true,
    ],
```
3. Open modal box with shop site in it OR call a shop site's URL with `&isXHR=1` parameter added
4. Check HTTP response headers and find, that request isn't from cache (miss, store)

### 4. Please link to the relevant issues (if any).

Plugin with a backport is available under https://github.com/buddhaCode/BucoStaticXhrHttpCache

### 5. Which documentation changes (if any) need to be made because of this PR?

Guess not.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.