### PR TITLE
Task/remove vote from compare

### DIFF
--- a/themes/Frontend/Bare/frontend/compare/col.tpl
+++ b/themes/Frontend/Bare/frontend/compare/col.tpl
@@ -51,9 +51,11 @@
                 {/block}
 
                 {block name='frontend_compare_votings'}
-                    <li class="list--entry entry--voting">
-                        {include file="frontend/_includes/rating.tpl" points=$sArticle.sVoteAverage.average label=false}
-                    </li>
+                    {if !{config name=VoteDisable}}
+                        <li class="list--entry entry--voting">
+                            {include file="frontend/_includes/rating.tpl" points=$sArticle.sVoteAverage.average label=false}
+                        </li>
+                    {/if}
                 {/block}
 
                 {block name='frontend_compare_description'}

--- a/themes/Frontend/Bare/frontend/compare/col_description.tpl
+++ b/themes/Frontend/Bare/frontend/compare/col_description.tpl
@@ -13,9 +13,11 @@
                 </li>
             {/block}
             {block name='frontend_compare_votings'}
-                <li class="list--entry entry--voting">
-                    {s name="CompareColumnRating"}{/s}
-                </li>
+                {if !{config name=VoteDisable}}
+                    <li class="list--entry entry--voting">
+                        {s name="CompareColumnRating"}{/s}
+                    </li>
+                {/if}
             {/block}
             {block name='frontend_compare_description'}
                 <li class="list--entry entry--description">


### PR DESCRIPTION
### 1. Why is this change necessary?
Because votings get displayed in the compare modal even if votings are disabled.

### 2. What does this change do, exactly?
Show votings in compare modal only when not disabled.

### 3. Describe each step to reproduce the issue or behaviour.
Deactivate voting, activate compare, put things for comparison and open the compare modal.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [X] I have read the contribution requirements and fulfil them.