### PR TITLE
Allow Customer & Address API to use country ISO 3166 code instead of ID

### DIFF
--- a/engine/Shopware/Bundle/AccountBundle/DependencyInjection/services.xml
+++ b/engine/Shopware/Bundle/AccountBundle/DependencyInjection/services.xml
@@ -115,6 +115,10 @@
             <argument type="service" id="front"/>
         </service>
 
+        <service id="shopware_account.country_service" class="Shopware\Bundle\AccountBundle\Service\CountryService" >
+            <argument type="service" id="models" />
+        </service>
+
         <service id="shopware_account.store_front_greeting_service" class="Shopware\Bundle\AccountBundle\Service\StoreFrontCustomerGreetingService" >
             <argument id="session" type="service"/>
             <argument id="dbal_connection" type="service"/>

--- a/engine/Shopware/Bundle/AccountBundle/Service/CountryService.php
+++ b/engine/Shopware/Bundle/AccountBundle/Service/CountryService.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\AccountBundle\Service;
+
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\QueryBuilder;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Models\Country\Country;
+use Shopware\Models\Country\State;
+
+class CountryService implements CountryServiceInterface
+{
+    /**
+     * @var ModelManager
+     */
+    private $em;
+
+    public function __construct(ModelManager $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchCountryData(array $data): array
+    {
+        $country = null;
+        $state = null;
+
+        if (isset($data['country']) && is_numeric($data['country'])) {
+            $country = $this->getCountry($data['country']);
+        }
+
+        if (!$country && isset($data['countryIso']) && ctype_print($data['countryIso'])) {
+            $country = $this->getCountryByIso($data['countryIso']);
+        }
+
+        if (isset($data['state']) && is_numeric($data['state'])) {
+            $state = $this->getState($data['state'], $country ? $country->getId() : null);
+        }
+
+        if ($state && !$country) {
+            $country = $state->getCountry();
+        } elseif (!$state && $country && isset($data['stateIso']) && ctype_print($data['stateIso'])) {
+            $state = $this->getStateByIso($data['stateIso'], $country->getId());
+        }
+        $data['country'] = $country;
+        $data['state'] = $state;
+
+        return $data;
+    }
+
+    private function getCountry(int $countryId): ?Country
+    {
+        /** @var Country|null $country */
+        $country = $this->em->getRepository(Country::class)->find($countryId);
+
+        return $country;
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     */
+    private function getCountryByIso(string $countryIso): ?Country
+    {
+        $builder = $this->em->createQueryBuilder();
+        $builder
+            ->select('country')
+            ->from(Country::class, 'country')
+            ->where('country.iso = :iso OR country.iso3 = :iso')
+            ->setParameter('iso', $countryIso)
+            ->setMaxResults(1);
+
+        return $builder->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     */
+    private function getState(int $stateId, ?int $countryId = null): ?State
+    {
+        $builder = $this->getStateQueryBuilder($countryId);
+        $builder
+            ->andWhere('s.id = :stateId')
+            ->setParameter('stateId', $stateId);
+
+        return $builder->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     */
+    private function getStateByIso(string $stateIso, int $countryId): ?State
+    {
+        $builder = $this->getStateQueryBuilder($countryId);
+        $builder
+            ->andWhere('s.shortCode = :stateIso')
+            ->setParameter('stateIso', $stateIso);
+
+        return $builder->getQuery()->getOneOrNullResult();
+    }
+
+    private function getStateQueryBuilder(?int $countryId = null): QueryBuilder
+    {
+        $builder = $this->em->createQueryBuilder();
+        $builder
+            ->select('s, c')
+            ->from(State::class, 's')
+            ->join('s.country', 'c')
+            ->setMaxResults(1);
+
+        if (is_int($countryId)) {
+            $builder
+                ->andWhere('c.id = :countryId')
+                ->setParameter('countryId', $countryId);
+        }
+
+        return $builder;
+    }
+}

--- a/engine/Shopware/Bundle/AccountBundle/Service/CountryServiceInterface.php
+++ b/engine/Shopware/Bundle/AccountBundle/Service/CountryServiceInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\AccountBundle\Service;
+
+interface CountryServiceInterface
+{
+    public function fetchCountryData(array $data): array;
+}

--- a/engine/Shopware/Components/Api/Resource/Address.php
+++ b/engine/Shopware/Components/Api/Resource/Address.php
@@ -26,8 +26,6 @@ namespace Shopware\Components\Api\Resource;
 
 use Shopware\Bundle\AccountBundle\Service\AddressServiceInterface;
 use Shopware\Components\Api\Exception as ApiException;
-use Shopware\Models\Country\Country;
-use Shopware\Models\Country\State;
 use Shopware\Models\Customer\Customer as CustomerModel;
 use Shopware\Models\Shop\Repository;
 use Shopware\Models\Shop\Shop as ShopModel;
@@ -271,44 +269,8 @@ class Address extends Resource
             unset($data['customer']);
         }
 
-        // fetch country via ID or ISO 3166
-        $em = $this->getContainer()->get('models');
-        if (is_numeric($data['country'])) {
-            $data['country'] = $em->find(Country::class, (int) $data['country']);
-        } elseif (ctype_print($data['country'])) {
-            $builder = $em->createQueryBuilder();
-            $builder
-                ->select('country')
-                ->from(Country::class, 'country')
-                ->where('country.iso3 = :iso or country.iso = :iso')
-                ->setParameter('iso', $data['country']);
-
-            $data['country'] = $builder->getQuery()->getSingleResult();
-        } else {
-            $data['country'] = null;
-        }
-
-        // try fetching state via ID or ISO 3166-2 extension
-        if (is_numeric($data['state'])) {
-            $data['state'] = $em->find(State::class, (int) $data['state']);
-            // use state to set country if no country is set
-            if ($data['state'] && is_null($data['country'])) {
-                $data['country'] = $data['state']->getCountry()->getId();
-            }
-        } elseif ($data['country'] && ctype_print($data['state'])) {
-            $builder = $em->createQueryBuilder();
-            $builder
-                ->select('state')
-                ->from(State::class, 'state')
-                ->join('state.country', 'country')
-                ->where('state.shortCode = :code')
-                ->andWhere('country.id = :countryId')
-                ->setParameter('code', $data['state'])
-                ->setParameter('countryId', $data['country']->getId());
-            $data['state'] = $builder->getQuery()->getSingleResult();
-        } else {
-            $data['state'] = null;
-        }
+        $countryService = $this->getContainer()->get('shopware_account.country_service');
+        $data = $countryService->fetchCountryData($data);
 
         return $filter ? array_filter($data) : $data;
     }

--- a/tests/Api/CustomerTest.php
+++ b/tests/Api/CustomerTest.php
@@ -48,6 +48,8 @@ use Shopware\Models\Customer\Customer;
  */
 class Shopware_Tests_Api_CustomerTest extends PHPUnit\Framework\TestCase
 {
+    use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
+
     public $apiBaseUrl = '';
 
     /**
@@ -164,7 +166,7 @@ class Shopware_Tests_Api_CustomerTest extends PHPUnit\Framework\TestCase
                 'firstName' => 'Max',
                 'lastName' => 'Mustermann',
                 'country' => 2,
-                'street' => 'Fakesreet 123',
+                'street' => 'Fakestreet 123',
                 'city' => 'City',
                 'zipcode' => 55555,
             ],
@@ -175,7 +177,7 @@ class Shopware_Tests_Api_CustomerTest extends PHPUnit\Framework\TestCase
                 'firstName' => 'Max',
                 'lastName' => 'Mustermann',
                 'country' => 2,
-                'street' => 'Fakesreet 123',
+                'street' => 'Fakestreet 123',
                 'city' => 'City',
                 'zipcode' => 55555,
             ],
@@ -245,7 +247,7 @@ class Shopware_Tests_Api_CustomerTest extends PHPUnit\Framework\TestCase
                 'firstName' => 'Max',
                 'lastName' => 'Mustermann',
                 'country' => 2,
-                'street' => 'Fakesreet 123',
+                'street' => 'Fakestreet 123',
                 'city' => 'City',
                 'zipcode' => 55555,
             ],
@@ -256,7 +258,7 @@ class Shopware_Tests_Api_CustomerTest extends PHPUnit\Framework\TestCase
                 'firstName' => 'Max',
                 'lastName' => 'Mustermann',
                 'country' => 2,
-                'street' => 'Fakesreet 123',
+                'street' => 'Fakestreet 123',
                 'city' => 'City',
                 'zipcode' => 55555,
             ],
@@ -335,7 +337,7 @@ class Shopware_Tests_Api_CustomerTest extends PHPUnit\Framework\TestCase
                 'firstName' => 'Max',
                 'lastName' => 'Mustermann',
                 'country' => 2,
-                'street' => 'Fakesreet 123',
+                'street' => 'Fakestreet 123',
                 'city' => 'City',
                 'zipcode' => 55555,
             ],
@@ -346,7 +348,7 @@ class Shopware_Tests_Api_CustomerTest extends PHPUnit\Framework\TestCase
                 'firstName' => 'Max',
                 'lastName' => 'Mustermann',
                 'country' => 2,
-                'street' => 'Fakesreet 123',
+                'street' => 'Fakestreet 123',
                 'city' => 'City',
                 'zipcode' => 55555,
             ],
@@ -631,5 +633,99 @@ class Shopware_Tests_Api_CustomerTest extends PHPUnit\Framework\TestCase
 
         $data = $result['data'];
         static::assertInternalType('array', $data);
+    }
+
+    public function testPostCustomerWithCountryIso()
+    {
+        $client = $this->getHttpClient()->setUri($this->apiBaseUrl . '/customers/');
+
+        $requestData = [
+            'password' => 'fooobar',
+            'active' => true,
+            'email' => uniqid('', true) . 'test@foobar.com',
+
+            'salutation' => 'mr',
+            'firstname' => 'Max',
+            'lastname' => 'Mustermann',
+
+            'billing' => [
+                'salutation' => 'Mr',
+                'firstName' => 'Max',
+                'lastName' => 'Mustermann',
+                'country' => 'DE',
+                'street' => 'Fakestreet 123',
+                'city' => 'City',
+                'zipcode' => 55555,
+            ],
+        ];
+
+        $requestData = Zend_Json::encode($requestData);
+        $client->setRawData($requestData, 'application/json; charset=UTF-8');
+
+        $response = $client->request('POST');
+
+        static::assertEquals('application/json', $response->getHeader('Content-Type'));
+        static::assertEquals(201, $response->getStatus());
+        static::assertArrayHasKey('Location', $response->getHeaders());
+
+        $result = $response->getBody();
+        $result = Zend_Json::decode($result);
+
+        static::assertArrayHasKey('success', $result);
+        static::assertTrue($result['success']);
+
+        $location = $response->getHeader('Location');
+        $identifier = (int) array_pop(explode('/', $location));
+
+        static::assertGreaterThan(0, $identifier);
+
+        return $identifier;
+    }
+
+    public function testPostCustomerWithoutCountryButState()
+    {
+        $client = $this->getHttpClient()->setUri($this->apiBaseUrl . '/customers/');
+
+        $requestData = [
+            'password' => 'fooobar',
+            'active' => true,
+            'email' => uniqid('', true) . 'test@foobar.com',
+
+            'salutation' => 'mr',
+            'firstname' => 'Max',
+            'lastname' => 'Mustermann',
+
+            'billing' => [
+                'salutation' => 'Mr',
+                'firstName' => 'Max',
+                'lastName' => 'Mustermann',
+                'state' => 10,
+                'street' => 'Fakestreet 123',
+                'city' => 'City',
+                'zipcode' => 55555,
+            ],
+        ];
+
+        $requestData = Zend_Json::encode($requestData);
+        $client->setRawData($requestData, 'application/json; charset=UTF-8');
+
+        $response = $client->request('POST');
+
+        static::assertEquals('application/json', $response->getHeader('Content-Type'));
+        static::assertEquals(201, $response->getStatus());
+        static::assertArrayHasKey('Location', $response->getHeaders());
+
+        $result = $response->getBody();
+        $result = Zend_Json::decode($result);
+
+        static::assertArrayHasKey('success', $result);
+        static::assertTrue($result['success']);
+
+        $location = $response->getHeader('Location');
+        $identifier = (int) array_pop(explode('/', $location));
+
+        static::assertGreaterThan(0, $identifier);
+
+        return $identifier;
     }
 }

--- a/tests/Api/CustomerTest.php
+++ b/tests/Api/CustomerTest.php
@@ -652,7 +652,7 @@ class Shopware_Tests_Api_CustomerTest extends PHPUnit\Framework\TestCase
                 'salutation' => 'Mr',
                 'firstName' => 'Max',
                 'lastName' => 'Mustermann',
-                'country' => 'DE',
+                'countryIso' => 'DE',
                 'street' => 'Fakestreet 123',
                 'city' => 'City',
                 'zipcode' => 55555,


### PR DESCRIPTION
### 1. Why is this change necessary?
Interoperability & flexibility. ISO codes are a standard that nearly every system "speaks".

### 2. What does this change do, exactly?
Check if the parameter _country_ is potential an iso string and use it for lookup.
If we have a valid country we can also use the state ISO 3166-2 code instead of an ID.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
Mention the possibility to use a `string` instead of `int` for field `country` in those APIs. 

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.