### PR TITLE
Use ES prefix for backend index name

### DIFF
--- a/engine/Shopware/Bundle/EsBackendBundle/EsBackendIndexer.php
+++ b/engine/Shopware/Bundle/EsBackendBundle/EsBackendIndexer.php
@@ -33,6 +33,11 @@ class EsBackendIndexer
     const INDEX_NAME = 'backend_index';
 
     /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
      * @var Client
      */
     private $client;
@@ -53,11 +58,13 @@ class EsBackendIndexer
     private $esVersion;
 
     public function __construct(
+        string $prefix,
         Client $client,
         \IteratorAggregate $repositories,
         EvaluationHelperInterface $evaluation,
         string $esVersion
     ) {
+        $this->prefix = $prefix;
         $this->client = $client;
         $this->repositories = $repositories;
         $this->evaluation = $evaluation;
@@ -67,9 +74,9 @@ class EsBackendIndexer
     public function index(ProgressHelperInterface $helper)
     {
         foreach ($this->repositories as $repository) {
-            $index = self::INDEX_NAME . '_' . $repository->getDomainName() . '_' . (new \DateTime())->format('YmdHis');
+            $index = $this->prefix . '_' . self::INDEX_NAME . '_' . $repository->getDomainName() . '_' . (new \DateTime())->format('YmdHis');
 
-            $alias = self::buildAlias($repository->getDomainName());
+            $alias = $this->prefix . '_' . self::buildAlias($repository->getDomainName());
 
             $this->createIndex($index);
             $this->createMapping($repository, $index);
@@ -143,7 +150,7 @@ class EsBackendIndexer
      */
     public function cleanupIndices()
     {
-        $prefix = self::INDEX_NAME;
+        $prefix = $this->prefix . '_' . self::INDEX_NAME;
         $aliases = $this->client->indices()->getAliases();
         foreach ($aliases as $index => $indexAliases) {
             if (strpos($index, $prefix) !== 0) {

--- a/engine/Shopware/Bundle/EsBackendBundle/services.xml
+++ b/engine/Shopware/Bundle/EsBackendBundle/services.xml
@@ -8,6 +8,7 @@
         <defaults public="true" />
 
         <service class="Shopware\Bundle\EsBackendBundle\EsBackendIndexer" id="shopware_es_backend.indexer">
+        	<argument>%shopware.es.prefix%</argument>
             <argument id="shopware_elastic_search.client" type="service"/>
             <argument type="tagged" tag="shopware_es_backend.repository" />
             <argument type="service" id="shopware_elastic_search.console.console_evaluation_helper"/>


### PR DESCRIPTION
### 1. Why is this change necessary?
If the ES prefix is missing it's not possible to have multiple ES backend indices in the same ES Server.

### 2. What does this change do, exactly?
It adds the ES prefix used for the frontend indices to the backend indices, too.

### 3. Describe each step to reproduce the issue or behaviour.
Build the ES backend index with and without this change.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-23540

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.