### PR TITLE
Increase actionColumn width for correct rendering in Chrome Wayland

### DIFF
--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/local_plugin_listing_page.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/view/list/local_plugin_listing_page.js
@@ -115,7 +115,7 @@ Ext.define('Shopware.apps.PluginManager.view.list.LocalPluginListingPage', {
 
         var actionColumn = me.callParent(arguments);
 
-        actionColumn.width = 120;
+        actionColumn.width = 125;
         return actionColumn;
     },
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Since I switched to Wayland (sway) in ArchLinux the rendering of the local update button in the plugin manager listing, is not shown anymore in Chrome.
Firefox works fine, but since Chrome is the recommend browser I guess this should be fixed. Note, you can get around the issue if you resize the columns such that you can extend the action column (resize all other columns).
![screenshot-22 09 2019-18 33 41](https://user-images.githubusercontent.com/6317761/65391332-4413db00-dd68-11e9-8cca-2f0f8a74484a.png)
*Without this patch*

![screenshot-22 09 2019-18 38 13](https://user-images.githubusercontent.com/6317761/65391343-60b01300-dd68-11e9-912b-3bbcaba66329.png)
*With this patch*
 
### 2. What does this change do, exactly?
Increase the width of the action column in the local plugin listing.

### 3. Describe each step to reproduce the issue or behaviour.
Install sway (or I would suspect other wayland window manager would have the same problems), and look at the plugin manager listing.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.