### PR TITLE
Improve service instantiation & use Doctrine DBAL instead of Zend DB in CacheManager

### DIFF
--- a/engine/Shopware/Bootstrap.php
+++ b/engine/Shopware/Bootstrap.php
@@ -22,7 +22,7 @@
  * our trademarks remain entirely with us.
  */
 
-use Shopware\Components\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @deprecated since 5.2 will be removed in 6.0
@@ -30,11 +30,11 @@ use Shopware\Components\DependencyInjection\Container;
 class Shopware_Bootstrap
 {
     /**
-     * @var Container
+     * @var ContainerInterface
      */
     protected $container;
 
-    public function __construct(Container $container)
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }
@@ -49,7 +49,7 @@ class Shopware_Bootstrap
      *
      * @deprecated 4.2
      *
-     * @return Enlight_Class Resource
+     * @return mixed Resource
      */
     public function __call($name, $arguments = null)
     {
@@ -69,7 +69,10 @@ class Shopware_Bootstrap
     {
         trigger_error('Shopware()->Bootstrap()->Application() is deprecated since version 5.2 and will be removed in 6.0. Use Shopware()->Container() instead', E_USER_DEPRECATED);
 
-        return $this->container->get('application');
+        /** @var Shopware $shopware */
+        $shopware = $this->container->get('application');
+
+        return $shopware;
     }
 
     /**

--- a/engine/Shopware/Components/Api/Resource/Cache.php
+++ b/engine/Shopware/Components/Api/Resource/Cache.php
@@ -24,10 +24,16 @@
 
 namespace Shopware\Components\Api\Resource;
 
+use Enlight_Controller_Request_Request;
+use Exception;
 use Shopware\Components\Api\BatchInterface;
-use Shopware\Components\Api\Exception as ApiException;
+use Shopware\Components\Api\Exception\NotFoundException;
+use Shopware\Components\Api\Exception\ParameterMissingException;
 use Shopware\Components\CacheManager;
 use Shopware\Components\DependencyInjection\Container;
+use Zend_Cache;
+use Zend_Cache_Core;
+use Zend_Cache_Exception;
 
 /**
  * Cache API Resource
@@ -38,7 +44,7 @@ use Shopware\Components\DependencyInjection\Container;
 class Cache extends Resource implements BatchInterface
 {
     /**
-     * @var \Enlight_Controller_Request_Request
+     * @var Enlight_Controller_Request_Request
      */
     private $request;
 
@@ -70,8 +76,7 @@ class Cache extends Resource implements BatchInterface
     /**
      * @param string $id
      *
-     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
-     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     * @throws ParameterMissingException
      *
      * @return array
      */
@@ -80,7 +85,7 @@ class Cache extends Resource implements BatchInterface
         $this->checkPrivilege('read');
 
         if (empty($id)) {
-            throw new ApiException\ParameterMissingException('id');
+            throw new ParameterMissingException('id');
         }
 
         return $this->getCacheInfo($id);
@@ -108,8 +113,7 @@ class Cache extends Resource implements BatchInterface
     /**
      * @param string $id
      *
-     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
-     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     * @throws ParameterMissingException
      *
      * @return true
      */
@@ -118,7 +122,7 @@ class Cache extends Resource implements BatchInterface
         $this->checkPrivilege('delete');
 
         if (empty($id)) {
-            throw new ApiException\ParameterMissingException('id');
+            throw new ParameterMissingException('id');
         }
 
         $this->clearCache($id);
@@ -131,11 +135,7 @@ class Cache extends Resource implements BatchInterface
      */
     public function getIdByData($data)
     {
-        if (isset($data['id'])) {
-            return $data['id'];
-        }
-
-        return false;
+        return $data['id'] ?? false;
     }
 
     /**
@@ -168,7 +168,7 @@ class Cache extends Resource implements BatchInterface
                     'operation' => 'delete',
                     'data' => $this->delete((string) $id),
                 ];
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $message = $e->getMessage();
 
                 $results[$key] = [
@@ -185,7 +185,7 @@ class Cache extends Resource implements BatchInterface
     /**
      * @deprecated in 5.6, will be removed without a replacement
      *
-     * @return \Enlight_Controller_Request_Request
+     * @return Enlight_Controller_Request_Request
      */
     protected function getRequest()
     {
@@ -199,7 +199,8 @@ class Cache extends Resource implements BatchInterface
      *
      * @param string $cache
      *
-     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     * @throws NotFoundException
+     * @throws Zend_Cache_Exception
      */
     protected function clearCache($cache)
     {
@@ -253,7 +254,7 @@ class Cache extends Resource implements BatchInterface
                 $this->cacheManager->clearOpCache();
                 break;
             default:
-                throw new ApiException\NotFoundException(sprintf('Cache "%s" is not a valid cache id.', $cache));
+                throw new NotFoundException(sprintf('Cache "%s" is not a valid cache id.', $cache));
         }
 
         if (!empty($capabilities['tags'])) {
@@ -270,11 +271,9 @@ class Cache extends Resource implements BatchInterface
      *
      * @param string $cache
      *
-     * @throws \Shopware\Components\Api\Exception\NotFoundException
-     *
-     * @return array
+     * @throws NotFoundException
      */
-    private function getCacheInfo($cache)
+    private function getCacheInfo($cache): array
     {
         switch ($cache) {
             case 'http':
@@ -296,7 +295,7 @@ class Cache extends Resource implements BatchInterface
                 $cacheInfo = $this->cacheManager->getOpCacheCacheInfo();
                 break;
             default:
-                throw new ApiException\NotFoundException(sprintf('Cache "%s" is not a valid cache id.', $cache));
+                throw new NotFoundException(sprintf('Cache "%s" is not a valid cache id.', $cache));
         }
 
         $cacheInfo['id'] = $cache;

--- a/engine/Shopware/Components/Api/Resource/Cache.php
+++ b/engine/Shopware/Components/Api/Resource/Cache.php
@@ -48,6 +48,11 @@ class Cache extends Resource implements BatchInterface
     private $cacheManager;
 
     /**
+     * @var Zend_Cache_Core
+     */
+    private $cache;
+
+    /**
      * Sets the Container.
      *
      * @param Container $container
@@ -57,6 +62,7 @@ class Cache extends Resource implements BatchInterface
         if ($container) {
             $this->request = $container->get('front')->Request();
             $this->cacheManager = $container->get('shopware.cache_manager');
+            $this->cache = $container->get('cache');
         }
         parent::setContainer($container);
     }
@@ -197,10 +203,10 @@ class Cache extends Resource implements BatchInterface
      */
     protected function clearCache($cache)
     {
-        $capabilities = $this->cacheManager->getCoreCache()->getBackend()->getCapabilities();
+        $capabilities = $this->cache->getBackend()->getCapabilities();
 
         if ($cache === 'all') {
-            $this->cacheManager->getCoreCache()->clean();
+            $this->cache->clean();
 
             $this->cacheManager->clearHttpCache();
             $this->cacheManager->clearConfigCache();
@@ -252,9 +258,9 @@ class Cache extends Resource implements BatchInterface
 
         if (!empty($capabilities['tags'])) {
             if (!empty($tags)) {
-                $this->cacheManager->getCoreCache()->clean(\Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG, $tags);
+                $this->cache->clean(Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG, $tags);
             } else {
-                $this->cacheManager->getCoreCache()->clean();
+                $this->cache->clean();
             }
         }
     }

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -147,7 +147,9 @@ class CacheManager
     }
 
     /**
-     * @return \Zend_Cache_Core
+     * @deprecated in 5.7, will be removed in 5.8. Use `cache` service directly via DI
+     *
+     * @return Zend_Cache_Core
      */
     public function getCoreCache()
     {

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -24,8 +24,21 @@
 
 namespace Shopware\Components;
 
-use Shopware\Components\DependencyInjection\Container;
+use Doctrine\DBAL\Connection;
+use Enlight_Controller_Request_Request;
+use Enlight_Event_EventManager;
+use PDO;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Redis;
+use Shopware\Components\Model\Configuration;
 use Shopware\Components\Theme\PathResolver;
+use Shopware_Components_Config;
+use SplFileInfo;
+use Zend_Cache;
+use Zend_Cache_Backend_Apcu;
+use Zend_Cache_Backend_Redis;
+use Zend_Cache_Core;
 
 class CacheManager
 {
@@ -44,32 +57,27 @@ class CacheManager
     public const ITEM_TAG_PLUGIN_CONFIG = 'Shopware_Plugin_Config_';
 
     /**
-     * @var Container
-     */
-    private $container;
-
-    /**
-     * @var \Shopware\Components\Model\Configuration
+     * @var Configuration
      */
     private $emConfig;
 
     /**
-     * @var \Zend_Cache_Core
+     * @var Zend_Cache_Core
      */
     private $cache;
 
     /**
-     * @var \Enlight_Components_Db_Adapter_Pdo_Mysql
+     * @var Connection
      */
     private $db;
 
     /**
-     * @var \Shopware_Components_Config
+     * @var Shopware_Components_Config
      */
     private $config;
 
     /**
-     * @var \Enlight_Event_EventManager
+     * @var Enlight_Event_EventManager
      */
     private $events;
 
@@ -78,16 +86,64 @@ class CacheManager
      */
     private $themePathResolver;
 
-    public function __construct(Container $container)
-    {
-        $this->container = $container;
+    /**
+     * @var array
+     */
+    private $httpCache;
 
-        $this->cache = $container->get('cache');
-        $this->emConfig = $container->get('shopware.model_config');
-        $this->db = $container->get('db');
-        $this->config = $container->get('config');
-        $this->events = $container->get('events');
-        $this->themePathResolver = $container->get('theme_path_resolver');
+    /**
+     * @var array
+     */
+    private $cacheConfig;
+
+    /**
+     * @var array
+     */
+    private $templateConfig;
+
+    /**
+     * @var string
+     */
+    private $docRoot;
+
+    /**
+     * @var string
+     */
+    private $hookProxyDir;
+
+    /**
+     * @var string
+     */
+    private $modelProxyDir;
+
+    public function __construct(
+        Zend_Cache_Core $cache,
+        Configuration $emConfig,
+        Connection $db,
+        Shopware_Components_Config $config,
+        ContainerAwareEventManager $events,
+        PathResolver $themePathResolver,
+
+        array $httpCache,
+        array $cacheConfig,
+        array $templateConfig,
+        string $docRoot,
+        string $hookProxyDir,
+        string $modelProxyDir
+    ) {
+        $this->cache = $cache;
+        $this->emConfig = $emConfig;
+        $this->db = $db;
+        $this->config = $config;
+        $this->events = $events;
+        $this->themePathResolver = $themePathResolver;
+
+        $this->httpCache = $httpCache;
+        $this->cacheConfig = $cacheConfig;
+        $this->templateConfig = $templateConfig;
+        $this->docRoot = $docRoot;
+        $this->hookProxyDir = $hookProxyDir;
+        $this->modelProxyDir = $modelProxyDir;
     }
 
     /**
@@ -103,10 +159,8 @@ class CacheManager
      */
     public function clearHttpCache()
     {
-        if ($this->container->getParameter('shopware.httpCache.enabled')) {
-            $this->clearDirectory(
-                $this->container->getParameter('shopware.httpCache.cache_dir')
-            );
+        if ($this->httpCache['enabled']) {
+            $this->clearDirectory($this->httpCache['cache_dir']);
         }
 
         // Fire event to let Plugin-Implementation clear cache
@@ -118,12 +172,12 @@ class CacheManager
      */
     public function clearTemplateCache()
     {
-        $cacheDir = $this->container->getParameter('shopware.template.cacheDir');
-        $compileDir = $this->container->getParameter('shopware.template.compileDir');
+        $cacheDir = $this->templateConfig['cacheDir'];
+        $compileDir = $this->templateConfig['compileDir'];
 
         $this->clearDirectory($compileDir);
 
-        if ($cacheDir != $compileDir) {
+        if ($cacheDir !== $compileDir) {
             $this->clearDirectory($cacheDir);
         }
     }
@@ -141,29 +195,25 @@ class CacheManager
      */
     public function clearRewriteCache()
     {
-        $cache = (int) $this->config->routerCache;
+        $cache = (int) $this->config->offsetGet('routerCache');
         $cache = $cache < 360 ? 86400 : $cache;
 
-        $sql = "SELECT `id` FROM `s_core_config_elements` WHERE `name` LIKE 'routerlastupdate'";
-        $elementId = $this->db->fetchOne($sql);
+        $builder = $this->db->createQueryBuilder();
+        $builder
+            ->from('s_core_config_values', 'v')
+            ->join('v', 's_core_config_elements', 'e', 'v.element_id = e.id')
+            ->select(['v.shop_id', 'v.value', 'e.id as element_id'])
+            ->where($builder->expr()->like('e.name', 'routerlastupdate'));
 
-        $sql = '
-            SELECT v.shop_id, v.value
-            FROM s_core_config_values v
-            WHERE v.element_id=?
-        ';
-        $values = $this->db->fetchPairs($sql, [$elementId]);
+        $values = $builder->execute()->fetchAll(PDO::FETCH_ASSOC);
+        $stmt = $this->db->prepare('UPDATE s_core_config_values SET value=? WHERE shop_id=? AND element_id=?');
 
-        foreach ($values as $shopId => $value) {
-            $value = unserialize($value, ['allowed_classes' => false]);
+        foreach ($values as $_value) {
+            $value = unserialize($_value['value'], ['allowed_classes' => false]);
             $value = min(strtotime($value), time() - $cache);
             $value = date('Y-m-d H:i:s', $value);
             $value = serialize($value);
-            $sql = '
-                UPDATE s_core_config_values SET value=?
-                WHERE shop_id=? AND element_id=?
-            ';
-            $this->db->query($sql, [$value, $shopId, $elementId]);
+            $stmt->execute([$value, $_value['shop_id'], $_value['element_id']]);
         }
     }
 
@@ -172,11 +222,10 @@ class CacheManager
      */
     public function clearSearchCache()
     {
-        $sql = "SELECT `id` FROM `s_core_config_elements` WHERE `name` LIKE 'fuzzysearchlastupdate'";
-        $elementId = $this->db->fetchOne($sql);
-
-        $sql = 'DELETE FROM s_core_config_values WHERE element_id=?';
-        $this->db->query($sql, [$elementId]);
+        $sql = 'DELETE v FROM s_core_config_values v
+                JOIN s_core_config_elements e ON e.id = v.element_id
+                WHERE `name` LIKE "fuzzysearchlastupdate"';
+        $this->db->executeQuery($sql);
     }
 
     /**
@@ -187,7 +236,7 @@ class CacheManager
         $capabilities = $this->cache->getBackend()->getCapabilities();
         if (!empty($capabilities['tags'])) {
             $this->cache->clean(
-                \Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG,
+                Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG,
                 [
                     self::ITEM_TAG_CONFIG,
                     self::ITEM_TAG_PLUGIN,
@@ -223,10 +272,10 @@ class CacheManager
         }
 
         // Clear Shopware Proxies / Classmaps / Container
-        $this->clearDirectory($this->container->getParameter('shopware.hook.proxyDir'));
+        $this->clearDirectory($this->hookProxyDir);
 
         // Clear Annotation file cache
-        $this->clearDirectory($this->container->getParameter('shopware.model.proxyDir'));
+        $this->clearDirectory($this->modelProxyDir);
     }
 
     public function clearOpCache()
@@ -239,26 +288,19 @@ class CacheManager
     /**
      * Returns cache information
      *
-     * @param \Enlight_Controller_Request_Request|null $request
+     * @param Enlight_Controller_Request_Request|null $request
      *
      * @return array
      */
     public function getHttpCacheInfo($request = null)
     {
-        if ($this->container->getParameter('shopware.httpCache.enabled')) {
-            $info = $this->getDirectoryInfo(
-                $this->container->getParameter('shopware.httpCache.cache_dir')
-            );
-        } else {
-            $info = [];
-        }
+        $info = $this->httpCache['enabled'] ? $this->getDirectoryInfo($this->httpCache['cache_dir']) : [];
 
         $info['name'] = 'Http-Reverse-Proxy';
+        $info['backend'] = 'Unknown';
 
         if ($request && $request->getHeader('Surrogate-Capability')) {
             $info['backend'] = $request->getHeader('Surrogate-Capability');
-        } else {
-            $info['backend'] = 'Unknown';
         }
 
         return $info;
@@ -273,28 +315,27 @@ class CacheManager
     {
         $backendCache = $this->cache->getBackend();
 
-        if ($backendCache instanceof \Zend_Cache_Backend_Apcu) {
+        if ($backendCache instanceof Zend_Cache_Backend_Apcu) {
             $info = [];
             $apcInfo = apcu_cache_info('user');
             $info['files'] = $apcInfo['num_entries'];
             $info['size'] = $this->encodeSize($apcInfo['mem_size']);
             $apcInfo = apcu_sma_info();
             $info['freeSpace'] = $this->encodeSize($apcInfo['avail_mem']);
-        } elseif ($backendCache instanceof \Zend_Cache_Backend_Redis) {
+        } elseif ($backendCache instanceof Zend_Cache_Backend_Redis) {
             $info = [];
 
-            /** @var \Redis $redis */
+            /** @var Redis $redis */
             $redis = $backendCache->getRedis();
             $info['files'] = $redis->dbSize();
             $info['size'] = $this->encodeSize($redis->info()['used_memory']);
         } else {
-            $cacheConfig = $this->container->getParameter('shopware.cache');
             $dir = null;
 
-            if (!empty($cacheConfig['backendOptions']['cache_dir'])) {
-                $dir = $cacheConfig['backendOptions']['cache_dir'];
-            } elseif (!empty($cacheConfig['backendOptions']['slow_backend_options']['cache_dir'])) {
-                $dir = $cacheConfig['backendOptions']['slow_backend_options']['cache_dir'];
+            if (!empty($this->cacheConfig['backendOptions']['cache_dir'])) {
+                $dir = $this->cacheConfig['backendOptions']['cache_dir'];
+            } elseif (!empty($this->cacheConfig['backendOptions']['slow_backend_options']['cache_dir'])) {
+                $dir = $this->cacheConfig['backendOptions']['slow_backend_options']['cache_dir'];
             }
             $info = $this->getDirectoryInfo($dir);
         }
@@ -316,8 +357,7 @@ class CacheManager
      */
     public function getTemplateCacheInfo()
     {
-        $dir = $this->container->getParameter('shopware.template.compileDir');
-        $info = $this->getDirectoryInfo($dir);
+        $info = $this->getDirectoryInfo($this->templateConfig['compileDir']);
         $info['name'] = 'Shopware templates';
 
         return $info;
@@ -330,7 +370,7 @@ class CacheManager
      */
     public function getThemeCacheInfo()
     {
-        $dir = $this->container->get('theme_path_resolver')->getCacheDirectory();
+        $dir = $this->themePathResolver->getCacheDirectory();
         $info = $this->getDirectoryInfo($dir);
         $info['name'] = 'Shopware theme';
 
@@ -344,8 +384,7 @@ class CacheManager
      */
     public function getDoctrineProxyCacheInfo()
     {
-        $dir = $this->container->getParameter('shopware.model.proxydir');
-        $info = $this->getDirectoryInfo($dir);
+        $info = $this->getDirectoryInfo($this->modelProxyDir);
         $info['name'] = 'Doctrine Proxies';
 
         return $info;
@@ -358,9 +397,7 @@ class CacheManager
      */
     public function getShopwareProxyCacheInfo()
     {
-        $dir = $this->container->getParameter('shopware.hook.proxyDir');
-
-        $info = $this->getDirectoryInfo($dir);
+        $info = $this->getDirectoryInfo($this->hookProxyDir);
         $info['name'] = 'Shopware Proxies';
 
         return $info;
@@ -396,10 +433,8 @@ class CacheManager
      */
     public function getDirectoryInfo($dir)
     {
-        $docRoot = $this->container->getParameter('shopware.app.rootdir') . '/';
-
         $info = [];
-        $info['dir'] = str_replace($docRoot, '', $dir);
+        $info['dir'] = str_replace($this->docRoot . '/', '', $dir);
         $info['dir'] = str_replace(DIRECTORY_SEPARATOR, '/', $info['dir']);
         $info['dir'] = rtrim($info['dir'], '/') . '/';
 
@@ -422,13 +457,13 @@ class CacheManager
         $info['size'] = (float) 0;
         $info['files'] = 0;
 
-        $dirIterator = new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS);
-        $iterator = new \RecursiveIteratorIterator(
+        $dirIterator = new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS);
+        $iterator = new RecursiveIteratorIterator(
             $dirIterator,
-            \RecursiveIteratorIterator::LEAVES_ONLY
+            RecursiveIteratorIterator::LEAVES_ONLY
         );
 
-        /** @var \SplFileInfo $entry */
+        /** @var SplFileInfo $entry */
         foreach ($iterator as $entry) {
             if ($entry->getFilename() === '.gitkeep') {
                 continue;

--- a/engine/Shopware/Components/DependencyInjection/Bridge/Plugins.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Plugins.php
@@ -24,20 +24,29 @@
 
 namespace Shopware\Components\DependencyInjection\Bridge;
 
+use Enlight_Event_EventManager;
+use Enlight_Loader;
+use Enlight_Plugin_PluginManager;
+use Shopware;
 use Shopware\Components\Plugin\ConfigReader;
+use Shopware_Components_Plugin_Namespace;
 
 class Plugins
 {
     /**
-     * @return \Enlight_Plugin_PluginManager
+     * @return Enlight_Plugin_PluginManager
      */
     public function factory(
-        \Enlight_Loader $loader, \Enlight_Event_EventManager $eventManager, \Shopware $application, array $pluginDirectories, ConfigReader $configReader
+        Enlight_Loader $loader,
+        Enlight_Event_EventManager $eventManager,
+        Shopware $application,
+        array $pluginDirectories,
+        ConfigReader $configReader
     ) {
-        $pluginManager = new \Enlight_Plugin_PluginManager($application);
+        $pluginManager = new Enlight_Plugin_PluginManager($application);
 
         foreach (['Core', 'Frontend', 'Backend'] as $namespace) {
-            $namespace = new \Shopware_Components_Plugin_Namespace(
+            $namespace = new Shopware_Components_Plugin_Namespace(
                 $namespace,
                 null,
                 $pluginDirectories,

--- a/engine/Shopware/Components/DependencyInjection/Bridge/Plugins.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Plugins.php
@@ -24,7 +24,7 @@
 
 namespace Shopware\Components\DependencyInjection\Bridge;
 
-use Shopware\Components\DependencyInjection\Container;
+use Shopware\Components\Plugin\ConfigReader;
 
 class Plugins
 {
@@ -32,15 +32,9 @@ class Plugins
      * @return \Enlight_Plugin_PluginManager
      */
     public function factory(
-        Container $container,
-        \Enlight_Loader $loader,
-        \Enlight_Event_EventManager $eventManager,
-        \Shopware $application,
-        array $pluginDirectories
+        \Enlight_Loader $loader, \Enlight_Event_EventManager $eventManager, \Shopware $application, array $pluginDirectories, ConfigReader $configReader
     ) {
         $pluginManager = new \Enlight_Plugin_PluginManager($application);
-
-        $configReader = $container->get('shopware.plugin.cached_config_reader');
 
         foreach (['Core', 'Frontend', 'Backend'] as $namespace) {
             $namespace = new \Shopware_Components_Plugin_Namespace(

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -113,11 +113,11 @@
         <service id="plugin_manager" alias="plugins" />
         <service id="plugins" class="Enlight_Plugin_PluginManager">
             <factory service="plugins_factory" method="factory" />
-            <argument type="service" id="service_container"/>
             <argument type="service" id="loader"/>
             <argument type="service" id="events"/>
             <argument type="service" id="application"/>
             <argument>%shopware.plugin_directories%</argument>
+            <argument type="service" id="shopware.plugin.cached_config_reader" />
         </service>
 
         <service id="router_factory" class="Shopware\Components\DependencyInjection\Bridge\Router" />
@@ -326,7 +326,19 @@
             <argument>%kernel.root_dir%/snippets/</argument>
         </service>
         <service id="shopware.cache_manager" class="Shopware\Components\CacheManager">
-            <argument type="service" id="service_container" />
+            <argument type="service" id="cache" />
+            <argument type="service" id="modelconfig" />
+            <argument type="service" id="dbal_connection" />
+            <argument type="service" id="config" />
+            <argument type="service" id="events"/>
+            <argument type="service" id="theme_path_resolver" />
+
+            <argument>%shopware.httpCache%</argument>
+            <argument>%shopware.cache%</argument>
+            <argument>%shopware.template%</argument>
+            <argument>%shopware.app.rootdir%</argument>
+            <argument>%shopware.hook.proxyDir%</argument>
+            <argument>%shopware.model.proxyDir%</argument>
         </service>
 
         <service id="mediasubscriber" class="Shopware\Models\Media\MediaSubscriber">

--- a/engine/Shopware/Components/Model/CategorySubscriber.php
+++ b/engine/Shopware/Components/Model/CategorySubscriber.php
@@ -30,7 +30,7 @@ use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Events;
 use Shopware\Models\Article\Article;
 use Shopware\Models\Category\Category;
-use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * CategorySubscriber
@@ -68,11 +68,11 @@ class CategorySubscriber implements BaseEventSubscriber
     protected $disabledForNextFlush = false;
 
     /**
-     * @var Container
+     * @var ContainerInterface
      */
     private $container;
 
-    public function __construct(Container $container)
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }

--- a/engine/Shopware/Components/ShopRegistrationService.php
+++ b/engine/Shopware/Components/ShopRegistrationService.php
@@ -24,11 +24,10 @@
 
 namespace Shopware\Components;
 
-use Psr\Container\ContainerInterface;
-use Shopware\Components\DependencyInjection\Container;
 use Shopware\Components\Theme\Inheritance;
 use Shopware\Models\Shop\Shop;
 use Shopware\Models\Shop\Template;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ShopRegistrationService implements ShopRegistrationServiceInterface
 {
@@ -37,7 +36,7 @@ class ShopRegistrationService implements ShopRegistrationServiceInterface
      */
     private $container;
 
-    public function __construct(Container $container)
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }

--- a/engine/Shopware/Components/Translation.php
+++ b/engine/Shopware/Components/Translation.php
@@ -24,8 +24,8 @@
 
 use Doctrine\DBAL\Connection;
 use Shopware\Bundle\AttributeBundle\Service\CrudServiceInterface;
-use Shopware\Components\DependencyInjection\Container;
 use Shopware\Components\Translation\ObjectTranslator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Shopware Translation Component
@@ -47,7 +47,7 @@ class Shopware_Components_Translation
      */
     private $fallbackLocaleId;
 
-    public function __construct(Connection $connection, Container $container)
+    public function __construct(Connection $connection, ContainerInterface $container)
     {
         $this->connection = $connection;
 

--- a/engine/Shopware/Controllers/Backend/Cache.php
+++ b/engine/Shopware/Controllers/Backend/Cache.php
@@ -95,7 +95,7 @@ class Shopware_Controllers_Backend_Cache extends Shopware_Controllers_Backend_Ex
     {
         $cache = $this->Request()->getPost('cache', []);
 
-        $cacheInstance = $this->cacheManager->getCoreCache();
+        $cacheInstance = $this->container->get('cache');
 
         $capabilities = $cacheInstance->getBackend()->getCapabilities();
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Several services are instantiated with parameter "service_container" which can basically be any `Container` that implements the `ContainerInterface` - therefore lots of service classes typehint to narrow with just `Container`.
Then there are several instances where the container is passed to the constructor to load other services. These cases can be simplified a lot.

### 2. What does this change do, exactly?
- Replace all typehints of `Container` with the interface `ContainerInterface` if possible.
- Instantiate services with their required services directly instead of going the route of loading them manually via container
  - if possible remove container completely from services 
- As a bonus I updated the CacheManager to use the `dbal_connection` service instead of `db`.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
The PR changes the factory method signature of `Shopware\Components\DependencyInjection\Bridge\Plugin::factory`

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.