### PR TITLE
Move greedy array_merge out of loops

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Repository/Reader/CategoryReader.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Repository/Reader/CategoryReader.php
@@ -71,8 +71,9 @@ class CategoryReader extends GenericReader
     {
         $parents = [];
         foreach ($data as $id => $row) {
-            $parents = array_merge($parents, explode('|', $row['path']));
+            $parents[] = explode('|', $row['path']);
         }
+        $parents = array_merge([], ...$parents);
         $parents = array_values(array_unique(array_filter($parents)));
 
         $query = $this->entityManager->getConnection()->createQueryBuilder();

--- a/engine/Shopware/Bundle/ContentTypeBundle/DependencyInjection/TypeReader.php
+++ b/engine/Shopware/Bundle/ContentTypeBundle/DependencyInjection/TypeReader.php
@@ -32,14 +32,15 @@ class TypeReader
 {
     public function getTypes(array $activePlugins, array $pluginDirectories, array $fieldAlias): array
     {
-        $result = [];
         $configs = $this->getConfigPaths($activePlugins, $pluginDirectories);
 
         $reader = new ContentTypesReader();
 
+        $result = [];
         foreach ($configs as $config) {
-            $result = array_merge($result, $reader->readType($config));
+            $result[] = $reader->readType($config);
         }
+        $result = array_merge([], ...$result);
 
         $result = self::resolveAlias($result, $fieldAlias);
 

--- a/engine/Shopware/Bundle/ContentTypeBundle/Services/Repository.php
+++ b/engine/Shopware/Bundle/ContentTypeBundle/Services/Repository.php
@@ -249,9 +249,11 @@ class Repository implements RepositoryInterface
 
         foreach ($items as &$item) {
             foreach ($translations as $translation) {
+                $data = [$item];
                 if ($translation['objectkey'] === $item['id']) {
-                    $item = array_merge($item, $translation['objectdata']);
+                    $data[] = $translation['objectdata'];
                 }
+                $item = array_merge(...$data);
             }
         }
 

--- a/engine/Shopware/Bundle/ContentTypeBundle/Services/TypeBuilder.php
+++ b/engine/Shopware/Bundle/ContentTypeBundle/Services/TypeBuilder.php
@@ -111,8 +111,9 @@ class TypeBuilder
         foreach ($type['fieldSets'] as $fieldSet) {
             $fieldSet = $this->createFieldset($fieldSet);
             $fieldSets[] = $fieldSet;
-            $fields = array_merge($fields, $fieldSet->getFields());
+            $fields[] = $fieldSet->getFields();
         }
+        $fields = array_merge([], ...$fields);
 
         $class->setFields($fields);
         $class->setFieldSets($fieldSets);

--- a/engine/Shopware/Bundle/ESIndexingBundle/ShopIndexer.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/ShopIndexer.php
@@ -158,9 +158,9 @@ class ShopIndexer implements ShopIndexerInterface
             throw new \RuntimeException(sprintf('ElasticSearch index %s already exist.', $configuration->getName()));
         }
 
-        $mergedSettings = [
+        $mergedSettings = [[
             'settings' => $configuration->toArray(),
-        ];
+        ]];
 
         // Merge default settings with those set by plugins
         foreach ($this->settings as $setting) {
@@ -169,8 +169,9 @@ class ShopIndexer implements ShopIndexerInterface
                 continue;
             }
 
-            $mergedSettings = array_replace_recursive($mergedSettings, $settings);
+            $mergedSettings[] = $settings;
         }
+        $mergedSettings = array_replace_recursive(...$mergedSettings);
 
         $this->client->indices()->create([
             'index' => $configuration->getName(),

--- a/engine/Shopware/Bundle/EmotionBundle/Service/StoreFrontEmotionDeviceConfiguration.php
+++ b/engine/Shopware/Bundle/EmotionBundle/Service/StoreFrontEmotionDeviceConfiguration.php
@@ -93,9 +93,9 @@ class StoreFrontEmotionDeviceConfiguration implements StoreFrontEmotionDeviceCon
     {
         $replacements = [];
         foreach ($configurations as $config) {
-            $replacements = array_merge($replacements, explode('|', $config['replacement']));
+            $replacements[] = explode('|', $config['replacement']);
         }
 
-        return array_filter($replacements);
+        return array_filter(array_merge([], ...$replacements));
     }
 }

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/CategoryFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/CategoryFacetHandler.php
@@ -158,10 +158,10 @@ class CategoryFacetHandler implements PartialFacetHandlerInterface
         $active = [];
         foreach ($criteria->getUserConditions() as $condition) {
             if ($condition instanceof CategoryCondition) {
-                $active = array_merge($active, $condition->getCategoryIds());
+                $active[] = $condition->getCategoryIds();
             }
         }
 
-        return $active;
+        return array_merge([], ...$active);
     }
 }

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/PropertyFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandler/PropertyFacetHandler.php
@@ -151,11 +151,11 @@ class PropertyFacetHandler implements PartialFacetHandlerInterface
         $values = [];
         foreach ($criteria->getConditions() as $condition) {
             if ($condition instanceof PropertyCondition) {
-                $values = array_merge($values, $condition->getValueIds());
+                $values[] = $condition->getValueIds();
             }
         }
 
