### PR TITLE
[WIP] Add support for passing attributes via API

### DIFF
--- a/engine/Shopware/Components/Api/Resource/CustomerGroup.php
+++ b/engine/Shopware/Components/Api/Resource/CustomerGroup.php
@@ -56,8 +56,9 @@ class CustomerGroup extends Resource
         }
 
         $builder = $this->getRepository()->createQueryBuilder('customerGroup')
-                ->select('customerGroup', 'd')
+                ->select('customerGroup', 'd', 'attribute')
                 ->leftJoin('customerGroup.discounts', 'd')
+                ->leftJoin('customerGroup.attribute', 'attribute')
                 ->where('customerGroup.id = :id')
                 ->setParameter(':id', $id);
 

--- a/engine/Shopware/Components/Api/Resource/Media.php
+++ b/engine/Shopware/Components/Api/Resource/Media.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\ORMException;
 use Shopware\Components\Api\Exception as ApiException;
 use Shopware\Components\Random;
 use Shopware\Components\Thumbnail\Manager;
+use Shopware\Models\Attribute\Media as MediaAttribute;
 use Shopware\Models\Media\Album;
 use Shopware\Models\Media\Media as MediaModel;
 use Symfony\Component\HttpFoundation\File\File;
@@ -127,6 +128,12 @@ class Media extends Resource
 
         $media = new MediaModel();
         $media->fromArray($params);
+        $attribute = new MediaAttribute();
+
+        if (isset($params['attribute']) && is_array($params['attribute'])) {
+            $attribute->fromArray($params['attribute']);
+        }
+        $media->setAttribute($attribute);
 
         $path = $this->prepareFilePath($media->getPath(), $media->getFileName());
         $media->setPath($path);
@@ -136,6 +143,7 @@ class Media extends Resource
             throw new ApiException\ValidationException($violations);
         }
 
+        $this->getManager()->persist($attribute);
         $this->getManager()->persist($media);
         $this->flush();
 
@@ -184,6 +192,15 @@ class Media extends Resource
                 @unlink($path);
                 throw new ApiException\CustomValidationException($exception->getMessage());
             }
+        }
+
+        if (!empty($params['attribute'])) {
+            $attribute = $media->getAttribute();
+            $attribute->fromArray($params['attribute']);
+
+            $media->setAttribute($attribute);
+            $this->getManager()->persist($attribute);
+            $this->getManager()->flush();
         }
 
         return $media;

--- a/engine/Shopware/Components/Api/Resource/Order.php
+++ b/engine/Shopware/Components/Api/Resource/Order.php
@@ -46,7 +46,7 @@ use Shopware\Models\Tax\Tax;
 class Order extends Resource
 {
     /**
-     * @return \Doctrine\ORM\EntityRepository
+     * @return \Shopware\Models\Order\Repository
      */
     public function getRepository()
     {

--- a/engine/Shopware/Models/Country/Repository.php
+++ b/engine/Shopware/Models/Country/Repository.php
@@ -101,8 +101,9 @@ class Repository extends ModelRepository
         $builder = $this->getEntityManager()->createQueryBuilder();
 
         $builder
-            ->select(['countries', 'states', 'area'])
+            ->select(['countries', 'states', 'area', 'attribute'])
             ->from(\Shopware\Models\Country\Country::class, 'countries')
+            ->leftJoin('countries.attribute', 'attribute')
             ->leftJoin('countries.states', 'states')
             ->leftJoin('countries.area', 'area');
 

--- a/engine/Shopware/Models/Media/Repository.php
+++ b/engine/Shopware/Models/Media/Repository.php
@@ -68,8 +68,9 @@ class Repository extends ModelRepository
     {
         /** @var QueryBuilder $builder */
         $builder = $this->getEntityManager()->createQueryBuilder();
-        $builder->select('media')
-                ->from(\Shopware\Models\Media\Media::class, 'media');
+        $builder->select('media', 'attribute')
+                ->from(\Shopware\Models\Media\Media::class, 'media')
+                ->leftJoin('media.attribute', 'attribute');
         if ($filter) {
             $builder->addFilter($filter);
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
While some API endpoints supply attributes not all do. But AFAIK none allows to pass the attributes for create or update calls. 

### 2. What does this change do, exactly?
- adds support for attributes on `create` & `update` calls
- adds attributes to `getOne` and `getList` resource calls that won't make these available yet

### 3. Describe each step to reproduce the issue or behaviour.
1. make sure you have attributes for `media` (`s_media`/`s_media_attributes`)
2. call api endpoint for media with valid post payload containing an `attribute` field
3. check for created media without those passed attributes without PR, with PR they will be there 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.