### PR TITLE
SW-24105 Add aria-label attribute

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/plugins/advanced_menu/index.tpl
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/plugins/advanced_menu/index.tpl
@@ -18,7 +18,7 @@
 
                 <li class="menu--list-item item--level-{$level}"{if $level === 0} style="width: 100%"{/if}>
                     {block name="frontend_plugins_advanced_menu_list_item"}
-                        <a href="{$categoryLink|escapeHtml}" class="menu--list-item-link" title="{$category.name|escape}"{if $category.external && $category.externalTarget} target="{$category.externalTarget}"{/if}>{$category.name}</a>
+                        <a href="{$categoryLink|escapeHtml}" class="menu--list-item-link" aria-label="{$category.name|escape}" title="{$category.name|escape}"{if $category.external && $category.externalTarget} target="{$category.externalTarget}"{/if}>{$category.name}</a>
 
                         {if $category.sub}
                             {call name=categories_top categories=$category.sub level=$level+1}
@@ -49,7 +49,7 @@
                 {block name="frontend_plugins_advanced_menu_main_container"}
                     <div class="button-container">
                         {block name="frontend_plugins_advanced_menu_button_category"}
-                            <a href="{$link|escapeHtml}" class="button--category" title="{s name="toCategoryBtn" namespace="frontend/plugins/advanced_menu/advanced_menu"}{/s}{$mainCategory.name|escape:'html'}"{if $mainCategory.external && $category.externalTarget} target="{$mainCategory.externalTarget}"{/if}>
+                            <a href="{$link|escapeHtml}" class="button--category" aria-label="{s name="toCategoryBtn" namespace="frontend/plugins/advanced_menu/advanced_menu"}{/s}{$mainCategory.name|escape:'html'}" title="{s name="toCategoryBtn" namespace="frontend/plugins/advanced_menu/advanced_menu"}{/s}{$mainCategory.name|escape:'html'}"{if $mainCategory.external && $category.externalTarget} target="{$mainCategory.externalTarget}"{/if}>
                                 <i class="icon--arrow-right"></i>
                                 {s name="toCategoryBtn" namespace="frontend/plugins/advanced_menu/advanced_menu"}{/s}{$mainCategory.name}
                             </a>
@@ -77,7 +77,7 @@
                                     {/if}
                                     <div class="menu--teaser"{if $hasCategories} style="width: {$columnAmount * 25}%;"{else} style="width: 100%;"{/if}>
                                         {if !empty($mainCategory.media)}
-                                            <a href="{$link|escapeHtml}" title="{s name="toCategoryBtn" namespace="frontend/plugins/advanced_menu/advanced_menu"}{/s}{$mainCategory.name|escape:'html'}" class="teaser--image" style="background-image: url({link file={$mainCategory.media.path}});"{if $mainCategory.external && $category.externalTarget} target="{$mainCategory.externalTarget}"{/if}></a>
+                                            <a href="{$link|escapeHtml}" aria-label="{s name="toCategoryBtn" namespace="frontend/plugins/advanced_menu/advanced_menu"}{/s}{$mainCategory.name|escape:'html'}" title="{s name="toCategoryBtn" namespace="frontend/plugins/advanced_menu/advanced_menu"}{/s}{$mainCategory.name|escape:'html'}" class="teaser--image" style="background-image: url({link file={$mainCategory.media.path}});"{if $mainCategory.external && $category.externalTarget} target="{$mainCategory.externalTarget}"{/if}></a>
                                         {/if}
 
                                         {if !empty($mainCategory.cmsHeadline)}
@@ -87,7 +87,7 @@
                                         {if !empty($mainCategory.cmsText)}
                                             <div class="teaser--text">
                                                 {$mainCategory.cmsText|strip_tags|truncate:250:"..."}
