### PR TITLE
Removed duplicate Code

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -981,10 +981,6 @@ class Article extends Resource implements BatchInterface
         // and if non of the following variants has the mainDetail's number
         $oldMainDetail = $article->getMainDetail();
 
-        if (isset($data['__options_variants']) && $data['__options_variants']['replace']) {
-            $this->removeArticleDetails($article);
-        }
-
         if ($oldMainDetail) {
             $mainDetailGetsConfigurator = false;
             foreach ($data['variants'] as $variantData) {


### PR DESCRIPTION
same code at Line 1005 to 1007
if (isset($data['__options_variants']) && $data['__options_variants']['replace']) {
            $this->removeArticleDetails($article);
        }

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Clean and smooth code?


### 2. What does this change do, exactly?
Nothing just clean up

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.