### PR TITLE
[AJAX-Search] prevent session blocking in slower requests

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.search.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.search.js
@@ -360,6 +360,11 @@
         onSubmit: function (event) {
             var me = this;
 
+            //we need to abort previous request
+            if (me.lastSearchAjax) {
+                me.lastSearchAjax.abort();
+            }
+
             if (me._isSubmitting) {
                 event.preventDefault();
                 return;
@@ -386,6 +391,11 @@
 
             if (me.lastSearchAjax) {
                 me.lastSearchAjax.abort();
+            }
+
+            //we don't need this, cause submitting is in process
+            if (me._isSubmitting) {
+                return;
             }
 
             me.lastSearchAjax = $.ajax({


### PR DESCRIPTION
### 1. Why is this change necessary?
In special environments and specified search-terms the search is slow. The input will fire the ajax search, but submit won't abort the ajax-search.
![before](https://user-images.githubusercontent.com/135993/62107303-9f18dc80-b2a7-11e9-8856-e01511a11286.JPG)


### 2. What does this change do, exactly?
- will abort ajax-search on submit
- won't fire ajax search while submit is in progress.
![image](https://user-images.githubusercontent.com/135993/62107682-6fb69f80-b2a8-11e9-9598-5ffdd15e65dd.png)


### 3. Describe each step to reproduce the issue or behaviour.
see 1

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.