### PR TITLE
Supports https connection in article api test

### DIFF
--- a/tests/Api/ArticleTest.php
+++ b/tests/Api/ArticleTest.php
@@ -36,14 +36,17 @@ class Shopware_Tests_Api_ArticleTest extends PHPUnit\Framework\TestCase
 
         $helper = Shopware();
 
-        $hostname = $helper->Shop()->getHost();
+        $shop = $helper->Shop();
+        $hostname = $shop->getHost();
         if (empty($hostname)) {
             static::markTestSkipped(
                 'Hostname is not available.'
             );
         }
 
-        $this->apiBaseUrl = 'http://' . $hostname . $helper->Shop()->getBasePath() . '/api';
+        $protocol = $shop->getSecure() ? 'https://' : 'http://';
+
+        $this->apiBaseUrl = $protocol . $hostname . $helper->Shop()->getBasePath() . '/api';
         Shopware()->Db()->query('UPDATE s_core_auth SET apiKey = ? WHERE username LIKE "demo"', [sha1('demo')]);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If your shop is configured to run on https and your hosting settings do http requests to your application, this test will fail, because it could not reach your application.

### 2. What does this change do, exactly?
Take the `secure` flag from `s_core_shops` into consideration when composing the api url.

### 3. Describe each step to reproduce the issue or behaviour.
1. Set up your shop for https.
2. Have hosting configuration that only routes https but not http to your application.
3. Run this test.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [x] I have ~~written tests and~~ verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.