### PR TITLE
Fix padding on hidden cookie-permission banner breakpoint update

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-permission.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-permission.js
@@ -134,7 +134,11 @@
          * @return {void}
          */
         update: function() {
-            this.setPermissionHeight();
+            this.displayCookiePermission(function(display) {
+                if (display) {
+                    this.setPermissionHeight();
+                }
+            });
         },
 
         /**


### PR DESCRIPTION
## 1. Why is this change necessary?
On breakpoint update the height of banner gets recalculated without checking the cookie

### 2. What does this change do, exactly?
Check if cookie isset and no banner displayed (same as on init)

### 3. Describe each step to reproduce the issue or behaviour.
If breakpoints is triggered the update sets a new height. If the element has a height in css it will be used. (display none is active). -> Depends on your theme

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.