### PR TITLE
Remove unnecessary break in switch statement of the link filter plugin

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/PostFilter/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/PostFilter/Bootstrap.php
@@ -182,44 +182,29 @@ class Shopware_Plugins_Core_PostFilter_Bootstrap extends Shopware_Components_Plu
         }
 
         $link = $src[3];
-
-        $anchorPart = '';
-        if (strpos($link, '#') !== false) {
-            $anchorPart = substr($link, strpos($link, '#'));
-        }
-
-        switch ($src[1]) {
-            case 'input':
-            case 'img':
-            case 'link':
-            case 'script':
-                if (strpos($src[3], self::$baseFile) === 0) {
-                    $link = $this->rewriteLink($src[3]);
-                }
-                break;
-            case 'form':
-            case 'a':
-                if (strpos($src[3], self::$baseFile) === 0) {
-                    $link = $this->rewriteLink($src[3]);
-                }
-                break;
-            default:
-                break;
-        }
-
         if (strpos($link, '{media') === 0) {
             $link = $this->handleMediaPlugin($link);
         } else {
+            $anchorPart = '';
+            if (strpos($link, '#') !== false) {
+                $anchorPart = substr($link, strpos($link, '#'));
+            }
+
+            // If the link begins with the baseFile (default shopware.php) we always want to rewrite the link
+            if (strpos($link, self::$baseFile) === 0) {
+                $link = $this->rewriteLink($link);
+            }
+
             if (strpos($link, 'www.') === 0) {
                 $link = 'http://' . $link;
             }
             if (!preg_match('#^[a-z]+:|^\#|^/#', $link)) {
                 $link = $this->basePathUrl . $link;
             }
-        }
 
-        if ($anchorPart !== '' && strpos($link, $anchorPart) === false) {
-            $link .= $anchorPart;
+            if ($anchorPart !== '' && strpos($link, $anchorPart) === false) {
+                $link .= $anchorPart;
+            }
         }
 
         // Check if the current link is a canonical link


### PR DESCRIPTION
### 1. Why is this change necessary?
I was currently debugging some problem in the link plugin, it took me some (short) time to figure out if there is some difference between `img` and `a` URLs, or not. Spoiler, it's the same :-)

### 2. What does this change do, exactly?
This change removes this confusion, as the `switch` statement is simplified.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.