### PR TITLE
Proper attribute entity selection for \Shopware\Models\Order\Detail

### DIFF
--- a/themes/Backend/ExtJs/backend/base/attribute/Shopware.attribute.Form.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/Shopware.attribute.Form.js
@@ -275,9 +275,9 @@ Ext.define('Shopware.attribute.Form', {
         if (fields.length <= 0) {
 
             /*{if !{acl_is_allowed resource=attributes privilege=read}}*/
-                hidden = true;
+            hidden = true;
 
-                me.fireEvent('hide-attribute-field-set');
+            me.fireEvent('hide-attribute-field-set');
 
             /*{/if}*/
 
@@ -387,6 +387,7 @@ Ext.define('Shopware.attribute.Form', {
             Ext.create('Shopware.attribute.FormFieldHandler'),
             Ext.create('Shopware.attribute.PartnerFieldHandler'),
             Ext.create('Shopware.attribute.NewsletterFieldHandler'),
+            Ext.create('Shopware.attribute.OrderDetailFieldHandler'),
             Ext.create('Shopware.attribute.ProductFeedFieldHandler'),
             Ext.create('Shopware.attribute.VoucherFieldHandler'),
             Ext.create('Shopware.attribute.PropertyOptionFieldHandler'),

--- a/themes/Backend/ExtJs/backend/base/attribute/field/Shopware.form.field.OrderDetailGrid.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field/Shopware.form.field.OrderDetailGrid.js
@@ -1,0 +1,60 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category    Shopware
+ * @package     Base
+ * @subpackage  Attribute
+ * @version     $Id$
+ * @author      shopware AG
+ */
+
+//{namespace name="backend/attributes/fields"}
+
+Ext.define('Shopware.form.field.OrderDetailGrid', {
+    extend: 'Shopware.form.field.Grid',
+    alias: 'widget.shopware-form-field-order-detail-grid',
+    mixins: ['Shopware.model.Helper'],
+
+    createColumns: function() {
+        var me = this;
+
+        return [
+            me.createSortingColumn(),
+            { dataIndex: 'quantity' },
+            { dataIndex: 'articleNumber' },
+            { dataIndex: 'price', renderer: me.priceRenderer },
+            { dataIndex: 'articleName' },
+            me.createActionColumn()
+        ];
+    },
+
+    priceRenderer: function(value) {
+        if ( value === Ext.undefined ) {
+            return value;
+        }
+        return Ext.util.Format.currency(value);
+    },
+
+    createSearchField: function() {
+        return Ext.create('Shopware.form.field.OrderDetailSingleSelection', this.getComboConfig());
+    }
+});

--- a/themes/Backend/ExtJs/backend/base/attribute/field/Shopware.form.field.OrderDetailSingleSelection.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field/Shopware.form.field.OrderDetailSingleSelection.js
@@ -1,0 +1,68 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category    Shopware
+ * @package     Base
+ * @subpackage  Attribute
+ * @version     $Id$
+ * @author      shopware AG
+ */
+
+//{namespace name="backend/attributes/fields"}
+
+Ext.define('Shopware.form.field.OrderDetailSingleSelection', {
+    extend: 'Shopware.form.field.SingleSelection',
+    alias: 'widget.shopware-form-field-oder-detail-single-selection',
+
+    getComboConfig: function() {
+        var me = this;
+        var config = me.callParent(arguments);
+
+        config.tpl = Ext.create('Ext.XTemplate',
+            '<tpl for=".">',
+                '<div class="x-boundlist-item">{literal}<b>{quantity}x {articleNumber}</b> ({[this.formatPrice(values.price)]}) - {articleName}{/literal}</div>',
+            '</tpl>',
+            {
+                formatPrice: function(value) {
+                    if ( value === Ext.undefined ) {
+                        return value;
+                    }
+                    return Ext.util.Format.currency(value);
+                }
+            }
+        );
+        config.displayTpl = Ext.create('Ext.XTemplate',
+            '<tpl for=".">',
+                    '{literal}{quantity}x {articleNumber}</b> ({[this.formatPrice(values.price)]}) - {articleName}{/literal}',
+            '</tpl>',
+            {
+                formatPrice: function(value) {
+                    if ( value === Ext.undefined ) {
+                        return value;
+                    }
+                    return Ext.util.Format.currency(value);
+                }
+            }
+        );
+        return config;
+    },
+});

--- a/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.OrderDetailFieldHandler.js
+++ b/themes/Backend/ExtJs/backend/base/attribute/field_handler/Shopware.attribute.OrderDetailFieldHandler.js
@@ -1,0 +1,35 @@
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ *
+ * @category    Shopware
+ * @package     Base
+ * @subpackage  Attribute
+ * @version     $Id$
+ * @author      shopware AG
+ */
+
+Ext.define('Shopware.attribute.OrderDetailFieldHandler', {
+    extend: 'Shopware.attribute.AbstractEntityFieldHandler',
+    entity: "Shopware\\Models\\Order\\Detail",
+    singleSelectionClass: 'Shopware.form.field.OrderDetailSingleSelection',
+    multiSelectionClass: 'Shopware.form.field.OrderDetailGrid'
+});

--- a/themes/Backend/ExtJs/backend/base/bootstrap.js
+++ b/themes/Backend/ExtJs/backend/base/bootstrap.js
@@ -167,6 +167,7 @@
 {include file='backend/base/store/corner_position.js'}
 {include file='backend/base/store/cookie_mode.js'}
 
+
 {* Include shopware related components *}
 {include file='backend/base/component/Shopware.button.HoverButton.js'}
 {include file='backend/base/component/Shopware.MediaManager.MediaSelection.js'}
@@ -288,6 +289,8 @@
 {include file='backend/base/attribute/field/Shopware.form.field.CustomSortingGrid.js'}
 {include file='backend/base/attribute/field/Shopware.form.field.CustomFacetGrid.js'}
 {include file='backend/base/attribute/field/Shopware.form.field.AttributeSingleSelection.js'}
+{include file='backend/base/attribute/field/Shopware.form.field.OrderDetailGrid.js'}
+{include file='backend/base/attribute/field/Shopware.form.field.OrderDetailSingleSelection.js'}
 {include file='backend/base/component/Shopware.form.field.ProductStreamSelection.js'}
 {include file='backend/base/attribute/field/Shopware.form.field.ContentTypeSelection.js'}
 
@@ -313,6 +316,7 @@
 {include file='backend/base/attribute/field_handler/Shopware.attribute.ProductStreamFieldHandler.js'}
 {include file='backend/base/attribute/field_handler/Shopware.attribute.ShopFieldHandler.js'}
 {include file='backend/base/attribute/field_handler/Shopware.attribute.ComboBoxFieldHandler.js'}
+{include file='backend/base/attribute/field_handler/Shopware.attribute.OrderDetailFieldHandler.js'}
 
 {include file='backend/base/attribute/Shopware.attribute.Form.js'}
 {include file='backend/base/attribute/Shopware.attribute.Window.js'}


### PR DESCRIPTION
### 1. Why is this change necessary?
If you reference `\Shopware\Models\Order\Detail` as an entity for an attribute you will get the default selectors that will fall back to the model field `number` - which is the ordernumber but nothing identifying the detail position itself. 

### 2. What does this change do, exactly?
Added new attribute field handler with the most important data fields.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create new attribute with entity set to `\Shopware\Models\Order\Detail` and `displayInBackend=true`
2. Open the parent entity and try to edit the association
3. Association just contains order number

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.