### PR TITLE
Support https in SitePageMenuTest

### DIFF
--- a/tests/Functional/Components/SitePageMenuTest.php
+++ b/tests/Functional/Components/SitePageMenuTest.php
@@ -151,7 +151,8 @@ class SitePageMenuTest extends TestCase
             $router->getContext()->getHost(),
             $router->getContext()->getBaseUrl(),
         ]);
+        $protocol = $router->getContext()->isSecure() ? 'https' : 'http';
 
-        return rtrim('http://' . $path, '/');
+        return rtrim($protocol . '://' . $path, '/');
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Say you want to run the `SitePageMenuTest` and you have configured your shop url with https. Now said test will always fail, because the protocol `http` is hardcoded in the test itself.

### 2. What does this change do, exactly?
Choose the protocol to be http or https according to `$router->getContext()->isSecure()`.

### 3. Describe each step to reproduce the issue or behaviour.
1. Let shop url begin with `https`.
2. Run `SitePageMenuTest`.
3. ???
4. PROFIT

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.