### PR TITLE
Windows-Fixes for generating theme cache

### DIFF
--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -259,6 +259,8 @@ class Compiler
         }
         $file->flock(LOCK_UN);   // release the lock
 
+        $file = null; // release file handles, else Windows still locks the file
+
         rename($this->pathResolver->getTmpCssFilePath($shop, $timestamp), $this->pathResolver->getCssFilePath($shop, $timestamp));
     }
 
@@ -297,6 +299,8 @@ class Compiler
 
         $file->fwrite($content);
         $file->flock(LOCK_UN);   // release the lock
+
+        $file = null; // release file handles, else Windows still locks the file
 
         rename($this->pathResolver->getTmpJsFilePath($shop, $timestamp), $this->pathResolver->getJsFilePath($shop, $timestamp));
     }

--- a/engine/Shopware/Components/Theme/PathResolver.php
+++ b/engine/Shopware/Components/Theme/PathResolver.php
@@ -254,7 +254,7 @@ class PathResolver
      */
     public function getCacheDirectory()
     {
-        return rtrim($this->cacheDir, '/');
+        return rtrim($this->cacheDir, DIRECTORY_SEPARATOR);
     }
 
     /**
@@ -301,7 +301,7 @@ class PathResolver
      */
     public function getCssFilePath(Shop\Shop $shop, $timestamp)
     {
-        return $this->getCacheDirectory() . '/' . $this->buildTimestampName($timestamp, $shop, 'css');
+        return $this->getCacheDirectory() . DIRECTORY_SEPARATOR . $this->buildTimestampName($timestamp, $shop, 'css');
     }
 
     /**
@@ -313,7 +313,7 @@ class PathResolver
      */
     public function getTmpCssFilePath(Shop\Shop $shop, string $timestamp): string
     {
-        return $this->getCacheDirectory() . '/' . $this->buildTimestampName($timestamp, $shop, 'css.tmp');
+        return $this->getCacheDirectory() . DIRECTORY_SEPARATOR . $this->buildTimestampName($timestamp, $shop, 'css.tmp');
     }
 
     /**
@@ -329,7 +329,7 @@ class PathResolver
      */
     public function getJsFilePath(Shop\Shop $shop, $timestamp)
     {
-        return $this->getCacheDirectory() . '/' . $this->buildTimestampName($timestamp, $shop, 'js');
+        return $this->getCacheDirectory() . DIRECTORY_SEPARATOR . $this->buildTimestampName($timestamp, $shop, 'js');
     }
 
     /**
@@ -341,7 +341,7 @@ class PathResolver
      */
     public function getTmpJsFilePath(Shop\Shop $shop, string $timestamp): string
     {
-        return $this->getCacheDirectory() . '/' . $this->buildTimestampName($timestamp, $shop, 'js.tmp');
+        return $this->getCacheDirectory() . DIRECTORY_SEPARATOR . $this->buildTimestampName($timestamp, $shop, 'js.tmp');
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
These changes will fix the problem, that css and js files are not correctly generated on Windows OS Servers when generating the theme caches.

### 2. What does this change do, exactly?
1. It sets the file objects of the generated tmp files to null after releasing the lock, else Windows would still lock the file (open file handler).
2. It replaces the '/' character with DIRECTORY_SEPARATOR in the PathResolver, so it does generate correct file paths.

### 3. Describe each step to reproduce the issue or behaviour.
Generate the theme cache via CLI or web-backend. On Windows OS the css and js files under "web/cache/" are still named with the ".tmp" file extension. After that the shop-frontend is a mess (no css or js can be loaded).

### 4. Please link to the relevant issues (if any).
N/A

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.