### PR TITLE
Add sorting for backend order filter entities dispatch, payment and shop

### DIFF
--- a/engine/Shopware/Models/Shop/Repository.php
+++ b/engine/Shopware/Models/Shop/Repository.php
@@ -160,7 +160,7 @@ class Repository extends ModelRepository
                 ->leftJoin('shop.category', 'category')
                 ->leftJoin('shop.currency', 'currency')
                 ->orderBy('default', 'DESC')
-                ->addOrderBy('name');
+                ->addOrderBy('shop.position');
 
         if ($filter !== null) {
             $builder->addFilter($filter);
@@ -230,7 +230,7 @@ class Repository extends ModelRepository
         return $this->createQueryBuilder('s')
             ->where('s.mainId IS NULL')
             ->orderBy('s.default', 'DESC')
-            ->addOrderBy('s.name');
+            ->addOrderBy('s.position');
     }
 
     /**

--- a/themes/Backend/ExtJs/backend/base/store/dispatch.js
+++ b/themes/Backend/ExtJs/backend/base/store/dispatch.js
@@ -40,6 +40,10 @@ Ext.define('Shopware.apps.Base.store.Dispatch', {
     model : 'Shopware.apps.Base.model.Dispatch',
     pageSize: 1000,
     remoteFilter: true,
+    sorters: [{
+        property: 'position',
+        direction: 'ASC'
+    }],
     filters: [{
         property: 'active',
         value: true

--- a/themes/Backend/ExtJs/backend/base/store/payment.js
+++ b/themes/Backend/ExtJs/backend/base/store/payment.js
@@ -40,6 +40,10 @@ Ext.define('Shopware.apps.Base.store.Payment', {
     model : 'Shopware.apps.Base.model.Payment',
     pageSize: 1000,
     remoteFilter: true,
+    sorters: [{
+        property: 'position',
+        direction: 'ASC'
+    }],
 
     proxy:{
         type:'ajax',


### PR DESCRIPTION
### 1. Why is this change necessary?
At the moment the filter values for dispatches and payments are sorted by id which produces random acting orders. The shops are at least sorted by their name but it makes more sence to use the `position` column here as well as in many other places.

### 2. What does this change do, exactly?
Change the sorting of the backend order filter dropdown entries for the entities `dispatch`, `payment` and `shop`.

### 3. Describe each step to reproduce the issue or behaviour.
Click on of the mentioned filters and be like
![WTF](https://user-images.githubusercontent.com/754074/63682286-dbccea80-c7f7-11e9-9ec2-2608b0e8ad4d.jpg)

### 4. Please link to the relevant issues (if any).
nope

### 5. Which documentation changes (if any) need to be made because of this PR?
nope

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.