### PR TITLE
Replace setTimeout with expire

### DIFF
--- a/engine/Library/Zend/Cache/Backend/Redis.php
+++ b/engine/Library/Zend/Cache/Backend/Redis.php
@@ -233,7 +233,7 @@ class Zend_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_
             }
             $this->_redis->sAdd($this->_keyFromItemTags($id), '');
             if ($lifetime !== null) {
-                $this->_redis->setTimeout($this->_keyFromItemTags($id), $lifetime);
+                $this->_redis->expire($this->_keyFromItemTags($id), $lifetime);
             } else {
                 $redis = $this->_redis->persist($this->_keyFromItemTags($id));
             }
@@ -295,9 +295,9 @@ class Zend_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_
 
         if ($lifetime !== null) {
             if (!$redis) {
-                $return[] = $this->_redis->setTimeout($this->_keyFromItemTags($id), $lifetime);
+                $return[] = $this->_redis->expire($this->_keyFromItemTags($id), $lifetime);
             } else {
-                $redis = $redis->setTimeout($this->_keyFromItemTags($id), $lifetime);
+                $redis = $redis->expire($this->_keyFromItemTags($id), $lifetime);
             }
         } else {
             if (!$redis) {
@@ -320,7 +320,7 @@ class Zend_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_
                 if ($lifetime === null && $ttl !== false && $ttl != -1) {
                     $this->_redis->persist($this->_keyFromTag($tag));
                 } elseif ($lifetime !== null && ($ttl === false || ($ttl < $lifetime && $ttl != -1))) {
-                    $this->_redis->setTimeout($this->_keyFromTag($tag), $lifetime);
+                    $this->_redis->expire($this->_keyFromTag($tag), $lifetime);
                 }
             }
         }
@@ -446,7 +446,7 @@ class Zend_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_
             $return = $this->_redis->sAdd($this->_keyFromId($set), $member);
         }
         if ($lifetime !== null) {
-            $this->_redis->setTimeout($this->_keyFromId($set), $lifetime);
+            $this->_redis->expire($this->_keyFromId($set), $lifetime);
         }
 
         return $return;
@@ -659,8 +659,8 @@ class Zend_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_
         $lifetime = $this->getLifetime($extraLifetime);
         $return = false;
         if ($lifetime !== null) {
-            $this->_redis->setTimeout($this->_keyFromItemTags($id), $lifetime);
-            $return = $this->_redis->setTimeout($this->_keyFromId($id), $lifetime);
+            $this->_redis->expire($this->_keyFromItemTags($id), $lifetime);
+            $return = $this->_redis->expire($this->_keyFromId($id), $lifetime);
         } else {
             $this->_redis->persist($this->_keyFromItemTags($id));
             $return = $this->_redis->persist($this->_keyFromId($id));
@@ -671,7 +671,7 @@ class Zend_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_
                 if ($tag) {
                     $ttl = $this->_redis->ttl($this->_keyFromTag($tag));
                     if ($ttl !== false && $ttl !== -1 && $ttl < $lifetime && $lifetime !== null) {
-                        $this->_redis->setTimeout($this->_keyFromTag($tag), $lifetime);
+                        $this->_redis->expire($this->_keyFromTag($tag), $lifetime);
                     } elseif ($ttl !== false && $ttl !== -1 && $lifetime === null) {
                         $this->_redis->persist($this->_keyFromTag($tag));
                     }


### PR DESCRIPTION
### 1. Why is this change necessary?
setTimeout is an alias for expire and will be removed in future versions of phpredis.

https://github.com/phpredis/phpredis#expire-settimeout-pexpire

### 2. What does this change do, exactly?
Replace setTimeout with expire

### 3. Describe each step to reproduce the issue or behaviour.
Use the Redis Cache Adapter

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.