### PR TITLE
Prefix MySQL query columns for the checkIfProductIsInBasket QueryBuilder

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2184,12 +2184,12 @@ SQL;
     {
         $builder = Shopware()->Models()->getConnection()->createQueryBuilder();
 
-        $builder->select('id', 'quantity')
+        $builder->select('basket.id', 'basket.quantity')
             ->from('s_order_basket', 'basket')
-            ->where('articleID = :articleId')
-            ->andWhere('sessionID = :sessionId')
-            ->andWhere('ordernumber = :ordernumber')
-            ->andWhere('modus != 1')
+            ->where('basket.articleID = :articleId')
+            ->andWhere('basket.sessionID = :sessionId')
+            ->andWhere('basket.ordernumber = :ordernumber')
+            ->andWhere('basket.modus != 1')
             ->setParameter('articleId', $productId)
             ->setParameter('sessionId', $sessionId)
             ->setParameter('ordernumber', $orderNumber);


### PR DESCRIPTION
### 1. Why is this change necessary?
If one wants to join for example `s_articles_attributes` where also an `articleID` column exists, it is hard to work with this query builder, since the column names are not prefixed and therefore not the `where` condition is not unique.

### 2. What does this change do, exactly?
Prefix the columns correctly.

### 3. Describe each step to reproduce the issue or behaviour.
Use a plugin to extend the DBAL querybuilder in the event `Shopware_Modules_Basket_AddArticle_CheckBasketForArticle` and join the table `s_articles_attributes`.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.