### PR TITLE
Fix mail context filter

### DIFF
--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -232,16 +232,16 @@ class Shopware_Components_TemplateMail
             ];
         }
 
-        // Save current context to mail model
-        $mailContext = json_decode(json_encode($context), true);
-
-        $mailContext = $eventManager->filter(
+        $context = $eventManager->filter(
             'TemplateMail_CreateMail_MailContext',
-            $mailContext,
+            $context,
             [
                 'mailModel' => $mailModel,
             ]
         );
+
+        // Save current context to mail model
+        $mailContext = json_decode(json_encode($context), true);
 
         $mailModel->setContext($mailContext);
         $this->getModelManager()->flush($mailModel);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Because the mail context filter ('TemplateMail_CreateMail_MailContext') has no effect on the context, that is actually being provided to the mail template.

### 2. What does this change do, exactly?

It fixes the issue mentioned above. The filter event now filters the variable $context, that is later being passed to the mail template.

### 3. Describe each step to reproduce the issue or behaviour.

- Subscribe the filter event 'TemplateMail_CreateMail_MailContext'
- Change the value of context variables or add you own variables
- Add an ouput of these variables to a random mail template
- Trigger this mail (e.g. playce an order to trigger the sORDER mail. Do not send a test mail from within the mail template manager in the backend!)

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
n/a

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.