### PR TITLE
Fix proxy generation return types

### DIFF
--- a/engine/Library/Enlight/Hook/ProxyFactory.php
+++ b/engine/Library/Enlight/Hook/ProxyFactory.php
@@ -367,13 +367,15 @@ class Enlight_Hook_ProxyFactory extends Enlight_Class
         // Create the method
         $methodGenerator = MethodGenerator::fromReflection($originalMethod);
         $methodGenerator->setDocblock('@inheritdoc');
-        $methodGenerator->setBody(
-            "return \$this->__getActiveHookManager(__FUNCTION__)->executeHooks(\n" .
+        $methodBody = "\$this->__getActiveHookManager(__FUNCTION__)->executeHooks(\n" .
             "    \$this,\n" .
             "    __FUNCTION__,\n" .
-            "    [" . implode(", ", $params) . "]\n" .
-            ");\n"
-        );
+            '    [' . implode(', ', $params) . "]\n" .
+            ");\n";
+        if (!$originalMethod->hasReturnType() || $originalMethod->getReturnType()->getName() !== 'void') {
+            $methodBody = 'return ' . $methodBody;
+        }
+        $methodGenerator->setBody($methodBody);
 
         return $methodGenerator;
     }

--- a/tests/Unit/Components/Hook/EnlightHookProxyFactoryTest.php
+++ b/tests/Unit/Components/Hook/EnlightHookProxyFactoryTest.php
@@ -43,6 +43,10 @@ class MyBasicTestClass implements MyInterface
         return $bar . $foo;
     }
 
+    public function myVoid(): void
+    {
+    }
+
     protected function myProtected($bar)
     {
     }
@@ -94,7 +98,7 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Sh
      */
     public static function getHookMethods()
     {
-        return ['myPublic', 'myProtected'];
+        return ['myPublic', 'myVoid', 'myProtected'];
     }
 
     /**
@@ -173,6 +177,18 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Sh
             $this,
             __FUNCTION__,
             ['bar' => $bar, 'foo' => $foo, 'barBar' => $barBar, 'fooFoo' => $fooFoo]
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function myVoid() : void
+    {
+        $this->__getActiveHookManager(__FUNCTION__)->executeHooks(
+            $this,
+            __FUNCTION__,
+            []
         );
     }
 

--- a/tests/Unit/Components/Hook/HookManagerTest.php
+++ b/tests/Unit/Components/Hook/HookManagerTest.php
@@ -81,6 +81,7 @@ class HookManagerTest extends TestCase
             $this->addHookListener(HookManagerTestTarget::RECURSIVE_TEST_METHOD_NAME, HookHandler::TypeReplace);
             $this->addHookListener(HookManagerTestTarget::PROTECTED_TEST_METHOD_NAME, HookHandler::TypeReplace);
             $this->addHookListener(HookManagerTestTarget::VARIABLE_NAME_COLLISION_TEST_METHOD_NAME, HookHandler::TypeAfter);
+            $this->addHookListener(HookManagerTestTarget::VOID_TEST_METHOD_NAME, HookHandler::TypeAfter);
             $proxyClass = $this->hookManager->getProxy(HookManagerTestTarget::class);
             $proxy = new $proxyClass();
         }

--- a/tests/Unit/Components/Hook/HookManagerTestTarget.php
+++ b/tests/Unit/Components/Hook/HookManagerTestTarget.php
@@ -30,6 +30,7 @@ class HookManagerTestTarget implements \Enlight_Hook
     const RECURSIVE_TEST_METHOD_NAME = 'recursiveTestMethod';
     const PROTECTED_TEST_METHOD_NAME = 'protectedTestMethod';
     const VARIABLE_NAME_COLLISION_TEST_METHOD_NAME = 'variableNameCollisionTestMethod';
+    const VOID_TEST_METHOD_NAME = 'voidTestMethod';
 
     public $originalMethodCallCounter = 0;
     public $originalRecursiveMethodCallCounter = 0;
@@ -56,6 +57,11 @@ class HookManagerTestTarget implements \Enlight_Hook
     public function variableNameCollisionTestMethod($class, $method, $context, $hookManager)
     {
         return $class . $method . $context . $hookManager;
+    }
+
+    public function voidTestMethod(): void
+    {
+        ++$this->originalMethodCallCounter;
     }
 
     protected function protectedTestMethod($name, array $values = [])


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently all generated proxy classes have a `return` statement present, even if they have return type `void` set. This breaks them in PHP 7.1+ environments. This is due to PHP 7.1 enforcing void return type functions/methods to have no return statement or an empty return statement: https://www.php.net/manual/de/migration71.new-features.php

### 2. What does this change do, exactly?
This change adds a `void` return type check and conditionally adds the `return` statement to the method body.

### 3. Describe each step to reproduce the issue or behavior.
Create and register a subscriber for any controller method having a void return type set and call the method in question. An example plugin can be found here: https://gist.github.com/felixbrucker/3e30a52c0846c38619bc82fd1e2d95a8
One then only needs to call `GET /api/orders` to trigger the error.

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
n/a

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.