### PR TITLE
make config parameters modifiable  while order document creation

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -29,6 +29,8 @@ This changelog references changes done in Shopware 5.5 patch versions.
     * `getPaymentsQueryBuilder`
     * `getDocumentsQueryBuilder`
 * Added product number and open action to product stream items
+* Added event `Shopware_Models_Order_Document_Filter_Config` to modify config settings for document creation
+* Added `_config` property to class `Shopware_Models_Document_Order` to make it usable while model creation
 
 ### Changes
 

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -173,6 +173,16 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         /** @var Shopware_Components_Document $document */
         $document = Enlight_Class::Instance('Shopware_Components_Document');
 
+        $config = Shopware()->Container()->get('events')->filter(
+            'Shopware_Models_Order_Document_Filter_Config',
+            $config,
+            [
+                'subject' => $document,
+                'orderID' => $orderID,
+                'documentID' => $documentID,
+            ]
+        );
+
         $document->setOrder(Enlight_Class::Instance('Shopware_Models_Document_Order', [$orderID, $config]));
 
         $document->setConfig($config);

--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -161,6 +161,13 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
     protected $_discount;
 
     /**
+     * Document configuration
+     *
+     * @var array
+     */
+    protected $_config;
+
+    /**
      * @var \Shopware\Models\Tax\Repository
      */
     protected $_taxRepository;
@@ -185,6 +192,8 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
         }
 
         $this->_id = $id;
+
+        $this->_config = $config;
 
         $this->_summaryNet = isset($config['summaryNet']) ? $config['summaryNet'] : false;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

I need to modify the config parameters prior to the creation of order documents. Besides, it would be nice to have them available in the model.

### 2. What does this change do, exactly?

* Added event `Shopware_Models_Order_Document_Filter_Config` to modify config settings for document creation
* Added `_config` property to class `Shopware_Models_Document_Order` to make it usable while model creation

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.