-        return $values;
+        return array_merge([], ...$values);
     }
 
     /**

--- a/engine/Shopware/Bundle/SearchBundleDBAL/ProductNumberSearch.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/ProductNumberSearch.php
@@ -137,8 +137,6 @@ class ProductNumberSearch implements SearchBundle\ProductNumberSearchInterface
             return [];
         }
 
-        $facets = [];
-
         $clone = clone $criteria;
 
         if (!$criteria->generatePartialFacets()) {
@@ -146,6 +144,7 @@ class ProductNumberSearch implements SearchBundle\ProductNumberSearchInterface
             $clone->resetSorting();
         }
 
+        $facets = [];
         foreach ($criteria->getFacets() as $facet) {
             $handler = $this->getFacetHandler($facet);
 
@@ -168,8 +167,9 @@ class ProductNumberSearch implements SearchBundle\ProductNumberSearchInterface
                 $result = [$result];
             }
 
-            $facets = array_merge($facets, $result);
+            $facets[] = $result;
         }
+        $facets = array_merge([], ...$facets);
 
         return $facets;
     }

--- a/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/KeywordFinder.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/KeywordFinder.php
@@ -75,10 +75,10 @@ class KeywordFinder implements KeywordFinderInterface
 
         $matches = [];
         foreach ($keywords as $searchTerm) {
-            $matches = array_merge($matches, $this->searchMatchingKeywords($searchTerm));
+            $matches[] = $this->searchMatchingKeywords($searchTerm);
         }
 
-        return $matches;
+        return array_merge([], ...$matches);
     }
 
     /**

--- a/engine/Shopware/Bundle/SearchBundleES/FacetHandler/CategoryFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/FacetHandler/CategoryFacetHandler.php
@@ -159,10 +159,10 @@ class CategoryFacetHandler implements HandlerInterface, ResultHydratorInterface
         $active = [];
         foreach ($criteria->getUserConditions() as $condition) {
             if ($condition instanceof CategoryCondition) {
-                $active = array_merge($active, $condition->getCategoryIds());
+                $active[] = $condition->getCategoryIds();
             }
         }
 
-        return $active;
+        return array_merge([], ...$active);
     }
 }

--- a/engine/Shopware/Bundle/SearchBundleES/FacetHandler/PropertyFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/FacetHandler/PropertyFacetHandler.php
@@ -299,10 +299,10 @@ class PropertyFacetHandler implements HandlerInterface, ResultHydratorInterface
         $values = [];
         foreach ($criteria->getConditions() as $condition) {
             if ($condition instanceof PropertyCondition) {
-                $values = array_merge($values, $condition->getValueIds());
+                $values[] = $condition->getValueIds();
             }
         }
 
-        return $values;
+        return array_merge([], ...$values);
     }
 }

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
@@ -169,10 +169,10 @@ class CategoryGateway implements Gateway\CategoryGatewayInterface
     {
         $ids = [];
         foreach ($mapping as $row) {
-            $ids = array_merge($ids, explode(',', $row));
+            $ids[] = explode(',', $row);
         }
         /** @var array<int> $ids */
-        $ids = array_unique($ids);
+        $ids = array_unique(array_merge([], ...$ids));
 
         return $ids;
     }