-                                                <a class="teaser--text-link" href="{$link|escapeHtml}" title="{s name="learnMoreLink" namespace="frontend/plugins/advanced_menu/advanced_menu"}mehr erfahren{/s}">
+                                                <a class="teaser--text-link" href="{$link|escapeHtml}" aria-label="{s name="learnMoreLink" namespace="frontend/plugins/advanced_menu/advanced_menu"}mehr erfahren{/s}" title="{s name="learnMoreLink" namespace="frontend/plugins/advanced_menu/advanced_menu"}mehr erfahren{/s}">
                                                     {s name="learnMoreLink" namespace="frontend/plugins/advanced_menu/advanced_menu"}mehr erfahren{/s}
                                                 </a>
                                             </div>

--- a/themes/Frontend/Bare/frontend/_includes/privacy.tpl
+++ b/themes/Frontend/Bare/frontend/_includes/privacy.tpl
@@ -2,7 +2,7 @@
     <p class="privacy-information">
         {if {config name=ACTDPRCHECK} && !$hideCheckbox}
             {block name="frontend_data_protection_information_checkbox"}
-                <input name="privacy-checkbox" type="checkbox" id="privacy-checkbox" required="required" aria-required="true" value="1" class="is--required"{if $smarty.post['privacy-checkbox']} checked{/if} />
+                <input name="privacy-checkbox" type="checkbox" id="privacy-checkbox" required="required" aria-label="{s name="PrivacyText" namespace="frontend/index/privacy"}{/s}" aria-required="true" value="1" class="is--required"{if $smarty.post['privacy-checkbox']} checked{/if} />
                 <label for="privacy-checkbox">
                     {s name="PrivacyText" namespace="frontend/index/privacy"}{/s}
                 </label>

--- a/themes/Frontend/Bare/frontend/index/main-navigation.tpl
+++ b/themes/Frontend/Bare/frontend/index/main-navigation.tpl
@@ -6,7 +6,7 @@
                     {block name='frontend_index_navigation_categories_top_home'}
                         <li class="navigation--entry{if $sCategoryCurrent == $sCategoryStart && $Controller == 'index'} is--active{/if} is--home" role="menuitem">
                             {block name='frontend_index_navigation_categories_top_link_home'}
-                                <a class="navigation--link is--first{if $sCategoryCurrent == $sCategoryStart && $Controller == 'index'} active{/if}" href="{url controller='index'}" title="{s name='IndexLinkHome' namespace="frontend/index/categories_top"}{/s}" itemprop="url">
+                                <a class="navigation--link is--first{if $sCategoryCurrent == $sCategoryStart && $Controller == 'index'} active{/if}" href="{url controller='index'}" title="{s name='IndexLinkHome' namespace="frontend/index/categories_top"}{/s}" aria-label="{s name='IndexLinkHome' namespace="frontend/index/categories_top"}{/s}" itemprop="url">
                                     <span itemprop="name">{s name='IndexLinkHome' namespace="frontend/index/categories_top"}{/s}</span>
                                 </a>
                             {/block}
@@ -20,7 +20,7 @@
                             {if !$sCategory.hideTop}
                                 <li class="navigation--entry{if $sCategory.flag} is--active{/if}" role="menuitem">
                                     {block name='frontend_index_navigation_categories_top_link'}
-                                        <a class="navigation--link{if $sCategory.flag} is--active{/if}" href="{$sCategory.link}" title="{$sCategory.description}" itemprop="url"{if $sCategory.external && $sCategory.externalTarget} target="{$sCategory.externalTarget}"{/if}>
+                                        <a class="navigation--link{if $sCategory.flag} is--active{/if}" href="{$sCategory.link}" title="{$sCategory.description}" aria-label="{$sCategory.description}" itemprop="url"{if $sCategory.external && $sCategory.externalTarget} target="{$sCategory.externalTarget}"{/if}>
                                             <span itemprop="name">{$sCategory.description}</span>
                                         </a>
                                     {/block}

--- a/themes/Frontend/Bare/frontend/index/search.tpl
+++ b/themes/Frontend/Bare/frontend/index/search.tpl
@@ -15,7 +15,7 @@
 
         {* Search input *}
         {block name='frontend_index_search_field_submit'}
