### PR TITLE
make DeviceConfiguration decorateable

### DIFF
--- a/engine/Shopware/Components/Emotion/LandingPageViewLoader.php
+++ b/engine/Shopware/Components/Emotion/LandingPageViewLoader.php
@@ -30,7 +30,7 @@ use Shopware_Components_Translation;
 class LandingPageViewLoader
 {
     /**
-     * @var DeviceConfiguration
+     * @var DeviceConfigurationInterface
      */
     private $deviceConfiguration;
 
@@ -40,7 +40,7 @@ class LandingPageViewLoader
     private $translationComponent;
 
     public function __construct(
-        DeviceConfiguration $deviceConfiguration,
+        DeviceConfigurationInterface $deviceConfiguration,
         Shopware_Components_Translation $translationComponent = null
     ) {
         $this->deviceConfiguration = $deviceConfiguration;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
there is a fatal error when requesting an emotion landingpage after decoratin DeviceConfiguration

### 2. What does this change do, exactly?
is exchanges the usage of the concrete class by its interface

### 3. Describe each step to reproduce the issue or behaviour.
- create a decorator for DeviceConfiguration (service "emotion_device_configuration")
- create an emotion landingpage
- request the landingpage in browser

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
n/a

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

(SHN)