### PR TITLE
Fixed openPdfAction in Order Backend Controller

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1220,8 +1220,6 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
         $response->headers->set('content-type', 'application/pdf');
         $response->headers->set('content-transfer-encoding', 'binary');
         $response->headers->set('content-length', $filesystem->getSize($file));
-        $response->sendHeaders();
-        $response->sendResponse();
 
         $upstream = $filesystem->readStream($file);
         $downstream = fopen('php://output', 'wb');


### PR DESCRIPTION
### 1. Why is this change necessary?
Download of order related files like the invoice is not working correctly since the response headers like "Content-Disposition" are set three times in the code. Some browsers (like Microsoft Edge) can't handle these headers correctly which will result in wrong filenames with a comma and/or the word "attachment" appended to the file-extension (like "xxxx.pdf," or "xxxx.pdf, attachment").

### 2. What does this change do, exactly?
Removes the two calls "sendHeaders" and "sendResponse" in the openPdfAction of the Order-Controller. These are unnecessary since the response is sent at the end of the execution with the "send" method of the response object.

### 3. Describe each step to reproduce the issue or behaviour.
1. Login into Shopware 5.6 Backend with Microsoft Edge
2. Open Menu "Customers"->"Orders"
3. Click the "Show Details" Icon at an order
4. Switch to the "Documents"-Tab
5. Create an document and try to download it by clicking on the name of the document

### 4. Please link to the relevant issues (if any).
There is an open thread in the german Shopware forum:
https://forum.shopware.com/discussion/63039/shopware-5-6-1-dokumente-enden-mit-komma

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.