### PR TITLE
Old default plugins: Use plugin config instead of relying in global core config object

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/Cron/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Cron/Bootstrap.php
@@ -57,9 +57,9 @@ class Shopware_Plugins_Core_Cron_Bootstrap extends Shopware_Components_Plugin_Bo
 
         // At least one of the security policies is enabled.
         // If at least one of them validates, cron tasks will be executed
-        $cronSecureAllowedKey = Shopware()->Config()->get('cronSecureAllowedKey');
-        $cronSecureAllowedIp = Shopware()->Config()->get('cronSecureAllowedIp');
-        $cronSecureByAccount = Shopware()->Config()->get('cronSecureByAccount');
+        $cronSecureAllowedKey = $this->Config()->get('cronSecureAllowedKey');
+        $cronSecureAllowedIp = $this->Config()->get('cronSecureAllowedIp');
+        $cronSecureByAccount = $this->Config()->get('cronSecureByAccount');
 
         // No security policy specified, accept all requests
         if (empty($cronSecureAllowedKey) && empty($cronSecureAllowedIp) && !$cronSecureByAccount) {

--- a/engine/Shopware/Plugins/Default/Frontend/Statistics/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Statistics/Bootstrap.php
@@ -108,7 +108,7 @@ ShopWiki;Bot;WebAlta;;abachobot;architext;ask jeeves;frooglebot;googlebot;lycos;
             return false;
         }
         $result = false;
-        $bots = preg_replace('/[^a-z;]/', '', strtolower(Shopware()->Config()->botBlackList));
+        $bots = preg_replace('/[^a-z;]/', '', strtolower($this->Config()->get('botBlackList')));
         $bots = explode(';', $bots);
         if (!empty($userAgent) && str_replace($bots, '', $userAgent) != $userAgent) {
             $result = true;
@@ -173,8 +173,8 @@ ShopWiki;Bot;WebAlta;;abachobot;architext;ask jeeves;frooglebot;googlebot;lycos;
         ) {
             return false;
         }
-        if (!empty(Shopware()->Config()->blockIp)
-            && strpos(Shopware()->Config()->blockIp, $request->getClientIp()) !== false
+        if (!empty($this->Config()->get('blockIp'))
+            && strpos($this->Config()->get('blockIp'), $request->getClientIp()) !== false
         ) {
             return false;
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
The default `Statistics` and `Cron` plugin both use the core Config object instead of relying on its plugin config values. As the core config is vulnerable to be overridden by plugin values (see #2154 for a fix) this should be fixed.

This PR blocks #2154 as the related unit tests fail.

### 2. What does this change do, exactly?
Replaces calls to the global core config object to the plugin calls. As those plugins use the legacy file structure they call the `Config()` method in their `bootstrap.php` files instead of a more modern `shopware.plugin.config_reader`.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
#2154 

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.