### PR TITLE
Shopware Theme compiler tmp css and js files

### DIFF
--- a/engine/Shopware/Components/Theme/PathResolver.php
+++ b/engine/Shopware/Components/Theme/PathResolver.php
@@ -288,7 +288,7 @@ class PathResolver
     }
 
     /**
-     * Helper function which build the directory path to the passed
+     * Helper function which builds the directory path to the passed
      * css file.
      * This function is used for the less smarty function.
      * The smarty function checks if this file is
@@ -305,6 +305,18 @@ class PathResolver
     }
 
     /**
+     * Helper function which builds the directory path to the tmp
+     * passed css file.
+     * This function is used for generating a .css.tmp file
+     * while writing the theme cache.
+     * The tmp file prevents serving a zero content css file.
+     */
+    public function getTmpCssFilePath(Shop\Shop $shop, string $timestamp): string
+    {
+        return $this->getCacheDirectory() . '/' . $this->buildTimestampName($timestamp, $shop, 'css.tmp');
+    }
+
+    /**
      * Builds the path to the passed javascript file.
      * This function is used for the javascript smarty function.
      * The smarty function checks if this file is
@@ -318,6 +330,18 @@ class PathResolver
     public function getJsFilePath(Shop\Shop $shop, $timestamp)
     {
         return $this->getCacheDirectory() . '/' . $this->buildTimestampName($timestamp, $shop, 'js');
+    }
+
+    /**
+     * Helper function which builds the directory path to the tmp
+     * passed js file.
+     * This function is used for generating a .js.tmp file
+     * while writing the theme cache.
+     * The tmp file prevents serving a zero content js file.
+     */
+    public function getTmpJsFilePath(Shop\Shop $shop, string $timestamp): string
+    {
+        return $this->getCacheDirectory() . '/' . $this->buildTimestampName($timestamp, $shop, 'js.tmp');
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
This change prevents zero content serves during the theme cache compile process.

### 2. What does this change do, exactly?
In default shopware is writing to the compiled theme cache files `timestamp.css` and `timestamp.js`.
With the default behaviour apache and nginx can't deilver the css and js file correctly while the files are written. If the files will be accessed while shopware is writing them zero content files will be served and it can also cause apache bus failures. 

With this change shopware will generate tmp files instead of writing the generated files directly. 
On theme cache compile tmp files will be written `timestamp.css.tmp` instead of `timestamp.css` and `timestamp.js.tmp` instead of `timestamp.js` 

### 3. Describe each step to reproduce the issue or behaviour.
1. Disable theme cache
2. Access generated cache files with siege for example (1563443442_2b2090eaa09b34311d796527ee91e5da.css)
3. Access any shopware page
4. Apache / nginx are not able to serve the cached files on writing process and will deliver a zero content file

#### Default behaviour:
![shopware-default-behaviour](https://user-images.githubusercontent.com/2674751/61512657-eb883080-a9fa-11e9-8a09-95cdff1e8bcb.gif)

#### Fixed behaviour:
![shopware-fixed-behaviour](https://user-images.githubusercontent.com/2674751/61512762-34d88000-a9fb-11e9-8b06-52a8cb31fc1f.gif)


### 4. Please link to the relevant issues (if any).
/ 

### 5. Which documentation changes (if any) need to be made because of this PR?
https://developers.shopware.com/developers-guide/shopware-5-performance-for-devs/#how-the-theme-cache-works

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.