### PR TITLE
make active flag of categories translatable

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/FieldHelper.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/FieldHelper.php
@@ -258,6 +258,7 @@ class FieldHelper
     {
         $fields = [
             'category.id as __category_id',
+            'category.active as __category_active',
             'category.parent as __category_parent_id',
             'category.position as __category_position',
             'category.path as __category_path',

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/CategoryHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/CategoryHydrator.php
@@ -106,6 +106,10 @@ class CategoryHydrator extends Hydrator
             $category->setName($data['__category_description']);
         }
 
+        if (isset($data['__category_active'])) {
+            $category->setActive($data['__category_active'] === "1");
+        }
+
         $category->setParentId((int) $data['__category_parent_id']);
 
         $category->setPosition((int) $data['__category_position']);

--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/CategoryService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/CategoryService.php
@@ -84,8 +84,14 @@ class CategoryService implements Service\CategoryServiceInterface
     {
         $customerGroup = $context->getCurrentCustomerGroup();
 
-        return array_filter($categories, function (Struct\Category $category) use ($customerGroup) {
+        $categories = array_filter($categories, function (Struct\Category $category) use ($customerGroup) {
             return !(in_array($customerGroup->getId(), $category->getBlockedCustomerGroupIds()));
         });
+
+        $categories = array_filter($categories, function (Struct\Category $category) use ($customerGroup) {
+            return $category->isActive();
+        });
+
+        return $categories;
     }
 }

--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/Category.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/Category.php
@@ -34,6 +34,11 @@ class Category extends Extendable
     protected $id;
 
     /**
+     * @var bool
+     */
+    protected $active = true;
+
+    /**
      * @var int|null
      */
     protected $parentId;
@@ -172,6 +177,22 @@ class Category extends Extendable
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    /**
+     * @param bool $active
+     */
+    public function setActive(bool $active): void
+    {
+        $this->active = $active;
     }
 
     /**

--- a/themes/Backend/ExtJs/backend/category/view/category/tabs/settings.js
+++ b/themes/Backend/ExtJs/backend/category/view/category/tabs/settings.js
@@ -423,7 +423,9 @@ Ext.define('Shopware.apps.Category.view.category.tabs.Settings', {
                     {
                         boxLabel:me.snippets.defaultSettingsActiveLabel,
                         name:'active',
-                        dataIndex:'active'
+                        dataIndex:'active',
+                        translatable: true,
+                        translationName: 'active',
                     },
                     {
                         boxLabel:me.snippets.defaultSettingsBlogLabel,


### PR DESCRIPTION
hide the categories from menu and make not reachable via category controller

### 1. Why is this change necessary?
because there's no ability to hide categories (that are translated and used for more than one sub- or language shop) in one or more specific shops

### 2. What does this change do, exactly?
make active flag of categories translatable and check the activity flag in the Core Category Service

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
category documentation

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.