### PR TITLE
Use fallback for widget label translation

### DIFF
--- a/engine/Shopware/Controllers/Backend/Widgets.php
+++ b/engine/Shopware/Controllers/Backend/Widgets.php
@@ -59,14 +59,16 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
 
         $data = $builder->getQuery()->getArrayResult();
 
+        $snippets = $this->get('snippets')->getNamespace('backend/widget/labels');
         $widgets = [];
+
         foreach ($data as &$widgetData) {
             if (!$this->_isAllowed($widgetData['name'], 'widgets')) {
                 continue;
             }
 
-            $widgetData['label'] = Shopware()->Container()->get('snippets')->getNamespace('backend/widget/labels')
-                ->get($widgetData['name'], $widgetData['label']);
+            // fallback: translation -> name
+            $widgetData['label'] = $snippets->get($widgetData['name'], $widgetData['name']);
 
             $widgets[] = $widgetData;
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
Not having a translation for a given language results in _NULL_ for the label making it hard to identify the widget.

### 2. What does this change do, exactly?
Adds a fallback chain to resolve to the internal widget name instead returning _NULL_ if no translation exists.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a plugin which adds an widget:
```
$plugin = $context->getPlugin();
$widget = new Widget();
$widget->setName('my-widget');
$widget->setPlugin($plugin);
$plugin->getWidgets()->add($widget);
```
As you already see the label prop is phased out and replaced by the better fitting snippet management.

2. Now install the new plugin, reload your backend and try to add the widget. Instead of a name _null_ will be provided. 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.