### PR TITLE
fix datepicker range for new flatpickr version that changed parameter…

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.datepicker.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.datepicker.js
@@ -524,7 +524,7 @@
 
             dateFormat = dateFormat || me.opts.dateFormat;
 
-            var formattedDate = me.flatpickr.formatDate(dateFormat, date);
+            var formattedDate = me.flatpickr.formatDate(date, dateFormat);
 
             $.publish('plugin/swDatePicker/onFormatDate', [ me, formattedDate, dateFormat, date ]);
 


### PR DESCRIPTION
… order

### 1. Why is this change necessary?
DatePicker Elements in mode "range" are broken, because flatpickr changed the parameter order of the formatDate function.

### 2. What does this change do, exactly?
It changes the order in which the parameters are given to said function to the new one.

### 3. Describe each step to reproduce the issue or behaviour.
Give an Element with `data-datepicker="true"` the attributes `data-mode="range"` and `data-rangeStartInput="name"`, add a hidden input with a `name="name"` attribute and try to select a date.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist
- [X] I have read the contribution requirements and fulfil them.