### PR TITLE
only show shipping countries

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/shipping_costs.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/shipping_costs.tpl
@@ -11,9 +11,11 @@
                 <div class="select-field">
                     <select id="basket_country_list" name="sCountry" data-auto-submit="true">
                         {foreach $sCountryList as $country}
-                            <option value="{$country.id}"{if $country.id eq $sCountry.id} selected="selected"{/if}>
-                                {$country.countryname}
-                            </option>
+                            {if $country.allow_shipping}
+                                <option value="{$country.id}"{if $country.id eq $sCountry.id} selected="selected"{/if}>
+                                    {$country.countryname}
+                                </option>
+                            {/if}
                         {/foreach}
                     </select>
                 </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
When calculating the shipping costs in cart, only those countries should be displayed which are also marked as shipping country

### 2. What does this change do, exactly?
Check if allow_shipping is marked

### 3. Describe each step to reproduce the issue or behaviour.
In cart open shipping costs calculation and open country drop down. All active countries will be displayed.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.