-            <button type="submit" aria-label="{s name="IndexSearchFieldSubmit"}{/s}" class="main-search--button">
+            <button type="submit" aria-label="{s name="IndexSearchFieldSubmit"}{/s}" class="main-search--button" aria-label="{s name="IndexSearchFieldSubmit"}{/s}">
 
                 {* Search icon *}
                 {block name='frontend_index_search_field_submit_icon'}

--- a/themes/Frontend/Bare/frontend/index/shop-navigation.tpl
+++ b/themes/Frontend/Bare/frontend/index/shop-navigation.tpl
@@ -4,7 +4,7 @@
         {* Menu (Off canvas left) trigger *}
         {block name='frontend_index_offcanvas_left_trigger'}
             <li class="navigation--entry entry--menu-left" role="menuitem">
-                <a class="entry--link entry--trigger btn is--icon-left" href="#offcanvas--left" data-offcanvas="true" data-offCanvasSelector=".sidebar-main">
+                <a class="entry--link entry--trigger btn is--icon-left" href="#offcanvas--left" data-offcanvas="true" data-offCanvasSelector=".sidebar-main" aria-label="{s namespace='frontend/index/menu_left' name="IndexLinkMenu"}{/s}">
                     <i class="icon--menu"></i> {s namespace='frontend/index/menu_left' name="IndexLinkMenu"}{/s}
                 </a>
             </li>
@@ -14,7 +14,7 @@
         {block name='frontend_index_search'}
             <li class="navigation--entry entry--search" role="menuitem" data-search="true" aria-haspopup="true"{if $theme.focusSearch && {controllerName|lower} == 'index'} data-activeOnStart="true"{/if} data-minLength="{config name="MinSearchLenght"}">
                 {s namespace="frontend/index/search" name="IndexTitleSearchToggle" assign="snippetIndexTitleSearchToggle"}{/s}
-                <a class="btn entry--link entry--trigger" href="#show-hide--search" title="{$snippetIndexTitleSearchToggle|escape}">
+                <a class="btn entry--link entry--trigger" href="#show-hide--search" title="{$snippetIndexTitleSearchToggle|escape}" aria-label="{$snippetIndexTitleSearchToggle|escape}">
                     <i class="icon--search"></i>
 
                     {block name='frontend_index_search_display'}

--- a/themes/Frontend/Bare/frontend/listing/product-box/button-buy.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/button-buy.tpl
@@ -21,7 +21,7 @@
             {/block}
 
             {block name="frontend_listing_product_box_button_buy_button"}
-                <button class="buybox--button block btn is--primary is--icon-right is--center is--large">
+                <button class="buybox--button block btn is--primary is--icon-right is--center is--large"  aria-label="{s namespace="frontend/listing/box_article" name="ListingBuyActionAdd"}{/s}">
                     {block name="frontend_listing_product_box_button_buy_button_text"}
                         {s namespace="frontend/listing/box_article" name="ListingBuyActionAdd"}{/s}<i class="icon--basket"></i> <i class="icon--arrow-right"></i>
                     {/block}

--- a/themes/Frontend/Bare/frontend/listing/product-box/product-actions.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/product-actions.tpl
@@ -10,6 +10,7 @@
                 <form action="{url controller='compare' action='add_article' articleID=$sArticle.articleID _seo=false}" method="post">
                     <button type="submit"
                        title="{s name='ListingBoxLinkCompare'}{/s}"
+                       aria-label="{s name='ListingBoxLinkCompare'}{/s}"
                        class="product--action action--compare"
                        data-product-compare-add="true">
                         <i class="icon--compare"></i> {s name='ListingBoxLinkCompare'}{/s}
@@ -24,6 +25,7 @@
                 {s name="DetailLinkNotepad" namespace="frontend/detail/actions" assign="snippetDetailLinkNotepad"}{/s}
                 <button type="submit"
                    title="{$snippetDetailLinkNotepad|escape}"
+                   aria-label="{$snippetDetailLinkNotepad|escape}"
                    class="product--action action--note"
                    data-ajaxUrl="{url controller='note' action='ajaxAdd' ordernumber=$sArticle.ordernumber _seo=false}"
                    data-text="{s name="DetailNotepadMarked"}{/s}">

