### PR TITLE
fixed issue for old order document types

### DIFF
--- a/engine/Shopware/Components/Translation.php
+++ b/engine/Shopware/Components/Translation.php
@@ -435,6 +435,9 @@ class Shopware_Components_Translation
             }
             if (array_key_exists('documents', $order)) {
                 foreach ($order['documents'] as $documentIndex => $document) {
+                    if (!$document['type']){
+                        continue;
+                    }
                     $documentTypes[$document['type']['id']] = $document['type'];
                 }
             }


### PR DESCRIPTION
fixed issue for old order with document types there are actualy not more exist

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
if the document ID is no longer available in the system but known at the time of ordering, it can no longer be filtered or sorted by order.

### 2. What does this change do, exactly?
If we do not receive any documents id from the system, the foreach query is not filled with a null

### 3. Describe each step to reproduce the issue or behaviour.

simply put an id in an order in the s_order_documents table that no longer exists in the s_core_documents

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
nothing

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.