### PR TITLE
Added getQuery function to CategoryGateway

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/CategoryQueryHelperInterface.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/CategoryQueryHelperInterface.php
@@ -24,36 +24,20 @@
 
 namespace Shopware\Bundle\StoreFrontBundle\Gateway;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Shopware\Bundle\StoreFrontBundle\Struct;
 
-interface CategoryGatewayInterface
+interface CategoryQueryHelperInterface
 {
     /**
-     * To get detailed information about the selection conditions, structure and content of the returned object,
-     * please refer to the linked classes.
-     *
-     * @see \Shopware\Bundle\StoreFrontBundle\Gateway\CategoryGatewayInterface::get()
-     *
-     * @return Struct\Category[] Indexed by the category id
+     * @return QueryBuilder
      */
-    public function getList(array $ids, Struct\ShopContextInterface $context);
+    public function getQuery(array $numbers, Struct\ShopContextInterface $context);
 
     /**
-     * The \Shopware\Bundle\StoreFrontBundle\Struct\Category requires the following data:
-     * - Category base data
-     * - Core attribute
-     * - Assigned media object
-     * - Core attribute of the media object
+     * @param int[] $ids
      *
-     *
-     * @return Struct\Category
+     * @return QueryBuilder
      */
-    public function get($id, Struct\ShopContextInterface $context);
-
-    /**
-     * @param Struct\BaseProduct[] $products
-     *
-     * @return array Indexed by product number, contains all categories of a product
-     */
-    public function getProductsCategories(array $products, Struct\ShopContextInterface $context);
+    public function getMapping(array $ids);
 }

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
@@ -24,7 +24,8 @@
 
 namespace Shopware\Bundle\StoreFrontBundle\Gateway\DBAL;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\ResultStatement;
+use PDO;
 use Shopware\Bundle\StoreFrontBundle\Gateway;
 use Shopware\Bundle\StoreFrontBundle\Service\MediaServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct;
