### PR TITLE
Add attribute fields to API + added API testcases

### DIFF
--- a/engine/Shopware/Components/Api/Resource/CustomerGroup.php
+++ b/engine/Shopware/Components/Api/Resource/CustomerGroup.php
@@ -56,8 +56,9 @@ class CustomerGroup extends Resource
         }
 
         $builder = $this->getRepository()->createQueryBuilder('customerGroup')
-                ->select('customerGroup', 'd')
+                ->select('customerGroup', 'd', 'attribute')
                 ->leftJoin('customerGroup.discounts', 'd')
+                ->leftJoin('customerGroup.attribute', 'attribute')
                 ->where('customerGroup.id = :id')
                 ->setParameter(':id', $id);
 

--- a/engine/Shopware/Components/Api/Resource/Media.php
+++ b/engine/Shopware/Components/Api/Resource/Media.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\ORMException;
 use Shopware\Components\Api\Exception as ApiException;
 use Shopware\Components\Random;
 use Shopware\Components\Thumbnail\Manager;
+use Shopware\Models\Attribute\Media as MediaAttribute;
 use Shopware\Models\Media\Album;
 use Shopware\Models\Media\Media as MediaModel;
 use Symfony\Component\HttpFoundation\File\File;
@@ -127,6 +128,12 @@ class Media extends Resource
 
         $media = new MediaModel();
         $media->fromArray($params);
+        $attribute = new MediaAttribute();
+
+        if (isset($params['attribute']) && is_array($params['attribute'])) {
+            $attribute->fromArray($params['attribute']);
+        }
+        $media->setAttribute($attribute);
 
         $path = $this->prepareFilePath($media->getPath(), $media->getFileName());
         $media->setPath($path);
@@ -136,6 +143,7 @@ class Media extends Resource
             throw new ApiException\ValidationException($violations);
         }
 
+        $this->getManager()->persist($attribute);
         $this->getManager()->persist($media);
         $this->flush();
 
@@ -184,6 +192,15 @@ class Media extends Resource
                 @unlink($path);
                 throw new ApiException\CustomValidationException($exception->getMessage());
             }
+        }
+
+        if (!empty($params['attribute'])) {
+            $attribute = $media->getAttribute();
+            $attribute->fromArray($params['attribute']);
+
+            $media->setAttribute($attribute);
+            $this->getManager()->persist($attribute);
+            $this->getManager()->flush();
         }
 
         return $media;

