### PR TITLE
Consider additional text for variants in basket update

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2868,6 +2868,10 @@ SQL;
             array_column($additionalInformation, 'ordernumber'),
             $this->contextService->getShopContext()
         );
+        $this->additionalTextService->buildAdditionalTextLists(
+            $products,
+            $this->contextService->getShopContext()
+        );
 
         foreach ($cartItems as $cartItem) {
             $additionalInfo = [];


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when a variant product is added to the basket it is first inserted with the correct product name, but after the update, the name is updated without the additional information regarding variants. 
This change should be also reviewed in terms of performance. If this fix properly scales to large shops and so on, since the additonal text service always loads the complete variant configuration: https://github.com/shopware/shopware/blob/406925fbb6a8e98beb94e71ceca1fd473a6edc31/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/AdditionalTextService.php#L58-L88

### 2. What does this change do, exactly?
Add the needed information.

### 3. Describe each step to reproduce the issue or behaviour.
Add a variant product to the cart.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.