### PR TITLE
Prefer Core config over Plugin config values

### DIFF
--- a/engine/Shopware/Components/Config.php
+++ b/engine/Shopware/Components/Config.php
@@ -280,7 +280,10 @@ class Shopware_Components_Config implements ArrayAccess
                 'parentShop.element_id = e.id AND parentShop.shop_id = :parentShopId')
             ->leftJoin('e', 's_core_config_values', 'fallbackShop',
                 'fallbackShop.element_id = e.id AND fallbackShop.shop_id = :fallbackShopId')
-            ->leftJoin('e', 's_core_config_forms', 'forms', 'forms.id = e.form_id');
+            ->leftJoin('e', 's_core_config_forms', 'forms', 'forms.id = e.form_id')
+            // prefering core config over plugin
+            // going for @deprecated for plugins with SW 5.7 by removing plugin data completely
+            ->orderBy('forms.plugin_id', 'DESC');
 
         $builder->setParameters([
             'fallbackShopId' => 1, // Shop parent id

--- a/tests/Functional/Components/Config/ShopwareConfigTest.php
+++ b/tests/Functional/Components/Config/ShopwareConfigTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+use Shopware\Models\Config\Form;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
+
+class ShopwareConfigTest extends Enlight_Components_Test_TestCase
+{
+    use DatabaseTransactionBehaviour;
+
+    /**
+     * Random plugin id that should be unique
+     */
+    const PLUGIN_ID = 20095;
+    const PLUGIN_NAME = 'Testplugin';
+
+    /**
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $form = $this->initForm();
+        $form->setElement('text', 'mail', ['value' => 'other@email.org']);
+        $form->setElement('number', 'sometestkey', ['value' => 0]);
+
+        Shopware()->Models()->flush();
+
+        // force reload from database
+        Shopware()->Container()->reset('cache');
+        Shopware()->Container()->reset('config');
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    protected function tearDown()
+    {
+        // force reload from database
+        Shopware()->Container()->reset('cache');
+        Shopware()->Container()->reset('config');
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test case
+     */
+    public function testCoreConfigIgnored()
+    {
+        static::assertNotEquals('other@email.org', Shopware()->Config()->get('mail'));
+    }
+
+    /**
+     * Test case
+     */
+    public function testCoreConfigNoCollision()
+    {
+        static::assertEquals(0, Shopware()->Config()->get('sometestkey'));
+    }
+
+    /**
+     * Test case
+     */
+    public function testCoreConfigPrefixed()
+    {
+        static::assertEquals('other@email.org', Shopware()->Config()->get(static::PLUGIN_NAME . '::mail'));
+    }
+
+    protected function initForm()
+    {
+        $repo = Shopware()->Models()->getRepository(Form::class);
+        $form = $repo->findOneBy(['name' => self::PLUGIN_NAME]);
+
+        if (!$form) {
+            $form = new Form();
+            $form->setPluginId(static::PLUGIN_ID);
+
+            $form->setName(self::PLUGIN_NAME);
+            $form->setLabel(self::PLUGIN_NAME);
+            $form->setDescription('');
+
+            /** @var Form $parent */
+            $parent = $repo->findOneBy([
+                'name' => 'Other',
+            ]);
+
+            $form->setParent($parent);
+            Shopware()->Models()->persist($form);
+        }
+
+        return $form;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Plugin config values pollute the core config but even worse can override those values as those are typical newer in the database.

### 2. What does this change do, exactly?
Based on #2147 this will ~remove all plugin config completely from Core config~ prefer Core config values over plugin values.

### 3. Describe each step to reproduce the issue or behaviour.
See #2145 

### 4. Please link to the relevant issues (if any).
- #2145 
- #2147

### 5. Which documentation changes (if any) need to be made because of this PR?
Devs should be aware that they shouldn't use the Core config for accessing plugin config. For now only on key collision changes will occur (but those were already faulty before).
Next step is completely remove as originally proposed but as this will be definitely BC this will be another change for 5.7. (will make another PR for 5.7 when this is accepted)

~While this shouldn't be done in the first place plugin devs can't use the core config (`Shopware()->Config()`) anymore for accessing their config values.
As this is a potential BC but 5.6 isn't released yet this shouldn't be a problem.~

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.