--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/RelatedProductsService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/RelatedProductsService.php
@@ -124,11 +124,11 @@ class RelatedProductsService implements Service\RelatedProductsServiceInterface
         // Collect all numbers to send a single list product request.
         $related = [];
         foreach ($numbers as $value) {
-            $related = array_merge($related, $value);
+            $related[] = $value;
         }
 
         // Filter duplicate numbers to prevent duplicate data requests and iterations.
-        $unique = array_unique($related);
+        $unique = array_unique(array_merge([], ...$related));
 
         return array_values($unique);
     }

--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/SimilarProductsService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/SimilarProductsService.php
@@ -180,11 +180,11 @@ class SimilarProductsService implements SimilarProductsServiceInterface
         // Collect all numbers to send a single list product request.
         $related = [];
         foreach ($numbers as $value) {
-            $related = array_merge($related, $value);
+            $related[] = $value;
         }
 
         // Filter duplicate numbers to prevent duplicate data requests and iterations.
-        $unique = array_unique($related);
+        $unique = array_unique(array_merge([], ...$related));
 
         return array_values($unique);
     }

--- a/engine/Shopware/Commands/PluginCommand.php
+++ b/engine/Shopware/Commands/PluginCommand.php
@@ -89,9 +89,9 @@ abstract class PluginCommand extends ShopwareCommand
                 continue;
             }
 
-            $tags = array_merge($tags, $context->getScheduled()['cache']);
+            $tags[] = $context->getScheduled()['cache'];
         }
 
-        return array_unique($tags);
+        return array_unique(array_merge([], ...$tags));
     }
 }

--- a/engine/Shopware/Commands/SnippetsValidateCommand.php
+++ b/engine/Shopware/Commands/SnippetsValidateCommand.php
@@ -111,15 +111,15 @@ class SnippetsValidateCommand extends ShopwareCommand implements CompletionAware
         $pluginDirectories = $this->container->getParameter('shopware.plugin_directories');
         foreach ($pluginDirectories as $key => $pluginBasePath) {
             if ($key === 'ShopwarePlugins') {
-                $invalidPaths = array_merge($invalidPaths, $this->getInvalidPaths($validator, $pluginBasePath));
+                $invalidPaths[] = $this->getInvalidPaths($validator, $pluginBasePath);
             } else {
                 foreach (['Backend', 'Core', 'Frontend'] as $namespace) {
-                    $invalidPaths = array_merge($invalidPaths, $this->getInvalidPaths($validator, $pluginBasePath . $namespace));
+                    $invalidPaths[] = $this->getInvalidPaths($validator, $pluginBasePath . $namespace);
                 }
             }
         }
 
-        return $invalidPaths;
+        return array_merge([], ...$invalidPaths);
     }
 
     /**
@@ -129,16 +129,16 @@ class SnippetsValidateCommand extends ShopwareCommand implements CompletionAware
      */
     protected function getInvalidPaths(SnippetValidator $validator, $pluginBasePath)
     {
-        $invalidPaths = [];
+        $invalidPaths = [[]];
 
         foreach (new \DirectoryIterator($pluginBasePath) as $pluginDir) {
             if ($pluginDir->isDot() || !$pluginDir->isDir()) {
                 continue;
             }
 
-            $invalidPaths = array_merge($invalidPaths, $validator->validate($pluginDir->getPathname()));
+            $invalidPaths[] = $validator->validate($pluginDir->getPathname());
         }
 
-        return $invalidPaths;
+        return array_merge(...$invalidPaths);
     }
 }

--- a/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
+++ b/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
@@ -177,10 +177,11 @@ class WarmUpHttpCacheCommand extends ShopwareCommand implements CompletionAwareI
             foreach ($options as $resource => $active) {
                 if ($active) {
                     $provider = $urlProviderFactory->getProvider($resource);
-                    $urls = array_merge($urls, $provider->getUrls($context));
+                    $urls[] = $provider->getUrls($context);
                     $totalResultCount += $provider->getCount($context);
                 }
             }
+            $urls = array_merge([], ...$urls);
 
             // Progressbar
             $progressBar = $io->createProgressBar($totalResultCount);

--- a/engine/Shopware/Components/Api/Resource/EmotionPreset.php
+++ b/engine/Shopware/Components/Api/Resource/EmotionPreset.php
@@ -241,10 +241,10 @@ class EmotionPreset extends Resource
         foreach ($presets as $id => $preset) {
             $plugins = json_decode($preset['requiredPlugins'], true);
             $preset['requiredPlugins'] = array_combine(array_column($plugins, 'name'), $plugins);
-            $pluginNames = array_merge($pluginNames, array_keys($preset['requiredPlugins']));
+            $pluginNames[] = array_keys($preset['requiredPlugins']);
             $presets[$id] = $preset;
         }
