### PR TITLE
Symfony events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "symfony/options-resolver": "3.4.29",
         "symfony/expression-language": "3.4.29",
         "symfony/web-link": "3.4.29",
+        "symfony/event-dispatcher": "3.4.29",
         "monolog/monolog": "1.23.0",
         "doctrine/common": "2.10.0",
         "doctrine/collections": "1.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "891d9664fb8d14fa700d2b54f5623fdc",
+    "content-hash": "0ef04c8c95eb62afb9f8c47ba601e967",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.102.1",
+            "version": "3.107.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "0fe11c62b118f3362a030e9994e3fe1eeea56172"
+                "reference": "ccd3d13ae49a45bdf6a394d701f207c276dbf05a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/0fe11c62b118f3362a030e9994e3fe1eeea56172",
-                "reference": "0fe11c62b118f3362a030e9994e3fe1eeea56172",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/ccd3d13ae49a45bdf6a394d701f207c276dbf05a",
+                "reference": "ccd3d13ae49a45bdf6a394d701f207c276dbf05a",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-06-27T00:22:45+00:00"
+            "time": "2019-07-12T18:07:41+00:00"
         },
         {
             "name": "bcremer/line-reader",
@@ -1733,16 +1733,16 @@
         },
         {
             "name": "grpc/grpc",
-            "version": "1.19.0",
+            "version": "1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/grpc/grpc-php.git",
-                "reference": "0f1ffdde45bfb9257c5d9eab81695d0f042bea22"
+                "reference": "88235e786ef9b55fcb049f00c5c5202f8086a299"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/0f1ffdde45bfb9257c5d9eab81695d0f042bea22",
-                "reference": "0f1ffdde45bfb9257c5d9eab81695d0f042bea22",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/88235e786ef9b55fcb049f00c5c5202f8086a299",
+                "reference": "88235e786ef9b55fcb049f00c5c5202f8086a299",
                 "shasum": ""
             },
             "require": {
@@ -1770,7 +1770,7 @@
             "keywords": [
                 "rpc"
             ],
-            "time": "2019-02-27T04:47:56+00:00"
+            "time": "2019-07-03T19:57:39+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2763,28 +2763,29 @@
         },
         {
             "name": "php-http/discovery",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "684855f2c2e9d0a61868b8f8d6bd0295c8a4b651"
+                "reference": "e822f86a6983790aa17ab13aa7e69631e86806b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/684855f2c2e9d0a61868b8f8d6bd0295c8a4b651",
-                "reference": "684855f2c2e9d0a61868b8f8d6bd0295c8a4b651",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/e822f86a6983790aa17ab13aa7e69631e86806b6",
+                "reference": "e822f86a6983790aa17ab13aa7e69631e86806b6",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0"
+                "php": "^7.1"
             },
             "conflict": {
                 "nyholm/psr7": "<1.0"
             },
             "require-dev": {
+                "akeneo/phpspec-skip-example-extension": "^4.0",
                 "php-http/httplug": "^1.0 || ^2.0",
                 "php-http/message-factory": "^1.0",
-                "phpspec/phpspec": "^2.4",
+                "phpspec/phpspec": "^5.1",
                 "puli/composer-plugin": "1.0.0-beta10"
             },
             "suggest": {
@@ -2794,7 +2795,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.7-dev"
                 }
             },
             "autoload": {
@@ -2823,7 +2824,7 @@
                 "message",
                 "psr7"
             ],
