### PR TITLE
Fix possible doctrine exception in affiliate marketing (map customer to affiliate)  with setting maxresults

### DIFF
--- a/engine/Shopware/Models/Partner/Repository.php
+++ b/engine/Shopware/Models/Partner/Repository.php
@@ -301,6 +301,7 @@ class Repository extends ModelRepository
         $builder->setParameter(0, $mappingValue);
         $builder->setParameter(1, $mappingValue);
         $builder->setParameter(2, $mappingValue);
+        $builder->setMaxResults(1);
 
         return $builder;
     }


### PR DESCRIPTION
If customer.number and customer.id are equal, there will be two results which causes exception because one or NULL result are expected. So we should set the maxresults to 1 .

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If you have an equal customer number and customer id (id of s_user), there will be an doctrine exception because "getOneOrNull" is expected in Partner.php Controller.

### 2. What does this change do, exactly?
Set the limit of results to 1

### 3. Describe each step to reproduce the issue or behaviour.
Make customernumber editable and put a number in it which is equal to one userID.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/SW-23091
### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.