### PR TITLE
Fix fallback for backend order mail to use default sender

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -998,9 +998,11 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
         } else {
             $mail->setBodyText($this->Request()->getParam('content', ''));
         }
+        $fromMail = $this->Request()->getParam('fromMail');
+        $fromName = $this->Request()->getParam('fromName');
 
-        $mail->setFrom($this->Request()->getParam('fromMail', ''), $this->Request()->getParam('fromName', ''));
-        $mail->addTo($this->Request()->getParam('to', ''));
+        $mail->setFrom($fromMail ?: null, $fromName ?: null);
+        $mail->addTo($this->Request()->getParam('to'));
 
         $mail->setAssociation(LogEntryBuilder::ORDER_ID_ASSOCIATION, $orderId);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The backend order mail dialog passes both a `fromMail` and `fromName` to the backend order module when sending PDFs. If those values are broken, for example via https://github.com/shopware/shopware/pull/2145 those will be empty strings.
When then passing those empty strings to `\Enlight_Components_Mail` respective its parent `\Zend_Mail` there is no check for a valid mail address but a check for `null`. When passing an empty string this in turn sets the sender to this empty string and the `\Zend_Mail::$_defaultFrom` won't be used but also you even aren't able to set FROM header later anyway.
Some mail servers won't accept mails without a FROM header and therefore the mail will be lost.

The bug itself should be quite rare as with a default shopware installation the function should at least provide the default field data (`info@example.com`) but combined with the error described in https://github.com/shopware/shopware/pull/2145 this is a real pain ;)

### 2. What does this change do, exactly?
With this PR shopware won't blindly pass empty strings to the mail object.

### 3. Describe each step to reproduce the issue or behaviour.
1. Set the `from` either via shopware backend or directly via `config.php` to an empty string
Alternative way: create a plugin that messes with config values by colliding with config key for `mail`
3. try sending document mails from backend order

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/1999
- https://github.com/shopware/shopware/pull/2145
- https://issues.shopware.com/issues/SW-23411

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.