### PR TITLE
Adds project plugins into grunt configuration

### DIFF
--- a/themes/grunt-tasks/config/chokidar.js
+++ b/themes/grunt-tasks/config/chokidar.js
@@ -6,7 +6,9 @@ module.exports = {
             '../themes/Frontend/**/*.less',
             '../themes/Frontend/**/*.css',
             '../custom/plugins/**/*.less',
-            '../custom/plugins/**/*.css'
+            '../custom/plugins/**/*.css',
+            '../custom/project/**/*.less',
+            '../custom/project/**/*.css'
         ],
         tasks: ['less:development'],
         options: {
@@ -19,7 +21,9 @@ module.exports = {
             '../themes/Frontend/**/_public/src/js/*.js',
             '../engine/Shopware/Plugins/**/frontend/**/src/js/**/*.js',
             '../custom/plugins/**/frontend/**/src/js/**/*.js',
-            '../custom/plugins/**/frontend/js/**/*.js'
+            '../custom/plugins/**/frontend/js/**/*.js',
+            '../custom/project/**/frontend/**/src/js/**/*.js',
+            '../custom/project/**/frontend/js/**/*.js'
         ],
         tasks: ['uglify:development'],
         options: {


### PR DESCRIPTION
### 1. Why is this change necessary?
To make plugins inside `custom/project` also work with a grunt task.

### 2. What does this change do, exactly?
Makes plugins inside `custom/project` also work with a grunt task.

### 3. Describe each step to reproduce the issue or behaviour.
Run a grunt task with resources inside a plugin in `custom/project`.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.