### PR TITLE
Add getter and setter to Config\Form model

### DIFF
--- a/engine/Shopware/Models/Config/Form.php
+++ b/engine/Shopware/Models/Config/Form.php
@@ -27,6 +27,7 @@ namespace Shopware\Models\Config;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
+use Shopware\Models\Plugin\Plugin;
 
 /**
  * @ORM\Table(name="s_core_config_forms")
@@ -35,7 +36,7 @@ use Shopware\Components\Model\ModelEntity;
 class Form extends ModelEntity
 {
     /**
-     * @var \Shopware\Models\Plugin\Plugin
+     * @var Plugin|null
      *
      * @ORM\ManyToOne(targetEntity="Shopware\Models\Plugin\Plugin", inversedBy="configForms")
      * @ORM\JoinColumn(name="plugin_id", referencedColumnName="id")
@@ -97,9 +98,9 @@ class Form extends ModelEntity
     private $description;
 
     /**
-     * @var int
+     * @var int|null
      *
-     * @ORM\Column(name="plugin_id", type="integer", nullable=false)
+     * @ORM\Column(name="plugin_id", type="integer")
      */
     private $pluginId;
 
@@ -312,7 +313,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @param int $pluginId
+     * @param int|null $pluginId
      */
     public function setPluginId($pluginId)
     {
@@ -320,7 +321,7 @@ class Form extends ModelEntity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getPluginId()
     {
@@ -386,5 +387,20 @@ class Form extends ModelEntity
     public function hasTranslations()
     {
         return $this->translations->count() > 0;
+    }
+
+    public function getPlugin(): ?Plugin
+    {
+        return $this->plugin;
+    }
+
+    /**
+     * @return static
+     */
+    public function setPlugin(?Plugin $plugin): self
+    {
+        $this->plugin = $plugin;
+
+        return $this;
     }
 }


### PR DESCRIPTION
For field \Shopware\Models\Config\Form::$plugin

### 1. Why is this change necessary?
Currently, if you have an instance of `\Shopware\Models\Config\Form` and you want the associated `\Shopware\Models\Plugin\Plugin`, you have to get the id and fetch the Plugin model manually

### 2. What does this change do, exactly?
It adds `\Shopware\Models\Config\Form::getPlugin` and `\Shopware\Models\Config\Form::setPlugin`

### 3. Describe each step to reproduce the issue or behaviour.
Fetch an instance of `\Shopware\Models\Config\Form` and try to get the associated `\Shopware\Models\Plugin\Plugin`?