-            "time": "2019-02-23T07:42:53+00:00"
+            "time": "2019-06-30T09:04:27+00:00"
         },
         {
             "name": "php-http/httplug",
@@ -4103,37 +4104,30 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.3.2",
+            "version": "v3.4.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "d257021c1ab28d48d24a16de79dfab445ce93398"
+                "reference": "f18fdd6cc7006441865e698420cee26bac94741f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d257021c1ab28d48d24a16de79dfab445ce93398",
-                "reference": "d257021c1ab28d48d24a16de79dfab445ce93398",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f18fdd6cc7006441865e698420cee26bac94741f",
+                "reference": "f18fdd6cc7006441865e698420cee26bac94741f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
-                "symfony/event-dispatcher-contracts": "^1.1"
+                "php": "^5.5.9|>=7.0.8"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.4"
-            },
-            "provide": {
-                "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "1.1"
+                "symfony/dependency-injection": "<3.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/expression-language": "~3.4|~4.0",
-                "symfony/http-foundation": "^3.4|^4.0",
-                "symfony/service-contracts": "^1.1",
-                "symfony/stopwatch": "~3.4|~4.0"
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/stopwatch": "~2.8|~3.0|~4.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -4142,7 +4136,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -4169,65 +4163,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-13T11:03:18+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher-contracts",
-            "version": "v1.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "c61766f4440ca687de1084a5c00b08e167a2575c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c61766f4440ca687de1084a5c00b08e167a2575c",
-                "reference": "c61766f4440ca687de1084a5c00b08e167a2575c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "suggest": {
-                "psr/event-dispatcher": "",
-                "symfony/event-dispatcher-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\EventDispatcher\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to dispatching event",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2019-06-20T06:46:26+00:00"
+            "time": "2019-06-25T07:45:31+00:00"
         },
         {
             "name": "symfony/expression-language",
@@ -4834,7 +4770,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",

--- a/engine/Library/Enlight/Event/EventArgs.php
+++ b/engine/Library/Enlight/Event/EventArgs.php
@@ -33,7 +33,7 @@ class Enlight_Event_EventArgs extends Enlight_Collection_ArrayCollection
     /**
      * @var bool Flag whether the listener has finished running.
      */
-    protected $_processed;
+    protected $_processed = false;
 
     /**
      * @var string Contains the name of the event.
@@ -44,18 +44,7 @@ class Enlight_Event_EventArgs extends Enlight_Collection_ArrayCollection
      * @var mixed Contains the return value, which can be set by the setReturn method.
      */
     protected $_return;
-
-    /**
-     * The Enlight_Event_EventArgs class constructor expects the name of the event.
-     *
-     * @param              $name
-     * @param   array|null $args
-     */
-    public function __construct(array $args = array())
-    {
-        parent::__construct($args);
-    }
-
+    
     /**
      * Stops the execution of the listener and sets the processed flag to true.
      *

--- a/engine/Library/Enlight/Event/Handler.php
+++ b/engine/Library/Enlight/Event/Handler.php
@@ -89,7 +89,7 @@ abstract class Enlight_Event_Handler
      * Getter method for the listener property.
      * @return  callback
      */
-    abstract public function getListener();
+    abstract public function getListener(): callable;
 
     /**
      * Executes the event handler with the Enlight_Event_EventArgs.

--- a/engine/Library/Enlight/Event/Handler/Default.php
+++ b/engine/Library/Enlight/Event/Handler/Default.php
@@ -72,7 +72,7 @@ class Enlight_Event_Handler_Default extends Enlight_Event_Handler
      * Getter method for the listener property.
      * @return  callback
      */
-    public function getListener()
+    public function getListener(): callable
     {
         return $this->listener;
     }

--- a/engine/Library/Enlight/Event/Handler/Plugin.php
+++ b/engine/Library/Enlight/Event/Handler/Plugin.php
@@ -31,11 +31,6 @@
 class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
 {
     /**
-     * @var string Contains the event listener.
-     */
-    protected $listener;
-
-    /**
      * @var Enlight_Plugin_Namespace Contains an instance of the Enlight_Plugin_Namespace.
      */
     protected $namespace;
@@ -47,6 +42,11 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
     protected $plugin;
 
     /**
+     * @var string
+     */
+    protected $method;
+
+    /**
      * The Enlight_Event_Handler_Plugin class constructor expects the event name.
      * All parameters are set in the internal properties.
      *
@@ -54,10 +54,10 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
      * @param   string                   $event
      * @param   Enlight_Plugin_Namespace $namespace
      * @param   Enlight_Plugin_Bootstrap $plugin
-     * @param   string                   $listener
+     * @param   string                   $method
      * @param   integer                  $position
      */
-    public function __construct($event, $namespace = null, $plugin = null, $listener = null, $position = null)
+    public function __construct($event, $namespace = null, $plugin = null, $method = null, $position = null)
     {
         if ($namespace !== null) {
             $this->setNamespace($namespace);
@@ -65,8 +65,8 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
         if ($plugin !== null) {
             $this->setPlugin($plugin);
         }
-        if ($listener !== null) {
-            $this->setListener($listener);
+        if ($method !== null) {
+            $this->setMethod($method);
         }
         parent::__construct($event);
         $this->setPosition($position);
@@ -98,22 +98,11 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
     }
 
     /**
-     * Setter method for the internal listener property.
-     * @param   string $listener
-     * @return  Enlight_Event_Handler_Plugin
+     * @return callable
      */
-    public function setListener($listener)
+    public function getListener(): callable
     {
-        $this->listener = $listener;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getListener()
-    {
-        return $this->listener;
+        return [$this, 'execute'];
     }
 
     /**
@@ -136,13 +125,13 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
     public function execute(Enlight_Event_EventArgs $args)
     {
         $plugin = $this->Plugin();
-        if (!method_exists($plugin, $this->listener)) {
+        if (!method_exists($plugin, $this->method)) {
             $name = $this->plugin instanceof Enlight_Plugin_Bootstrap ? $this->plugin->getName() : $this->plugin;
-            trigger_error('Listener "' . $this->listener . '" in "' . $name . '" is not callable.', E_USER_ERROR);
+            trigger_error('Listener "' . $this->method . '" in "' . $name . '" is not callable.', E_USER_ERROR);
             //throw new Enlight_Exception('Listener "' . $this->listener . '" in "' . $name . '" is not callable.');
             return;
         }
-        return $this->Plugin()->{$this->listener}($args);
+        return $this->Plugin()->{$this->method}($args);
     }
 
     /**
@@ -155,7 +144,25 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
             'name' => $this->name,
             'position' => $this->position,
             'plugin' => $this->plugin instanceof Enlight_Plugin_Bootstrap ? $this->plugin->getName() : $this->plugin,
-            'listener' => $this->listener
+            'method' => $this->method
         );
+    }
+
+    /**
+     * @param string $method
+     * @return $this
+     */
+    public function setMethod(string $method)
+    {
+        $this->method = $method;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return $this->method;
     }
 }

--- a/engine/Library/Enlight/Hook/HookExecutionContext.php
+++ b/engine/Library/Enlight/Hook/HookExecutionContext.php
@@ -145,7 +145,7 @@ class Enlight_Hook_HookExecutionContext
         // again, to allow repeated calls of 'executeParent()' in the same listener to call the whole chain again.
         $currentLevel = $this->parentExecutionLevel;
         $this->parentExecutionLevel++;
-        $listeners[$currentLevel]->execute($this->args);
+        $listeners[$currentLevel]($this->args);
         $this->parentExecutionLevel--;
 
         return $this->args->getReturn();

--- a/engine/Library/Enlight/Plugin/Namespace/Config.php
+++ b/engine/Library/Enlight/Plugin/Namespace/Config.php
@@ -218,4 +218,10 @@ class Enlight_Plugin_Namespace_Config extends Enlight_Plugin_Namespace
     protected function initStorage()
     {
     }
+
+    public function resetSubscriber(): self
+    {
+        $this->subscriber = null;
+        return $this;
+    }
 }

--- a/engine/Shopware/Bundle/ControllerBundle/DependencyInjection/Compiler/ControllerCompilerPass.php
+++ b/engine/Shopware/Bundle/ControllerBundle/DependencyInjection/Compiler/ControllerCompilerPass.php
@@ -38,11 +38,12 @@ class ControllerCompilerPass implements CompilerPassInterface
             $options = $options[0];
 
             if (!isset($options['module'])) {
-                throw new \RuntimeException(sprintf('Attribute "module" is required for "shopware.controller" tagged service with id "%s"', $id));
+                // It's maybe a symfony controller
+                continue;
             }
 
             if (!isset($options['controller'])) {
-                throw new \RuntimeException(sprintf('Attribute "module" is required for "shopware.controller" tagged service with id "%s"', $id));
+                throw new \RuntimeException(sprintf('Attribute "controller" is required for "shopware.controller" tagged service with id "%s"', $id));
             }
 
             $controllers[strtolower(sprintf('%s_%s', $options['module'], $options['controller']))] = $id;

--- a/engine/Shopware/Bundle/ControllerBundle/services.xml
+++ b/engine/Shopware/Bundle/ControllerBundle/services.xml
@@ -19,7 +19,7 @@
             <argument type="tagged" tag="controller.argument_value_resolver"/>
         </service>
 
-        <service id="argument_resolver.service" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\ServiceValueResolver">
+        <service id="argument_resolver.service" class="Shopware\Components\Controller\ServiceValueResolver">
             <tag name="controller.argument_value_resolver" priority="0" />
             <argument type="collection" />
         </service>

--- a/engine/Shopware/Components/Console/Application.php
+++ b/engine/Shopware/Components/Console/Application.php
@@ -88,6 +88,7 @@ class Application extends BaseApplication
     {
         try {
             $this->kernel->boot();
+            $this->setDispatcher($this->kernel->getContainer()->get('event_dispatcher'));
         } catch (\Exception $e) {
             $this->kernel->boot(true);
             $formatter = $this->getHelperSet()->get('formatter');

--- a/engine/Shopware/Components/ContainerAwareEventManager.php
+++ b/engine/Shopware/Components/ContainerAwareEventManager.php
@@ -25,6 +25,7 @@
 namespace Shopware\Components;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContainerAwareEventManager extends \Enlight_Event_EventManager
 {
@@ -46,9 +47,10 @@ class ContainerAwareEventManager extends \Enlight_Event_EventManager
      */
     private $listenerIds = [];
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, EventDispatcherInterface $eventDispatcher = null)
     {
         $this->container = $container;
+        parent::__construct($eventDispatcher);
     }
 
     /**

--- a/engine/Shopware/Components/Controller/AbstractController.php
+++ b/engine/Shopware/Components/Controller/AbstractController.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+
+abstract class AbstractController implements ContainerAwareInterface
+{
+    use ControllerTrait;
+}

--- a/engine/Shopware/Components/Controller/ControllerResolver.php
+++ b/engine/Shopware/Components/Controller/ControllerResolver.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\HttpKernel\Controller\ContainerControllerResolver;
+
+class ControllerResolver extends ContainerControllerResolver
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function instantiateController($class)
+    {
+        return $this->configureController(parent::instantiateController($class), $class);
+    }
+
+    private function configureController($controller, string $class)
+    {
+        if ($controller instanceof ContainerAwareInterface) {
+            $controller->setContainer($this->container);
+        }
+
+        return $controller;
+    }
+}

--- a/engine/Shopware/Components/Controller/ControllerTrait.php
+++ b/engine/Shopware/Components/Controller/ControllerTrait.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Controller;
+
+use Fig\Link\GenericLinkProvider;
+use Fig\Link\Link;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\WebLink\EventListener\AddLinkHeaderListener;
+
+trait ControllerTrait
+{
+    use ContainerAwareTrait;
+
+    /**
+     * Returns true if the service id is defined.
+     *
+     * @final
+     */
+    protected function has(string $id): bool
+    {
+        return $this->container->has($id);
+    }
+
+    /**
+     * Gets a container service by its id.
+     *
+     * @return object The service
+     *
+     * @final
+     */
+    protected function get(string $id)
+    {
+        return $this->container->get($id);
+    }
+
+    /**
+     * Generates a URL from the given parameters.
+     *
+     * @final
+     */
+    protected function generateUrl(array $parameters = []): string
+    {
+        return $this->container->get('router')->assemble($parameters);
+    }
+
+    /**
+     * Forwards the request to another controller.
+     *
+     *
+     * @final
+     */
+    protected function forward(array $parameters = []): Response
+    {
+        $request = $this->container->get('request_stack')->getCurrentRequest();
+        $subRequest = $request->duplicate($parameters, [], []);
+
+        return $this->container->get('http_kernel')->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+    }
+
+    /**
+     * Returns a RedirectResponse to the given URL.
+     *
+     * @final
+     */
+    protected function redirect(string $url, int $status = 302): RedirectResponse
+    {
+        return new RedirectResponse($url, $status);
+    }
+
+    /**
+     * Returns a RedirectResponse to the given route with the given parameters.
+     *
+     * @final
+     */
+    protected function redirectToRoute(array $parameters = [], int $status = 302): RedirectResponse
+    {
+        return $this->redirect($this->generateUrl($parameters), $status);
+    }
+
+    /**
+     * Returns a JsonResponse that uses the serializer component if enabled, or json_encode.
+     *
+     * @final
+     */
+    protected function json($data, int $status = 200, array $headers = [], array $context = []): JsonResponse
+    {
+        return new JsonResponse($data, $status, $headers);
+    }
+
+    /**
+     * Returns a BinaryFileResponse object with original or customized file name and disposition header.
+     *
+     * @param \SplFileInfo|string $file File object or path to file to be sent as response
+     *
+     * @final
+     */
+    protected function file($file, string $fileName = null, string $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT): BinaryFileResponse
+    {
+        $response = new BinaryFileResponse($file);
+        $response->setContentDisposition($disposition, $fileName === null ? $response->getFile()->getFilename() : $fileName);
+
+        return $response;
+    }
+
+    /**
+     * Returns a rendered view.
+     *
+     * @final
+     */
+    protected function renderView(string $view, array $parameters = []): string
+    {
+        /** @var \Enlight_Template_Manager $template */
+        $template = $this->container->get('template');
+        $template = $template->createTemplate($view);
+        $template->assign($parameters);
+
+        return $template->fetch($view, $parameters);
+    }
+
+    /**
+     * Renders a view.
+     *
+     * @final
+     */
+    protected function render(string $view, array $parameters = [], Response $response = null): Response
+    {
+        $content = $this->renderView($view, $parameters);
+
+        if ($response === null) {
+            $response = new Response();
+        }
+
+        $response->setContent($content);
+
+        return $response;
+    }
+
+    /**
+     * Returns a NotFoundHttpException.
+     *
+     * This will result in a 404 response code. Usage example:
+     *
+     *     throw $this->createNotFoundException('Page not found!');
+     *
+     * @final
+     */
+    protected function createNotFoundException(string $message = 'Not Found', \Exception $previous = null): NotFoundHttpException
+    {
+        return new NotFoundHttpException($message, $previous);
+    }
+
+    /**
+     * Creates and returns a Form instance from the type of the form.
+     *
+     * @final
+     */
+    protected function createForm(string $type, $data = null, array $options = []): FormInterface
+    {
+        return $this->container->get('form.factory')->create($type, $data, $options);
+    }
+
+    /**
+     * Creates and returns a form builder instance.
+     *
+     * @final
+     */
+    protected function createFormBuilder($data = null, array $options = []): FormBuilderInterface
+    {
+        return $this->container->get('form.factory')->createBuilder(FormType::class, $data, $options);
+    }
+
+    /**
+     * Adds a Link HTTP header to the current response.
+     *
+     * @see https://tools.ietf.org/html/rfc5988
+     *
+     * @final
+     */
+    protected function addLink(Request $request, Link $link)
+    {
+        if (!class_exists(AddLinkHeaderListener::class)) {
+            throw new \LogicException('You can not use the "addLink" method if the WebLink component is not available. Try running "composer require symfony/web-link".');
+        }
+
+        if (null === $linkProvider = $request->attributes->get('_links')) {
+            $request->attributes->set('_links', new GenericLinkProvider([$link]));
+
+            return;
+        }
+
+        $request->attributes->set('_links', $linkProvider->withLink($link));
+    }
+}

--- a/engine/Shopware/Components/Controller/FrontController.php
+++ b/engine/Shopware/Components/Controller/FrontController.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Controller;
+
+use Enlight_Controller_Front as EnlightFront;
+use Enlight_Controller_Request_RequestHttp as EnlightRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class FrontController
+{
+    private $front;
+
+    public function __construct(EnlightFront $front)
+    {
+        $this->front = $front;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        if (!$request instanceof EnlightRequest) {
+            $request = $this->transformSymfonyRequestToEnlightRequest($request);
+        }
+
+        if ($this->front->Request() === null) {
+            $this->front->setRequest($request);
+            $response = $this->front->dispatch();
+        } else {
+            $dispatcher = clone $this->front->Dispatcher();
+            $response = clone $this->front->Response();
+
+            $response->clearHeaders()
+                ->clearBody();
+
+            $response->setStatusCode(Response::HTTP_OK);
+            $request->setDispatched();
+            $dispatcher->dispatch($request, $response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return EnlightRequest
+     */
+    private function transformSymfonyRequestToEnlightRequest(Request $request)
+    {
+        // Overwrite superglobals with state of the SymfonyRequest
+        $request->overrideGlobals();
+
+        return EnlightRequest::createFromGlobals();
+    }
+}

--- a/engine/Shopware/Components/Controller/RouterListener.php
+++ b/engine/Shopware/Components/Controller/RouterListener.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Controller;
+
+use Enlight_Controller_Request_RequestHttp as EnlightRequest;
+use Shopware\Components\Routing\Router;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class RouterListener implements EventSubscriberInterface
+{
+    private $router;
+
+    public function __construct(Router $router)
+    {
+        $this->router = $router;
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (!$request instanceof EnlightRequest) {
+            return;
+        }
+
+        $this->setCurrentRequest($request);
+
+        if ($request->attributes->has('_controller')) {
+            // routing is already done
+            return;
+        }
+
+        $request->attributes->set('_controller', FrontController::class);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => [['onKernelRequest', -100]],
+        ];
+    }
+
+    private function setCurrentRequest(EnlightRequest $request)
+    {
+        $this->router->getContext()->updateFromEnlightRequest($request);
+    }
+}

--- a/engine/Shopware/Components/Controller/ServiceValueResolver.php
+++ b/engine/Shopware/Components/Controller/ServiceValueResolver.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Controller;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\ServiceValueResolver as InnerService;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+class ServiceValueResolver implements ArgumentValueResolverInterface
+{
+    private $container;
+    private $innerService;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        $this->innerService = new InnerService($container);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, ArgumentMetadata $argument)
+    {
+        if ($this->innerService->supports($request, $argument)) {
+            return true;
+        }
+
+        $controller = $request->attributes->get('_controller');
+
+        if (\is_array($controller) && \is_callable($controller, true) && \is_string($controller[0])) {
+            $controller = $controller[0] . ':' . $controller[1];
+        } elseif (!\is_string($controller) || $controller === '') {
+            return false;
+        }
+
+        if (strpos($controller, ':') === false) {
+            $controller .= ':__invoke';
+        }
+
+        return $this->container->has($controller) && $this->container->get($controller)->has($argument->getName());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, ArgumentMetadata $argument)
+    {
+        if ($this->innerService->supports($request, $argument)) {
+            yield from $this->innerService->resolve($request, $argument);
+
+            return;
+        }
+
+        if (\is_array($controller = $request->attributes->get('_controller'))) {
+            $controller = $controller[0] . ':' . $controller[1];
+        }
+
+        if (strpos($controller, ':') === false) {
+            $controller .= ':__invoke';
+        }
+
+        yield $this->container->get($controller)->get($argument->getName());
+    }
+}

--- a/engine/Shopware/Components/DependencyInjection/Container.php
+++ b/engine/Shopware/Components/DependencyInjection/Container.php
@@ -191,6 +191,9 @@ class Container extends BaseContainer
      */
     private function doLoad($id, $fallbackName = null, $invalidBehavior = self::NULL_ON_INVALID_REFERENCE)
     {
+        if (!$this->initialized('events')) {
+            return parent::get($id, $invalidBehavior);
+        }
         $eventManager = parent::get('events');
 
         /** @var \Enlight_Event_EventArgs|null $event */

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -209,9 +209,12 @@
             <argument type="service" id="service_container"/>
         </service>
 
+        <service id="event_dispatcher" class="\Symfony\Component\EventDispatcher\EventDispatcher" public="true" />
+
         <service id="shopware.event_manager" alias="events" public="true"/>
         <service id="events" class="Shopware\Components\ContainerAwareEventManager" public="true">
             <argument type="service" id="service_container"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="shopware.hook_manager" alias="hooks" />
@@ -967,6 +970,32 @@
 
         <service id="shopware.components.shop_registration_service" class="Shopware\Components\ShopRegistrationService">
             <argument type="service" id="service_container"/>
+        </service>
+
+        <service id="Shopware\Components\Controller\FrontController">
+            <argument type="service" id="front"/>
+        </service>
+
+        <service id="controller_resolver" class="\Shopware\Components\Controller\ControllerResolver">
+            <argument type="service" id="service_container"/>
+            <argument type="service" id="corelogger"/>
+        </service>
+
+        <service id="response_listener" class="Symfony\Component\HttpKernel\EventListener\ResponseListener">
+            <argument>%shopware.front.charset%</argument>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="router_listener" class="\Shopware\Components\Controller\RouterListener">
+            <argument type="service" id="router"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="http_kernel" class="Symfony\Component\HttpKernel\HttpKernel">
+            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="controller_resolver"/>
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="argument_resolver"/>
         </service>
     </services>
 </container>

--- a/shopware.php
+++ b/shopware.php
@@ -96,7 +96,7 @@ require __DIR__ . '/autoload.php';
 
 use Shopware\Components\HttpCache\AppCache;
 use Shopware\Kernel;
-use Symfony\Component\HttpFoundation\Request;
+use Enlight_Controller_Request_RequestHttp as Request;
 
 $environment = getenv('SHOPWARE_ENV') ?: getenv('REDIRECT_SHOPWARE_ENV') ?: 'production';
 

--- a/tests/Functional/Components/Controller/ServiceValueResolverTest.php
+++ b/tests/Functional/Components/Controller/ServiceValueResolverTest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Functional\Components\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Components\Controller\ServiceValueResolver;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+class ServiceValueResolverTest extends TestCase
+{
+    public function testDoNotSupportWhenControllerDoNotExists()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator([]));
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+        $request = $this->requestWithAttributes(['_controller' => 'my_controller']);
+
+        static::assertFalse($resolver->supports($request, $argument));
+    }
+
+    public function testExistingController()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator([
+            'App\\Controller\\Mine::method' => function () {
+                return new ServiceLocator([
+                    'dummy' => function () {
+                        return new DummyService();
+                    },
+                ]);
+            },
+        ]));
+
+        $request = $this->requestWithAttributes(['_controller' => 'App\\Controller\\Mine::method']);
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+
+        static::assertTrue($resolver->supports($request, $argument));
+        $this->assertYieldEquals([new DummyService()], $resolver->resolve($request, $argument));
+    }
+
+    public function testExistingControllerWithATrailingBackSlash()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator([
+            'App\\Controller\\Mine::method' => function () {
+                return new ServiceLocator([
+                    'dummy' => function () {
+                        return new DummyService();
+                    },
+                ]);
+            },
+        ]));
+
+        $request = $this->requestWithAttributes(['_controller' => '\\App\\Controller\\Mine::method']);
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+
+        static::assertTrue($resolver->supports($request, $argument));
+        $this->assertYieldEquals([new DummyService()], $resolver->resolve($request, $argument));
+    }
+
+    public function testExistingControllerWithMethodNameStartUppercase()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator([
+            'App\\Controller\\Mine::method' => function () {
+                return new ServiceLocator([
+                    'dummy' => function () {
+                        return new DummyService();
+                    },
+                ]);
+            },
+        ]));
+        $request = $this->requestWithAttributes(['_controller' => 'App\\Controller\\Mine::Method']);
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+
+        static::assertTrue($resolver->supports($request, $argument));
+        $this->assertYieldEquals([new DummyService()], $resolver->resolve($request, $argument));
+    }
+
+    public function testControllerNameIsAnArray()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator([
+            'App\\Controller\\Mine::method' => function () {
+                return new ServiceLocator([
+                    'dummy' => function () {
+                        return new DummyService();
+                    },
+                ]);
+            },
+        ]));
+
+        $request = $this->requestWithAttributes(['_controller' => ['App\\Controller\\Mine', 'method']]);
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+
+        static::assertTrue($resolver->supports($request, $argument));
+        $this->assertYieldEquals([new DummyService()], $resolver->resolve($request, $argument));
+    }
+
+    public function testServiceNotation()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator([
+            'App\\Controller\\Mine:method' => function () {
+                return new ServiceLocator([
+                    'dummy' => function () {
+                        return new DummyService();
+                    },
+                ]);
+            },
+        ]));
+
+        $request = $this->requestWithAttributes(['_controller' => ['App\\Controller\\Mine', 'method']]);
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+
+        static::assertTrue($resolver->supports($request, $argument));
+        $this->assertYieldEquals([new DummyService()], $resolver->resolve($request, $argument));
+    }
+
+    public function testServiceNotationAndInvoke()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator([
+            'App\\Controller\\Mine:__invoke' => function () {
+                return new ServiceLocator([
+                    'dummy' => function () {
+                        return new DummyService();
+                    },
+                ]);
+            },
+        ]));
+
+        $request = $this->requestWithAttributes(['_controller' => 'App\\Controller\\Mine']);
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+
+        static::assertTrue($resolver->supports($request, $argument));
+        $this->assertYieldEquals([new DummyService()], $resolver->resolve($request, $argument));
+    }
+
+    private function requestWithAttributes(array $attributes)
+    {
+        $request = Request::create('/');
+
+        foreach ($attributes as $name => $value) {
+            $request->attributes->set($name, $value);
+        }
+
+        return $request;
+    }
+
+    private function assertYieldEquals(array $expected, \Generator $generator)
+    {
+        $args = [];
+        foreach ($generator as $arg) {
+            $args[] = $arg;
+        }
+
+        static::assertEquals($expected, $args);
+    }
+}
+
+class DummyService
+{
+}

