### PR TITLE
dump beberlei/assert from 2.9.2 to 2.9.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "doctrine/dbal": "2.6.3",
         "doctrine/orm": "2.6.3",
         "doctrine/cache": "1.8.0",
-        "beberlei/assert": "2.9.9",
+        "beberlei/assert": "2.9.6",
         "zendframework/zend-escaper": "2.5.2",
         "oyejorge/less.php": "1.7.0.14",
         "guzzlehttp/guzzle": "5.3.3",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "doctrine/dbal": "2.6.3",
         "doctrine/orm": "2.6.3",
         "doctrine/cache": "1.8.0",
-        "beberlei/assert": "2.9.6",
+        "beberlei/assert": "2.9.9",
         "zendframework/zend-escaper": "2.5.2",
         "oyejorge/less.php": "1.7.0.14",
         "guzzlehttp/guzzle": "5.3.3",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "doctrine/dbal": "2.6.3",
         "doctrine/orm": "2.6.3",
         "doctrine/cache": "1.8.0",
-        "beberlei/assert": "2.9.2",
+        "beberlei/assert": "2.9.6",
         "zendframework/zend-escaper": "2.5.2",
         "oyejorge/less.php": "1.7.0.14",
         "guzzlehttp/guzzle": "5.3.3",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Assertion::url has errors with PHP 7.3. This issue was fixed with the latest version.

### 2. What does this change do, exactly?
This change dump the version of beberlei/assert from 2.9.2 to 2.9.9.

### 3. Describe each step to reproduce the issue or behaviour.
Test a url with https on Assertion::url

### 4. Please link to the relevant issues (if any).
https://github.com/beberlei/assert/commits/v2

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.