### PR TITLE
Return StateManager from destroyPlugin method to allow chaining

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
@@ -1099,6 +1099,7 @@
          * @method destroyPlugin
          * @param {String|jQuery} selector
          * @param {String} pluginName
+         * @returns {StateManager}
          */
         destroyPlugin: function (selector, pluginName) {
             var $el = (typeof selector === 'string') ? $(selector) : selector,
@@ -1120,6 +1121,8 @@
                     $currentEl.removeData(name);
                 }
             }
+
+            return this;
         },
 
         /**


### PR DESCRIPTION
### 1. Why is this change necessary?
To give the `destroyPlugin` method a similar function signature as most of the other `StateManager` methods.

### 2. What does this change do, exactly?
Returns the `StateManager` instance from the `destroyPlugin` method.

### 3. Describe each step to reproduce the issue or behaviour.
```js
StateManager
    .destroyPlugin('.foo--class', 'baz--plugin')
    .destroyPlugin('.bar--class', 'qux--plugin')
;
```
### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.