### PR TITLE
Add information about out of stock products and disable checkout proceed button in shopping cart

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -2141,7 +2141,9 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
             }
 
             if (!empty($item['additional_details'])) {
-                continue;
+                if (!$item['additional_details']['laststock'] || $item['additional_details']['instock'] > 0) {
+                    continue;
+                }
             }
 
             $products[] = $item['articlename'];


### PR DESCRIPTION
Add information about out of stock products and disable checkout proceed button in shopping cart

### 1. Why is this change necessary?
customers with sold out products in shopping cart should not go in the checkout process

### 2. What does this change do, exactly?
It checks the laststock and instock value like in frontend_checkout_cart_item_quantity_selection

### 3. Describe each step to reproduce the issue or behaviour.
Add product to basket and set instock to 0 and laststock to 1 and compare it with active 0