--- a/themes/Frontend/Bare/widgets/checkout/info.tpl
+++ b/themes/Frontend/Bare/widgets/checkout/info.tpl
@@ -2,7 +2,7 @@
 {block name="frontend_index_checkout_actions_notepad"}
     <li class="navigation--entry entry--notepad" role="menuitem">
         {s namespace="frontend/index/checkout_actions" name="IndexLinkNotepad" assign="snippetIndexLinkNotepad"}{/s}
-        <a href="{url controller='note'}" title="{$snippetIndexLinkNotepad|escape}" class="btn">
+        <a href="{url controller='note'}" title="{$snippetIndexLinkNotepad|escape}" aria-label="{$snippetIndexLinkNotepad|escape}" class="btn">
             <i class="icon--heart"></i>
             {if $sNotesQuantity > 0}
                 <span class="badge notes--quantity">
@@ -22,6 +22,7 @@
         {block name="frontend_index_checkout_actions_account"}
             <a href="{url controller='account'}"
                title="{"{if $userInfo}{s name="AccountGreetingBefore" namespace="frontend/account/sidebar"}{/s}{$userInfo['firstname']}{s name="AccountGreetingAfter" namespace="frontend/account/sidebar"}{/s} - {/if}{s namespace='frontend/index/checkout_actions' name='IndexLinkAccount'}{/s}"|escape}"
+               aria-label="{"{if $userInfo}{s name="AccountGreetingBefore" namespace="frontend/account/sidebar"}{/s}{$userInfo['firstname']}{s name="AccountGreetingAfter" namespace="frontend/account/sidebar"}{/s} - {/if}{s namespace='frontend/index/checkout_actions' name='IndexLinkAccount'}{/s}"|escape}"
                class="btn is--icon-left entry--link account--link{if $userInfo} account--user-loggedin{/if}">
                 <i class="icon--account"></i>
                 {if $userInfo}
@@ -50,7 +51,8 @@
                             <div class="entry--close-off-canvas">
                                 <a href="#close-account-menu"
                                    class="account--close-off-canvas"
-                                   title="{s namespace='frontend/index/menu_left' name="IndexActionCloseMenu"}{/s}">
+                                   title="{s namespace='frontend/index/menu_left' name="IndexActionCloseMenu"}{/s}"
+                                   aria-label="{s namespace='frontend/index/menu_left' name="IndexActionCloseMenu"}{/s}">
                                     {s namespace='frontend/index/menu_left' name="IndexActionCloseMenu"}{/s} <i class="icon--arrow-right"></i>
                                 </a>
                             </div>
@@ -70,7 +72,7 @@
 {block name="frontend_index_checkout_actions_cart"}
     <li class="navigation--entry entry--cart" role="menuitem">
         {s namespace="frontend/index/checkout_actions" name="IndexLinkCart" assign="snippetIndexLinkCart"}{/s}
-        <a class="btn is--icon-left cart--link" href="{url controller='checkout' action='cart'}" title="{$snippetIndexLinkCart|escape}">
+        <a class="btn is--icon-left cart--link" href="{url controller='checkout' action='cart'}" title="{$snippetIndexLinkCart|escape}" aria-label="{$snippetIndexLinkCart|escape}">
             <span class="cart--display">
                 {if $sUserLoggedIn}
                     {s name='IndexLinkCheckout' namespace='frontend/index/checkout_actions'}{/s}


### PR DESCRIPTION
### 1. Why is this change necessary?
web.dev tells that elements must have labels
https://lighthouse-dot-webdotdevsite.appspot.com/lh/html?url=http://shopwaredemo.de
"Names and labelsThese are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."

![image](https://user-images.githubusercontent.com/12100810/58643024-c3cff280-82fe-11e9-8292-4333e4b6a28f.png)

(by the way title and alt - tags are missing on EKW Banners with mapping...)

### 2. What does this change do, exactly?
Add aria-label to some default elements like Form/Input/Button in AdvMenu / Navigation / Footer / Listing (Prod.Box)

### 3. Describe each step to reproduce the issue or behaviour.
-
### 4. Please link to the relevant issues (if any).
-
### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.