### PR TITLE
fix 404 when loading category of another subshop

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -579,7 +579,7 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
      */
     private function loadCategoryContent($requestCategoryId)
     {
-        if (empty($requestCategoryId) && !$this->isValidCategoryPath($requestCategoryId)) {
+        if (empty($requestCategoryId) || !$this->isValidCategoryPath($requestCategoryId)) {
             throw new Enlight_Controller_Exception(
                 'Listing category missing, non-existent or invalid for the current shop',
                 404


### PR DESCRIPTION
### 1. Why is this change necessary?
Because it is possible to reach categories from other subshops, which leads to confusion for customers and maybe duplicate content.

### 2. What does this change do, exactly?
It fixes an if condition to check if a requested category is empty or is in another subshop. Before the conditions where linked with AND but it should be OR to match both cases.

### 3. Describe each step to reproduce the issue or behaviour.
You need two subshops with different category trees: mainshop.de, subshop.de
Let's say category 123 is the main category of subshop.de
https://mainshop.de/cat/index/sCategory/123 will open the main category of subshop and load the emotions but within mainshop template.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.