### PR TITLE
Hide shopware edition with no backend login

### DIFF
--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -533,9 +533,14 @@
             <tag name="shopware.event_subscriber" />
         </service>
 
+        <service id="Shopware\Components\License\Service\ShopwareEditionServiceInterface" class="Shopware\Components\License\Service\ShopwareEditionService">
+            <argument type="service" id="models"/>
+            <argument type="service" id="shopware_core.local_license_unpack_service" />
+        </service>
+
         <service id="shopware_core.license_service_subscriber" class="Shopware\Components\License\Service\LicenseServiceSubscriber">
-            <argument type="service" id="service_container" />
             <tag name="shopware.event_subscriber" />
+            <argument type="service" id="Shopware\Components\License\Service\ShopwareEditionServiceInterface" />
         </service>
 
         <service id="shopware_core.local_license_unpack_service" class="Shopware\Components\License\Service\LocalLicenseUnpackService" />

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -541,6 +541,7 @@
         <service id="shopware_core.license_service_subscriber" class="Shopware\Components\License\Service\LicenseServiceSubscriber">
             <tag name="shopware.event_subscriber" />
             <argument type="service" id="Shopware\Components\License\Service\ShopwareEditionServiceInterface" />
+            <argument type="service" id="plugins" />
         </service>
 
         <service id="shopware_core.local_license_unpack_service" class="Shopware\Components\License\Service\LocalLicenseUnpackService" />

--- a/engine/Shopware/Components/License/Service/ShopwareEditionService.php
+++ b/engine/Shopware/Components/License/Service/ShopwareEditionService.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\License\Service;
+
+use Shopware\Components\License\Struct\LicenseUnpackRequest;
+use Shopware\Components\License\Struct\ShopwareEdition;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Models\Plugin\License;
+use Shopware\Models\Shop\Repository as ShopRepository;
+use Shopware\Models\Shop\Shop;
+
+class ShopwareEditionService implements ShopwareEditionServiceInterface
+{
+    /**
+     * @var ModelManager
+     */
+    private $models;
+
+    /**
+     * @var LicenseUnpackServiceInterface
+     */
+    private $licenseUnpackService;
+
+    public function __construct(ModelManager $models, LicenseUnpackServiceInterface $licenseUnpackService)
+    {
+        $this->models = $models;
+        $this->licenseUnpackService = $licenseUnpackService;
+    }
+
+    public function getProductEdition(): string
+    {
+        $licenseRepository = $this->models->getRepository(License::class);
+
+        $license = $licenseRepository->findOneBy([
+            'active' => 1,
+            'module' => 'SwagCommercial',
+        ]);
+
+        if (!$license instanceof License) {
+            return ShopwareEdition::CE;
+        }
+
+        /** @var ShopRepository $shopRepository */
+        $shopRepository = $this->models->getRepository(Shop::class);
+        $host = $shopRepository->getActiveDefault()->getHost();
+
+        try {
+            return $this->licenseUnpackService->evaluateLicense(
+                new LicenseUnpackRequest($license->getLicense(), $host)
+            )->edition;
+        } catch (\RuntimeException $e) {
+            return ShopwareEdition::CE;
+        }
+    }
+}

--- a/engine/Shopware/Components/License/Service/ShopwareEditionServiceInterface.php
+++ b/engine/Shopware/Components/License/Service/ShopwareEditionServiceInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -24,36 +24,7 @@
 
 namespace Shopware\Components\License\Service;
 
-use Enlight\Event\SubscriberInterface;
-use Enlight_Controller_Action;
-use Enlight_Event_EventArgs;
-
-class LicenseServiceSubscriber implements SubscriberInterface
+interface ShopwareEditionServiceInterface
 {
-    /**
-     * @var ShopwareEditionServiceInterface
-     */
-    private $shopwareEditionService;
-
-    public function __construct(ShopwareEditionServiceInterface $shopwareEditionService)
-    {
-        $this->shopwareEditionService = $shopwareEditionService;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function getSubscribedEvents()
-    {
-        return [
-            'Enlight_Controller_Action_PostDispatchSecure_Backend_Index' => 'onPostDispatchBackendIndex',
-        ];
-    }
-
-    public function onPostDispatchBackendIndex(Enlight_Event_EventArgs $args)
-    {
-        /** @var Enlight_Controller_Action $controller */
-        $controller = $args->get('subject');
-        $controller->View()->assign('product', $this->shopwareEditionService->getProductEdition());
-    }
+    public function getProductEdition(): string;
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is possible to see without a login what shopware edition is used. Nothing really bad but nothing that a random visitor should know.

If a plugin is needed that makes this bugfix already available for any shopware 5.2+ shop I can provide one.

### 2. What does this change do, exactly?
Check if one is logged in before reading the edition from database. Defaulting community edition.

### 3. Describe each step to reproduce the issue or behaviour.
1. Open any licensed shopware backend (your own or some well known shopware shops)
2. Open source code or browser inspection
3. Check the body tag and find one of these:
    * `<body class="shopware-ce">`
    * `<body class="shopware-pe">`
    * `<body class="shopware-pp">`
    * `<body class="shopware-ee">`
    * `<body class="shopware-eb">`
    * `<body class="shopware-ec">`

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.