### PR TITLE
create event classes for shopware events

### DIFF
--- a/engine/Library/Enlight/Controller/Dispatcher/Default.php
+++ b/engine/Library/Enlight/Controller/Dispatcher/Default.php
@@ -1,20 +1,25 @@
 <?php
 /**
- * Enlight
+ * Shopware 5
+ * Copyright (c) shopware AG
  *
- * LICENSE
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
  *
- * This source file is subject to the new BSD license that is bundled
- * with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://enlight.de/license
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@shopware.de so we can send you a copy immediately.
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
  *
- * @category   Enlight
- * @copyright  Copyright (c) 2011, shopware AG (http://www.shopware.de)
- * @license    http://enlight.de/license     New BSD License
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
  */
 
 use Shopware\Components\DependencyInjection\ContainerAwareInterface;
@@ -27,9 +32,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface as Container;
  * to dispatch the request object on the controller. Implements all methods to
  * register single or multiple controllers and load them automatically
  *
- * @category   Enlight
  *
- * @copyright  Copyright (c) 2011, shopware AG (http://www.shopware.de)
  * @license    http://enlight.de/license     New BSD License
  */
 class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatcher
@@ -75,6 +78,7 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
 
     /**
      * Holds all valid modules
+     *
      * @var array
      */
     protected $modules = ['frontend', 'api', 'widgets', 'backend'];
@@ -117,8 +121,6 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
      * Returns the formatted controller name. Removes all '_' .
      *
      * @param string $unFormatted
-     *
-     * @return mixed
      */
     public function formatControllerName($unFormatted)
     {
@@ -131,8 +133,6 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
      * Returns the formatted action name. Removes all '_' .
      *
      * @param string $unFormatted
-     *
-     * @return mixed
      */
     public function formatActionName($unFormatted)
     {
@@ -230,7 +230,6 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
     /**
      * Returns the controller class of the given request class. The class name is imploded by '_'
      *
-     * @param Enlight_Controller_Request_Request $request
      *
      * @return array|string
      */
@@ -259,7 +258,6 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
     /**
      * Returns the controller path of the given request class.
      *
-     * @param Enlight_Controller_Request_Request $request
      *
      * @return string
      */
@@ -271,6 +269,7 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
         $controllerId = $this->getControllerServiceId($moduleName, $controllerName);
         $request->unsetAttribute('controllerId');
 
+        // TODO add controllerpath event? Not sure because it's in the Enlight Library
         if ($event = Shopware()->Events()->notifyUntil(
                 'Enlight_Controller_Dispatcher_ControllerPath_' . $moduleName . '_' . $controllerName,
                 ['subject' => $this, 'request' => $request]
@@ -281,6 +280,7 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
 
         if ($controllerId) {
             $request->setAttribute('controllerId', $controllerId);
+
             return clone $this->container->get($controllerId);
         }
 
@@ -291,7 +291,6 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
      * Returns the action method of the given request class.
      * If no action name is set in the request class, the default action is used.
      *
-     * @param Enlight_Controller_Request_Request $request
      *
      * @return string
      */
@@ -313,7 +312,6 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
      * To generate the full controller path the module and controller name must be set in the given request object.
      * The module and controller path is imploded by '_'
      *
-     * @param Enlight_Controller_Request_Request $request
      *
      * @return string
      */
@@ -332,7 +330,6 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
      * To generate the full action path the module, controller and action name must be set in the given request object.
      * The module, controller and action path is imploded by '_'.
      *
-     * @param Enlight_Controller_Request_Request $request
      *
      * @return string
      */
@@ -352,7 +349,6 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
      * Checks first if the controller class of the request object exists.
      * If the controller class exists, the enlight loader class checks if the controller path is readable.
      *
-     * @param Enlight_Controller_Request_Request $request
      *
      * @return bool|string
      */
@@ -414,8 +410,6 @@ class Enlight_Controller_Dispatcher_Default extends Enlight_Controller_Dispatche
      * After that, run the dispatch on the controller.
      * At the ending the body is added to the response object.
      *
-     * @param Enlight_Controller_Request_Request   $request
-     * @param Enlight_Controller_Response_Response $response
      *
      * @throws Enlight_Controller_Exception|Enlight_Exception|Exception
      */

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -26,6 +26,7 @@ namespace Shopware\Components;
 
 use Shopware\Components\DependencyInjection\Container;
 use Shopware\Components\Theme\PathResolver;
+use ShopwarePlugins\HttpCache\Events\ClearCacheEvent;
 
 class CacheManager
 {
@@ -110,7 +111,10 @@ class CacheManager
         }
 
         // Fire event to let Plugin-Implementation clear cache
-        $this->events->notify('Shopware_Plugins_HttpCache_ClearCache');
+        $this->events->notify(
+            ClearCacheEvent::EVENT_NAME,
+            new ClearCacheEvent()
+        );
     }
 
     /**

--- a/engine/Shopware/Components/Console/Application.php
+++ b/engine/Shopware/Components/Console/Application.php
@@ -28,6 +28,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\ORM\Tools\Console\ConsoleRunner as DoctrineConsoleRunner;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Shopware\Components\Console\Events\BeforeRunEvent;
 use Shopware\Components\DependencyInjection\ContainerAwareInterface;
 use Shopware\Kernel;
 use Symfony\Component\Console\Application as BaseApplication;
@@ -114,11 +115,14 @@ class Application extends BaseApplication
         /** @var \Enlight_Event_EventManager $eventManager */
         $eventManager = $this->kernel->getContainer()->get('events');
 
-        $event = $eventManager->notifyUntil('Shopware_Command_Before_Run', [
-            'command' => $command,
-            'input' => $input,
-            'output' => $output,
-        ]);
+        $event = $eventManager->notifyUntil(
+            BeforeRunEvent::EVENT_NAME,
+            new BeforeRunEvent([
+                'command' => $command,
+                'input' => $input,
+                'output' => $output,
+            ])
+        );
 
         if ($event) {
             return (int) $event->getReturn();

--- a/engine/Shopware/Components/Console/Application.php
+++ b/engine/Shopware/Components/Console/Application.php
@@ -28,7 +28,8 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\ORM\Tools\Console\ConsoleRunner as DoctrineConsoleRunner;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
-use Shopware\Components\Console\Events\BeforeRunEvent;
+use Shopware\Components\Console\Events\CommandAfterRunEvent;
+use Shopware\Components\Console\Events\CommandBeforeRunEvent;
 use Shopware\Components\DependencyInjection\ContainerAwareInterface;
 use Shopware\Kernel;
 use Symfony\Component\Console\Application as BaseApplication;
@@ -116,8 +117,8 @@ class Application extends BaseApplication
         $eventManager = $this->kernel->getContainer()->get('events');
 
         $event = $eventManager->notifyUntil(
-            BeforeRunEvent::EVENT_NAME,
-            new BeforeRunEvent([
+            CommandBeforeRunEvent::EVENT_NAME,
+            new CommandBeforeRunEvent([
                 'command' => $command,
                 'input' => $input,
                 'output' => $output,
@@ -130,12 +131,15 @@ class Application extends BaseApplication
 
         $exitCode = parent::doRunCommand($command, $input, $output);
 
-        $eventManager->notify('Shopware_Command_After_Run', [
-           'exitCode' => $exitCode,
-           'command' => $command,
-           'input' => $input,
-           'output' => $output,
-       ]);
+        $eventManager->notify(
+            CommandAfterRunEvent::EVENT_NAME,
+            new CommandAfterRunEvent([
+                'exitCode' => $exitCode,
+                'command' => $command,
+                'input' => $input,
+                'output' => $output,
+            ])
+        );
 
         return $exitCode;
     }

--- a/engine/Shopware/Components/Console/Events/BeforeRunEvent.php
+++ b/engine/Shopware/Components/Console/Events/BeforeRunEvent.php
@@ -22,22 +22,29 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Components\Console\Events;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class BeforeRunEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Command_Before_Run';
 
-    public function getSubject(): sBasket
+    public function getCommand(): Command
     {
-        return $this->get('subject');
+        return $this->get('command');
     }
 
-    public function getDiscount(): array
+    public function getInput(): InputInterface
     {
-        return $this->get('discount');
+        return $this->get('input');
+    }
+
+    public function getOutput(): OutputInterface
+    {
+        return $this->get('output');
     }
 }

--- a/engine/Shopware/Components/Console/Events/CommandAfterRunEvent.php
+++ b/engine/Shopware/Components/Console/Events/CommandAfterRunEvent.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Console\Events;
+
+use Enlight_Event_EventArgs;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CommandAfterRunEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Command_After_Run';
+
+    public function getExitCode(): int
+    {
+        return $this->get('exitCode');
+    }
+
+    public function getCommand(): Command
+    {
+        return $this->get('command');
+    }
+
+    public function getInput(): InputInterface
+    {
+        return $this->get('input');
+    }
+
+    public function getOutput(): OutputInterface
+    {
+        return $this->get('output');
+    }
+}

--- a/engine/Shopware/Components/Console/Events/CommandBeforeRunEvent.php
+++ b/engine/Shopware/Components/Console/Events/CommandBeforeRunEvent.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Console\Events;
+
+use Enlight_Event_EventArgs;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CommandBeforeRunEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Command_Before_Run';
+
+    public function getCommand(): Command
+    {
+        return $this->get('command');
+    }
+
+    public function getInput(): InputInterface
+    {
+        return $this->get('input');
+    }
+
+    public function getOutput(): OutputInterface
+    {
+        return $this->get('output');
+    }
+}

--- a/engine/Shopware/Components/DependencyInjection/Container.php
+++ b/engine/Shopware/Components/DependencyInjection/Container.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Components\DependencyInjection;
 
+use Shopware\Components\DependencyInjection\Events\InitResourceEvent;
 use Symfony\Component\DependencyInjection\Container as BaseContainer;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 
@@ -200,13 +201,22 @@ class Container extends BaseContainer
 
         /** @var \Enlight_Event_EventArgs|null $event */
         $event = $eventManager->notifyUntil(
-            'Enlight_Bootstrap_InitResource_' . $id,
-            ['subject' => $this]
+            InitResourceEvent::EVENT_NAME . $id,
+            new InitResourceEvent([
+                'subject' => $this,
+                'resourceId' => $id,
+                'isFallback' => false,
+            ])
         );
 
         if ($fallbackName !== null && !$event && $fallbackName !== $id) {
             $event = $eventManager->notifyUntil(
-                'Enlight_Bootstrap_InitResource_' . $fallbackName, ['subject' => $this]
+                InitResourceEvent::EVENT_NAME . $fallbackName,
+                new InitResourceEvent([
+                    'subject' => $this,
+                    'resourceId' => $fallbackName,
+                    'isFallback' => true,
+                ])
             );
         }
 

--- a/engine/Shopware/Components/DependencyInjection/Container.php
+++ b/engine/Shopware/Components/DependencyInjection/Container.php
@@ -24,6 +24,8 @@
 
 namespace Shopware\Components\DependencyInjection;
 
+use Shopware\Components\DependencyInjection\Events\AfterInitResourceEvent;
+use Shopware\Components\DependencyInjection\Events\AfterRegisterResourceEvent;
 use Shopware\Components\DependencyInjection\Events\InitResourceEvent;
 use Symfony\Component\DependencyInjection\Container as BaseContainer;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
@@ -61,10 +63,12 @@ class Container extends BaseContainer
         parent::set($name, $resource);
 
         parent::get('events')->notify(
-            'Enlight_Bootstrap_AfterRegisterResource_' . $name, [
+            AfterRegisterResourceEvent::EVENT_NAME . $name,
+            new AfterRegisterResourceEvent([
                 'subject' => $this,
+                'resourceName' => $name,
                 'resource' => $resource,
-            ]
+            ])
         );
 
         return $this;
@@ -234,12 +238,22 @@ class Container extends BaseContainer
         } finally {
             if ($circularReference === false) {
                 $eventManager->notify(
-                    'Enlight_Bootstrap_AfterInitResource_' . $id, ['subject' => $this]
+                    AfterInitResourceEvent::EVENT_NAME . $id,
+                    new AfterInitResourceEvent([
+                        'subject' => $this,
+                        'resourceId' => $id,
+                        'isFallback' => false,
+                    ])
                 );
 
                 if ($fallbackName !== null && $fallbackName !== $id) {
                     $eventManager->notify(
-                        'Enlight_Bootstrap_AfterInitResource_' . $fallbackName, ['subject' => $this]
+                        AfterInitResourceEvent::EVENT_NAME . $fallbackName,
+                        new AfterInitResourceEvent([
+                            'subject' => $this,
+                            'resourceId' => $fallbackName,
+                            'isFallback' => true,
+                        ])
                     );
                 }
             }

--- a/engine/Shopware/Components/DependencyInjection/Events/AfterInitResourceEvent.php
+++ b/engine/Shopware/Components/DependencyInjection/Events/AfterInitResourceEvent.php
@@ -22,29 +22,27 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Components\Console\Events;
+namespace Shopware\Components\DependencyInjection\Events;
 
 use Enlight_Event_EventArgs;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Shopware\Components\DependencyInjection\Container;
 
-class BeforeRunEvent extends Enlight_Event_EventArgs
+class AfterInitResourceEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Command_Before_Run';
+    public const EVENT_NAME = 'Enlight_Bootstrap_AfterInitResource_';
 
-    public function getCommand(): Command
+    public function getSubject(): Container
     {
-        return $this->get('command');
+        return $this->get('subject');
     }
 
-    public function getInput(): InputInterface
+    public function getResourceId(): string
     {
-        return $this->get('input');
+        return $this->get('resourceId');
     }
 
-    public function getOutput(): OutputInterface
+    public function isFallback(): bool
     {
-        return $this->get('output');
+        return $this->get('isFallback');
     }
 }

--- a/engine/Shopware/Components/DependencyInjection/Events/AfterRegisterResourceEvent.php
+++ b/engine/Shopware/Components/DependencyInjection/Events/AfterRegisterResourceEvent.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\DependencyInjection\Events;
+
+use Enlight_Event_EventArgs;
+use Shopware\Components\DependencyInjection\Container;
+
+class AfterRegisterResourceEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Enlight_Bootstrap_AfterRegisterResource_';
+
+    public function getSubject(): Container
+    {
+        return $this->get('subject');
+    }
+
+    public function getResourceName(): string
+    {
+        return $this->get('resourceName');
+    }
+
+    public function getResource()
+    {
+        return $this->get('resource');
+    }
+}

--- a/engine/Shopware/Components/DependencyInjection/Events/InitResourceEvent.php
+++ b/engine/Shopware/Components/DependencyInjection/Events/InitResourceEvent.php
@@ -22,22 +22,27 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Components\DependencyInjection\Events;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use Shopware\Components\DependencyInjection\Container;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class InitResourceEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Enlight_Bootstrap_InitResource_';
 
-    public function getSubject(): sBasket
+    public function getSubject(): Container
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    public function getResourceId(): string
     {
-        return $this->get('discount');
+        return $this->get('resourceId');
+    }
+
+    public function isFallback(): bool
+    {
+        return $this->get('isFallback');
     }
 }

--- a/engine/Shopware/Components/Events/Basket/AddVoucherStartEvent.php
+++ b/engine/Shopware/Components/Events/Basket/AddVoucherStartEvent.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Components\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class AddVoucherStartEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_AddVoucher_Start';
+
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+
+    public function getCode(): string
+    {
+        return $this->get('code');
+    }
+
+
+    public function getBasket(): string
+    {
+        return $this->get('basket');
+    }
+}

--- a/engine/Shopware/Components/HttpCache/CacheWarmer.php
+++ b/engine/Shopware/Components/HttpCache/CacheWarmer.php
@@ -30,6 +30,7 @@ use GuzzleHttp\Event\ErrorEvent;
 use GuzzleHttp\Pool;
 use Psr\Log\LoggerInterface;
 use Shopware\Components\ContainerAwareEventManager;
+use Shopware\Components\HttpCache\Events\CacheWarmerErrorOccuredEvent;
 use Shopware\Components\HttpClient\GuzzleFactory;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Components\Routing\Context;
@@ -119,7 +120,10 @@ class CacheWarmer
             [
                 'pool_size' => $concurrentRequests,
                 'error' => function (ErrorEvent $e) use ($shopId, $events) {
-                    $events->notify('Shopware_Components_CacheWarmer_ErrorOccured');
+                    $events->notify(
+                        CacheWarmerErrorOccuredEvent::EVENT_NAME,
+                        new CacheWarmerErrorOccuredEvent()
+                    );
                     if ($e->getResponse() !== null && $e->getResponse()->getStatusCode() === 404) {
                         $this->logger->error(
                             'Warm up http-cache error with shopId ' . $shopId . ' ' . $e->getException()->getMessage()

--- a/engine/Shopware/Components/HttpCache/Events/CacheWarmerErrorOccuredEvent.php
+++ b/engine/Shopware/Components/HttpCache/Events/CacheWarmerErrorOccuredEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\HttpCache\Events;
+
+use Enlight_Event_EventArgs;
+
+class CacheWarmerErrorOccuredEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Components_CacheWarmer_ErrorOccured';
+}

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/BatchProcess.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/BatchProcess.php
@@ -27,6 +27,7 @@ namespace Shopware\Components\MultiEdit\Resource\Product;
 use Doctrine\ORM\Query\Expr\Literal;
 use Shopware\Components\MultiEdit\Resource\Product;
 use Shopware\Models\MultiEdit\Queue;
+use ShopwarePlugins\HttpCache\Events\InvalidateCacheIdEvent;
 
 /**
  * The batch process resource handles the batch processes for updating products
@@ -292,8 +293,11 @@ class BatchProcess
         // Notify event - you might want register for this in order to clear the cache?
         foreach ($this->getDqlHelper()->getIdForForeignEntity('article', $detailIds) as $productId) {
             $this->getDqlHelper()->getEventManager()->notify(
-                'Shopware_Plugins_HttpCache_InvalidateCacheId',
-                ['subject' => $this, 'cacheId' => 'a' . $productId]
+                InvalidateCacheIdEvent::EVENT_NAME,
+                new InvalidateCacheIdEvent([
+                    'subject' => $this,
+                    'cacheId' => 'a' . $productId,
+                ])
             );
         }
     }

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
@@ -26,6 +26,7 @@ namespace Shopware\Components\MultiEdit\Resource\Product;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Components\Model\ModelManager;
+use Shopware\Components\MultiEdit\Resource\Product\Events\GetDqlFromTokensTokenEvent;
 use Shopware\Models\Article\Article;
 use Shopware\Models\Article\Configurator\Group as ConfiguratorGroup;
 use Shopware\Models\Article\Configurator\Option as ConfiguratorOption;
@@ -652,13 +653,13 @@ class DqlHelper
             // Allow anyone to subscribe to any token and replace it with his own logic
             // Also allows you to add own tokens
             if ($event = $this->getEventManager()->notifyUntil(
-                'SwagMultiEdit_Product_DqlHelper_getDqlFromTokens_Token_' . ucfirst(strtolower($token['type'])),
-                [
+                GetDqlFromTokensTokenEvent::EVENT_NAME . ucfirst(strtolower($token['type'])),
+                new GetDqlFromTokensTokenEvent([
                     'subject' => $this,
                     'currentToken' => $token,
                     'alltokens' => $tokens,
                     'processedTokens' => $newTokens,
-                ]
+                ])
             )
             ) {
                 $return = $event->getReturn();

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Events/GetDqlFromTokensTokenEvent.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Events/GetDqlFromTokensTokenEvent.php
@@ -22,22 +22,32 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Components\MultiEdit\Resource\Product\Events;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use Shopware\Components\MultiEdit\Resource\Product\DqlHelper;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class GetDqlFromTokensTokenEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'SwagMultiEdit_Product_DqlHelper_getDqlFromTokens_Token_';
 
-    public function getSubject(): sBasket
+    public function getSubject(): DqlHelper
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    public function getCurrentToken(): array
     {
-        return $this->get('discount');
+        return $this->get('token');
+    }
+
+    public function getAllTokens(): array
+    {
+        return $this->get('alltokens');
+    }
+
+    public function getProcessedTokens(): array
+    {
+        return $this->get('processedTokens');
     }
 }

--- a/engine/Shopware/Components/Routing/Events/RouterRouteEvent.php
+++ b/engine/Shopware/Components/Routing/Events/RouterRouteEvent.php
@@ -22,22 +22,23 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Components\Routing\Events;
 
+use Enlight_Controller_Request_RequestHttp;
 use Enlight_Event_EventArgs;
-use sBasket;
+use Shopware\Components\Routing\Context;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class RouterRouteEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Enlight_Controller_Router_Route';
 
-    public function getSubject(): sBasket
+    public function getRequest(): Enlight_Controller_Request_RequestHttp
     {
-        return $this->get('subject');
+        return $this->get('request');
     }
 
-    public function getDiscount(): array
+    public function getContext(): Context
     {
-        return $this->get('discount');
+        return $this->get('context');
     }
 }

--- a/engine/Shopware/Components/Routing/Matchers/EventMatcher.php
+++ b/engine/Shopware/Components/Routing/Matchers/EventMatcher.php
@@ -27,6 +27,7 @@ namespace Shopware\Components\Routing\Matchers;
 use Enlight_Controller_Request_RequestHttp as EnlightRequest;
 use Enlight_Event_EventManager as EnlightEventManager;
 use Shopware\Components\Routing\Context;
+use Shopware\Components\Routing\Events\RouterRouteEvent;
 use Shopware\Components\Routing\MatcherInterface;
 
 class EventMatcher implements MatcherInterface
@@ -57,10 +58,13 @@ class EventMatcher implements MatcherInterface
         $request->setBaseUrl($context->getBaseUrl());
         $request->setPathInfo($pathInfo);
 
-        $event = $this->eventManager->notifyUntil('Enlight_Controller_Router_Route', [
-            'request' => $request,
-            'context' => $context,
-        ]);
+        $event = $this->eventManager->notifyUntil(
+            RouterRouteEvent::EVENT_NAME,
+            new RouterRouteEvent([
+                'request' => $request,
+                'context' => $context,
+            ])
+        );
 
         return $event !== null ? $event->getReturn() : false;
     }

--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -29,6 +29,7 @@ use Doctrine\ORM\AbstractQuery;
 use Shopware\Components\ShopwareReleaseStruct;
 use Shopware\Components\Theme\Compressor\CompressorInterface;
 use Shopware\Components\Theme\Compressor\Js;
+use Shopware\Components\Theme\Events\CompileLessEvent;
 use Shopware\Models\Shop;
 
 /**
@@ -360,10 +361,11 @@ class Compiler
         }
 
         $this->eventManager->notify(
-            'Theme_Compiler_Compile_Less', [
+            CompileLessEvent::EVENT_NAME,
+            new CompileLessEvent([
                 'shop' => $shop,
                 'less' => $definition,
-            ]
+            ])
         );
 
         // Need to iterate files, to generate source map if configured.

--- a/engine/Shopware/Components/Theme/Events/CompileLessEvent.php
+++ b/engine/Shopware/Components/Theme/Events/CompileLessEvent.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Theme\Events;
+
+use Enlight_Event_EventArgs;
+use Shopware\Components\Theme\LessDefinition;
+use Shopware\Models\Shop\Shop;
+
+class CompileLessEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Theme_Compiler_Compile_Less';
+
+    public function getShop(): Shop
+    {
+        return $this->get('shop');
+    }
+
+    public function getLess(): LessDefinition
+    {
+        return $this->get('less');
+    }
+}

--- a/engine/Shopware/Components/Theme/Events/ContainerInjectedEvent.php
+++ b/engine/Shopware/Components/Theme/Events/ContainerInjectedEvent.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Theme\Events;
+
+use Enlight_Event_EventArgs;
+use Shopware\Components\Form\Container\TabContainer;
+use Shopware\Components\Theme;
+use Shopware\Models\Shop\Template;
+
+class ContainerInjectedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Theme_Configurator_Container_Injected';
+
+    public function getTheme(): Theme
+    {
+        return $this->get('theme');
+    }
+
+    public function getTemplate(): Template
+    {
+        return $this->get('template');
+    }
+
+    public function getContainer(): TabContainer
+    {
+        return $this->get('container');
+    }
+}

--- a/engine/Shopware/Components/Theme/Events/ThemeConfigCreatedEvent.php
+++ b/engine/Shopware/Components/Theme/Events/ThemeConfigCreatedEvent.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Theme\Events;
+
+use Enlight_Event_EventArgs;
+use Shopware\Components\Form\Container\TabContainer;
+use Shopware\Components\Theme;
+use Shopware\Models\Shop\Template;
+
+class ThemeConfigCreatedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Theme_Configurator_Theme_Config_Created';
+
+    public function getTheme(): Theme
+    {
+        return $this->get('theme');
+    }
+
+    public function getTemplate(): Template
+    {
+        return $this->get('template');
+    }
+
+    public function getContainer(): TabContainer
+    {
+        return $this->get('container');
+    }
+}

--- a/engine/Shopware/Components/Theme/Events/ThemeConfigSavedEvent.php
+++ b/engine/Shopware/Components/Theme/Events/ThemeConfigSavedEvent.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Theme\Events;
+
+use Enlight_Event_EventArgs;
+use Shopware\Components\Form\Container\TabContainer;
+use Shopware\Components\Theme;
+use Shopware\Models\Shop\Template;
+
+class ThemeConfigSavedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Theme_Configurator_Theme_Config_Saved';
+
+    public function getTheme(): Theme
+    {
+        return $this->get('theme');
+    }
+
+    public function getTemplate(): Template
+    {
+        return $this->get('template');
+    }
+
+    public function getContainer(): TabContainer
+    {
+        return $this->get('container');
+    }
+}

--- a/engine/Shopware/Components/Theme/Events/ThemeConfigSetUpdatedEvent.php
+++ b/engine/Shopware/Components/Theme/Events/ThemeConfigSetUpdatedEvent.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Theme\Events;
+
+use Enlight_Event_EventArgs;
+use Shopware\Components\Theme;
+use Shopware\Models\Shop\Template;
+use Shopware\Models\Shop\TemplateConfig\Set;
+
+class ThemeConfigSetUpdatedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Theme_Configurator_Theme_ConfigSet_Updated';
+
+    public function getTheme(): Theme
+    {
+        return $this->get('theme');
+    }
+
+    public function getTemplate(): Template
+    {
+        return $this->get('template');
+    }
+
+    public function getExisting(): Set
+    {
+        return $this->get('existing');
+    }
+
+    public function getDefined(): Theme\ConfigSet
+    {
+        return $this->get('defined');
+    }
+}

--- a/engine/Shopware/Components/Theme/Events/ThemeConfigSetsSynchronizedEvent.php
+++ b/engine/Shopware/Components/Theme/Events/ThemeConfigSetsSynchronizedEvent.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Theme\Events;
+
+use Enlight_Event_EventArgs;
+use Shopware\Components\Theme;
+use Shopware\Models\Shop\Template;
+
+class ThemeConfigSetsSynchronizedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Theme_Configurator_Theme_ConfigSets_Synchronized';
+
+    public function getTheme(): Theme
+    {
+        return $this->get('theme');
+    }
+
+    public function getTemplate(): Template
+    {
+        return $this->get('template');
+    }
+}

--- a/engine/Shopware/Components/Theme/Events/ThemeConfigSynchronizedEvent.php
+++ b/engine/Shopware/Components/Theme/Events/ThemeConfigSynchronizedEvent.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Theme\Events;
+
+use Enlight_Event_EventArgs;
+use Shopware\Components\Form\Container\TabContainer;
+use Shopware\Components\Theme;
+use Shopware\Models\Shop\Template;
+
+class ThemeConfigSynchronizedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Theme_Configurator_Theme_Config_Synchronized';
+
+    public function getTheme(): Theme
+    {
+        return $this->get('theme');
+    }
+
+    public function getTemplate(): Template
+    {
+        return $this->get('template');
+    }
+
+    public function getContainer(): TabContainer
+    {
+        return $this->get('container');
+    }
+}

--- a/engine/Shopware/Controllers/Backend/Config.php
+++ b/engine/Shopware/Controllers/Backend/Config.php
@@ -22,6 +22,7 @@
  * our trademarks remain entirely with us.
  */
 
+use Shopware\Controllers\Backend\Events\AfterSaveConfigElementEvent;
 use Shopware\Models\Config\Element;
 use Shopware\Models\Config\Value;
 use Shopware\Models\Shop\Shop;
@@ -1399,10 +1400,13 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
 
         Shopware()->Models()->flush($element);
 
-        Shopware()->Events()->notify('Shopware_Controllers_Backend_Config_After_Save_Config_Element', [
-            'subject' => $this,
-            'element' => $element,
-        ]);
+        Shopware()->Events()->notify(
+            AfterSaveConfigElementEvent::EVENT_NAME,
+            new AfterSaveConfigElementEvent([
+                'subject' => $this,
+                'element' => $element,
+            ])
+        );
     }
 
     /**

--- a/engine/Shopware/Controllers/Backend/Events/AfterSaveConfigElementEvent.php
+++ b/engine/Shopware/Controllers/Backend/Events/AfterSaveConfigElementEvent.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Controllers\Backend\Events;
+
+use Enlight_Event_EventArgs;
+use Shopware\Models\Config\Element;
+use Shopware_Controllers_Backend_Config;
+
+class AfterSaveConfigElementEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Controllers_Backend_Config_After_Save_Config_Element';
+
+    public function getSubject(): Shopware_Controllers_Backend_Config
+    {
+        return $this->get('subject');
+    }
+
+    public function getElement(): Element
+    {
+        return $this->get('element');
+    }
+}

--- a/engine/Shopware/Controllers/Frontend/Events/CustomerGroupRegisterEvent.php
+++ b/engine/Shopware/Controllers/Frontend/Events/CustomerGroupRegisterEvent.php
@@ -22,22 +22,30 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Controllers\Frontend\Events;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use Shopware_Controllers_Frontend_Register;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class CustomerGroupRegisterEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Controllers_Frontend_Register_CustomerGroupRegister';
 
-    public function getSubject(): sBasket
+    public function getSubject(): Shopware_Controllers_Frontend_Register
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    /**
+     * @deprecated use @see \Shopware\Controllers\Frontend\Events\CustomerGroupRegister::getCustomerGroupId
+     */
+    public function getValidation(): string
     {
-        return $this->get('discount');
+        return $this->get('sValidation');
+    }
+
+    public function getCustomerGroupId(): int
+    {
+        return (int) $this->get('customerGroupId');
     }
 }

--- a/engine/Shopware/Controllers/Frontend/Register.php
+++ b/engine/Shopware/Controllers/Frontend/Register.php
@@ -28,6 +28,7 @@ use Shopware\Bundle\AccountBundle\Service\RegisterServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\Attribute;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Components\Captcha\Exception\CaptchaNotFoundException;
+use Shopware\Controllers\Frontend\Events\CustomerGroupRegisterEvent;
 use Shopware\Models\Customer\Address;
 use Shopware\Models\Customer\Customer;
 use Symfony\Component\Form\Form;
@@ -480,8 +481,12 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
         }
 
         $event = Shopware()->Events()->notifyUntil(
-            'Shopware_Controllers_Frontend_Register_CustomerGroupRegister',
-            ['subject' => $this, 'sValidation' => $customerGroupId]
+            CustomerGroupRegisterEvent::EVENT_NAME,
+            new CustomerGroupRegisterEvent([
+                'subject' => $this,
+                'sValidation' => $customerGroupId,
+                'customerGroupId' => $customerGroupId,
+            ])
         );
 
         if ($event) {

--- a/engine/Shopware/Core/Events/Admin/CheckUserFailureEvent.php
+++ b/engine/Shopware/Core/Events/Admin/CheckUserFailureEvent.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Components_Session_Namespace;
+use Enlight_Event_EventArgs;
+use sAdmin;
+
+class CheckUserFailureEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_CheckUser_Failure';
+
+    public function getSubject(): sAdmin
+    {
+        return $this->get('subject');
+    }
+
+    public function getSession(): Enlight_Components_Session_Namespace
+    {
+        return $this->get('session');
+    }
+
+    public function getUser(): array
+    {
+        return $this->get('user');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/CheckUserStartEvent.php
+++ b/engine/Shopware/Core/Events/Admin/CheckUserStartEvent.php
@@ -22,22 +22,17 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Admin;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use sAdmin;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class CheckUserStartEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Modules_Admin_CheckUser_Start';
 
-    public function getSubject(): sBasket
+    public function getSubject(): sAdmin
     {
         return $this->get('subject');
-    }
-
-    public function getDiscount(): array
-    {
-        return $this->get('discount');
     }
 }

--- a/engine/Shopware/Core/Events/Admin/CheckUserSuccessfulEvent.php
+++ b/engine/Shopware/Core/Events/Admin/CheckUserSuccessfulEvent.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Components_Session_Namespace;
+use Enlight_Event_EventArgs;
+use sAdmin;
+
+class CheckUserSuccessfulEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_CheckUser_Successful';
+
+    public function getSubject(): sAdmin
+    {
+        return $this->get('subject');
+    }
+
+    public function getSession(): Enlight_Components_Session_Namespace
+    {
+        return $this->get('session');
+    }
+
+    public function getUser(): array
+    {
+        return $this->get('user');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/ExecuteRiskRuleEvent.php
+++ b/engine/Shopware/Core/Events/Admin/ExecuteRiskRuleEvent.php
@@ -22,22 +22,44 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Admin;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use sAdmin;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class ExecuteRiskRuleEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Modules_Admin_Execute_Risk_Rule_';
 
-    public function getSubject(): sBasket
+    public function getSubject(): sAdmin
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    public function getRule(): string
     {
-        return $this->get('discount');
+        return $this->get('rule');
+    }
+
+    public function getUser(): array
+    {
+        return $this->get('user');
+    }
+
+    public function getBasket(): array
+    {
+        return $this->get('basket');
+    }
+
+    public function getValue(): string
+    {
+        return $this->get('value');
+    }
+
+    public function getPaymentId(): ?int
+    {
+        $paymentId = $this->get('paymentID');
+
+        return $paymentId !== null ? (int) $paymentId : null;
     }
 }

--- a/engine/Shopware/Core/Events/Admin/GetDispatchBasketCalculationQueryBuilderEvent.php
+++ b/engine/Shopware/Core/Events/Admin/GetDispatchBasketCalculationQueryBuilderEvent.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Enlight_Event_EventArgs;
+
+class GetDispatchBasketCalculationQueryBuilderEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_GetDispatchBasket_Calculation_QueryBuilder';
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->get('queryBuilder');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/GetDispatchBasketQueryBuilderEvent.php
+++ b/engine/Shopware/Core/Events/Admin/GetDispatchBasketQueryBuilderEvent.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Enlight_Event_EventArgs;
+
+class GetDispatchBasketQueryBuilderEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_GetDispatchBasket_QueryBuilder';
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->get('queryBuilder');
+    }
+
+    public function getAmount(): string
+    {
+        return $this->get('amount');
+    }
+
+    public function getAmountNet(): string
+    {
+        return $this->get('amount_net');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/GetPremiumDispatchesQueryBuilderEvent.php
+++ b/engine/Shopware/Core/Events/Admin/GetPremiumDispatchesQueryBuilderEvent.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Enlight_Event_EventArgs;
+
+class GetPremiumDispatchesQueryBuilderEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_GetPremiumDispatches_QueryBuilder';
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->get('queryBuilder');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/GetUserDataStartEvent.php
+++ b/engine/Shopware/Core/Events/Admin/GetUserDataStartEvent.php
@@ -22,22 +22,17 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Admin;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use sAdmin;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class GetUserDataStartEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Modules_Admin_GetUserData_Start';
 
-    public function getSubject(): sBasket
+    public function getSubject(): sAdmin
     {
         return $this->get('subject');
-    }
-
-    public function getDiscount(): array
-    {
-        return $this->get('discount');
     }
 }

--- a/engine/Shopware/Core/Events/Admin/LoginFailureEvent.php
+++ b/engine/Shopware/Core/Events/Admin/LoginFailureEvent.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Event_EventArgs;
+use sAdmin;
+
+class LoginFailureEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_Login_Failure';
+
+    public function getSubject(): sAdmin
+    {
+        return $this->get('subject');
+    }
+
+    public function getEmail(): string
+    {
+        return $this->get('email');
+    }
+
+    public function getPassword(): string
+    {
+        return $this->get('password');
+    }
+
+    public function getError(): array
+    {
+        return $this->get('error');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/LoginStartEvent.php
+++ b/engine/Shopware/Core/Events/Admin/LoginStartEvent.php
@@ -22,22 +22,27 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Admin;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use sAdmin;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class LoginStartEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Modules_Admin_Login_Start';
 
-    public function getSubject(): sBasket
+    public function getSubject(): sAdmin
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    public function getIgnoreAccountMode(): bool
     {
-        return $this->get('discount');
+        return $this->get('ignoreAccountMode');
+    }
+
+    public function getPost(): array
+    {
+        return $this->get('post');
     }
 }

--- a/engine/Shopware/Core/Events/Admin/LoginSuccessfulEvent.php
+++ b/engine/Shopware/Core/Events/Admin/LoginSuccessfulEvent.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Event_EventArgs;
+use sAdmin;
+
+class LoginSuccessfulEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_Login_Successful';
+
+    public function getSubject(): sAdmin
+    {
+        return $this->get('subject');
+    }
+
+    public function getEmail(): string
+    {
+        return $this->get('email');
+    }
+
+    public function getPassword(): string
+    {
+        return $this->get('password');
+    }
+
+    public function getUser(): array
+    {
+        return $this->get('user');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/LogoutSuccessfulEvent.php
+++ b/engine/Shopware/Core/Events/Admin/LogoutSuccessfulEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Event_EventArgs;
+
+class LogoutSuccessfulEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_Logout_Successful';
+}

--- a/engine/Shopware/Core/Events/Admin/NewsletterRegistrationSuccessEvent.php
+++ b/engine/Shopware/Core/Events/Admin/NewsletterRegistrationSuccessEvent.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Event_EventArgs;
+
+class NewsletterRegistrationSuccessEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_Newsletter_Registration_Success';
+
+    public function getSubject(): \sAdmin
+    {
+        return $this->get('subject');
+    }
+
+    public function getEmail(): string
+    {
+        return $this->get('email');
+    }
+
+    public function getGroudId(): int
+    {
+        return (int) $this->get('groupID');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/NewsletterUnsubscribeEvent.php
+++ b/engine/Shopware/Core/Events/Admin/NewsletterUnsubscribeEvent.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Event_EventArgs;
+
+class NewsletterUnsubscribeEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_Newsletter_Unsubscribe';
+
+    public function getEmail(): string
+    {
+        return $this->get('email');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/PaymentFallbackEvent.php
+++ b/engine/Shopware/Core/Events/Admin/PaymentFallbackEvent.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Event_EventArgs;
+
+class PaymentFallbackEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_Payment_Fallback';
+
+    public function getId(): int
+    {
+        return (int) $this->get('id');
+    }
+
+    public function getPaymentName(): string
+    {
+        return $this->get('name');
+    }
+
+    public function getDescription(): string
+    {
+        return $this->get('description');
+    }
+
+    public function getTemplate(): string
+    {
+        return $this->get('template');
+    }
+
+    public function getClass(): string
+    {
+        return $this->get('class');
+    }
+
+    public function getTable(): string
+    {
+        return $this->get('table');
+    }
+
+    public function getHide(): bool
+    {
+        return (bool) $this->get('hide');
+    }
+
+    public function getAdditionalDescription(): string
+    {
+        return $this->get('additionaldescription');
+    }
+
+    public function getDebitPercent(): float
+    {
+        return (float) $this->get('debit_percent');
+    }
+
+    public function getSurcharge(): float
+    {
+        return (float) $this->get('surcharge');
+    }
+
+    public function getSurchargestring(): string
+    {
+        return $this->get('surchargestring');
+    }
+
+    public function getPosition(): int
+    {
+        return (int) $this->get('position');
+    }
+
+    public function isActive(): bool
+    {
+        return (bool) $this->get('active');
+    }
+
+    public function isEsdactive(): bool
+    {
+        return (bool) $this->get('esdactive');
+    }
+
+    public function getEmbediframe(): string
+    {
+        return $this->get('embediframe');
+    }
+
+    public function isHideprospect(): bool
+    {
+        return (bool) $this->get('hideprospect');
+    }
+
+    public function getAction(): ?string
+    {
+        return $this->get('action');
+    }
+
+    public function getPluginID(): ?int
+    {
+        $pluginId = $this->get('pluginID');
+
+        return $pluginId !== null ? (int) $pluginId : null;
+    }
+
+    public function getSource(): ?int
+    {
+        $source = $this->get('source');
+
+        return $source !== null ? (int) $source : null;
+    }
+
+    public function isMobileInactive(): bool
+    {
+        return (bool) $this->get('mobile_inactive');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/RegenerateSessionIdEvent.php
+++ b/engine/Shopware/Core/Events/Admin/RegenerateSessionIdEvent.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Event_EventArgs;
+use sAdmin;
+
+class RegenerateSessionIdEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_Regenerate_Session_Id';
+
+    public function getSubject(): sAdmin
+    {
+        return $this->get('subject');
+    }
+
+    public function getOldSessionId(): string
+    {
+        return $this->get('oldSessionId');
+    }
+
+    public function getNewSessionId(): string
+    {
+        return $this->get('newSessionId');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/RegenerateSessionIdStartEvent.php
+++ b/engine/Shopware/Core/Events/Admin/RegenerateSessionIdStartEvent.php
@@ -22,22 +22,22 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Admin;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use sAdmin;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class RegenerateSessionIdStartEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Modules_Admin_regenerateSessionId_Start';
 
-    public function getSubject(): sBasket
+    public function getSubject(): sAdmin
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    public function getSessionId(): string
     {
-        return $this->get('discount');
+        return $this->get('sessionId');
     }
 }

--- a/engine/Shopware/Core/Events/Admin/SaveRegisterSendConfirmationBeforeSendEvent.php
+++ b/engine/Shopware/Core/Events/Admin/SaveRegisterSendConfirmationBeforeSendEvent.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Event_EventArgs;
+
+class SaveRegisterSendConfirmationBeforeSendEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_SaveRegisterSendConfirmation_BeforeSend';
+
+    public function getSubject(): \sAdmin
+    {
+        return $this->get('subject');
+    }
+
+    public function getEmail(): string
+    {
+        return $this->get('email');
+    }
+
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Admin\SaveRegisterSendConfirmationBeforeSendEvent::getEmail
+     */
+    public function getMail(): string
+    {
+        return $this->get('mail');
+    }
+}

--- a/engine/Shopware/Core/Events/Admin/SaveRegisterSendConfirmationStartEvent.php
+++ b/engine/Shopware/Core/Events/Admin/SaveRegisterSendConfirmationStartEvent.php
@@ -22,22 +22,22 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Admin;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use sAdmin;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class SaveRegisterSendConfirmationStartEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Modules_Admin_SaveRegisterSendConfirmation_Start';
 
-    public function getSubject(): sBasket
+    public function getSubject(): sAdmin
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    public function getEmail(): string
     {
-        return $this->get('discount');
+        return $this->get('email');
     }
 }

--- a/engine/Shopware/Core/Events/Admin/UpdateNewsletterSubscribeEvent.php
+++ b/engine/Shopware/Core/Events/Admin/UpdateNewsletterSubscribeEvent.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Admin;
+
+use Enlight_Event_EventArgs;
+
+class UpdateNewsletterSubscribeEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Admin_sUpdateNewsletter_Subscribe';
+
+    public function getEmail(): string
+    {
+        return $this->get('email');
+    }
+}

--- a/engine/Shopware/Core/Events/Articles/GetArticleChartsEvent.php
+++ b/engine/Shopware/Core/Events/Articles/GetArticleChartsEvent.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Articles;
+
+use Enlight_Event_EventArgs;
+use sArticles;
+
+class GetArticleChartsEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Articles_GetArticleCharts';
+
+    public function getSubject(): sArticles
+    {
+        return $this->get('subject');
+    }
+
+    public function getCategoryId(): int
+    {
+        return $this->get('categoryId');
+    }
+
+    public function getProducts(): array
+    {
+        return $this->get('products');
+    }
+
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Articles\GetArticleChartsEvent::getCategoryId
+     */
+    public function getCategory(): int
+    {
+        return $this->get('category');
+    }
+
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Articles\GetArticleChartsEvent::getProducts
+     */
+    public function getArticles(): array
+    {
+        return $this->get('articles');
+    }
+}

--- a/engine/Shopware/Core/Events/Articles/GetArticlePicturesStartEvent.php
+++ b/engine/Shopware/Core/Events/Articles/GetArticlePicturesStartEvent.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Articles;
+
+use Enlight_Event_EventArgs;
+use sArticles;
+
+class GetArticlePicturesStartEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Articles_GetArticlePictures_Start';
+
+    public function getSubject(): sArticles
+    {
+        return $this->get('subject');
+    }
+
+    public function getProductId(): int
+    {
+        return $this->get('productId');
+    }
+
+    public function getId(): int
+    {
+        return $this->get('id');
+    }
+}

