### PR TITLE
Prevent gramma error in filter while using 0 in the middle of a filter

### DIFF
--- a/themes/Backend/ExtJs/backend/article_list/resource/lexer.js
+++ b/themes/Backend/ExtJs/backend/article_list/resource/lexer.js
@@ -379,7 +379,7 @@ Ext.define('Lexer', {
         var me = this;
 
         // First token
-        if (token == 0) {
+        if (token == 0 && tokenType != 'values') {
             me.setSuggestion(Object.keys(me.grammar.attributes).concat(Object.keys(me.grammar.nullaryOperators)));
             return { rules: 'expression', message: '{s name=lexer/expressionOrAttribute}expression or attribute{/s}'}
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
Prevent gramma error in filter while using 0 in the middle of a filter in backend article list

### 2. What does this change do, exactly?
Token type check added

### 3. Describe each step to reproduce the issue or behaviour.
![1555956868_5cbe048438581_Screenshot_1](https://user-images.githubusercontent.com/10171867/58547815-be947a00-8210-11e9-938d-f6884aa8df0c.jpg)

### 4. Please link to the relevant issues (if any).
/

### 5. Which documentation changes (if any) need to be made because of this PR?
/

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.