### PR TITLE
Use mousemove listner only then needed and remove afterwards

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
@@ -157,8 +157,6 @@
                 me._on($el, 'click', $.proxy(me.onClick, me, i, $el));
             });
 
-            $body.on('mousemove touchstart', $.proxy(me.onMouseMove, me));
-
             me._on(me._$closeButton, 'click', $.proxy(me.onCloseButtonClick, me));
         },
 
@@ -309,6 +307,8 @@
         openMenu: function () {
             var me = this;
 
+            $body.on('mousemove touchstart', $.proxy(me.onMouseMove, me));
+
             me.$el.show();
 
             $.publish('plugin/swAdvancedMenu/onOpenMenu', [ me ]);
@@ -327,6 +327,8 @@
             me._$list.find('.' + opts.itemHoverClass).removeClass(opts.itemHoverClass);
 
             me.$el.hide();
+
+            $body.off('mousemove touchstart', $.proxy(me.onMouseMove, me));
 
             me._targetIndex = -1;
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Every pixel the mouse moves on the screen or touch ... `closeMenu` is triggered and `$.publish` is fired. (User FroshProfiler - available/triggered JS subscriber and on 4k Screen the browser nearly crashes).
**Selector is on body!**

### 2. What does this change do, exactly?
Adds the needed event-listener if the menu is open an removes it afterwards. Still a lot of calles of `onMouseMove` but line 255 returns the function and no `closeMenu` is used.
First Pageload has no event on body until the menu is triggered and never on off-canvas menu/mobile.

Even better would be if advanced menu panel would be excluded like `body:not(.advanced-menu)`. So unnenned calls on `onMouseMove` are gone, but few tries didn't work. Tried `body:not(.advanced-menu)`, `$body = $('body').not('.advanced-menu')` and  `$body.on('mousemove touchstart',":not(.advanced-menu)", $.proxy(me.onMouseMove, me));` (or [data-advanced-menu="true"]), but maybe somebody has a better approach.

### 3. Describe each step to reproduce the issue or behaviour.
Add a console log to `closeMenu` or enable FroshProfiler. Better script evaluation time on Mobile Lighthouse (difference depends a lot on your setup and other JS onload)

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.