--- a/engine/Shopware/Core/Events/Articles/GetArticlesByCategoryStartEvent.php
+++ b/engine/Shopware/Core/Events/Articles/GetArticlesByCategoryStartEvent.php
@@ -22,22 +22,34 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Articles;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use sArticles;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class GetArticlesByCategoryStartEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Modules_Articles_sGetArticlesByCategory_Start';
 
-    public function getSubject(): sBasket
+    public function getSubject(): sArticles
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    /**
+     * @return int|string|null
+     *
+     * @deprecated use @see \Shopware\Core\Events\Articles\GetArticlesByCategoryStart::getCategoryId
+     */
+    public function getId()
     {
-        return $this->get('discount');
+        return $this->get('id');
+    }
+
+    public function getCategoryId(): ?int
+    {
+        $categoryId = $this->get('categoryId');
+
+        return $categoryId !== null ? (int) $categoryId : null;
     }
 }

--- a/engine/Shopware/Core/Events/Articles/GetProductByOrdernumberStartEvent.php
+++ b/engine/Shopware/Core/Events/Articles/GetProductByOrdernumberStartEvent.php
@@ -22,22 +22,30 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Articles;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use sArticles;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class GetProductByOrdernumberStartEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Modules_Articles_sGetProductByOrdernumber_Start';
 