--- a/engine/Shopware/Components/Api/Resource/Order.php
+++ b/engine/Shopware/Components/Api/Resource/Order.php
@@ -47,7 +47,7 @@ use Shopware\Models\Tax\Tax;
 class Order extends Resource
 {
     /**
-     * @return \Doctrine\ORM\EntityRepository
+     * @return \Shopware\Models\Order\Repository
      */
     public function getRepository()
     {

--- a/engine/Shopware/Models/Country/Repository.php
+++ b/engine/Shopware/Models/Country/Repository.php
@@ -101,8 +101,9 @@ class Repository extends ModelRepository
         $builder = $this->getEntityManager()->createQueryBuilder();
 
         $builder
-            ->select(['countries', 'states', 'area'])
+            ->select(['countries', 'states', 'area', 'attribute'])
             ->from(\Shopware\Models\Country\Country::class, 'countries')
+            ->leftJoin('countries.attribute', 'attribute')
             ->leftJoin('countries.states', 'states')
             ->leftJoin('countries.area', 'area');
 

--- a/engine/Shopware/Models/Media/Repository.php
+++ b/engine/Shopware/Models/Media/Repository.php
@@ -68,8 +68,9 @@ class Repository extends ModelRepository
     {
         /** @var QueryBuilder $builder */
         $builder = $this->getEntityManager()->createQueryBuilder();
-        $builder->select('media')
-                ->from(\Shopware\Models\Media\Media::class, 'media');
+        $builder->select('media', 'attribute')
+                ->from(\Shopware\Models\Media\Media::class, 'media')
+                ->leftJoin('media.attribute', 'attribute');
         if ($filter) {
             $builder->addFilter($filter);
         }

--- a/tests/Functional/Api/ArticleTest.php
+++ b/tests/Functional/Api/ArticleTest.php
@@ -24,6 +24,9 @@
 
 namespace Shopware\Tests\Functional\Api;
 
+/**
+ * @covers \Shopware_Controllers_Api_Articles
+ */
 class ArticleTest extends AbstractApiTestCase
 {
     public function testRequestWithoutAuthenticationShouldReturnError(): void
@@ -89,13 +92,13 @@ class ArticleTest extends AbstractApiTestCase
                 [
                     'value' => 'testWert',
                     'option' => [
-                        'name' => 'neueOption' . uniqid(rand()),
+                        'name' => 'neueOption' . uniqid(mt_rand(), true),
                     ],
                 ],
             ],
 
             'mainDetail' => [
-                'number' => 'swTEST' . uniqid(rand()),
+                'number' => 'swTEST' . uniqid(mt_rand(), true),
                 'inStock' => 15,
                 'unitId' => 1,
 
@@ -150,7 +153,7 @@ class ArticleTest extends AbstractApiTestCase
 
             'variants' => [
                 [
-                    'number' => 'swTEST.variant.' . uniqid(rand()),
+                    'number' => 'swTEST.variant.' . uniqid(mt_rand(), true),
                     'inStock' => 17,
                     // create a new unit
                     'unit' => [
@@ -193,7 +196,7 @@ class ArticleTest extends AbstractApiTestCase
                     ],
                 ],
                 [
-                    'number' => 'swTEST.variant.' . uniqid(rand()),
+                    'number' => 'swTEST.variant.' . uniqid(mt_rand(), true),
                     'inStock' => 17,
                     // create a new unit
                     'unit' => [
@@ -276,9 +279,9 @@ class ArticleTest extends AbstractApiTestCase
         static::assertTrue($result['success']);
 
         $location = $response->headers->get('location');
-        $identifier = (int) array_pop(explode('/', $location));
+        $identifier = array_pop(explode('/', $location));
 
-        static::assertGreaterThan(0, $identifier);
+        static::assertGreaterThan(0, (int) $identifier);
 
         return $identifier;
     }
@@ -452,7 +455,7 @@ class ArticleTest extends AbstractApiTestCase
         $result = $response->getContent();
         $result = json_decode($result, true);
 
-        $variantNumbers = array_map(function ($item) {
+        $variantNumbers = array_map(static function ($item) {
             return $item['number'];
         }, $result['data']['details']);
 
@@ -491,7 +494,7 @@ class ArticleTest extends AbstractApiTestCase
             static::assertEquals($variantNumber, $result['data']['mainDetail']['number']);
 
             foreach ($result['data']['details'] as $variantData) {
-                if ($variantData['number'] == $oldMain) {
+                if ($variantData['number'] === $oldMain) {
                     static::assertEquals(2, $variantData['kind']);
                 }
             }
@@ -684,13 +687,13 @@ class ArticleTest extends AbstractApiTestCase
                   [
                       'value' => 'testWert',
                       'option' => [
-                          'name' => 'neueOption' . uniqid(rand()),
+                          'name' => 'neueOption' . uniqid(mt_rand(), true),
                       ],
                   ],
               ],
 
               'mainDetail' => [
-                  'number' => 'swTEST' . uniqid(rand()),
+                  'number' => 'swTEST' . uniqid(mt_rand(), true),
                   'inStock' => 15,
                   'unitId' => 1,
 

--- a/tests/Functional/Api/CategoryTest.php
+++ b/tests/Functional/Api/CategoryTest.php
@@ -24,6 +24,9 @@
 
 namespace Shopware\Tests\Functional\Api;
 
+/**
+ * @covers \Shopware_Controllers_Api_Categories
+ */
 class CategoryTest extends AbstractApiTestCase
 {
     public function testRequestWithoutAuthenticationShouldReturnError(): void
@@ -175,6 +178,8 @@ class CategoryTest extends AbstractApiTestCase
 
     /**
      * @depends testPostCategoriesShouldBeSuccessful
+     *
+     * @return string
      */
     public function testPutCategoriesShouldBeSuccessful(string $id)
     {

--- a/tests/Functional/Api/CustomerGroupTest.php
+++ b/tests/Functional/Api/CustomerGroupTest.php
@@ -25,57 +25,70 @@
 namespace Shopware\Tests\Functional\Api;
 
 /**
- * @covers \Shopware_Controllers_Api_GenerateArticleImages
+ * @covers \Shopware_Controllers_Api_CustomerGroups
  */
-class GenerateArticleImagesTest extends AbstractApiTestCase
+class CustomerGroupTest extends AbstractApiTestCase
 {
-    public function testRequestWithoutAuthenticationShouldReturnError()
+    public function getApiResource(): string
     {
-        $this->client->request('GET', '/api/generateArticleImages');
-        $response = $this->client->getResponse();
-
-        static::assertEquals('application/json', $response->getHeader('Content-Type'));
-        static::assertEquals(401, $response->getStatusCode());
-
-        $result = $response->getBody();
-        $result = json_decode($result, true);
-
-        static::assertArrayHasKey('success', $result);
-        static::assertFalse($result['success']);
-        static::assertArrayHasKey('message', $result);
+        return 'customerGroups';
     }
 
-    public function testBatchDeleteShouldFail(): void
+    public function testRequestWithoutAuthenticationShouldReturnError(): void
     {
-        $this->authenticatedApiRequest('DELETE', '/api/generateArticleImages');
+        $this->client->request('GET', '/api/customerGroups/');
         $response = $this->client->getResponse();
 
         static::assertEquals('application/json', $response->headers->get('Content-Type'));
         static::assertEquals(null, $response->headers->get('Set-Cookie'));
-        static::assertEquals(405, $response->getStatusCode());
+        static::assertEquals(401, $response->getStatusCode());
 
         $result = $response->getContent();
+
         $result = json_decode($result, true);
 
         static::assertArrayHasKey('success', $result);
         static::assertFalse($result['success']);
-        static::assertEquals('This resource has no support for batch operations.', $result['message']);
+
+        static::assertArrayHasKey('message', $result);
     }
 
-    public function testBatchPutShouldFail()
+    public function testGetCustomerGroupWithInvalidIdShouldReturnMessage(): void
     {
-        $this->authenticatedApiRequest('PUT', '/api/generateArticleImages');
+        $id = 999999;
+        $this->authenticatedApiRequest('GET', '/api/customerGroups/' . $id);
         $response = $this->client->getResponse();
 
-        static::assertEquals('application/json', $response->headers->get('content-type'));
-        static::assertEquals(null, $response->headers->get('set-cookie'));
-        static::assertEquals(405, $response->getStatusCode());
+        static::assertEquals('application/json', $response->getHeader('Content-Type'));
+        static::assertEquals(404, $response->getStatusCode());
 
-        $result = $response->getContent();
+        $result = $response->getBody();
+
         $result = json_decode($result, true);
 
         static::assertArrayHasKey('success', $result);
         static::assertFalse($result['success']);
-        static::assertEquals('This resource has no support for batch operations.', $result['message']);
+
+        static::assertArrayHasKey('message', $result);
+    }
+
+    public function testGetCustomerGroupEK(): void
+    {
+        $id = 1;
+        $this->authenticatedApiRequest('GET', '/api/customerGroups/' . $id);
+        $response = $this->client->getResponse();
+
+        static::assertEquals('application/json', $response->getHeader('Content-Type'));
+        static::assertEquals(200, $response->getStatusCode());
+
+        $result = $response->getBody();
+
+        $result = json_decode($result, true);
+
+        static::assertArrayHasKey('success', $result);
+        static::assertTrue($result['success']);
+
+        static::assertArrayHasKey('data', $result);
+        static::assertArrayHasKey('attribute', $result['data']);
     }
 }

--- a/tests/Functional/Api/CustomerTest.php
+++ b/tests/Functional/Api/CustomerTest.php
@@ -27,6 +27,9 @@ namespace Shopware\Tests\Functional\Api;
 use DateTime;
 use Shopware\Models\Customer\Customer;
 
+/**
+ * @covers \Shopware_Controllers_Api_Customers
+ */
 class CustomerTest extends AbstractApiTestCase
 {
     public function testRequestWithoutAuthenticationShouldReturnError(): void
@@ -143,16 +146,16 @@ class CustomerTest extends AbstractApiTestCase
     }
 
     /**
-     * @return int
+     * @throws \Exception
      */
     public function testPostCustomersWithDebitShouldCreatePaymentData()
     {
         $date = new DateTime();
         $date->modify('-10 days');
-        $firstlogin = $date->format(DateTime::ATOM);
+        $firstLogin = $date->format(DateTime::ATOM);
 
         $date->modify('+2 day');
-        $lastlogin = $date->format(DateTime::ATOM);
+        $lastLogin = $date->format(DateTime::ATOM);
 
         $birthday = DateTime::createFromFormat('Y-m-d', '1986-12-20')->format(DateTime::ATOM);
 
@@ -161,8 +164,8 @@ class CustomerTest extends AbstractApiTestCase
             'active' => true,
             'email' => uniqid('', true) . 'test@foobar.com',
 
-            'firstlogin' => $firstlogin,
-            'lastlogin' => $lastlogin,
+            'firstlogin' => $firstLogin,
+            'lastlogin' => $lastLogin,
 
             'salutation' => 'mr',
             'firstname' => 'Max',
@@ -227,7 +230,7 @@ class CustomerTest extends AbstractApiTestCase
     }
 
     /**
-     * @return int
+     * @throws \Exception
      */
     public function testPostCustomersWithDebitPaymentDataShouldCreateDebitData()
     {

--- a/tests/Functional/Api/ManufacturerTest.php
+++ b/tests/Functional/Api/ManufacturerTest.php
@@ -24,6 +24,9 @@
 
 namespace Shopware\Tests\Functional\Api;
 
+/**
+ * @covers \Shopware_Controllers_Api_Manufacturers
+ */
 class ManufacturerTest extends AbstractApiTestCase
 {
     public function testGetManufacturersShouldBeSuccessful(): void

--- a/tests/Functional/Api/MediaTest.php
+++ b/tests/Functional/Api/MediaTest.php
@@ -27,6 +27,9 @@ namespace Shopware\Tests\Functional\Api;
 use Shopware\Models\Media\Media;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+/**
+ * @covers \Shopware_Controllers_Api_Media
+ */
 class MediaTest extends AbstractApiTestCase
 {
     private const UPLOAD_FILE_NAME = 'test-bild';
@@ -158,7 +161,7 @@ class MediaTest extends AbstractApiTestCase
     /**
      * @depends testPostMediaShouldBeSuccessful
      */
-    public function testGetMediaWithIdShouldBeSuccessful($identifier)
+    public function testGetMediaWithIdShouldBeSuccessful($id)
     {
         $this->authenticatedApiRequest('GET', '/api/media/' . $id);
         $response = $this->client->getResponse();
@@ -177,6 +180,7 @@ class MediaTest extends AbstractApiTestCase
 
         $data = $response['data'];
         static::assertIsArray($data);
+        static::assertArrayHasKey('attribute', $data);
     }
 
     /**
@@ -239,9 +243,9 @@ class MediaTest extends AbstractApiTestCase
     /**
      * @depends testPostMediaWithFileUploadShouldBeSuccessful
      */
-    public function testGetMediaWithUploadedFileByIdShouldBeSuccessful($identifier): void
+    public function testGetMediaWithUploadedFileByIdShouldBeSuccessful($id): void
     {
-        $this->authenticatedApiRequest('GET', '/api/media/' . $identifier);
+        $this->authenticatedApiRequest('GET', '/api/media/' . $id);
         $response = $this->client->getResponse();
 
         static::assertEquals('application/json', $response->headers->get('Content-Type'));

--- a/tests/Functional/Api/OrderTest.php
+++ b/tests/Functional/Api/OrderTest.php
@@ -25,57 +25,45 @@
 namespace Shopware\Tests\Functional\Api;
 
 /**
- * @covers \Shopware_Controllers_Api_GenerateArticleImages
+ * @covers \Shopware_Controllers_Api_Orders
  */
-class GenerateArticleImagesTest extends AbstractApiTestCase
+class OrderTest extends AbstractApiTestCase
 {
-    public function testRequestWithoutAuthenticationShouldReturnError()
+    public function testRequestWithoutAuthenticationShouldReturnError(): void
     {
-        $this->client->request('GET', '/api/generateArticleImages');
-        $response = $this->client->getResponse();
-
-        static::assertEquals('application/json', $response->getHeader('Content-Type'));
-        static::assertEquals(401, $response->getStatusCode());
-
-        $result = $response->getBody();
-        $result = json_decode($result, true);
-
-        static::assertArrayHasKey('success', $result);
-        static::assertFalse($result['success']);
-        static::assertArrayHasKey('message', $result);
-    }
-
-    public function testBatchDeleteShouldFail(): void
-    {
-        $this->authenticatedApiRequest('DELETE', '/api/generateArticleImages');
+        $this->client->request('GET', '/api/orders/');
         $response = $this->client->getResponse();
 
         static::assertEquals('application/json', $response->headers->get('Content-Type'));
         static::assertEquals(null, $response->headers->get('Set-Cookie'));
-        static::assertEquals(405, $response->getStatusCode());
+        static::assertEquals(401, $response->getStatusCode());
 
         $result = $response->getContent();
+
         $result = json_decode($result, true);
 
         static::assertArrayHasKey('success', $result);
         static::assertFalse($result['success']);
-        static::assertEquals('This resource has no support for batch operations.', $result['message']);
+
+        static::assertArrayHasKey('message', $result);
     }
 
-    public function testBatchPutShouldFail()
+    public function testGetOrderWithInvalidIdShouldReturnMessage(): void
     {
-        $this->authenticatedApiRequest('PUT', '/api/generateArticleImages');
+        $id = 9999999999;
+        $this->authenticatedApiRequest('GET', '/api/orders/' . $id);
         $response = $this->client->getResponse();
 
-        static::assertEquals('application/json', $response->headers->get('content-type'));
-        static::assertEquals(null, $response->headers->get('set-cookie'));
-        static::assertEquals(405, $response->getStatusCode());
+        static::assertEquals('application/json', $response->getHeader('Content-Type'));
+        static::assertEquals(404, $response->getStatusCode());
 
-        $result = $response->getContent();
+        $result = $response->getBody();
+
         $result = json_decode($result, true);
 
         static::assertArrayHasKey('success', $result);
         static::assertFalse($result['success']);
-        static::assertEquals('This resource has no support for batch operations.', $result['message']);
+
+        static::assertArrayHasKey('message', $result);
     }
 }

--- a/tests/Functional/Api/PaymentMethodsTest.php
+++ b/tests/Functional/Api/PaymentMethodsTest.php
@@ -26,6 +26,9 @@ namespace Shopware\Tests\Functional\Api;
 
 use Shopware\Models\Payment\Payment;
 
+/**
+ * @covers \Shopware_Controllers_Api_PaymentMethods
+ */
 class PaymentMethodsTest extends AbstractApiTestCase
 {
     public function testRequestWithoutAuthenticationShouldReturnError(): void

--- a/tests/Functional/Api/VersionTest.php
+++ b/tests/Functional/Api/VersionTest.php
@@ -26,9 +26,12 @@ namespace Shopware\Tests\Functional\Api;
 
 use Shopware\Kernel;
 
+/**
+ * @covers \Shopware_Controllers_Api_Version
+ */
 class VersionTest extends AbstractApiTestCase
 {
-    public function testGetVersionShouldBeSuccessful()
+    public function testGetVersionShouldBeSuccessful(): void
     {
         $kernel = new Kernel('testing', true);
         $release = $kernel->getRelease();


### PR DESCRIPTION
### 1. Why is this change necessary?
While some API endpoints supply attributes not all do. But AFAIK none allows to pass the attributes for create or update calls.
Also the API isn't part of the typical test cases right now and has low coverage.

### 2. What does this change do, exactly?
- adds support for attributes on `create` & `update` calls
- adds attributes to `getOne` and `getList` resource calls that won't make these available yet
- add & extend api tests

### 3. Describe each step to reproduce the issue or behaviour.
1. make sure you have attributes for `media` (`s_media`/`s_media_attributes`)
2. call api endpoint for media with valid post payload containing an `attribute` field
3. check for created media without those passed attributes without PR, with PR they will be there 

### 4. Please link to the relevant issues (if any).
- #2196 

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.