### PR TITLE
StateManager.getScrollBarSize() fetches scrollbar-size lazily

### DIFF
--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -55,6 +55,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
         * `city`
         * `country`
         * `state`
+* Changed `StateManager.getScrollBarSize` to lazily get the size of the scrollbar
 
 ## 5.6.1
 

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
@@ -1337,7 +1337,6 @@
             if (window.secureShop !== undefined && window.secureShop === true) {
                 cookieString = 'x-ua-device=' + device + ';secure; path=/';
             }
-
             document.cookie = cookieString;
         },
 
@@ -1346,33 +1345,43 @@
          * and saves it to a object that can be accessed.
          *
          * @private
-         * @property _scrollBarSize
+         * @method _getScrollBarSize
          * @type {Object}
          */
-        _scrollBarSize: (function () {
-            var $el = $('<div>', {
-                    css: {
-                        width: 100,
-                        height: 100,
-                        overflow: 'scroll',
-                        position: 'absolute',
-                        top: -9999
-                    }
-                }),
-                el = $el[0],
-                width,
-                height;
+        _getScrollBarSize: (function () {
+            var cache;
+            var getSize = function(){
+                var $el = $('<div>', {
+                        css: {
+                            width: 100,
+                            height: 100,
+                            overflow: 'scroll',
+                            position: 'absolute',
+                            top: -9999
+                        }
+                    }),
+                    el = $el[0],
+                    width,
+                    height;
 
-            $('body').append($el);
+                $('body').append($el);
 
-            width = el.offsetWidth - el.clientWidth;
-            height = el.offsetHeight - el.clientHeight;
+                width = el.offsetWidth - el.clientWidth;
+                height = el.offsetHeight - el.clientHeight;
 
-            $($el).remove();
+                $($el).remove();
 
-            return {
-                width: width,
-                height: height
+                return {
+                    width: width,
+                    height: height
+                };
+            };
+
+            return function() {
+                if (!cache) {
+                    cache = getSize();
+                }
+                return cache;
             };
         }()),
 
@@ -1385,7 +1394,7 @@
          * @returns {Object} The width/height pair of the scroll bar size.
          */
         getScrollBarSize: function () {
-            return $.extend({}, this._scrollBarSize);
+            return $.extend({}, this._getScrollBarSize());
         },
 
         /**
@@ -1396,7 +1405,7 @@
          * @returns {Number} Width of the default browser scroll bar.
          */
         getScrollBarWidth: function () {
-            return this._scrollBarSize.width;
+            return this._getScrollBarSize().width;
         },
 
         /**
@@ -1407,7 +1416,7 @@
          * @returns {Number} Height of the default browser scroll bar.
          */
         getScrollBarHeight: function () {
-            return this._scrollBarSize.height;
+            return this._getScrollBarSize().height;
         },
 
         /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Calculating the Scrollbar-Size right at the pageload forces a reflow by the browser. To prevent this ~60ms js-block, we can fetch the scrollbar-size lazily.

![image](https://user-images.githubusercontent.com/765896/64960004-ac5b4c00-d892-11e9-833b-70c3f09e13a2.png)

### 2. What does this change do, exactly?
Change the private property `StateManager._scrollBarSize` to a private method `StateManager._getScrollBarSize` which uses a cache internally, so only one calculation is made.

Also:
* `StateManager.getScrollBarSize()`
* `StateManager.getScrollBarWidth()`
* `StateManager.getScrollBarHeight()`

were changed to call this new function.

### 3. Describe each step to reproduce the issue or behaviour.
Use the Chrome DevTools to profile a shopware-shop. On pageload you will see a flamegraph like in the screenshot above.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
None, as the removed property was private.

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] I have read the contribution requirements and fulfil them.