### PR TITLE
Fix PT-9148

### DIFF
--- a/themes/Backend/ExtJs/backend/partner/controller/statistic.js
+++ b/themes/Backend/ExtJs/backend/partner/controller/statistic.js
@@ -138,7 +138,7 @@ Ext.define('Shopware.apps.Partner.controller.Statistic', {
      * @param date
      */
     convertDate:function(date){
-        var day = (date.getDate() +1 < 10) ? "0" + date.getDate() : date.getDate() +1;
+        var day = (date.getDate() < 10) ? "0" + date.getDate() : date.getDate();
         var month = (date.getMonth() +1 < 10) ? "0" + (date.getMonth() +1) : date.getMonth() +1;
         var year = date.getFullYear();
 


### PR DESCRIPTION
Don't know why there is a +1 - deleting it solves the exception when selection the 31th of a month.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Sovles exception

### 2. What does this change do, exactly?
Does not add +1

### 3. Describe each step to reproduce the issue or behaviour.
Go to affilate marketing, select a range of 01.03.2018 to 31.07.2018, and clock on Download - you will get an expcetion with an invalid date (2018-08-32)

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/PT-9148

### 5. Which documentation changes (if any) need to be made because of this PR?
No.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.