### PR TITLE
Fixed: return type for getter getRegisterOptInId of nullable property registerOptInId

### DIFF
--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -34,6 +34,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
   * `partner`
   * `sUniqueID`
 * Changed `unitize` mixin to only output rem values
+* Changed `Shopware\Models\Customer\Customer`, set correct return type for `getregisterOptInId`
 
 ### Removals
 

--- a/engine/Shopware/Models/Customer/Customer.php
+++ b/engine/Shopware/Models/Customer/Customer.php
@@ -1485,7 +1485,7 @@ class Customer extends LazyFetchModelEntity
         $this->changed = new \DateTime();
     }
 
-    public function getRegisterOptInId(): int
+    public function getRegisterOptInId(): ?int
     {
         return $this->registerOptInId;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Serialization of Customer entity results in fatal error if value for registerOptInId is NULL

### 2. What does this change do, exactly?
Return type has been set correctly to allow NULL

### 3. Describe each step to reproduce the issue or behaviour.
1. set registerOptInId = NULL for customer
2. load entity
3. calling getter getRegisterOptInId() will result in Fatal Error 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.