--- a/tests/Functional/Plugins/Core/HttpCache/BootstrapTest.php
+++ b/tests/Functional/Plugins/Core/HttpCache/BootstrapTest.php
@@ -63,10 +63,9 @@ class BootstrapTest extends \Enlight_Components_Test_Controller_TestCase
 
         $this->cacheManager = Shopware()->Container()->get('shopware.cache_manager');
 
-        $plugin = $this->pluginManager->getPluginByName('HttpCache');
+        $this->installPlugin('HttpCache');
 
-        $this->pluginManager->installPlugin($plugin);
-        $this->pluginManager->activatePlugin($plugin);
+        $plugin = $this->pluginManager->getPluginByName('HttpCache');
 
         $this->previousConfig = $this->pluginManager->getPluginConfig($plugin);
 

--- a/tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
+++ b/tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
@@ -36,7 +36,6 @@ use Shopware\Models\Article\Article;
 use Shopware\Models\Blog\Blog;
 use Shopware\Models\Category\Category;
 use Shopware\Models\Emotion\Emotion;
-use Shopware\Models\Plugin\Plugin;
 
 class DynamicCacheTimeServiceTest extends TestCase
 {
@@ -57,13 +56,7 @@ class DynamicCacheTimeServiceTest extends TestCase
      */
     public static function setUpBeforeClass()
     {
-        $pluginManager = Shopware()->Container()->get('shopware_plugininstaller.plugin_manager');
-
-        /** @var Plugin $plugin */
-        $plugin = $pluginManager->getPluginByName('HttpCache');
-
-        $pluginManager->installPlugin($plugin);
-        $pluginManager->activatePlugin($plugin);
+        \Enlight_Components_Test_Controller_TestCase::installPlugin('HttpCache');
     }
 
     /**

--- a/tests/Functional/config.php
+++ b/tests/Functional/config.php
@@ -27,6 +27,7 @@ return array_replace_recursive($this->loadConfig($this->AppPath() . 'Configs/Def
         'throwExceptions' => true,
         'disableOutputBuffering' => false,
         'showException' => true,
+        'charset' => 'utf-8',
     ],
     'errorhandler' => [
         'throwOnRecoverableError' => true,

--- a/tests/Unit/Components/Event/EventManagerTest.php
+++ b/tests/Unit/Components/Event/EventManagerTest.php
@@ -30,6 +30,7 @@ use PHPUnit\Framework\TestCase;
 
 class EventManagerTest extends TestCase
 {
+    /** @var \Enlight_Event_EventManager */
     private $eventManager;
 
     public function setUp()
@@ -300,8 +301,23 @@ class EventManagerTest extends TestCase
         static::assertCount(3, $this->eventManager->getListeners('eventName3'));
 
         $listeners = $this->eventManager->getListeners('eventName3');
-        $listener = $listeners[5];
-        static::assertEquals(5, $listener->getPosition());
+        $listener = array_pop($listeners);
+
+        static::assertEquals($eventSubscriber, $listener[0]);
+        static::assertEquals('callback3_0', $listener[1]);
+    }
+
+    public function testPriority()
+    {
+        $eventSubscriber = new EventPriorityTest();
+        $this->eventManager->addSubscriber($eventSubscriber);
+
+        $listeners = $this->eventManager->getListeners('eventName');
+        static::assertCount(7, $listeners);
+
+        $listener = array_pop($listeners);
+        static::assertEquals($eventSubscriber, $listener[0]);
+        static::assertEquals('callback4_0', $listener[1]);
     }
 
     public function testRemoveSubscriber()
