### PR TITLE
[Bugfix] mappingName = fieldName

### DIFF
--- a/engine/Shopware/Controllers/Backend/Application.php
+++ b/engine/Shopware/Controllers/Backend/Application.php
@@ -853,7 +853,9 @@ abstract class Shopware_Controllers_Backend_Application extends Shopware_Control
                     $data[$mapping['fieldName']] = $associationModel;
 
                     //remove the foreign key data.
-                    unset($data[$field]);
+                    if ($field !== $mapping['fieldName']) {
+                        unset($data[$field]);
+                    }
                 }
             } elseif ($mapping['type'] === ClassMetadataInfo::MANY_TO_MANY) {
                 /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The $data wouldn't provide the needed relation if it is cleared
Additionally I couldn't find a reason why it wouldn't work

### 2. What does this change do, exactly?
Checks if the fieldName is exactly the same as the looped field

### 3. Describe each step to reproduce the issue or behaviour.
Create a new model with an extjs backend with an media selection.
Create a new item via extjs and publish it via image: { "id": field.id }

include the following into the model
```php
    /**
     * @var Media
     *
     * @ORM\ManyToOne(targetEntity="Shopware\Models\Media\Media")
     * @ORM\JoinColumn(name="image", referencedColumnName="id")
     */
    private $image;
```
### 4. Please link to the relevant issues (if any).
///

### 5. Which documentation changes (if any) need to be made because of this PR?
///

### 6. Checklist
**According to #2081 the needed plugin is downloadable [here](https://filebin.net/tpnz5y5hjlpj2nyj/JinnExample.zip?t=ccn6kaa8)**

- [x] I have written tests and verified that they fail without my change
-- Tested it on my own
- [x] I have squashed any insignificant commits
-- Not needed
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
-- Not needed
- [x] I have read the contribution requirements and fulfil them.