### PR TITLE
Considers minimum purchase quantity for graduated prices

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/GraduatedPricesGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/GraduatedPricesGateway.php
@@ -98,12 +98,14 @@ class GraduatedPricesGateway implements Gateway\GraduatedPricesGatewayInterface
 
         $query->select($this->fieldHelper->getPriceFields());
         $query->addSelect('variants.ordernumber as number');
+        $query->addSelect('GREATEST(price.from, variants.minpurchase) __price_from');
 
         $query->from('s_articles_prices', 'price')
             ->innerJoin('price', 's_articles_details', 'variants', 'variants.id = price.articledetailsID')
             ->leftJoin('price', 's_articles_prices_attributes', 'priceAttribute', 'priceAttribute.priceID = price.id')
             ->where('price.articledetailsID IN (:products)')
             ->andWhere('price.pricegroup = :customerGroup')
+            ->andWhere($query->expr()->orX('price.to >= variants.minpurchase', 'price.to = "beliebig"'))
             ->orderBy('price.articledetailsID', 'ASC')
             ->addOrderBy('price.from', 'ASC')
             ->setParameter(':products', $ids, Connection::PARAM_INT_ARRAY)

--- a/tests/Functional/Bundle/StoreFrontBundle/GraduatedPricesTest.php
+++ b/tests/Functional/Bundle/StoreFrontBundle/GraduatedPricesTest.php
@@ -48,6 +48,31 @@ class GraduatedPricesTest extends TestCase
         }
     }
 
+    public function testGraduationWithMinimumPurchase()
+    {
+        $number = __FUNCTION__;
+        $context = $this->getContext();
+        $data = $this->getProduct($number, $context);
+        $data['mainDetail']['minPurchase'] = 15;
+
+        $this->helper->createArticle($data);
+
+        $listProduct = $this->helper->getListProduct($number, $context);
+        $graduation = $listProduct->getPrices();
+
+        static::assertCount(2, $graduation);
+
+        /** @var Price $price */
+        $price = array_shift($graduation);
+        static::assertEquals(15, $price->getFrom());
+        static::assertEquals(75, $price->getCalculatedPrice());
+
+        /** @var Price $price */
+        $price = array_shift($graduation);
+        static::assertEquals(21, $price->getFrom());
+        static::assertEquals(50, $price->getCalculatedPrice());
+    }
+
     public function testFallbackGraduation()
     {
         $number = __FUNCTION__;


### PR DESCRIPTION
### 1. Why is this change necessary?
Say you have a product with graduated prices for quantities from `1` to `10` and from `11` to `beliebig`. Now say you set the minimum purchase quantity to `15`. The table will still show the prices up to `10` but you cannot buy the product in such low quantities.

### 2. What does this change do, exactly?
It removes every entry from the displayed price table that is impossible to purchase. It also raises the smallest displayed quantity to the maximum of `prices.to` or `variant.minpurchase`. So the case above would then display one row starting from `15`.

### 3. Describe each step to reproduce the issue or behaviour.
See 1.

### 4. Please link to the relevant issues (if any).
https://git.shopware.com/plugins/SwagCustomProducts/merge_requests/2

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.