### PR TITLE
Fix for undefined index

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductManualPositionLoader.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductManualPositionLoader.php
@@ -48,10 +48,14 @@ class ProductManualPositionLoader implements ProductManualPositionLoaderInterfac
             ->execute()
             ->fetchAll(\PDO::FETCH_GROUP | \PDO::FETCH_ASSOC);
 
-        foreach ($data as $item) {
-            $item['category_id'] = (int) $item['category_id'];
-            $item['position'] = (int) $item['position'];
+        foreach ($data as &$fetchGroup) {
+            foreach ($fetchGroup as &$item) {
+                $item['category_id'] = (int) $item['category_id'];
+                $item['position'] = (int) $item['position'];
+            }
+            unset($item);
         }
+        unset($fetchGroup);
 
         return $data;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
```
Indexing products

Notice: Undefined index: category_id in /Users/a.wink/Code/sw56-surteco/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductManualPositionLoader.php on line 52

Notice: Undefined index: position in /Users/a.wink/Code/sw56-surteco/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductManualPositionLoader.php on line 53
```
### 2. What does this change do, exactly?
Fix the undefined indexes

#### Current:
##### before: 
```
{"7":[{"category_id":"6","position":"1"}]}
```
##### after: 
```
{"7":[{"category_id":"6","position":"1"}]}
```
-- With output (see above)
#### Fixed:
##### before: 
```
{"7":[{"category_id":"6","position":"1"}]}
```
##### after: 
```
{"7":[{"category_id":6,"position":1}]}
```

### 3. Describe each step to reproduce the issue or behaviour.
Execute
`php bin/console sw:es:index:populate` 
or
`php bin/console sw:es:index:populate --index product`

### 4. Please link to the relevant issues (if any).
///

### 5. Which documentation changes (if any) need to be made because of this PR?
///

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
  - Tested by my self
- [X] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.