### PR TITLE
Fix line calculation with quantity=0

### DIFF
--- a/engine/Shopware/Components/Cart/NetRounding/RoundLineAfterQuantity.php
+++ b/engine/Shopware/Components/Cart/NetRounding/RoundLineAfterQuantity.php
@@ -28,11 +28,12 @@ class RoundLineAfterQuantity implements RoundingInterface
 {
     public function round(float $netPrice, float $tax, int $quantity = null): float
     {
-        $netPrice = round($netPrice, 2) / 100 * (100 + $tax);
-
-        if ($quantity) {
-            $netPrice = round($netPrice * $quantity, 2);
+        if ($quantity === 0) {
+            return 0.0;
         }
+
+        $netPrice = round($netPrice, 2) / 100 * (100 + $tax);
+        $netPrice = (is_int($quantity) && $quantity !== 1) ? round($netPrice * $quantity, 2) : $netPrice;
 
         return $netPrice;
     }

--- a/engine/Shopware/Components/Cart/NetRounding/RoundLineAfterTax.php
+++ b/engine/Shopware/Components/Cart/NetRounding/RoundLineAfterTax.php
@@ -28,11 +28,12 @@ class RoundLineAfterTax implements RoundingInterface
 {
     public function round(float $netPrice, float $tax, int $quantity = null): float
     {
-        $netPrice = round(round($netPrice, 2) / 100 * (100 + $tax), 2);
-
-        if ($quantity) {
-            $netPrice = round($netPrice * $quantity, 2);
+        if ($quantity === 0) {
+            return 0.0;
         }
+
+        $netPrice = round(round($netPrice, 2) / 100 * (100 + $tax), 2);
+        $netPrice = (is_int($quantity) && $quantity !== 1) ? round($netPrice * $quantity, 2) : $netPrice;
 
         return $netPrice;
     }

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2649,9 +2649,9 @@ SQL;
                 || (!$this->sSYSTEM->sUSERGROUPDATA['tax'] && $this->sSYSTEM->sUSERGROUPDATA['id'])
             ) {
                 if (empty($getProducts[$key]['modus'])) {
-                    $priceWithTax = Shopware()->Container()->get('shopware.cart.net_rounding')->round($netprice, $tax);
+                    $getProducts[$key]['amountWithTax'] = Shopware()->Container()->get('shopware.cart.net_rounding')
+                        ->round($netprice, $tax, $quantity);
 
-                    $getProducts[$key]['amountWithTax'] = $quantity * $priceWithTax;
                     // If basket comprised any discount, calculate brutto-value for the discount
                     if ($this->sSYSTEM->sUSERGROUPDATA['basketdiscount'] && $this->sCheckForDiscount()) {
                         $discount += ($getProducts[$key]['amountWithTax'] / 100 * $this->sSYSTEM->sUSERGROUPDATA['basketdiscount']);

--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -556,7 +556,7 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
 
                 if ($this->_net == true) {
                     $position['netto'] = round($position['price'], 2);
-                    $position['price'] = Shopware()->Container()->get('shopware.cart.net_rounding')->round($position['price'], $position['tax']);
+                    $position['price'] = Shopware()->Container()->get('shopware.cart.net_rounding')->round($position['price'], $position['tax'], 1);
                 } else {
                     $position['netto'] = $position['price'] / (100 + $position['tax']) * 100;
                 }

--- a/tests/Unit/Components/Cart/CartLinecalculationTest.php
+++ b/tests/Unit/Components/Cart/CartLinecalculationTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\tests\Unit\Components\Cart;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Components\Cart\NetRounding\RoundLineAfterQuantity;
+use Shopware\Components\Cart\NetRounding\RoundLineAfterTax;
+
+class CartLinecalculationTest extends TestCase
+{
+    public function testRoundingAfterQuantity()
+    {
+        $calculator = new RoundLineAfterQuantity();
+
+        $lineValue = $calculator->round(1.0, 19, 1);
+        static::assertEquals(1.19, $lineValue);
+    }
+
+    public function testRoundingDownAfterQuantity()
+    {
+        $calculator = new RoundLineAfterQuantity();
+
+        $lineValue = $calculator->round(1.111, 11.1, 1);
+        static::assertEquals(1.23321, $lineValue);
+    }
+
+    public function testRoundingUpAfterQuantity()
+    {
+        $calculator = new RoundLineAfterQuantity();
+
+        $lineValue = $calculator->round(1.26, 26, 1);
+        static::assertEquals(1.5876000000000001, $lineValue);
+    }
+
+    public function testRoundingAfterQuantityMultipleQuantity()
+    {
+        $calculator = new RoundLineAfterQuantity();
+
+        $lineValue = $calculator->round(1.26, 26, 10);
+        static::assertEquals(15.88, $lineValue);
+    }
+
+    public function testRoundingAfterQuantityNoQuanity()
+    {
+        $calculator = new RoundLineAfterQuantity();
+
+        $lineValue = $calculator->round(1.26, 26, 0);
+        static::assertEquals(0.0, $lineValue);
+    }
+
+    public function testRoundingAfterQuantityDefaultQuanity()
+    {
+        $calculator = new RoundLineAfterQuantity();
+
+        $lineValue = $calculator->round(1.0, 19);
+        static::assertEquals(1.19, $lineValue);
+    }
+
+    public function testRoundingafterTax()
+    {
+        $calculator = new RoundLineafterTax();
+
+        $lineValue = $calculator->round(1.0, 19, 1);
+        static::assertEquals(1.19, $lineValue);
+    }
+
+    public function testRoundingDownafterTax()
+    {
+        $calculator = new RoundLineafterTax();
+
+        $lineValue = $calculator->round(1.111, 11.1, 1);
+        static::assertEquals(1.23, $lineValue);
+    }
+
+    public function testRoundingUpafterTax()
+    {
+        $calculator = new RoundLineafterTax();
+
+        $lineValue = $calculator->round(1.26, 26, 1);
+        static::assertEquals(1.59, $lineValue);
+    }
+
+    public function testRoundingafterTaxMultipleQuantity()
+    {
+        $calculator = new RoundLineafterTax();
+
+        $lineValue = $calculator->round(1.26, 26, 10);
+        static::assertEquals(15.90, $lineValue);
+    }
+
+    public function testRoundingafterTaxNoQuanity()
+    {
+        $calculator = new RoundLineafterTax();
+
+        $lineValue = $calculator->round(1.26, 26, 0);
+        static::assertEquals(0.0, $lineValue);
+    }
+
+    public function testRoundingafterTaxDefaultQuanity()
+    {
+        $calculator = new RoundLineafterTax();
+
+        $lineValue = $calculator->round(1.0, 19);
+        static::assertEquals(1.19, $lineValue);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
With the release of Shopware 5.6 there had been changes how each order position is calculated. Those are handled now inside a separate service (yeay) but those introduce a big problem:
If you set the quantity to `0` the line is still calculated as the base price, eg. quantity=1.

This happens for example if you use Shopware ERP which sets the position's quantity to 0 if you cancel the position or the complete order.
As this breaks lots of things like the official Shopware/Pickware ERP this should be fixed ASAP.

### 2. What does this change do, exactly?
Skip all calculations and return `0.0` if the passed quantity isn't valid (`0` or `null`)

### 3. Describe each step to reproduce the issue or behaviour.
1. Create an order
2. Change the quantity of a position to 0
3. Check order's invoice amount. If you have just one position and no shipping costs it will be the price of the position with qty=1 instead of 0.0

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.