### PR TITLE
Use Doctrine DBAL instead of Zend_Db in Core Config

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/Bridge/Config.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Config.php
@@ -24,19 +24,22 @@
 
 namespace Shopware\Components\DependencyInjection\Bridge;
 
+use Doctrine\DBAL\Connection;
 use Shopware\Components\ShopwareReleaseStruct;
+use Shopware_Components_Config;
+use Zend_Cache_Core;
 
 class Config
 {
     /**
-     * @param \Enlight_Components_Db_Adapter_Pdo_Mysql $db
-     * @param array                                    $config
+     * @param Connection $db
+     * @param array      $config
      *
-     * @return \Shopware_Components_Config|null
+     * @return Shopware_Components_Config|null
      */
     public function factory(
-        \Zend_Cache_Core $cache,
-        \Enlight_Components_Db_Adapter_Pdo_Mysql $db = null,
+        Zend_Cache_Core $cache,
+        Connection $db = null,
         $config = [],
         ShopwareReleaseStruct $release
     ) {
@@ -50,6 +53,6 @@ class Config
         $config['db'] = $db;
         $config['release'] = $release;
 
-        return new \Shopware_Components_Config($config);
+        return new Shopware_Components_Config($config);
     }
 }

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -199,7 +199,7 @@
         <service id="config" class="Shopware_Components_Config">
             <factory service="config_factory" method="factory" />
             <argument type="service" id="cache" />
-            <argument type="service" id="db" on-invalid="ignore"/>
+            <argument type="service" id="dbal_connection" on-invalid="ignore"/>
             <argument>%shopware.config%</argument>
             <argument type="service" id="shopware.release" />
          </service>


### PR DESCRIPTION
### 1. Why is this change necessary?
Dependency reduction and improved readability by using Doctrine DBAL builder instead of plain sql.
Plus this PR contains https://github.com/shopware/shopware/pull/2145 (preferring core config over plugin config values)

### 2. What does this change do, exactly?
- Replacing db reference in core config with reference of Doctrine's DBAL Connection
- Using DBAL Builder instead of plain sql
- preferring core config over plugin config values by sorting by plugin_id (core configs are `null`)

### 3. Describe each step to reproduce the issue or behaviour.
For core config over plugin config see https://github.com/shopware/shopware/pull/2145 

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/pull/2145

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.