### PR TITLE
remove px from unitize

### DIFF
--- a/themes/Frontend/Bare/frontend/_public/src/less/_mixins/unitize.less
+++ b/themes/Frontend/Bare/frontend/_public/src/less/_mixins/unitize.less
@@ -28,33 +28,21 @@ In addition to the general `.unitize()` mixin, Shopware contains specific mixins
 
     // @deprecated unitize mixin which should be called like ```.unitize(200, @remScaleFactor, height);```
 .unitize(@value, @baseValue: @remScaleFactor, @property: font-size) when (isnumber(@value)) and(isnumber(@baseValue)) and (iskeyword(@property)) {
-    @pxValue: @value;
     @remValue: (@value / @baseValue);
-    @{property}: ~"@{pxValue}px";
     @{property}: ~"@{remValue}rem";
 }
     // New default unitize mixin which should be called like ```.unitize(height, 200);```
 .unitize(@property, @value, @baseValue: @remScaleFactor) when (iskeyword(@property)) and (isnumber(@value)) and (isnumber(@baseValue)) {
-    @pxValue: @value;
     @remValue: (@value / @baseValue);
-    @{property}: ~"@{pxValue}px";
     @{property}: ~"@{remValue}rem";
 }
 
 .unitize-multiple(@topValue, @rightValue: @topValue, @bottomValue: @topValue, @leftValue: @rightValue, @baseValue: @remScaleFactor, @property: padding) {
-    @pxTopValue: @topValue;
     @emTopValue: (@topValue / @baseValue);
-
-    @pxRightValue: @rightValue;
     @emRightValue: (@rightValue / @baseValue);
-
-    @pxBottomValue: @bottomValue;
     @emBottomValue: (@bottomValue / @baseValue);
-
-    @pxLeftValue: @leftValue;
     @emLeftValue: (@leftValue / @baseValue);
 
-    @{property}: ~"@{pxTopValue}px @{pxRightValue}px @{pxBottomValue}px @{pxLeftValue}px";
     @{property}: ~"@{emTopValue}rem @{emRightValue}rem @{emBottomValue}rem @{emLeftValue}rem";
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
These duplicated properties aren't necessary. This will save filesize.

### 2. What does this change do, exactly?
Remove printing of pixel-properties in css while using unitize

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.