### PR TITLE
Address Controller - Handle sessionKey correctly in isShippingRequest()

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Address.php
+++ b/engine/Shopware/Controllers/Frontend/Address.php
@@ -508,7 +508,7 @@ class Shopware_Controllers_Frontend_Address extends Enlight_Controller_Action
     private function isShippingRequest()
     {
         $extraData = $this->Request()->getParam('extraData', []);
-        $keys = array_filter(explode(';', $extraData['sessionKey']));
+        $keys = array_filter(explode(',', $extraData['sessionKey']));
 
         return $extraData['setDefaultShippingAddress'] === '1'
             || in_array('checkoutShippingAddressId', $keys, true);


### PR DESCRIPTION
### 1. Why is this change necessary?
The correct separator for sessionKey is `,` not `;`

### 2. What does this change do, exactly?
Change the separator in the explode-call

### 3. Describe each step to reproduce the issue or behaviour.
1. In the shop you should have two countries active. One of which should not be available for shipping.
2. Create a new account (no alternative shipping-address)
3. Add a new address with the non-shipping-country selected
3. Go to the checkout
4. Open the modal for editing the current address (which is both shipping & billing)
5. The non-shipping-country is selectable, even though according to the template file it shouldn't be, as this should be a `shippingRequest` but isn't.

This happens because in the template-files and the `Shopware_Controller_Frontend_Address:handleExtraData()`-function the sessionKey is separated by a `,`. Only the `isShippingRequest()`-function handles this wrong.

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] I have read the contribution requirements and fulfil them.