### PR TITLE
Fix RegExp expression issue in filters

### DIFF
--- a/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
@@ -683,7 +683,7 @@ class DqlHelper
                 $mode = $lastToken === '~' ? 1 : 0;
 
                 // Build the DQL Token - we've registered our own RegExp DoctrineExtension before
-                $newTokens[] = ' RegExp (?' . count($params) . ", {$attribute}) = {$mode}";
+                $newTokens[] = " RegExp ({$attribute}, ?" . count($params) . ") = {$mode}";
                 // Consume the next token as param and skip it in the next iteration
                 $params[] = substr($token['token'], 1, -1);
                 continue;


### PR DESCRIPTION
The order of the REGEXP parameters in beberlei/DoctrineExtensions is different.
https://github.com/beberlei/DoctrineExtensions/blob/a8747a2aef34f602c365cf2efd1abc94c5ae7e0a/src/Query/Mysql/Regexp.php#L18

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Solves the issue in RegExp expressions in filters

### 2. What does this change do, exactly?

Reorder parameters in RegExp to fix work with beberlei/DoctrineExtensions

### 3. Describe each step to reproduce the issue or behaviour.

Using any RegExp expression in filters produces the wrong result.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.