### PR TITLE
Only apply refreshOrderedVariant() for basket items that are products

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -762,7 +762,7 @@ class sOrder implements \Enlight_Hook
             $this->sBasketData['content'][$key]['attributes'] = $detailAttributes;
 
             // Update sales and stock
-            if ($basketRow['priceNumeric'] >= 0) {
+            if ($basketRow['priceNumeric'] >= 0 && $basketRow['modus'] == '0') {
                 $this->refreshOrderedVariant(
                     $basketRow['ordernumber'],
                     $basketRow['quantity']


### PR DESCRIPTION
### 1. Why is this change necessary?

Let the situation be as follows: Your shop has enabled proportional tax calculation. You have a voucher that is restricted to a set of products. A customer has a cart with two products and said voucher. One of the products matches the voucher restriction and the other product does not. The products have different tax rates.

The voucher now is split into two different vouchers; one for each tax rate. The voucher with the tax rate of the matching product has a value below zero. The voucher with a tax rate of the non-matching product has a value of exactly zero, as it does not reduce the value of any line items in the cart.

Shopware would normally not notify the event `product_stock_was_changed` for line items that have a value below zero. So since vouchers typically have a value below zero, this event is not normally notified for vouchers. But in this specific case, we have a voucher in the cart that has a value of exactly zero, so this event does get notified.

Trying to change `sales` and `instock` of a voucher does not break anything, but it is wrong. The actual problematic part is the event notification for `product_stock_was_changed`. Third party plugin developers rely on this event to only be notified when an actual product stock was changed. If no data is found by the provided identifier, this could result in unexpected errors, since the scenario pictured above is kind of an edge case.

### 2. What does this change do, exactly?

Only execute the method `refreshOrderedVariant` when the basket item in question is actually a product. (`modus = 0`)

### 3. Describe each step to reproduce the issue or behaviour.

See 1.

### 4. Please link to the relevant issues (if any).

None.

### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.