### PR TITLE
Ticket: SW-24565 | Action-Link zum Entfernen zugeordneter Artikel im Blogeintrag nicht mehr sichtbar

### DIFF
--- a/themes/Backend/ExtJs/backend/blog/view/blog/detail/sidebar/assigned_articles.js
+++ b/themes/Backend/ExtJs/backend/blog/view/blog/detail/sidebar/assigned_articles.js
@@ -235,7 +235,7 @@ Ext.define('Shopware.apps.Blog.view.blog.detail.sidebar.AssignedArticles', {
                     flex: 1
                 }, {
                     xtype: 'actioncolumn',
-                    width: 50,
+                    width: 52,
                     items: [
                         {
                             iconCls: 'sprite-inbox',


### PR DESCRIPTION
### 1. Why is this change necessary?
Deletion of associated articles in blog-entry not possible

### 2. What does this change do, exactly?
Raise the width of the column, so the action-link gets visible.

### 3. Describe each step to reproduce the issue or behaviour.
look at screen :-)

### 4. Please link to the relevant issues (if any).
[SW-24565](https://issues.shopware.com/issues/SW-24565)

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.