### PR TITLE
Fix issue with context on console

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/ContextService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/ContextService.php
@@ -161,6 +161,25 @@ class ContextService implements ContextServiceInterface
     }
 
     /**
+     * @param int         $shopId
+     * @param int|null    $currencyId
+     * @param string|null $customerGroupKey
+     *
+     * @return ShopContextInterface
+     */
+    public function setShopContext($shopId, $currencyId = null, $customerGroupKey = null)
+    {
+        $this->context = $this->shopContextFactory->create(
+            $this->getStoreFrontBaseUrl(),
+            $shopId,
+            $currencyId,
+            $customerGroupKey
+        );
+
+        return $this->context;
+    }
+
+    /**
      * @return string
      */
     private function getStoreFrontBaseUrl()

--- a/engine/Shopware/Components/Api/Resource/Customer.php
+++ b/engine/Shopware/Components/Api/Resource/Customer.php
@@ -33,8 +33,6 @@ use Shopware\Models\Country\State as StateModel;
 use Shopware\Models\Customer\Address as AddressModel;
 use Shopware\Models\Customer\Customer as CustomerModel;
 use Shopware\Models\Customer\PaymentData;
-use Shopware\Models\Shop\Repository;
-use Shopware\Models\Shop\Shop as ShopModel;
 
 /**
  * Customer API Resource
@@ -470,19 +468,7 @@ class Customer extends Resource
      */
     private function setupContext($shopId = null)
     {
-        /** @var Repository $shopRepository */
-        $shopRepository = $this->getContainer()->get('models')->getRepository(ShopModel::class);
-
-        if ($shopId) {
-            $shop = $shopRepository->getActiveById($shopId);
-            if (!$shop) {
-                throw new ApiException\CustomValidationException(sprintf('Shop by id %s not found', $shopId));
-            }
-        } else {
-            $shop = $shopRepository->getActiveDefault();
-        }
-
-        $this->getContainer()->get('shopware.components.shop_registration_service')->registerShop($shop);
+        $this->getContainer()->get('shopware_storefront.context_service')->setShopContext($shopId ?: 1);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
You can't use the api resource on console anymore.
You will get the error: 
Zend_Session_Exception: You must call Zend_Session::setId() before any output has been sent to the browser;

### 2. What does this change do, exactly?

It use now only the bundle context and not the old.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.