### PR TITLE
Change escaping for snippets on csv export

### DIFF
--- a/engine/Shopware/Controllers/Backend/Snippet.php
+++ b/engine/Shopware/Controllers/Backend/Snippet.php
@@ -897,7 +897,7 @@ class Shopware_Controllers_Backend_Snippet extends Shopware_Controllers_Backend_
                         $settings['fieldmark'], $settings['escaped_fieldmark'], $line[$key]
                     ) . $settings['fieldmark'];
                 } else {
-                    $csv .= "'" . $line[$key];
+                    $csv .= "\"" . $line[$key]. "\"";
                 }
             }
             if ($lastKey != $key) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The exported file contains wrong escaping for Excel. The End-Separator is missing and the singe quote is also wrong.

![Bildschirmfoto 2019-06-17 um 13 49 53](https://user-images.githubusercontent.com/10058559/59602420-f7848800-9106-11e9-94ea-aba63481fed8.png)


### 2. What does this change do, exactly?
Change the escaping to a double quote and complete the quoting by adding another one after the string.

![Bildschirmfoto 2019-06-17 um 13 53 09](https://user-images.githubusercontent.com/10058559/59602573-54803e00-9107-11e9-9d6e-243d98ac2406.png)


### 3. Describe each step to reproduce the issue or behaviour.
Export snippets as "CSV (Excel)" in the snippets manager of the backend

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.