### PR TITLE
Prefer core config values over plugins

### DIFF
--- a/engine/Shopware/Components/Config.php
+++ b/engine/Shopware/Components/Config.php
@@ -262,6 +262,7 @@ class Shopware_Components_Config implements ArrayAccess
      */
     protected function readData()
     {
+        // use order by on fetch query to prefer core configs over config values from plugins with the same name
         $sql = "
             SELECT
               LOWER(REPLACE(e.name, '_', '')) as name,
@@ -287,6 +288,8 @@ class Shopware_Components_Config implements ArrayAccess
 
             LEFT JOIN s_core_config_forms forms
               ON forms.id = e.form_id
+            
+            ORDER BY forms.plugin_id DESC
         ";
 
         $data = $this->_db->fetchAll($sql, [


### PR DESCRIPTION
### 1. Why is this change necessary?
When having a plugin with the same config key shopware can't distinguish those values from core configs as all are organised in the same table. The main differentiator is the plugin_id field on forms which is used for cleanup on plugin deinstallation.
As the config SQL query returns newer entries after older ones, plugins with the same config keys can override core fields.

EDIT: This is superseded by https://github.com/shopware/shopware/pull/2147 which replaces Zend_Db with Doctrine ModelManager and DBAL builder for improved readability.
You might close this PR and continue over at the newer PR.

### 2. What does this change do, exactly?
Prefer core config (=> plugin_id = null) over plugins while still allowing custom config values be in the global config object.
As an alternative you might add a condition that prohibits all plugin values in the SQL query.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a plugin with a config field called "mail" without default value
- install & activate plugin
- have lots of problems when sending mails which won't explicitly set the sender and therefore use the default one

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.