### PR TITLE
Allow resize on emotion detail window

### DIFF
--- a/themes/Backend/ExtJs/backend/emotion/view/detail/window.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/detail/window.js
@@ -45,7 +45,7 @@ Ext.define('Shopware.apps.Emotion.view.detail.Window', {
     stateId: 'emotion-detail-window',
 
     border: false,
-    resizable: false,
+    resizable: true,
     collapsible: false,
     maximizable: true,
     minimizable: true,


### PR DESCRIPTION
### 1. Why is this change necessary?
You you open the Backend on a large screen and size is not changeable. Not via close ExtJS window and open it again. Also trick of resizing the OS window won't work.

**Now**
- You detach from your dock and use the 13/15" Notebook screen with lower resultion.
- Same for 720p beamer or 1080 if you use a QHD or 4k display to develop.
- Screen sharing (resenting a backend or discussion an issue). You adjust the window size to Resolution on screen or bandwidth limitation.
- You zoom into the browser window

**Result**
 No way to reach the save button.

### 2. What does this change do, exactly?
Allows resize of the ExtJs window

### 3. Describe each step to reproduce the issue or behaviour.
See 1.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.