### PR TITLE
fix wrong value on shipping comment column

### DIFF
--- a/themes/Backend/ExtJs/backend/shipping/view/main/list.js
+++ b/themes/Backend/ExtJs/backend/shipping/view/main/list.js
@@ -285,13 +285,13 @@ Ext.define('Shopware.apps.Shipping.view.main.List', {
     /**
      * Formats the comment column
      *
-     * @param [string] value - Description for the dispatch
+     * @param [string] value - Comment for the dispatch
      * @param [object] metaData - Meta data for this column
      * @param [object] record - current record
      */
     commentColumn : function (value, metaData, record) {
-        // Show the translated description in the overview
-        return record.get('translatedDescription');
+        // Show the comment in the overview
+        return record.get('comment');
     },
     /**
      * Formats the action column


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
In the shipping cost backend widget, the column "Interner Kommentar" has the value of the description instead of the value of the comment column.
That's confusing.

### 2. What does this change do, exactly?
This PR changed the view from the description to the comment field.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.