@@ -348,6 +364,24 @@ class EventSubsciberTest implements SubscriberInterface
                 ['callback3_0', 5],
                 ['callback3_1'],
                 ['callback3_2'],
+            ],
+        ];
+    }
+}
+
+class EventPriorityTest implements SubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            'eventName' => [
+                ['callback3_0'],
+                ['callback3_1'],
+                ['callback3_2'],
+                ['callback3_3'],
+                ['callback3_4'],
+                ['callback4_0', 5],
+                ['callback3_5'],
             ],
         ];
     }


### PR DESCRIPTION
###   1. Why is this change necessary?

Alternative to #2143. We use symfony as event listener list.

### 2. What does this change do, exactly?
- You can now use symfony listener and subscribers.
- Adds symfony console events
- You can use enlight events in symfony and symfony events in enlight.
- HttpKernel added. So KernelEvents and smyfony controller are useable.

Breaks:
- Return values of the methods getListeners and getAllListeners in event manger changed from Enlight_Event_Handler to callable.
- Renamed getListener to getMethod in Enlight_Event_Handler_Plugin. getListener returns now a callable.

Example with symfony event subscriber:
 https://github.com/hlohaus/SheTest/blob/master/Subscribers/ConsoleEvents.php#L30

Example controller:

https://github.com/hlohaus/SheTest/blob/master/SheTest.php#L49

2x faster... 💃 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.