@@ -32,29 +33,14 @@ use Shopware\Bundle\StoreFrontBundle\Struct;
 class CategoryGateway implements Gateway\CategoryGatewayInterface
 {
     /**
+     * @var Gateway\CategoryQueryHelperInterface
+     */
+    private $queryHelper;
+
+    /**
      * @var Hydrator\CategoryHydrator
      */
     private $categoryHydrator;
-
-    /**
-     * The FieldHelper class is used for the
-     * different table column definitions.
-     *
-     * This class helps to select each time all required
-     * table data for the store front.
-     *
-     * Additionally the field helper reduce the work, to
-     * select in a second step the different required
-     * attribute tables for a parent table.
-     *
-     * @var FieldHelper
-     */
-    private $fieldHelper;
-
-    /**
-     * @var Connection
-     */
-    private $connection;
 
     /**
      * @var MediaServiceInterface
@@ -62,33 +48,20 @@ class CategoryGateway implements Gateway\CategoryGatewayInterface
     private $mediaService;
 
     public function __construct(
-        Connection $connection,
-        FieldHelper $fieldHelper,
+        Gateway\CategoryQueryHelperInterface $queryHelper,
         Hydrator\CategoryHydrator $categoryHydrator,
         MediaServiceInterface $mediaService
     ) {
-        $this->connection = $connection;
+        $this->queryHelper = $queryHelper;
         $this->categoryHydrator = $categoryHydrator;
-        $this->fieldHelper = $fieldHelper;
         $this->mediaService = $mediaService;
     }
 
     /**
-     * @param int|array $id
-     *
      * @return Struct\Category
      */
     public function get($id, Struct\ShopContextInterface $context)
     {
-        /*
-         * @deprecated since 5.5, will be removed in Shopware 5.6
-         *
-         * Allowing an array as a parameter is supported in 5.5.x for legacy reasons.
-         * The check below will be removed in Shopware 5.6
-         */
-        if (is_array($id)) {
-            $id = $id[0];
-        }
         $categories = $this->getList([$id], $context);
 
         return array_shift($categories);
@@ -136,38 +109,12 @@ class CategoryGateway implements Gateway\CategoryGatewayInterface
      */
     public function getList(array $ids, Struct\ShopContextInterface $context)
     {
-        $query = $this->connection->createQueryBuilder();
+        $query = $this->getQuery($ids, $context);
 
-        $query->select($this->fieldHelper->getCategoryFields())
-            ->addSelect($this->fieldHelper->getMediaFields())
-            ->addSelect($this->fieldHelper->getRelatedProductStreamFields())
-            ->addSelect('GROUP_CONCAT(customerGroups.customergroupID) as __category_customer_groups')
-        ;
-
-        $query->from('s_categories', 'category')
-            ->leftJoin('category', 's_categories_attributes', 'categoryAttribute', 'categoryAttribute.categoryID = category.id')
-            ->leftJoin('category', 's_categories_avoid_customergroups', 'customerGroups', 'customerGroups.categoryID = category.id')
-            ->leftJoin('category', 's_media', 'media', 'media.id = category.mediaID')
-            ->leftJoin('media', 's_media_album_settings', 'mediaSettings', 'mediaSettings.albumID = media.albumID')
-            ->leftJoin('media', 's_media_attributes', 'mediaAttribute', 'mediaAttribute.mediaID = media.id')
-            ->leftJoin('category', 's_product_streams', 'stream', 'category.stream_id = stream.id')
-            ->leftJoin('stream', 's_product_streams_attributes', 'productStreamAttribute', 'stream.id = productStreamAttribute.streamId')
-            ->where('category.id IN (:categories)')
-            ->andWhere('category.active = 1')
-            ->andWhere('category.shops IS NULL OR category.shops LIKE :shopId')
-            ->addGroupBy('category.id')
-            ->setParameter(':categories', $ids, Connection::PARAM_INT_ARRAY)
-            ->setParameter(':shopId', '%|' . $context->getShop()->getId() . '|%');
-
-        $this->fieldHelper->addCategoryTranslation($query, $context);
-        $this->fieldHelper->addMediaTranslation($query, $context);
-        $this->fieldHelper->addProductStreamTranslation($query, $context);
-        $this->fieldHelper->addCategoryMainDataTranslation($query, $context);
-
-        /** @var \Doctrine\DBAL\Driver\ResultStatement $statement */
+        /** @var ResultStatement $statement */
         $statement = $query->execute();
 
-        $data = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $data = $statement->fetchAll(PDO::FETCH_ASSOC);
 
         //use php usort instead of running mysql order by to prevent file-sort and temporary table statement
         usort($data, function ($a, $b) {
@@ -187,23 +134,19 @@ class CategoryGateway implements Gateway\CategoryGatewayInterface
         return $categories;
     }
 
+    protected function getQuery(array $numbers, Struct\ShopContextInterface $context)
+    {
+        return $this->queryHelper->getQuery($numbers, $context);
+    }
+
     /**
      * @param int[] $ids
      *
      * @return array<int, string> indexed by product id
      */
-    private function getMapping(array $ids)
+    protected function getMapping(array $ids)
     {
-        $query = $this->connection->createQueryBuilder();
-
-        $query->select(['mapping.articleID', 'GROUP_CONCAT(DISTINCT mapping.categoryID)']);
-
-        $query->from('s_articles_categories_ro', 'mapping')
-            ->where('mapping.articleID IN (:ids)')
-            ->setParameter(':ids', array_values($ids), Connection::PARAM_INT_ARRAY)
-            ->groupBy('mapping.articleID');
-
-        return $query->execute()->fetchAll(\PDO::FETCH_KEY_PAIR);
+        return $this->queryHelper->getMapping($ids)->execute()->fetchAll(PDO::FETCH_KEY_PAIR);
     }
 
     /**

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryQueryHelper.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryQueryHelper.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\StoreFrontBundle\Gateway\DBAL;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Shopware\Bundle\StoreFrontBundle\Gateway;
+use Shopware\Bundle\StoreFrontBundle\Struct;
+
+class CategoryQueryHelper implements Gateway\CategoryQueryHelperInterface
+{
+    /**
+     * The FieldHelper class is used for the
+     * different table column definitions.
+     *
+     * This class helps to select each time all required
+     * table data for the store front.
+     *
+     * Additionally the field helper reduce the work, to
+     * select in a second step the different required
+     * attribute tables for a parent table.
+     *
+     * @var FieldHelper
+     */
+    private $fieldHelper;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(
+        Connection $connection,
+        FieldHelper $fieldHelper
+    ) {
+        $this->connection = $connection;
+        $this->fieldHelper = $fieldHelper;
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    public function getQuery(array $ids, Struct\ShopContextInterface $context)
+    {
+        $query = $this->connection->createQueryBuilder();
+
+        $query->select($this->fieldHelper->getCategoryFields())
+            ->addSelect($this->fieldHelper->getMediaFields())
+            ->addSelect($this->fieldHelper->getRelatedProductStreamFields())
+            ->addSelect('GROUP_CONCAT(customerGroups.customergroupID) as __category_customer_groups')
+        ;
+
+        $query->from('s_categories', 'category')
+            ->leftJoin('category', 's_categories_attributes', 'categoryAttribute', 'categoryAttribute.categoryID = category.id')
+            ->leftJoin('category', 's_categories_avoid_customergroups', 'customerGroups', 'customerGroups.categoryID = category.id')
+            ->leftJoin('category', 's_media', 'media', 'media.id = category.mediaID')
+            ->leftJoin('media', 's_media_album_settings', 'mediaSettings', 'mediaSettings.albumID = media.albumID')
+            ->leftJoin('media', 's_media_attributes', 'mediaAttribute', 'mediaAttribute.mediaID = media.id')
+            ->leftJoin('category', 's_product_streams', 'stream', 'category.stream_id = stream.id')
+            ->leftJoin('stream', 's_product_streams_attributes', 'productStreamAttribute', 'stream.id = productStreamAttribute.streamId')
+            ->where('category.id IN (:categories)')
+            ->andWhere('category.active = 1')
+            ->andWhere('category.shops IS NULL OR category.shops LIKE :shopId')
+            ->addGroupBy('category.id')
+            ->setParameter(':categories', $ids, Connection::PARAM_INT_ARRAY)
+            ->setParameter(':shopId', '%|' . $context->getShop()->getId() . '|%');
+
+        $this->fieldHelper->addCategoryTranslation($query, $context);
+        $this->fieldHelper->addMediaTranslation($query, $context);
+        $this->fieldHelper->addProductStreamTranslation($query, $context);
+        $this->fieldHelper->addCategoryMainDataTranslation($query, $context);
+
+        return $query;
+    }
+
+    /**
+     * @param int[] $ids
+     *
+     * @return QueryBuilder
+     */
+    public function getMapping(array $ids)
+    {
+        $query = $this->connection->createQueryBuilder();
+
+        $query->select(['mapping.articleID', 'GROUP_CONCAT(DISTINCT mapping.categoryID)']);
+
+        $query->from('s_articles_categories_ro', 'mapping')
+            ->where('mapping.articleID IN (:ids)')
+            ->setParameter(':ids', array_values($ids), Connection::PARAM_INT_ARRAY)
+            ->groupBy('mapping.articleID');
+
+        return $query;
+    }
+}

--- a/engine/Shopware/Bundle/StoreFrontBundle/services.xml
+++ b/engine/Shopware/Bundle/StoreFrontBundle/services.xml
@@ -314,10 +314,14 @@
         </service>
 
         <service id="shopware_storefront.category_gateway" class="Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\CategoryGateway">
-            <argument type="service" id="dbal_connection"/>
-            <argument type="service" id="shopware_storefront.field_helper_dbal"/>
+            <argument type="service" id="shopware_storefront.category_query_helper"/>
             <argument type="service" id="shopware_storefront.category_hydrator_dbal"/>
             <argument type="service" id="shopware_storefront.media_service"/>
+        </service>
+
+        <service id="shopware_storefront.category_query_helper" class="Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\CategoryQueryHelper">
+            <argument type="service" id="dbal_connection"/>
+            <argument type="service" id="shopware_storefront.field_helper_dbal"/>
         </service>
 
         <service id="shopware_storefront.payment_gateway" class="Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\PaymentGateway">


### PR DESCRIPTION
Added possibility to overwrite only the categoryQuery instead of overwriting the whole getList function or work with arrays after
### 1. Why is this change necessary?
Because it should be possible to edit only the query instead of the getList method

### 2. What does this change do, exactly?
Puts the Query in an own method and executes it in the getList method
Removed deprecated int|array from get method

### 3. Describe each step to reproduce the issue or behaviour.
Try to edit the query instead of overwrite the getList method.

### 4. Please link to the relevant issues (if any).
I don't know any

### 5. Which documentation changes (if any) need to be made because of this PR?
I don't know any

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.