### PR TITLE
Article detail page - ajax variants - use replaceState instead of pushState for better UX

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -158,7 +158,7 @@
                 location += '&c=' + stateObj.params.c;
             }
 
-            window.history.pushState(stateObj.state, stateObj.title, location);
+            window.history.replaceState(stateObj.state, stateObj.title, location);
         },
 
         /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently selecting variants on the article detail page produces browser history entries that no user will want because they expect to be taken back to the listing page when they use the corresponding browser functionality

### 2. What does this change do, exactly?
Just replace the history.pushState() method by history.replaceState() so the URL still changes for bookmarks but the browser history stays clean.


### 3. Describe each step to reproduce the issue or behaviour.
Open an article with variants and play around with the configurator options. Then try to go back to the listing. You will notice that you have to step through each single selection you have tried.


### 4. Please link to the relevant issues (if any).



### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.