### PR TITLE
Bump PHP default version to 7.3

### DIFF
--- a/.psh.yaml.dist
+++ b/.psh.yaml.dist
@@ -27,7 +27,7 @@ const:
   DB_PORT: "3306"
   SW_HOST: "localhost:8088"
   SW_BASE_PATH: ""
-  PHP_VERSION: "7.2"
+  PHP_VERSION: "7.3"
   MYSQL_VERSION: "5.7"
   ELASTICSEARCH_IMAGE: "docker.elastic.co/elasticsearch/elasticsearch"
   ELASTICSEARCH_VERSION: "6.7.2"

--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
         "autoloader-suffix": "Shopware",
         "optimize-autoloader": true,
         "platform": {
-            "php": "7.2.0"
+            "php": "7.3.0"
         }
     },
     "scripts": {

--- a/dev-ops/bamboo.shopware.com/actions/.cs-fixer.sh
+++ b/dev-ops/bamboo.shopware.com/actions/.cs-fixer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-if [ "$1" = "7.2" ]; then
+if [ "$1" = "7.3" ]; then
     vendor/bin/php-cs-fixer fix --dry-run --stop-on-violation --verbose --show-progress=dots
 fi

--- a/dev-ops/common/actions/.cs-fixer.sh
+++ b/dev-ops/common/actions/.cs-fixer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-if [ "$1" = "7.2" ]; then
+if [ "$1" = "7.3" ]; then
     vendor/bin/php-cs-fixer fix --verbose --show-progress=dots
 fi

--- a/dev-ops/common/actions/.phpstan.sh
+++ b/dev-ops/common/actions/.phpstan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ "$1" = "7.2" ]; then
+if [ "$1" = "7.3" ]; then
     if [ ! -e phpstan.phar ]; then
         curl -s -L "https://github.com/phpstan/phpstan/releases/download/0.11.12/phpstan.phar" > phpstan.phar
         chmod +x phpstan.phar


### PR DESCRIPTION
### 1. Why is this change necessary?
![](https://media1.tenor.com/images/ea32189ee5887f68d509b24000888259/tenor.gif?itemid=12563747 "New is always better")

### 2. What does this change do, exactly?
Bumping default PHP version from 7.2 to 7.3

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.