### PR TITLE
Add laststock to sExport.php

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -924,6 +924,7 @@ class sExport implements \Enlight_Hook
                    FROM s_articles_vote as av WHERE active=1
                    AND articleID=a.id
                 ) as sVoteCount,
+                d.laststock,
                 d.stockmin,
                 d.weight,
                 d.position,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

`laststock` is needed to correctly define product availability for product feeds. By adding it to this query it will allow users to use it in the item export for feeds.

### 2. What does this change do, exactly?

Adds an existing column to the query so it will be available for use in the template for item exports (item feeds).

### 3. Describe each step to reproduce the issue or behaviour.

Go to shopware backend -> item export 
Create a feed and try to use `laststock` in the body, it does not exist.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?

`laststock` needs to be added to the available variables here: https://docs.shopware.com/en/shopware-5-en/marketing-and-shopping-worlds/item-exports

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.