### PR TITLE
allow custom acl resource for extjs-based controller

### DIFF
--- a/engine/Shopware/Controllers/Backend/ExtJs.php
+++ b/engine/Shopware/Controllers/Backend/ExtJs.php
@@ -44,6 +44,13 @@ abstract class Shopware_Controllers_Backend_ExtJs extends Enlight_Controller_Act
     protected $errorMessage;
 
     /**
+     * Holds optionally acl resource name. Defaults to lowercased controller name.
+     *
+     * @var string
+     */
+    private $aclResourceName;
+
+    /**
      * Enable script renderer and json request plugin
      * Do acl checks
      */
@@ -172,6 +179,16 @@ abstract class Shopware_Controllers_Backend_ExtJs extends Enlight_Controller_Act
     }
 
     /**
+     * Get controller resource name
+     *
+     * Defaults to the lowercased controller name, if not overwritten.
+     */
+    public function getAclResourceName(): string
+    {
+        return $this->aclResourceName ?: strtolower($this->controller_name);
+    }
+
+    /**
      * This method must be overwritten by any module which wants to use ACL.
      *
      * Method to define acl dependencies in backend controllers
@@ -203,6 +220,16 @@ abstract class Shopware_Controllers_Backend_ExtJs extends Enlight_Controller_Act
             'privilege' => $privilege,
             'errorMessage' => $errorMessage,
         ];
+    }
+
+    /**
+     * Overwrite default controller resource name
+     *
+     * @param string $resourceName
+     */
+    protected function setAclResourceName($resourceName)
+    {
+        $this->aclResourceName = $resourceName;
     }
 
     /**

--- a/engine/Shopware/Plugins/Default/Backend/Auth/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Backend/Auth/Bootstrap.php
@@ -197,7 +197,7 @@ class Shopware_Plugins_Backend_Auth_Bootstrap extends Shopware_Components_Plugin
     {
         $this->action = $args->getSubject();
         $this->request = $this->action->Request();
-        $this->aclResource = strtolower($this->request->getControllerName());
+        $this->aclResource = $this->action->getAclResourceName();
 
         if ($this->aclResource === 'error' || $this->request->getModuleName() !== 'backend') {
             return;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

A [comment in the ExtJs base controller](https://github.com/buddhaCode/shopware/blob/f73651f21413445005c3de78b007d9ef44949782/engine/Shopware/Controllers/Backend/ExtJs.php#L202) states the possibility to change the default ACL resource for an ExtJS controller. Sadly, this method isn't implemented. This change make up for this.

### 2. What does this change do, exactly?

Add a method the ExtJS base controller to overwrite the default ACL resource name, which defaults to the lowercased controller name. So it's possible to use a custom ACL resource name.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.