### PR TITLE
Trim voucher codes for less errors

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -677,7 +677,7 @@ SQL;
             return false;
         }
 
-        $voucherCode = strtolower(stripslashes($voucherCode));
+        $voucherCode = trim(strtolower(stripslashes($voucherCode)));
 
         // Load the voucher details
         $voucherDetails = $this->db->fetchRow(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
We get a lot of customers who are copying vouchers from mails, websites etc. with a leading space, which will result in an error that the voucher is no longer valid or not available.

### 2. What does this change do, exactly?
It simple trims the voucher before sending the query to the DB.

### 3. Describe each step to reproduce the issue or behaviour.
Create a voucher named "Test02" and try to use it in the checkout form with " Test02".

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.