### PR TITLE
Replace tabs with spaces

### DIFF
--- a/themes/Backend/ExtJs/backend/_resources/resources/themes/stylesheets/ext4/default/widgets/form/_all.scss
+++ b/themes/Backend/ExtJs/backend/_resources/resources/themes/stylesheets/ext4/default/widgets/form/_all.scss
@@ -3,11 +3,11 @@
     .#{$prefix}webkit {
         * {
             &:focus {
-                outline:none !important;
+                outline: none !important;
             }
         }
     }
-    
+
     // form items
     .#{$prefix}form-item {
         vertical-align: top;
@@ -48,6 +48,7 @@
             border-collapse: collapse;
             border-spacing: 0;
         }
+
         .#{$prefix}form-form-item {
             td {
                 border-top-width: 0;
@@ -59,17 +60,17 @@
             height: 5px;
         }
     }
-    
+
     // No padding when inside an Editor
     .#{$prefix}editor .#{$prefix}form-item-body {
         padding-bottom: 0;
     }
-    
+
     .#{$prefix}form-item-label {
         display: block;
         padding: 3px 0 0;
         font-size: $form-label-font-size;
-		text-shadow: 0 1px 0 #fff;
+        text-shadow: 0 1px 0 #fff;
         @include no-select;
     }
 
@@ -109,9 +110,11 @@
         background: no-repeat 2px 3px;
         background-image: theme-background-image($theme-name, $form-exclamation-icon);
         overflow: hidden;