-    public function getSubject(): sBasket
+    public function getSubject(): sArticles
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Articles\GetProductByOrdernumberStart::getOrdernumber
+     */
+    public function getValue(): string
     {
-        return $this->get('discount');
+        return $this->get('value');
+    }
+
+    public function getOrdernumber(): string
+    {
+        return $this->get('ordernumber');
     }
 }

--- a/engine/Shopware/Core/Events/Articles/GetPromotionByIdStartEvent.php
+++ b/engine/Shopware/Core/Events/Articles/GetPromotionByIdStartEvent.php
@@ -22,27 +22,57 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Articles;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use sArticles;
 
-class AddVoucherStartEvent extends Enlight_Event_EventArgs
+class GetPromotionByIdStartEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_AddVoucher_Start';
+    public const EVENT_NAME = 'Shopware_Modules_Articles_GetPromotionById_Start';
 
-    public function getSubject(): sBasket
+    public function getSubject(): sArticles
     {
         return $this->get('subject');
     }
 
-    public function getCode(): string
+    public function getMode(): string
     {
-        return $this->get('code');
+        return $this->get('mode');
     }
 
-    public function getBasket(): string
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Articles\GetPromotionByIdStart::getCategoryId
+     */
+    public function getCategory(): int
     {
-        return $this->get('basket');
+        return $this->get('category');
+    }
+
+    public function getCategoryId(): int
+    {
+        return $this->get('categoryId');
+    }
+
+    /**
+     * returns the product id or product number
+     *
+     * @return int|string
+     *
+     * @deprecated use @see \Shopware\Core\Events\Articles\GetPromotionByIdStart::getProduct
+     */
+    public function getValue()
+    {
+        return $this->get('value');
+    }
+
+    /**
+     * returns the product id or product number
+     *
+     * @return int|string
+     */
+    public function getProduct()
+    {
+        return $this->get('product');
     }
 }

