### PR TITLE
add Scope to hrefLangCountry

### DIFF
--- a/_sql/migrations/1634-href-lang-scope.php
+++ b/_sql/migrations/1634-href-lang-scope.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+class Migrations_Migration1634 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        // Add scope to hrefLangCountry
+        $sql = "UPDATE `s_core_config_elements` SET `scope` = 1 WHERE `name` = 'hrefLangCountry'";
+        $this->addSql($sql);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently there is no possibility to make hrefLangCountry configurable per language-shop.

### 2. What does this change do, exactly?
Let the config be configurable per shop, so you can successfully build something like:
```
<link rel="alternate" href="http://www.domain.com/" hreflang="x-default" />
<link rel="alternate" href="http://www.domain.com/de/" hreflang="de" />
<link rel="alternate" href="http://www.domain.com/de-AT/" hreflang="de-AT" />
<link rel="alternate" href="http://www.domain.com/en/" hreflang="en" />
<link rel="alternate" href="http://www.domain.com/en-GB/" hreflang="en-GB" />
<link rel="alternate" href="http://www.domain.com/es/" hreflang="es" />
```

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.