### PR TITLE
Add separate option "stock" to "Apply Standard Data"

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -2252,7 +2252,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
         if ($mapping['settings']) {
             $mainData['supplierNumber'] = $mainDetail->getSupplierNumber();
             $mainData['weight'] = $mainDetail->getWeight();
-            $mainData['inStock'] = $mainDetail->getInStock();
             $mainData['stockMin'] = $mainDetail->getStockMin();
             $mainData['ean'] = $mainDetail->getEan();
             $mainData['minPurchase'] = $mainDetail->getMinPurchase();
@@ -2264,6 +2263,9 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
             $mainData['width'] = $mainDetail->getWidth();
             $mainData['height'] = $mainDetail->getHeight();
             $mainData['len'] = $mainDetail->getLen();
+        }
+        if ($mapping['stock']) {
+            $mainData['inStock'] = $mainDetail->getInStock();
         }
         if ($mapping['attributes']) {
             $builder = Shopware()->Models()->createQueryBuilder();

--- a/themes/Backend/ExtJs/backend/article/model/mapping.js
+++ b/themes/Backend/ExtJs/backend/article/model/mapping.js
@@ -45,6 +45,7 @@ Ext.define('Shopware.apps.Article.model.Mapping', {
         { name: 'id', type: 'int' },
         { name: 'articleId', type: 'int' },
         { name: 'settings', type: 'boolean', defaultValue: true },
+        { name: 'stock', type: 'boolean', defaultValue: false },
         { name: 'prices', type: 'boolean', defaultValue: true },
         { name: 'basePrice', type: 'boolean', defaultValue: true },
         { name: 'purchasePrice', type: 'boolean', defaultValue: true },

--- a/themes/Backend/ExtJs/backend/article/view/variant/configurator/mapping.js
+++ b/themes/Backend/ExtJs/backend/article/view/variant/configurator/mapping.js
@@ -98,6 +98,7 @@ Ext.define('Shopware.apps.Article.view.variant.configurator.Mapping', {
         basePrice: '{s name=variant/configurator/mapping/basePrice}Apply base price configuration{/s}',
         purchasePrice: '{s name=variant/configurator/mapping/purchasePrice}Apply pruchase price configuration{/s}',
         settings: '{s name=variant/configurator/mapping/settings}Apply settings configuration{/s}',
+        stock: '{s name=variant/configurator/mapping/settings}Apply stock{/s}',
         translations: '{s name=variant/configurator/mapping/translations}Apply translations{/s}',
         save: '{s name=variant/configurator/mapping/save}Save{/s}',
         cancel: '{s name=variant/configurator/mapping/cancel}Cancel{/s}'
@@ -180,6 +181,9 @@ Ext.define('Shopware.apps.Article.view.variant.configurator.Mapping', {
         } , {
             name: 'settings',
             fieldLabel: me.snippets.settings
+        } , {
+            name: 'stock',
+            fieldLabel: me.snippets.stock
         } , {
             name: 'attributes',
             fieldLabel: me.snippets.attribute


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When using "Apply Standard Data" the stock value of all variants gets overwritten. I can't think of a case where this is intended.

### 2. What does this change do, exactly?
add another option to sync stock to all variants if someone needs it
exclude stock syncing when syncing the "settings" section

### 3. Describe each step to reproduce the issue or behaviour.
open article with multiple variants. each variant has a different stock (reflecting the current situation in the warehouse)
change setting (for example enable "last stock")
use the "Apply Standard Data" feature
stock for all variants is now the same

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-24189
https://issues.shopware.com/issues/SW-21371

### 5. Which documentation changes (if any) need to be made because of this PR?
explain the additional option in the "Apply Standard Data" dialog

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.