--- a/engine/Shopware/Core/Events/Basket/AddArticleAddedEvent.php
+++ b/engine/Shopware/Core/Events/Basket/AddArticleAddedEvent.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class AddArticleAddedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_AddArticle_Added';
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+    public function getBasketItemId(): int
+    {
+        $basketItemId = $this->get('basketItemId');
+
+        return is_numeric($basketItemId) ? (int) $basketItemId : $basketItemId;
+    }
+
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Basket\AddArticleAddedEvent::getBasketItemId
+     */
+    public function getId(): int
+    {
+        $basketItemId = $this->get('id');
+
+        return is_numeric($basketItemId) ? (int) $basketItemId : $basketItemId;
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/AddArticleCheckBasketForArticleEvent.php
+++ b/engine/Shopware/Core/Events/Basket/AddArticleCheckBasketForArticleEvent.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Basket;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class AddArticleCheckBasketForArticleEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_AddArticle_CheckBasketForArticle';
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->get('queryBuilder');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/AddArticleStartEvent.php
+++ b/engine/Shopware/Core/Events/Basket/AddArticleStartEvent.php
@@ -1,4 +1,26 @@
 <?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
 
 namespace Shopware\Core\Events\Basket;
 
@@ -9,18 +31,23 @@ class AddArticleStartEvent extends Enlight_Event_EventArgs
 {
     public const EVENT_NAME = 'Shopware_Modules_Basket_AddArticle_Start';
 
-
     public function getSubject(): sBasket
     {
         return $this->get('subject');
     }
 
-
-    public function getId(): int
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Basket\AddArticleStartEvent::getOrdernumber
+     */
+    public function getId(): string
     {
         return $this->get('id');
     }
 
+    public function getOrdernumber(): string
+    {
+        return $this->get('ordernumber');
+    }
 
     public function getQuantity(): int
     {

--- a/engine/Shopware/Core/Events/Basket/AddArticleStartEvent.php
+++ b/engine/Shopware/Core/Events/Basket/AddArticleStartEvent.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class AddArticleStartEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_AddArticle_Start';
+
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+
+    public function getId(): int
+    {
+        return $this->get('id');
+    }
+
+
+    public function getQuantity(): int
+    {
+        return $this->get('quantity');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/AddVoucherStartEvent.php
+++ b/engine/Shopware/Core/Events/Basket/AddVoucherStartEvent.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Components\Events\Basket;
+namespace Shopware\Core\Events\Basket;
 
 use Enlight_Event_EventArgs;
 use sBasket;

--- a/engine/Shopware/Core/Events/Basket/BasketClearedEvent.php
+++ b/engine/Shopware/Core/Events/Basket/BasketClearedEvent.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class BasketClearedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_BasketCleared';
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+    public function getSessionId(): string
+    {
+        return $this->get('sessionId');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/BeforeAddMinimumOrderSurchargeEvent.php
+++ b/engine/Shopware/Core/Events/Basket/BeforeAddMinimumOrderSurchargeEvent.php
@@ -1,4 +1,26 @@
 <?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
 
 namespace Shopware\Core\Events\Basket;
 
@@ -9,12 +31,10 @@ class BeforeAddMinimumOrderSurchargeEvent extends Enlight_Event_EventArgs
 {
     public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddMinimumOrderSurcharge';
 
-
     public function getSubject(): sBasket
     {
         return $this->get('subject');
     }
-
 
     public function getSurcharge(): array
     {

--- a/engine/Shopware/Core/Events/Basket/BeforeAddMinimumOrderSurchargeEvent.php
+++ b/engine/Shopware/Core/Events/Basket/BeforeAddMinimumOrderSurchargeEvent.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class BeforeAddMinimumOrderSurchargeEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddMinimumOrderSurcharge';
+
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+
+    public function getSurcharge(): array
+    {
+        return $this->get('surcharge');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/BeforeAddOrderDiscountEvent.php
+++ b/engine/Shopware/Core/Events/Basket/BeforeAddOrderDiscountEvent.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+
+    public function getDiscount(): array
+    {
+        return $this->get('discount');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/BeforeAddOrderSurchargePercentEvent.php
+++ b/engine/Shopware/Core/Events/Basket/BeforeAddOrderSurchargePercentEvent.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class BeforeAddOrderSurchargePercentEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderSurchargePercent';
+
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+
+    public function getSurcharge(): array
+    {
+        return $this->get('surcharge');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/BeforeAddOrderSurchargePercentEvent.php
+++ b/engine/Shopware/Core/Events/Basket/BeforeAddOrderSurchargePercentEvent.php
@@ -1,4 +1,26 @@
 <?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
 
 namespace Shopware\Core\Events\Basket;
 
@@ -9,12 +31,10 @@ class BeforeAddOrderSurchargePercentEvent extends Enlight_Event_EventArgs
 {
     public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderSurchargePercent';
 
-
     public function getSubject(): sBasket
     {
         return $this->get('subject');
     }
-
 
     public function getSurcharge(): array
     {

--- a/engine/Shopware/Core/Events/Basket/DeleteArticleStartEvent.php
+++ b/engine/Shopware/Core/Events/Basket/DeleteArticleStartEvent.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class DeleteArticleStartEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_DeleteArticle_Start';
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+
+    public function getId(): int
+    {
+        return $this->get('id');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/DeleteArticleStartEvent.php
+++ b/engine/Shopware/Core/Events/Basket/DeleteArticleStartEvent.php
@@ -1,4 +1,26 @@
 <?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
 
 namespace Shopware\Core\Events\Basket;
 
@@ -14,9 +36,8 @@ class DeleteArticleStartEvent extends Enlight_Event_EventArgs
         return $this->get('subject');
     }
 
-
     public function getId(): int
     {
-        return $this->get('id');
+        return (int) $this->get('id');
     }
 }

--- a/engine/Shopware/Core/Events/Basket/DeleteNoteStartEvent.php
+++ b/engine/Shopware/Core/Events/Basket/DeleteNoteStartEvent.php
@@ -1,4 +1,26 @@
 <?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
 
 namespace Shopware\Core\Events\Basket;
 
@@ -13,7 +35,6 @@ class DeleteNoteStartEvent extends Enlight_Event_EventArgs
     {
         return $this->get('subject');
     }
-
 
     public function getId(): int
     {

--- a/engine/Shopware/Core/Events/Basket/DeleteNoteStartEvent.php
+++ b/engine/Shopware/Core/Events/Basket/DeleteNoteStartEvent.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class DeleteNoteStartEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_DeleteNote_Start';
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+
+    public function getId(): int
+    {
+        return $this->get('id');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/DeletedArticleEvent.php
+++ b/engine/Shopware/Core/Events/Basket/DeletedArticleEvent.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class DeletedArticleEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_DeletedArticle';
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+    /**
+     * @return int|string
+     *
+     * @deprecated use @see \Shopware\Core\Events\Basket\DeletedArticleEvent::getBasketItemId
+     */
+    public function getId()
+    {
+        $basketItemId = $this->get('id');
+
+        return is_numeric($basketItemId) ? (int) $basketItemId : $basketItemId;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getBasketItemId()
+    {
+        $basketItemId = $this->get('basketItemId');
+
+        return is_numeric($basketItemId) ? (int) $basketItemId : $basketItemId;
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/GetAmountArticlesQueryBuilderEvent.php
+++ b/engine/Shopware/Core/Events/Basket/GetAmountArticlesQueryBuilderEvent.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Basket;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Enlight_Event_EventArgs;
+
+class GetAmountArticlesQueryBuilderEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_GetAmountArticles_QueryBuilder';
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->get('queryBuilder');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/GetBasketAllowEmptyBasketEvent.php
+++ b/engine/Shopware/Core/Events/Basket/GetBasketAllowEmptyBasketEvent.php
@@ -1,4 +1,26 @@
 <?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
 
 namespace Shopware\Core\Events\Basket;
 
@@ -8,30 +30,25 @@ class GetBasketAllowEmptyBasketEvent extends Enlight_Event_EventArgs
 {
     public const EVENT_NAME = 'Shopware_Modules_Basket_sGetBasket_AllowEmptyBasket';
 
-
     public function getArticles(): array
     {
         return $this->get('articles');
     }
-
 
     public function getTotalAmount(): float
     {
         return $this->get('totalAmount');
     }
 
-
     public function getTotalAmountWithTax(): float
     {
         return $this->get('totalAmountWithTax');
     }
 
-
     public function getTotalCount(): int
     {
         return $this->get('totalCount');
     }
-
 
     public function getTotalAmountNet(): float
     {

--- a/engine/Shopware/Core/Events/Basket/GetBasketAllowEmptyBasketEvent.php
+++ b/engine/Shopware/Core/Events/Basket/GetBasketAllowEmptyBasketEvent.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+
+class GetBasketAllowEmptyBasketEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_sGetBasket_AllowEmptyBasket';
+
+
+    public function getArticles(): array
+    {
+        return $this->get('articles');
+    }
+
+
+    public function getTotalAmount(): float
+    {
+        return $this->get('totalAmount');
+    }
+
+
+    public function getTotalAmountWithTax(): float
+    {
+        return $this->get('totalAmountWithTax');
+    }
+
+
+    public function getTotalCount(): int
+    {
+        return $this->get('totalCount');
+    }
+
+
+    public function getTotalAmountNet(): float
+    {
+        return $this->get('totalAmountNet');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/GetPricesForItemUpdatesQueryBuilderEvent.php
+++ b/engine/Shopware/Core/Events/Basket/GetPricesForItemUpdatesQueryBuilderEvent.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Basket;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Enlight_Event_EventArgs;
+use sBasket;
+
+class GetPricesForItemUpdatesQueryBuilderEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_getPricesForItemUpdates_QueryBuilder';
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->get('queryBuilder');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/UpdateArticleStartEvent.php
+++ b/engine/Shopware/Core/Events/Basket/UpdateArticleStartEvent.php
@@ -1,4 +1,26 @@
 <?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
 
 namespace Shopware\Core\Events\Basket;
 
@@ -10,26 +32,22 @@ class UpdateArticleStartEvent extends Enlight_Event_EventArgs
 {
     public const EVENT_NAME = 'Shopware_Modules_Basket_UpdateArticle_Start';
 
-
     public function getSubject(): sBasket
     {
         return $this->get('subject');
     }
-
 
     public function getId(): int
     {
         return $this->get('id');
     }
 
-
     public function getQuantity(): int
     {
         return $this->get('quantity');
     }
 
-
-    public function getcartItem(): CartItemStruct
+    public function getCartItem(): CartItemStruct
     {
         return $this->get('cartItem');
     }

--- a/engine/Shopware/Core/Events/Basket/UpdateArticleStartEvent.php
+++ b/engine/Shopware/Core/Events/Basket/UpdateArticleStartEvent.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+use Shopware\Components\Cart\Struct\CartItemStruct;
+
+class UpdateArticleStartEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_UpdateArticle_Start';
+
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+
+    public function getId(): int
+    {
+        return $this->get('id');
+    }
+
+
+    public function getQuantity(): int
+    {
+        return $this->get('quantity');
+    }
+
+
+    public function getcartItem(): CartItemStruct
+    {
+        return $this->get('cartItem');
+    }
+}

--- a/engine/Shopware/Core/Events/Basket/UpdateCartItemsUpdatedEvent.php
+++ b/engine/Shopware/Core/Events/Basket/UpdateCartItemsUpdatedEvent.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Basket;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+use Shopware\Components\Cart\Struct\CartItemStruct;
+
+class UpdateCartItemsUpdatedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Basket_UpdateCartItems_Updated';
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+    /**
+     * @return CartItemStruct[]
+     */
+    public function getItems(): array
+    {
+        return $this->get('items');
+    }
+
+    /**
+     * @return CartItemStruct[]
+     */
+    public function getUpdateableItems(): array
+    {
+        return $this->get('updateableItems');
+    }
+}

--- a/engine/Shopware/Core/Events/Marketing/AlsoBoughtArticlesEvent.php
+++ b/engine/Shopware/Core/Events/Marketing/AlsoBoughtArticlesEvent.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Marketing;
+
+use Enlight_Event_EventArgs;
+use sMarketing;
+
+class AlsoBoughtArticlesEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Marketing_AlsoBoughtArticles';
+
+    public function getSubject(): sMarketing
+    {
+        return $this->get('subject');
+    }
+
+    public function getProducts(): array
+    {
+        return $this->get('products');
+    }
+
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Marketing\GetSimilarShownArticles::getProducts
+     */
+    public function getArticles(): array
+    {
+        return $this->get('articles');
+    }
+}

--- a/engine/Shopware/Core/Events/Marketing/GetSimilarShownArticlesEvent.php
+++ b/engine/Shopware/Core/Events/Marketing/GetSimilarShownArticlesEvent.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Marketing;
+
+use Enlight_Event_EventArgs;
+use sMarketing;
+
+class GetSimilarShownArticlesEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Marketing_GetSimilarShownArticles';
+
+    public function getSubject(): sMarketing
+    {
+        return $this->get('subject');
+    }
+
+    public function getProducts(): array
+    {
+        return $this->get('products');
+    }
+
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Marketing\GetSimilarShownArticles::getProducts
+     */
+    public function getArticles(): array
+    {
+        return $this->get('articles');
+    }
+}

--- a/engine/Shopware/Core/Events/Order/OrderStateNotifyEvent.php
+++ b/engine/Shopware/Core/Events/Order/OrderStateNotifyEvent.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Order;
+
+use Enlight_Controller_Front;
+use Enlight_Event_EventArgs;
+
+class OrderStateNotifyEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Controllers_Backend_OrderState_Notify';
+
+    public function getSubject(): ?Enlight_Controller_Front
+    {
+        return $this->get('subject');
+    }
+
+    public function getOrderId(): int
+    {
+        return $this->get('orderId');
+    }
+
+    public function getStatusId(): int
+    {
+        return $this->get('statusId');
+    }
+
+    public function getMailname(): string
+    {
+        return $this->get('mailname');
+    }
+
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Order\OrderStateNotify::getOrderId
+     */
+    public function getId(): int
+    {
+        return $this->get('id');
+    }
+
+    /**
+     * @deprecated use @see \Shopware\Core\Events\Order\OrderStateNotify::getStatusId
+     */
+    public function getStatus(): int
+    {
+        return $this->get('status');
+    }
+}

--- a/engine/Shopware/Core/Events/Order/OrderStateSendBeforeSendEvent.php
+++ b/engine/Shopware/Core/Events/Order/OrderStateSendBeforeSendEvent.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Order;
+
+use Enlight_Components_Mail;
+use Enlight_Controller_Front;
+use Enlight_Event_EventArgs;
+
+class OrderStateSendBeforeSendEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Controllers_Backend_OrderState_Send_BeforeSend';
+
+    public function getSubject(): ?Enlight_Controller_Front
+    {
+        return $this->get('subject');
+    }
+
+    public function getMail(): Enlight_Components_Mail
+    {
+        return $this->get('mail');
+    }
+}

--- a/engine/Shopware/Core/Events/Order/ProductStockWasChangedEvent.php
+++ b/engine/Shopware/Core/Events/Order/ProductStockWasChangedEvent.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Order;
+
+use Enlight_Event_EventArgs;
+
+class ProductStockWasChangedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'product_stock_was_changed';
+
+    public function getNumber(): string
+    {
+        return $this->get('number');
+    }
+
+    public function getQuantity(): int
+    {
+        return (int) $this->get('quantity');
+    }
+}

--- a/engine/Shopware/Core/Events/Order/SaveOrderProcessDetailsEvent.php
+++ b/engine/Shopware/Core/Events/Order/SaveOrderProcessDetailsEvent.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Order;
+
+use Enlight_Event_EventArgs;
+use sOrder;
+
+class SaveOrderProcessDetailsEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Order_SaveOrder_ProcessDetails';
+
+    public function getSubject(): sOrder
+    {
+        return $this->get('subject');
+    }
+
+    public function getDetails(): array
+    {
+        return $this->get('details');
+    }
+
+    public function getOrderId(): int
+    {
+        return (int) $this->get('orderId');
+    }
+}

--- a/engine/Shopware/Core/Events/Order/SendMailBeforeSendEvent.php
+++ b/engine/Shopware/Core/Events/Order/SendMailBeforeSendEvent.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Core\Events\Order;
+
+use Enlight_Event_EventArgs;
+use sBasket;
+use Zend_Mail;
+
+class SendMailBeforeSendEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Modules_Order_SendMail_BeforeSend';
+
+    public function getSubject(): sBasket
+    {
+        return $this->get('subject');
+    }
+
+    public function getMail(): Zend_Mail
+    {
+        return $this->get('mail');
+    }
+
+    public function getContext(): array
+    {
+        return $this->get('context');
+    }
+
+    public function getVariables(): array
+    {
+        return $this->get('variables');
+    }
+}

--- a/engine/Shopware/Core/Events/Order/SendMailCreateEvent.php
+++ b/engine/Shopware/Core/Events/Order/SendMailCreateEvent.php
@@ -22,22 +22,27 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Order;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use sOrder;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class SendMailCreateEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Modules_Order_SendMail_Create';
 
-    public function getSubject(): sBasket
+    public function getSubject(): sOrder
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    public function getContext(): array
     {
-        return $this->get('discount');
+        return $this->get('context');
+    }
+
+    public function getVariables(): array
+    {
+        return $this->get('variables');
     }
 }

--- a/engine/Shopware/Core/Events/Order/SendMailSendEvent.php
+++ b/engine/Shopware/Core/Events/Order/SendMailSendEvent.php
@@ -22,22 +22,33 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace Shopware\Core\Events\Order;
 
 use Enlight_Event_EventArgs;
 use sBasket;
+use Zend_Mail;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class SendMailSendEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Modules_Order_SendMail_Send';
 
     public function getSubject(): sBasket
     {
         return $this->get('subject');
     }
 
-    public function getDiscount(): array
+    public function getMail(): Zend_Mail
     {
-        return $this->get('discount');
+        return $this->get('mail');
+    }
+
+    public function getContext(): array
+    {
+        return $this->get('context');
+    }
+
+    public function getVariables(): array
+    {
+        return $this->get('variables');
     }
 }

--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -32,6 +32,12 @@ use Shopware\Components\Cart\Struct\DiscountContext;
 use Shopware\Components\NumberRangeIncrementerInterface;
 use Shopware\Components\Random;
 use Shopware\Components\Validator\EmailValidatorInterface;
+use Shopware\Core\Events\Admin\CheckUserStartEvent;
+use Shopware\Core\Events\Admin\ExecuteRiskRuleEvent;
+use Shopware\Core\Events\Admin\GetUserDataStartEvent;
+use Shopware\Core\Events\Admin\LoginStartEvent;
+use Shopware\Core\Events\Admin\RegenerateSessionIdStartEvent;
+use Shopware\Core\Events\Admin\SaveRegisterSendConfirmationStartEvent;
 use Shopware\Models\Customer\Address;
 use Shopware\Models\Customer\Customer;
 
@@ -720,12 +726,12 @@ class sAdmin implements \Enlight_Hook
     public function sLogin($ignoreAccountMode = false)
     {
         if ($this->eventManager->notifyUntil(
-            'Shopware_Modules_Admin_Login_Start',
-            [
+            LoginStartEvent::EVENT_NAME,
+            new LoginStartEvent([
                 'subject' => $this,
                 'ignoreAccountMode' => $ignoreAccountMode,
                 'post' => $this->front->Request()->getPost(),
-            ]
+            ])
         )) {
             return false;
         }
@@ -847,8 +853,10 @@ class sAdmin implements \Enlight_Hook
     public function sCheckUser()
     {
         if ($this->eventManager->notifyUntil(
-            'Shopware_Modules_Admin_CheckUser_Start',
-            ['subject' => $this]
+            CheckUserStartEvent::EVENT_NAME,
+            new CheckUserStartEvent([
+                'subject' => $this,
+            ])
         )) {
             return false;
         }
@@ -1149,8 +1157,11 @@ class sAdmin implements \Enlight_Hook
     public function sSaveRegisterSendConfirmation($email)
     {
         if ($this->eventManager->notifyUntil(
-            'Shopware_Modules_Admin_SaveRegisterSendConfirmation_Start',
-            ['subject' => $this, 'email' => $email]
+            SaveRegisterSendConfirmationStartEvent::EVENT_NAME,
+            new SaveRegisterSendConfirmationStartEvent([
+                'subject' => $this,
+                'email' => $email,
+            ])
         )) {
             return false;
         }
@@ -1494,8 +1505,10 @@ class sAdmin implements \Enlight_Hook
     public function sGetUserData()
     {
         if ($this->eventManager->notifyUntil(
-            'Shopware_Modules_Admin_GetUserData_Start',
-            ['subject' => $this]
+            GetUserDataStartEvent::EVENT_NAME,
+            new GetUserDataStartEvent([
+                'subject' => $this,
+            ])
         )) {
             return false;
         }
@@ -1629,14 +1642,14 @@ class sAdmin implements \Enlight_Hook
     public function executeRiskRule($rule, $user, $basket, $value, $paymentID = null)
     {
         if ($event = $this->eventManager->notifyUntil(
-            'Shopware_Modules_Admin_Execute_Risk_Rule_' . $rule,
-            [
+            ExecuteRiskRuleEvent::EVENT_NAME . $rule,
+            new ExecuteRiskRuleEvent([
                 'rule' => $rule,
                 'user' => $user,
                 'basket' => $basket,
                 'value' => $value,
                 'paymentID' => $paymentID,
-            ]
+            ])
         )) {
             return $event->getReturn();
         }
@@ -3306,8 +3319,11 @@ class sAdmin implements \Enlight_Hook
         $oldSessionId = session_id();
 
         if ($this->eventManager->notifyUntil(
-            'Shopware_Modules_Admin_regenerateSessionId_Start',
-            ['subject' => $this, 'sessionId' => $oldSessionId]
+            RegenerateSessionIdStartEvent::EVENT_NAME,
+            new RegenerateSessionIdStartEvent([
+                'subject' => $this,
+                'sessionId' => $oldSessionId,
+            ])
         )) {
             return;
         }

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -48,6 +48,8 @@ use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Components\Compatibility\LegacyEventManager;
 use Shopware\Components\Compatibility\LegacyStructConverter;
 use Shopware\Components\QueryAliasMapper;
+use Shopware\Core\Events\Articles\GetArticleChartsEvent;
+use Shopware\Core\Events\Articles\GetArticlePicturesStartEvent;
 use Shopware\Core\Events\Articles\GetArticlesByCategoryStartEvent;
 use Shopware\Core\Events\Articles\GetProductByOrdernumberStartEvent;
 use Shopware\Core\Events\Articles\GetPromotionByIdStartEvent;
@@ -684,8 +686,14 @@ class sArticles implements \Enlight_Hook
         $products = $this->legacyStructConverter->convertListProductStructList($result->getProducts());
 
         $this->eventManager->notify(
-            'Shopware_Modules_Articles_GetArticleCharts',
-            ['subject' => $this, 'category' => $category, 'articles' => $products]
+            GetArticleChartsEvent::EVENT_NAME,
+            new GetArticleChartsEvent([
+                'subject' => $this,
+                'category' => $category,
+                'categoryId' => $category,
+                'articles' => $products,
+                'products' => $products,
+            ])
         );
 
         return $products;
@@ -1423,8 +1431,12 @@ class sArticles implements \Enlight_Hook
         $productId = (int) $sArticleID;
 
         $this->eventManager->notify(
-            'Shopware_Modules_Articles_GetArticlePictures_Start',
-            ['subject' => $this, 'id' => $productId]
+            GetArticlePicturesStartEvent::EVENT_NAME,
+            new GetArticlePicturesStartEvent([
+                'subject' => $this,
+                'productId' => $productId,
+                'id' => $productId,
+            ])
         );
 
         // First we get the product cover

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -365,7 +365,7 @@ class sBasket implements \Enlight_Hook
               GROUP BY sessionID';
         $params = [$this->session->get('sessionId')];
 
-        $sql = Shopware()->Events()->filter(
+        $sql = $this->eventManager->filter(
             'Shopware_Modules_Basket_InsertDiscount_FilterSql_BasketAmount',
             $sql,
             ['subject' => $this, 'params' => $params]
@@ -1566,7 +1566,7 @@ SQL;
             DeleteNoteStartEvent::EVENT_NAME,
             new DeleteNoteStartEvent([
                 'subject' => $this,
-                'id' => $id
+                'id' => $id,
             ])
         )) {
             return false;
@@ -1876,6 +1876,7 @@ SQL;
             new AddArticleStartEvent([
                 'subject' => $this,
                 'id' => $id,
+                'ordernumber' => $id,
                 'quantity' => $quantity,
             ])
         )) {

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -28,6 +28,7 @@ use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
 use Shopware\Components\Cart\BasketHelperInterface;
 use Shopware\Components\Cart\Struct\CartItemStruct;
 use Shopware\Components\Cart\Struct\DiscountContext;
+use Shopware\Components\Events\Basket\AddVoucherStartEvent;
 use Shopware\Components\Random;
 use Symfony\Component\HttpFoundation\Cookie;
 
@@ -671,8 +672,12 @@ SQL;
     public function sAddVoucher($voucherCode, $basket = '')
     {
         if ($this->eventManager->notifyUntil(
-            'Shopware_Modules_Basket_AddVoucher_Start',
-            ['subject' => $this, 'code' => $voucherCode, 'basket' => $basket]
+            AddVoucherStartEvent::EVENT_NAME,
+            new AddVoucherStartEvent([
+                'subject' => $this,
+                'code' => $voucherCode,
+                'basket' => $basket,
+            ])
         )) {
             return false;
         }

--- a/engine/Shopware/Core/sMarketing.php
+++ b/engine/Shopware/Core/sMarketing.php
@@ -23,6 +23,8 @@
  */
 
 use Shopware\Bundle\StoreFrontBundle;
+use Shopware\Core\Events\Marketing\AlsoBoughtArticlesEvent;
+use Shopware\Core\Events\Marketing\GetSimilarShownArticlesEvent;
 use Shopware\Models\Banner\Banner;
 
 /**
@@ -153,10 +155,14 @@ class sMarketing implements \Enlight_Hook
             'customerGroupId' => (int) $this->customerGroupId,
         ]);
 
-        Shopware()->Events()->notify('Shopware_Modules_Marketing_GetSimilarShownArticles', [
-            'subject' => $this,
-            'articles' => $similarShownProducts,
-        ]);
+        Shopware()->Events()->notify(
+            GetSimilarShownArticlesEvent::EVENT_NAME,
+            new GetSimilarShownArticlesEvent([
+                'subject' => $this,
+                'products' => $similarShownProducts,
+                'articles' => $similarShownProducts,
+            ])
+        );
 
         return $similarShownProducts;
     }
@@ -215,10 +221,14 @@ class sMarketing implements \Enlight_Hook
             'customerGroupId' => (int) $this->customerGroupId,
         ]);
 
-        Shopware()->Events()->notify('Shopware_Modules_Marketing_AlsoBoughtArticles', [
-            'subject' => $this,
-            'articles' => $alsoBought,
-        ]);
+        Shopware()->Events()->notify(
+            AlsoBoughtArticlesEvent::EVENT_NAME,
+            new AlsoBoughtArticlesEvent([
+                'subject' => $this,
+                'products' => $alsoBought,
+                'articles' => $alsoBought,
+            ])
+        );
 
         return $alsoBought;
     }

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -24,6 +24,8 @@
 
 use Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface;
 use Shopware\Components\NumberRangeIncrementerInterface;
+use Shopware\Core\Events\Order\SendMailCreateEvent;
+use Shopware\Core\Events\Order\SendMailSendEvent;
 use Shopware\Models\Customer\Customer;
 
 /**
@@ -931,12 +933,12 @@ class sOrder implements \Enlight_Hook
 
         $mail = null;
         if ($event = $this->eventManager->notifyUntil(
-            'Shopware_Modules_Order_SendMail_Create',
-            [
+            SendMailCreateEvent::EVENT_NAME,
+            new SendMailCreateEvent([
                 'subject' => $this,
                 'context' => $context,
                 'variables' => $variables,
-            ]
+            ])
         )) {
             $mail = $event->getReturn();
         }
@@ -972,13 +974,13 @@ class sOrder implements \Enlight_Hook
         );
 
         $shouldSendMail = !(bool) $this->eventManager->notifyUntil(
-            'Shopware_Modules_Order_SendMail_Send',
-            [
+            SendMailSendEvent::EVENT_NAME,
+            new SendMailSendEvent([
                 'subject' => $this,
                 'mail' => $mail,
                 'context' => $context,
                 'variables' => $variables,
-            ]
+            ])
         );
 
         if ($shouldSendMail && $this->config->get('sendOrderMail')) {

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -29,6 +29,8 @@ use Shopware\Components\HttpCache\Store;
 use Shopware\Components\Model\ModelManager;
 use ShopwarePlugins\HttpCache\CacheControl;
 use ShopwarePlugins\HttpCache\CacheIdCollector;
+use ShopwarePlugins\HttpCache\Events\ClearCacheEvent;
+use ShopwarePlugins\HttpCache\Events\InvalidateCacheIdEvent;
 use ShopwarePlugins\HttpCache\Events\ShouldNotInvalidateCacheEvent;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
@@ -95,12 +97,13 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
         );
 
         $this->subscribeEvent(
-            'Shopware_Plugins_HttpCache_InvalidateCacheId',
+            InvalidateCacheIdEvent::EVENT_NAME,
             'onInvalidateCacheId'
         );
 
+        // TODO fix event autoloading
         $this->subscribeEvent(
-            'Shopware_Plugins_HttpCache_ClearCache',
+            ClearCacheEvent::EVENT_NAME,
             'onClearCache'
         );
 
@@ -412,7 +415,10 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      * to check if the http-cache-plugin is installed and enabled.
      *
      * <code>
-     * Shopware()->Events()->notify('Shopware_Plugins_HttpCache_ClearCache');
+     * Shopware()->Events()->notify(
+     *     \ShopwarePlugins\HttpCache\Events\ClearCacheEvent::EVENT_NAME',
+     *     new \ShopwarePlugins\HttpCache\Events\ClearCacheEvent()
+     * );
      * </code>
      */
     public function onClearCache(\Enlight_Event_EventArgs $args)
@@ -430,14 +436,20 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      *
      * <code>
      * Shopware()->Events()->notify(
-     *     'Shopware_Plugins_HttpCache_InvalidateCacheId',
-     *     array('cacheId' => 'a123')
+     *     \ShopwarePlugins\HttpCache\Events\InvalidateCacheIdEvent:EVENT_NAME,
+     *     new \ShopwarePlugins\HttpCache\Events\InvalidateCacheIdEvent(['cacheId' => 'a123'])
      * );
      * </code>
      */
     public function onInvalidateCacheId(\Enlight_Event_EventArgs $args)
     {
-        $cacheId = $args->get('cacheId');
+        // TODO fix event autoloading
+        if ($args instanceof InvalidateCacheIdEvent) {
+            $cacheId = $args->getCacheId();
+        } else {
+            $cacheId = $args->get('cacheId');
+        }
+
         if (!$cacheId) {
             $args->setReturn(false);
 

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -29,6 +29,7 @@ use Shopware\Components\HttpCache\Store;
 use Shopware\Components\Model\ModelManager;
 use ShopwarePlugins\HttpCache\CacheControl;
 use ShopwarePlugins\HttpCache\CacheIdCollector;
+use ShopwarePlugins\HttpCache\Events\ShouldNotInvalidateCacheEvent;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 
@@ -180,7 +181,9 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
     public function afterInit()
     {
-        $this->get('loader')->registerNamespace('ShopwarePlugins\\HttpCache', __DIR__);
+        /** @var Enlight_Loader $loader */
+        $loader = $this->get('loader');
+        $loader->registerNamespace('ShopwarePlugins\\HttpCache', __DIR__);
         parent::afterInit();
     }
 
@@ -661,11 +664,12 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
         }
 
         if (Shopware()->Events()->notifyUntil(
-            'Shopware_Plugins_HttpCache_ShouldNotInvalidateCache',
-            [
+            // TODO ShouldNotInvalidateCacheEvent is not loaded, but I don't know why
+            ShouldNotInvalidateCacheEvent::EVENT_NAME,
+            new ShouldNotInvalidateCacheEvent([
                 'entity' => $entity,
                 'entityName' => $entityName,
-            ]
+            ])
         )) {
             return;
         }

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Events/ClearCacheEvent.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Events/ClearCacheEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace ShopwarePlugins\HttpCache\Events;
+
+use Enlight_Event_EventArgs;
+
+class ClearCacheEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Plugins_HttpCache_ClearCache';
+}

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Events/InvalidateCacheIdEvent.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Events/InvalidateCacheIdEvent.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace ShopwarePlugins\HttpCache\Events;
+
+use Enlight_Event_EventArgs;
+
+class InvalidateCacheIdEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Plugins_HttpCache_InvalidateCacheId';
+
+    public function getSubject(): object
+    {
+        return $this->get('subject');
+    }
+
+    public function getCacheId(): string
+    {
+        return $this->get('cacheId');
+    }
+}

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Events/ShouldNotInvalidateCacheEvent.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Events/ShouldNotInvalidateCacheEvent.php
@@ -22,22 +22,22 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Core\Events\Basket;
+namespace ShopwarePlugins\HttpCache\Events;
 
 use Enlight_Event_EventArgs;
-use sBasket;
+use Shopware\Components\Model\ModelEntity;
 
-class BeforeAddOrderDiscountEvent extends Enlight_Event_EventArgs
+class ShouldNotInvalidateCacheEvent extends Enlight_Event_EventArgs
 {
-    public const EVENT_NAME = 'Shopware_Modules_Basket_BeforeAddOrderDiscount';
+    public const EVENT_NAME = 'Shopware_Plugins_HttpCache_ShouldNotInvalidateCache';
 
-    public function getSubject(): sBasket
+    public function getEntity(): ModelEntity
     {
-        return $this->get('subject');
+        return $this->get('entity');
     }
 
-    public function getDiscount(): array
+    public function getEntityName(): string
     {
-        return $this->get('discount');
+        return $this->get('entityName');
     }
 }

--- a/engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php
@@ -23,6 +23,7 @@
  */
 
 use Shopware\Bundle\SearchBundleDBAL\SearchTerm\SearchIndexerInterface;
+use ShopwarePlugins\RebuildIndex\Events\CreateRewriteTableEvent;
 
 class Shopware_Plugins_Core_RebuildIndex_Bootstrap extends Shopware_Components_Plugin_Bootstrap
 {
@@ -176,12 +177,13 @@ class Shopware_Plugins_Core_RebuildIndex_Bootstrap extends Shopware_Components_P
             $this->RewriteTable()->sCreateRewriteTableStatic();
             $this->RewriteTable()->createContentTypeUrls($context);
 
+            // TODO fix event autoloading
             Shopware()->Events()->notify(
-                'Shopware_CronJob_RefreshSeoIndex_CreateRewriteTable',
-                [
+                CreateRewriteTableEvent::EVENT_NAME,
+                new CreateRewriteTableEvent([
                     'shopContext' => $context,
                     'cachedTime' => $currentTime,
-                ]
+                ])
             );
         }
 

--- a/engine/Shopware/Plugins/Default/Core/RebuildIndex/Events/CreateRewriteTableEvent.php
+++ b/engine/Shopware/Plugins/Default/Core/RebuildIndex/Events/CreateRewriteTableEvent.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace ShopwarePlugins\RebuildIndex\Events;
+
+use DateTimeInterface;
+use Enlight_Event_EventArgs;
+use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
+
+class CreateRewriteTableEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_CronJob_RefreshSeoIndex_CreateRewriteTable';
+
+    public function getContext(): ShopContextInterface
+    {
+        return $this->get('context');
+    }
+
+    public function getCachedTime(): DateTimeInterface
+    {
+        return $this->get('cachedTime');
+    }
+}

--- a/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
@@ -23,6 +23,8 @@
  */
 
 use Shopware\Components\Routing\Context;
+use ShopwarePlugins\Notification\Events\NotificationProductQueryBuilderEvent;
+use ShopwarePlugins\Notification\Events\NotificationSavedEvent;
 
 /**
  * Shopware Notification Plugin
@@ -267,11 +269,15 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
                     $params
                 );
 
-                $eventManager->notify('Shopware_Notification_Notification_Saved', [
-                    'subject' => $this,
-                    'id' => $insertId,
-                    'data' => $json_data,
-                ]);
+                $eventManager->notify(
+                    NotificationSavedEvent::EVENT_NAME,
+                    new NotificationSavedEvent([
+                        'subject' => $this,
+                        'notificationId' => $insertId,
+                        'id' => $insertId,
+                        'data' => $json_data,
+                    ])
+                );
 
                 $action->View()->NotifyValid = true;
                 $this->get('session')->sNotifcationArticleWaitingForOptInApprovement[$json_data['notifyOrdernumber']] = false;
@@ -330,10 +336,10 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
                 ->setParameter('number', $notify['ordernumber']);
 
             $this->get('events')->notify(
-                'Shopware_CronJob_Notification_Product_QueryBuilder',
-                [
+                NotificationProductQueryBuilderEvent::EVENT_NAME,
+                new NotificationProductQueryBuilderEvent([
                     'queryBuilder' => $queryBuilder,
-                ]
+                ])
             );
 
             $product = $queryBuilder->execute()->fetch(\PDO::FETCH_ASSOC);

--- a/engine/Shopware/Plugins/Default/Frontend/Notification/Events/NotificationProductQueryBuilderEvent.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Notification/Events/NotificationProductQueryBuilderEvent.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace ShopwarePlugins\Notification\Events;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Enlight_Event_EventArgs;
+
+class NotificationProductQueryBuilderEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_CronJob_Notification_Product_QueryBuilder';
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->get('queryBuilder');
+    }
+}

--- a/engine/Shopware/Plugins/Default/Frontend/Notification/Events/NotificationSavedEvent.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Notification/Events/NotificationSavedEvent.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace ShopwarePlugins\Notification\Events;
+
+use Enlight_Event_EventArgs;
+use Shopware_Plugins_Frontend_Notification_Bootstrap;
+
+class NotificationSavedEvent extends Enlight_Event_EventArgs
+{
+    public const EVENT_NAME = 'Shopware_Notification_Notification_Saved';
+
+    public function getSubject(): Shopware_Plugins_Frontend_Notification_Bootstrap
+    {
+        return $this->get('subject');
+    }
+
+    public function getNotificationId(): int
+    {
+        return (int) $this->get('notificationId');
+    }
+
+    public function getData(): array
+    {
+        return $this->get('data');
+    }
+
+    /**
+     * @deprecated use @see \ShopwarePlugins\Notification\Events\NotificationSavedEvent::getNotificationId
+     */
+    public function getId(): int
+    {
+        return (int) $this->get('id');
+    }
+}

--- a/engine/Shopware/Plugins/Default/Frontend/Seo/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Seo/Bootstrap.php
@@ -208,7 +208,8 @@ class Shopware_Plugins_Frontend_Seo_Bootstrap extends Shopware_Components_Plugin
         /** @var Enlight_Event_EventManager $events */
         $events = $this->get('events');
 
-        if ($event = $events->notifyUntil(__CLASS__ . '_canBeMinified', [
+        // TODO add event class and register namespace!
+        if ($event = $events->notifyUntil('Shopware_Plugins_Frontend_Seo_Bootstrap_canBeMinified', [
             'controller' => $controller,
             'subject' => $this,
         ])) {


### PR DESCRIPTION
The Symfony Event System and therefore shopware 6 have those nice named events. For example when the shopware 6 product detail page was loaded, it will emit the event ProductPageLoadedEvent. It has getters for all the data it provides and your IDE helps you with code completion.
This pull request would create similar events for shopware 5.x, but I wanted to make sure this feature is wanted before I implement it. I also don't really know where to put those event classes in the shopware core, just tell me a good place.

You also won't have to copy the event names into your subscriber

```
use Enlight\Event\SubscriberInterface;

final class MySubscriber implements SubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [
            AddVoucherStartEvent::EVENT_NAME => 'mySubscriberCallback',
        ];
    }


    public function mySubscriberCallback(AddVoucherStartEvent $event)
    {
        echo $event->getCode();
    }
}
```


### 1. Why is this change necessary?
it is not, but might be helpful

### 2. What does this change do, exactly?
replaces all those generic Enlight_Event_EventArgs with named events, which provide getters and setters for the event data.

### 3. Describe each step to reproduce the issue or behaviour.
If you subscribe to any event in Shopware, you will get an Enlight_Event_EventArgs as parameter of your subscriber, but either you know which data is provided or you have to check where the event is emitted.
With the named events your IDE will provide you with code completion.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
the event documentation should be extended, I would provide those changes too, if you like the idea of this PR

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.