+
         ul {
             display: block;
             width: $form-error-icon-width;
+
             li {
                 /* prevent inner elements from interfering with QuickTip hovering */
                 display: none;

--- a/themes/Frontend/Bare/frontend/checkout/cart_footer.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/cart_footer.tpl
@@ -1,180 +1,180 @@
 {* Add product using the sku *}
 {block name='frontend_checkout_cart_footer_add_product'}
-	<form method="post" action="{url action='addArticle' sTargetAction=$sTargetAction}"
-		  class="table--add-product add-product--form block-group">
+    <form method="post" action="{url action='addArticle' sTargetAction=$sTargetAction}"
+          class="table--add-product add-product--form block-group">
 
-		{block name='frontend_checkout_cart_footer_add_product_field'}
-			<input name="sAdd" class="add-product--field block" type="text"
-				   placeholder="{s name='CheckoutFooterAddProductPlaceholder' namespace='frontend/checkout/cart_footer_left'}{/s}"/>
-		{/block}
+        {block name='frontend_checkout_cart_footer_add_product_field'}
+            <input name="sAdd" class="add-product--field block" type="text"
+                   placeholder="{s name='CheckoutFooterAddProductPlaceholder' namespace='frontend/checkout/cart_footer_left'}{/s}"/>
+        {/block}
 
-		{block name='frontend_checkout_cart_footer_add_product_button'}
-			<button type="submit" class="add-product--button btn is--primary is--center block">
-				<i class="icon--arrow-right"></i>
-			</button>
-		{/block}
-	</form>
+        {block name='frontend_checkout_cart_footer_add_product_button'}
+            <button type="submit" class="add-product--button btn is--primary is--center block">
+                <i class="icon--arrow-right"></i>
+            </button>
+        {/block}
+    </form>
 {/block}
 
 {block name='frontend_checkout_cart_footer_element'}
-	<div class="basket--footer">
-		<div class="table--aggregation">
-			{* Add product using a voucher *}
-			{block name='frontend_checkout_cart_footer_add_voucher'}
-				{if {config name=showVoucherModeForCart} != 0}
-					<form method="post" action="{url action='addVoucher' sTargetAction=$sTargetAction}"
-						  class="table--add-voucher add-voucher--form">
-						{if {config name=showVoucherModeForCart} == 1}
-							{block name='frontend_checkout_cart_footer_add_voucher_trigger'}
-								<input type="checkbox" id="add-voucher--trigger" class="add-voucher--checkbox">
-							{/block}
+    <div class="basket--footer">
+        <div class="table--aggregation">
+            {* Add product using a voucher *}
+            {block name='frontend_checkout_cart_footer_add_voucher'}
+                {if {config name=showVoucherModeForCart} != 0}
+                    <form method="post" action="{url action='addVoucher' sTargetAction=$sTargetAction}"
+                          class="table--add-voucher add-voucher--form">
+                        {if {config name=showVoucherModeForCart} == 1}
+                            {block name='frontend_checkout_cart_footer_add_voucher_trigger'}
+                                <input type="checkbox" id="add-voucher--trigger" class="add-voucher--checkbox">
+                            {/block}
 
-							{block name='frontend_checkout_cart_footer_add_voucher_label'}
-								<label for="add-voucher--trigger"
-									   class="add-voucher--label">{s name="CheckoutFooterVoucherTrigger"}{/s}</label>
-							{/block}
-						{/if}
+                            {block name='frontend_checkout_cart_footer_add_voucher_label'}
+                                <label for="add-voucher--trigger"
+                                       class="add-voucher--label">{s name="CheckoutFooterVoucherTrigger"}{/s}</label>
+                            {/block}
+                        {/if}
 
-						<div class="add-voucher--panel {if {config name=showVoucherModeForCart} == 1}is--hidden {/if}block-group">
-							{block name='frontend_checkout_cart_footer_add_voucher_field'}
-								{s name="CheckoutFooterAddVoucherLabelInline" assign="snippetCheckoutFooterAddVoucherLabelInline"}{/s}
-								<input type="text" class="add-voucher--field is--medium block" name="sVoucher"
-									   placeholder="{$snippetCheckoutFooterAddVoucherLabelInline|escape}"/>
-							{/block}
+                        <div class="add-voucher--panel {if {config name=showVoucherModeForCart} == 1}is--hidden {/if}block-group">
+                            {block name='frontend_checkout_cart_footer_add_voucher_field'}
+                                {s name="CheckoutFooterAddVoucherLabelInline" assign="snippetCheckoutFooterAddVoucherLabelInline"}{/s}
+                                <input type="text" class="add-voucher--field is--medium block" name="sVoucher"
+                                       placeholder="{$snippetCheckoutFooterAddVoucherLabelInline|escape}"/>
+                            {/block}
 
-							{block name='frontend_checkout_cart_footer_add_voucher_button'}
-								<button type="submit"
-										class="add-voucher--button is--medium btn is--primary is--center block">
-									<i class="icon--arrow-right"></i>
-								</button>
-							{/block}
-						</div>
-					</form>
-				{/if}
-			{/block}
+                            {block name='frontend_checkout_cart_footer_add_voucher_button'}
+                                <button type="submit"
+                                        class="add-voucher--button is--medium btn is--primary is--center block">
+                                    <i class="icon--arrow-right"></i>
+                                </button>
+                            {/block}
+                        </div>
+                    </form>
+                {/if}
+            {/block}
 
-			{* Shipping costs pre-calculation *}
-			{if $sBasket.content && !$sUserLoggedIn && !$sUserData.additional.user.id && {config name=basketShowCalculation} != 0}
+            {* Shipping costs pre-calculation *}
+            {if $sBasket.content && !$sUserLoggedIn && !$sUserData.additional.user.id && {config name=basketShowCalculation} != 0}
 
-				{block name='frontend_checkout_shipping_costs_country_trigger'}
-					{if {config name=basketShowCalculation} == 1}
+                {block name='frontend_checkout_shipping_costs_country_trigger'}
+                    {if {config name=basketShowCalculation} == 1}
                         <a href="#show-hide--shipping-costs" class="table--shipping-costs-trigger">
-							{s name='CheckoutFooterEstimatedShippingCosts'}{/s}
+                            {s name='CheckoutFooterEstimatedShippingCosts'}{/s}
                             <i class="icon--arrow-right"></i>
                         </a>
-					{/if}
-				{/block}
+                    {/if}
+                {/block}
 
-				{block name='frontend_checkout_shipping_costs_country_include'}
-					{if {config name=basketShowCalculation} == 2}
+                {block name='frontend_checkout_shipping_costs_country_include'}
+                    {if {config name=basketShowCalculation} == 2}
                         <span class="is--bold">{s name='CheckoutFooterEstimatedShippingCosts'}{/s}</span>
-					{/if}
-					{include file="frontend/checkout/shipping_costs.tpl" calculateShippingCosts=$calculateShippingCosts == true || {config name=basketShowCalculation} == 2}
-				{/block}
-			{/if}
+                    {/if}
+                    {include file="frontend/checkout/shipping_costs.tpl" calculateShippingCosts=$calculateShippingCosts == true || {config name=basketShowCalculation} == 2}
+                {/block}
+            {/if}
         </div>
 
-		{block name='frontend_checkout_cart_footer_field_labels'}
-			<ul class="aggregation--list">
+        {block name='frontend_checkout_cart_footer_field_labels'}
+            <ul class="aggregation--list">
 
-				{* Basket sum *}
-				{block name='frontend_checkout_cart_footer_field_labels_sum'}
-					<li class="list--entry block-group entry--sum">
+                {* Basket sum *}
+                {block name='frontend_checkout_cart_footer_field_labels_sum'}
+                    <li class="list--entry block-group entry--sum">
 
-						{block name='frontend_checkout_cart_footer_field_labels_sum_label'}
-							<div class="entry--label block">
-								{s name="CartFooterLabelSum"}{/s}
-							</div>
-						{/block}
+                        {block name='frontend_checkout_cart_footer_field_labels_sum_label'}
+                            <div class="entry--label block">
+                                {s name="CartFooterLabelSum"}{/s}
+                            </div>
+                        {/block}
 
-						{block name='frontend_checkout_cart_footer_field_labels_sum_value'}
-							<div class="entry--value block">
-								{$sBasket.Amount|currency}{s name="Star" namespace="frontend/listing/box_article"}{/s}
-							</div>
-						{/block}
-					</li>
-				{/block}
+                        {block name='frontend_checkout_cart_footer_field_labels_sum_value'}
+                            <div class="entry--value block">
+                                {$sBasket.Amount|currency}{s name="Star" namespace="frontend/listing/box_article"}{/s}
+                            </div>
+                        {/block}
+                    </li>
+                {/block}
 
-				{* Shipping costs *}
-				{block name='frontend_checkout_cart_footer_field_labels_shipping'}
-					<li class="list--entry block-group entry--shipping">
+                {* Shipping costs *}
+                {block name='frontend_checkout_cart_footer_field_labels_shipping'}
+                    <li class="list--entry block-group entry--shipping">
 
-						{block name='frontend_checkout_cart_footer_field_labels_shipping_label'}
-							<div class="entry--label block">
-								{s name="CartFooterLabelShipping"}{/s}
-							</div>
-						{/block}
+                        {block name='frontend_checkout_cart_footer_field_labels_shipping_label'}
+                            <div class="entry--label block">
+                                {s name="CartFooterLabelShipping"}{/s}
+                            </div>
+                        {/block}
 
-						{block name='frontend_checkout_cart_footer_field_labels_shipping_value'}
-							<div class="entry--value block">
-								{$sShippingcosts|currency}{s name="Star" namespace="frontend/listing/box_article"}{/s}
-							</div>
-						{/block}
-					</li>
-				{/block}
+                        {block name='frontend_checkout_cart_footer_field_labels_shipping_value'}
+                            <div class="entry--value block">
+                                {$sShippingcosts|currency}{s name="Star" namespace="frontend/listing/box_article"}{/s}
+                            </div>
+                        {/block}
+                    </li>
+                {/block}
 
-				{* Total sum *}
-				{block name='frontend_checkout_cart_footer_field_labels_total'}
-					<li class="list--entry block-group entry--total">
+                {* Total sum *}
+                {block name='frontend_checkout_cart_footer_field_labels_total'}
+                    <li class="list--entry block-group entry--total">
 
-						{block name='frontend_checkout_cart_footer_field_labels_total_label'}
-							<div class="entry--label block">
-								{s name="CartFooterLabelTotal"}{/s}
-							</div>
-						{/block}
+                        {block name='frontend_checkout_cart_footer_field_labels_total_label'}
+                            <div class="entry--label block">
+                                {s name="CartFooterLabelTotal"}{/s}
+                            </div>
+                        {/block}
 
-						{block name='frontend_checkout_cart_footer_field_labels_total_value'}
-							<div class="entry--value block is--no-star">
-								{if $sAmountWithTax && $sUserData.additional.charge_vat}{$sAmountWithTax|currency}{else}{$sAmount|currency}{/if}
-							</div>
-						{/block}
-					</li>
-				{/block}
+                        {block name='frontend_checkout_cart_footer_field_labels_total_value'}
+                            <div class="entry--value block is--no-star">
+                                {if $sAmountWithTax && $sUserData.additional.charge_vat}{$sAmountWithTax|currency}{else}{$sAmount|currency}{/if}
+                            </div>
+                        {/block}
+                    </li>
+                {/block}
 
-				{* Total net *}
-				{block name='frontend_checkout_cart_footer_field_labels_totalnet'}
-					{if $sUserData.additional.charge_vat}
-						<li class="list--entry block-group entry--totalnet">
+                {* Total net *}
+                {block name='frontend_checkout_cart_footer_field_labels_totalnet'}
+                    {if $sUserData.additional.charge_vat}
+                        <li class="list--entry block-group entry--totalnet">
 
-							{block name='frontend_checkout_cart_footer_field_labels_totalnet_label'}
-								<div class="entry--label block">
-									{s name="CartFooterTotalNet"}{/s}
-								</div>
-							{/block}
+                            {block name='frontend_checkout_cart_footer_field_labels_totalnet_label'}
+                                <div class="entry--label block">
+                                    {s name="CartFooterTotalNet"}{/s}
+                                </div>
+                            {/block}
 
-							{block name='frontend_checkout_cart_footer_field_labels_totalnet_value'}
-								<div class="entry--value block is--no-star">
-									{$sAmountNet|currency}
-								</div>
-							{/block}
-						</li>
-					{/if}
-				{/block}
+                            {block name='frontend_checkout_cart_footer_field_labels_totalnet_value'}
+                                <div class="entry--value block is--no-star">
+                                    {$sAmountNet|currency}
+                                </div>
+                            {/block}
+                        </li>
+                    {/if}
+                {/block}
 
-				{* Taxes *}
-				{block name='frontend_checkout_cart_footer_field_labels_taxes'}
-					{if $sUserData.additional.charge_vat}
-						{foreach $sBasket.sTaxRates as $rate => $value}
-							{block name='frontend_checkout_cart_footer_field_labels_taxes_entry'}
-								<li class="list--entry block-group entry--taxes">
+                {* Taxes *}
+                {block name='frontend_checkout_cart_footer_field_labels_taxes'}
+                    {if $sUserData.additional.charge_vat}
+                        {foreach $sBasket.sTaxRates as $rate => $value}
+                            {block name='frontend_checkout_cart_footer_field_labels_taxes_entry'}
+                                <li class="list--entry block-group entry--taxes">
 
-									{block name='frontend_checkout_cart_footer_field_labels_taxes_label'}
-										<div class="entry--label block">
-											{s name="CartFooterTotalTax"}{/s}
-										</div>
-									{/block}
+                                    {block name='frontend_checkout_cart_footer_field_labels_taxes_label'}
+                                        <div class="entry--label block">
+                                            {s name="CartFooterTotalTax"}{/s}
+                                        </div>
+                                    {/block}
 
-									{block name='frontend_checkout_cart_footer_field_labels_taxes_value'}
-										<div class="entry--value block is--no-star">
-											{$value|currency}
-										</div>
-									{/block}
-								</li>
-							{/block}
-						{/foreach}
-					{/if}
-				{/block}
-			</ul>
-		{/block}
-	</div>
+                                    {block name='frontend_checkout_cart_footer_field_labels_taxes_value'}
+                                        <div class="entry--value block is--no-star">
+                                            {$value|currency}
+                                        </div>
+                                    {/block}
+                                </li>
+                            {/block}
+                        {/foreach}
+                    {/if}
+                {/block}
+            </ul>
+        {/block}
+    </div>
 {/block}

--- a/themes/Frontend/Bare/frontend/checkout/confirm_footer.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/confirm_footer.tpl
@@ -1,17 +1,17 @@
 {extends file='frontend/checkout/cart_footer.tpl'}
 
 {block name='frontend_checkout_cart_footer_field_labels_taxes'}
-	{$smarty.block.parent}
-	{if {config name=countrynotice} && $sCountry.notice && {include file="string:{$sCountry.notice}"} !== ""}
-		<li class="list--entry table-footer--country-notice">
-			{* Include country specific notice message *}
-			<p>{include file='string:{$sCountry.notice}'}</p>
-		</li>
-	{/if}
+    {$smarty.block.parent}
+    {if {config name=countrynotice} && $sCountry.notice && {include file="string:{$sCountry.notice}"} !== ""}
+        <li class="list--entry table-footer--country-notice">
+            {* Include country specific notice message *}
+            <p>{include file='string:{$sCountry.notice}'}</p>
+        </li>
+    {/if}
 
-	{if !$sUserData.additional.charge_vat && {config name=nettonotice}}
-		<li class="list--entry table-footer--netto-notice">
-		{include file="frontend/_includes/messages.tpl" type="warning" content="*{s name='CheckoutFinishTaxInformation'}{/s}"}
+    {if !$sUserData.additional.charge_vat && {config name=nettonotice}}
+        <li class="list--entry table-footer--netto-notice">
+        {include file="frontend/_includes/messages.tpl" type="warning" content="*{s name='CheckoutFinishTaxInformation'}{/s}"}
         </li>
     {/if}
 {/block}
@@ -19,34 +19,34 @@
 {block name='frontend_checkout_cart_footer_add_product'}{/block}
 
 {block name='frontend_checkout_cart_footer_add_voucher'}
-	{if {config name=showVoucherModeForCheckout} != 0}
-		<form method="post" action="{url action='addVoucher' sTargetAction=$sTargetAction}"
-						  class="table--add-voucher add-voucher--form">
-			{if {config name=showVoucherModeForCheckout} == 1}
-				{block name='frontend_checkout_cart_footer_add_voucher_trigger'}
-					<input type="checkbox" id="add-voucher--trigger" class="add-voucher--checkbox">
-				{/block}
+    {if {config name=showVoucherModeForCheckout} != 0}
+        <form method="post" action="{url action='addVoucher' sTargetAction=$sTargetAction}"
+                          class="table--add-voucher add-voucher--form">
+            {if {config name=showVoucherModeForCheckout} == 1}
+                {block name='frontend_checkout_cart_footer_add_voucher_trigger'}
+                    <input type="checkbox" id="add-voucher--trigger" class="add-voucher--checkbox">
+                {/block}
 
-				{block name='frontend_checkout_cart_footer_add_voucher_label'}
-					<label for="add-voucher--trigger"
-						   class="add-voucher--label">{s name="CheckoutFooterVoucherTrigger" namespace="frontend/checkout/cart_footer"}{/s}</label>
-				{/block}
-			{/if}
+                {block name='frontend_checkout_cart_footer_add_voucher_label'}
+                    <label for="add-voucher--trigger"
+                           class="add-voucher--label">{s name="CheckoutFooterVoucherTrigger" namespace="frontend/checkout/cart_footer"}{/s}</label>
+                {/block}
+            {/if}
 
-			<div class="add-voucher--panel {if {config name=showVoucherModeForCheckout} == 1}is--hidden {/if}block-group">
-				{block name='frontend_checkout_cart_footer_add_voucher_field'}
-{s name="CheckoutFooterAddVoucherLabelInline" namespace="frontend/checkout/cart_footer" assign="snippetCheckoutFooterAddVoucherLabelInline"}{/s}
+            <div class="add-voucher--panel {if {config name=showVoucherModeForCheckout} == 1}is--hidden {/if}block-group">
+                {block name='frontend_checkout_cart_footer_add_voucher_field'}
+    {s name="CheckoutFooterAddVoucherLabelInline" namespace="frontend/checkout/cart_footer" assign="snippetCheckoutFooterAddVoucherLabelInline"}{/s}
 <input type="text" class="add-voucher--field is--medium block" name="sVoucher"
 placeholder="{$snippetCheckoutFooterAddVoucherLabelInline|escape}"/>
-				{/block}
+                {/block}
 
-				{block name='frontend_checkout_cart_footer_add_voucher_button'}
-					<button type="submit"
-							class="add-voucher--button is--medium btn is--primary is--center block">
-						<i class="icon--arrow-right"></i>
-					</button>
-				{/block}
-			</div>
-		</form>
-	{/if}
+                {block name='frontend_checkout_cart_footer_add_voucher_button'}
+                    <button type="submit"
+                            class="add-voucher--button is--medium btn is--primary is--center block">
+                        <i class="icon--arrow-right"></i>
+                    </button>
+                {/block}
+            </div>
+        </form>
+    {/if}
 {/block}

--- a/themes/Frontend/Responsive/frontend/_public/vendors/less/pocketgrid/pocketgrid.less
+++ b/themes/Frontend/Responsive/frontend/_public/vendors/less/pocketgrid/pocketgrid.less
@@ -16,22 +16,22 @@
     list-style-type: none;
     padding: 0;
     margin: 0;
-    
+
     &:before, &:after {
-		display: table;
-		content: "";
-		line-height: 0;
+        display: table;
+        content: "";
+        line-height: 0;
     }
-    
+
     &:after {
-	    clear: both;
+        clear: both;
     }
-    
+
     /** Nested grid */
     & > .block-group {
-		clear: none;
-		float: left;
-		margin: 0 !important;
+        clear: none;
+        float: left;
+        margin: 0 !important;
     }
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It is annoying to compare sources while shopware stats switching in cart_footer.tpl & confirm_footer.tpl to tabs as only files in project. Also removed last spaces in mixed non vendor files. jamine lib has also **one** single tab in complete file :rage:

### 2. What does this change do, exactly?
Stops insanity! Respect the .editorconfig!

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

PS: Please check commits for regex \t :)