-        $localPlugins = $this->getPlugins($pluginNames);
+        $localPlugins = $this->getPlugins(array_merge([], ...$pluginNames));
 
         $result = [];
         foreach ($presets as $preset) {

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Grammar.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Grammar.php
@@ -88,8 +88,9 @@ class Grammar
             foreach ($mappings as $key => $value) {
                 $newMapping[strtoupper($prefix . '.' . $key)] = $value;
             }
-            $columnInfo = array_merge($columnInfo, $newMapping);
+            $columnInfo[] = $newMapping;
         }
+        $columnInfo = array_merge([], ...$columnInfo);
 
         $attributes = [];
 

--- a/engine/Shopware/Components/Plugin/MenuSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/MenuSynchronizer.php
@@ -54,14 +54,14 @@ class MenuSynchronizer
      */
     public function synchronize(Plugin $plugin, array $menu)
     {
-        $menuNames = array_column($menu, 'name');
+        $menuNames = [array_column($menu, 'name')];
 
         $items = [];
         foreach ($menu as $menuItem) {
             if (isset($menuItem['children'])) {
                 $childMenuNames = array_column($menuItem['children'], 'name');
                 if ($childMenuNames) {
-                    $menuNames = array_merge($menuNames, $childMenuNames);
+                    $menuNames[] = $childMenuNames;
                 }
             }
 
@@ -82,7 +82,7 @@ class MenuSynchronizer
         }
 
         $this->em->flush($items);
-        $this->removeNotExistingEntries($plugin->getId(), $menuNames);
+        $this->removeNotExistingEntries($plugin->getId(), array_merge(...$menuNames));
     }
 
     /**

--- a/engine/Shopware/Components/SitemapXMLRepository.php
+++ b/engine/Shopware/Components/SitemapXMLRepository.php
@@ -269,13 +269,14 @@ class SitemapXMLRepository
     private function readStaticUrls()
     {
         $shopId = $this->contextService->getShopContext()->getShop()->getId();
-        $sites = $this->getSitesByShopId($shopId);
+        $sites = [$this->getSitesByShopId($shopId)];
 
         foreach ($sites as $site) {
             if (!empty($site['children'])) {
-                $sites = array_merge($sites, $site['children']);
+                $sites[] = $site['children'];
             }
         }
+        $sites = array_merge(...$sites);
 
         foreach ($sites as &$site) {
             $site['urlParams'] = [
@@ -285,6 +286,7 @@ class SitemapXMLRepository
 
             $site['show'] = $this->filterLink($site['link'], $site['urlParams']);
         }
+        unset($site);
 
         return $sites;
     }

--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -1199,10 +1199,11 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
             $value = [];
         }
 
+        $shopValues = [];
         foreach ($data['values'] as $shopValue) {
-            $value = array_merge($value, explode(',', $shopValue['value']));
+            $shopValues[] = explode(',', $shopValue['value']);
         }
-        $value = array_unique(array_filter($value));
+        $value = array_unique(array_filter(array_merge($value, ...$shopValues)));
 
         return $value;
     }

--- a/engine/Shopware/Controllers/Backend/Config.php
+++ b/engine/Shopware/Controllers/Backend/Config.php
@@ -1350,14 +1350,14 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
 
         $salutations = [];
         foreach ($elementData['values'] as $value) {
-            $salutations = array_merge($salutations, explode(',', $value['value']));
+            $salutations[] = explode(',', $value['value']);
         }
-        $salutations = array_unique($salutations);
+        $salutations = array_unique(array_merge([], ...$salutations));
 
         $date = new DateTime();
         foreach ($shops as $localeId => $shopId) {
             foreach ($salutations as $salutation) {
-                if (strlen(trim($salutation)) === 0) {
+                if (trim($salutation) === '') {
                     continue;
                 }
 

--- a/engine/Shopware/Controllers/Backend/EmotionPreset.php
+++ b/engine/Shopware/Controllers/Backend/EmotionPreset.php
@@ -276,8 +276,10 @@ class Shopware_Controllers_Backend_EmotionPreset extends Shopware_Controllers_Ba
 
         $names = [];
         foreach ($presets as $preset) {
-            $names = array_merge($names, array_column($preset['requiredPlugins'], 'name'));
+            $names[] = array_column($preset['requiredPlugins'], 'name');
         }
+        $names = array_merge([], ...$names);
+
         if (empty($names)) {
             return $presets;
         }

--- a/engine/Shopware/Controllers/Backend/MediaManager.php
+++ b/engine/Shopware/Controllers/Backend/MediaManager.php
@@ -790,16 +790,15 @@ class Shopware_Controllers_Backend_MediaManager extends Shopware_Controllers_Bac
 
         foreach ($albums as $album) {
             if (stripos($album['text'], $search) === 0) {
-                $found[] = $album;
+                $found[] = [$album];
             }
             $children = $album['data'];
             if (count($children) > 0) {
-                $foundChildren = $this->filterAlbums($children, $search);
-                $found = array_merge($found, $foundChildren);
+                $found[] = $this->filterAlbums($children, $search);
             }
         }
 
-        return $found;
+        return array_merge([], ...$found);
     }
 
     /**

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1398,12 +1398,12 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
 
         $numbers = [];
         foreach ($orders as $orderKey => $order) {
-            $temp = array_column($order['details'], 'articleNumber');
-            $numbers = array_merge($numbers, (array) $temp);
+            $numbers[] = (array) array_column($order['details'], 'articleNumber');
 
             $orders[$orderKey]['orderStatus'] = $stateTranslator->translateState(StateTranslatorService::STATE_ORDER, $order['orderStatus']);
             $orders[$orderKey]['paymentStatus'] = $stateTranslator->translateState(StateTranslatorService::STATE_PAYMENT, $order['paymentStatus']);
         }
+        $numbers = array_merge([], ...$numbers);
 
         $stocks = $this->getVariantsStock($numbers);
 

--- a/engine/Shopware/Controllers/Backend/Search.php
+++ b/engine/Shopware/Controllers/Backend/Search.php
@@ -389,10 +389,10 @@ class Shopware_Controllers_Backend_Search extends Shopware_Controllers_Backend_E
     {
         $ids = [];
         foreach ($data as $row) {
-            $ids = array_merge($ids, explode('|', $row['path']));
-            $ids[] = $row['id'];
+            $ids[] = explode('|', $row['path']);
+            $ids[] = [$row['id']];
         }
-        $ids = array_values(array_unique(array_filter($ids)));
+        $ids = array_values(array_unique(array_filter(array_merge([], ...$ids))));
         $categories = $this->getCategories($ids);
 
         foreach ($data as &$row) {

--- a/engine/Shopware/Controllers/Backend/Snippet.php
+++ b/engine/Shopware/Controllers/Backend/Snippet.php
@@ -783,12 +783,11 @@ class Shopware_Controllers_Backend_Snippet extends Shopware_Controllers_Backend_
         }
 
         $result = [];
-
         foreach ($nodes as $arr) {
-            $result = array_merge_recursive($result, $arr);
+            $result[] = $arr;
         }
 
-        return $this->normalize($result);
+        return $this->normalize(array_merge_recursive([], ...$result));
     }
 
     /**

--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -450,13 +450,13 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
         foreach ($emotions as $emotion) {
             // Always show the listing in the emotion viewports when the option "show listing" is active
             if ($emotion['showListing']) {
-                $permanentVisibleDevices = array_merge($permanentVisibleDevices, $emotion['devicesArray']);
+                $permanentVisibleDevices[] = $emotion['devicesArray'];
             }
 
             $visibleDevices = array_diff($visibleDevices, $emotion['devicesArray']);
         }
 
-        $visibleDevices = array_merge($permanentVisibleDevices, $visibleDevices);
+        $visibleDevices = array_merge(array_merge([], ...$permanentVisibleDevices), $visibleDevices);
 
         return array_values($visibleDevices);
     }

--- a/engine/Shopware/Models/Category/Repository.php
+++ b/engine/Shopware/Models/Category/Repository.php
@@ -435,15 +435,14 @@ class Repository extends ModelRepository
             $category['childrenCount'] = $child['childrenCount'];
             $category['articleCount'] = $child['articleCount'];
 
-            $categories[] = $category;
+            $categories[] = [$category];
             // Check if no depth passed or the current depth is lower than the passed depth
             if ($depth === null || $depth > 0) {
-                $subCategories = $this->getActiveChildrenList($child['category']['id'], $customerGroupId, $depth);
-                $categories = array_merge($categories, $subCategories);
+                $categories[] = $this->getActiveChildrenList($child['category']['id'], $customerGroupId, $depth);
             }
         }
 
-        return $categories;
+        return array_merge([], ...$categories);
     }
 
     /**

--- a/engine/Shopware/Models/CustomerStream/CustomerStreamRepository.php
+++ b/engine/Shopware/Models/CustomerStream/CustomerStreamRepository.php
@@ -299,9 +299,9 @@ class CustomerStreamRepository implements CustomerStreamRepositoryInterface
 
         $streamIds = [];
         foreach ($mapping as $row) {
-            $streamIds = array_merge($streamIds, $row);
+            $streamIds[] = $row;
         }
-        $streamIds = array_keys(array_flip($streamIds));
+        $streamIds = array_keys(array_flip(array_merge([], ...$streamIds)));
 
         $query = $this->connection->createQueryBuilder();
         $query->select(['streams.id as array_key', 'streams.id', 'streams.name']);

--- a/engine/Shopware/Models/Media/Media.php
+++ b/engine/Shopware/Models/Media/Media.php
@@ -1295,13 +1295,11 @@ class Media extends ModelEntity
         $sizes = [];
         foreach ($joinedSizes as $sizeItem) {
             $explodedSizes = explode(';', $sizeItem);
-            if (empty($explodedSizes)) {
-                continue;
+            if (!empty($explodedSizes)) {
+                $sizes[] = array_flip($explodedSizes);
             }
-
-            $sizes = array_merge($sizes, array_flip($explodedSizes));
         }
 
-        return array_keys($sizes);
+        return array_keys(array_merge([], ...$sizes));
     }
 }

--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Checks/RegexCheck.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Checks/RegexCheck.php
@@ -65,14 +65,13 @@ class RegexCheck implements CheckInterface
     {
         $results = [];
         foreach ($requirement['value']['directories'] as $dir) {
-            $result = $this->scanDirectoryForRegex(
+            $results[] = $this->scanDirectoryForRegex(
                 Shopware()->DocPath($dir),
                 $requirement['value']['expression'],
                 $requirement['value']['fileRegex']
             );
-
-            $results = array_merge($results, $result);
         }
+        $results = array_merge([], ...$results);
 
         $message = $this->extractLocalizedMessage($requirement['value']['message']);
 

--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Checks/WritableCheck.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Checks/WritableCheck.php
@@ -62,22 +62,19 @@ class WritableCheck implements CheckInterface
      */
     public function check($requirement)
     {
-        $directories = [];
-        $checkedDirectories = [];
-
         $successMessage = $this->namespace->get('controller/check_writable_success', 'The following directories are writeable <br/>%s');
         $failMessage = $this->namespace->get('controller/check_writable_failure', 'The following directories are not writable: <br> %s');
 
+        $directories = [];
+        $checkedDirectories = [];
         foreach ($requirement['value'] as $path) {
             $fullPath = rtrim(Shopware()->DocPath($path), '/');
             $checkedDirectories[] = $fullPath;
 
             $fixPermissions = true;
-            $directories = array_merge(
-                $directories,
-                $this->fileSystem->checkSingleDirectoryPermissions($fullPath, $fixPermissions)
-            );
+            $directories[] = $this->fileSystem->checkSingleDirectoryPermissions($fullPath, $fixPermissions);
         }
+        $directories = array_merge([], ...$directories);
 
         if (empty($directories)) {
             return [


### PR DESCRIPTION
### 1. Why is this change necessary?
Several array-operations are quite expensive and `array_merge` is no exception. Executing the same op over and over with the same input is therefore unnecessary.

### 2. What does this change do, exactly?
Improving code performance by moving `array_merge` batching within foreach-loops outside of the loop. This results in a slightly higher temporary memory consumptions but should be beneficial enough in most cases.

I haven't checked every file yet, skipping all those horrible sClasses completely ;)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
see https://github.com/kalessil/phpinspectionsea/blob/master/docs/performance.md#slow-array-function-used-in-loop and https://github.com/dseguy/clearPHP/blob/master/rules/no-array_merge-in-loop.md for more related array functions

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.