### PR TITLE
Add getter and setter for $formatDateTime in json renderer

### DIFF
--- a/engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
+++ b/engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
@@ -79,13 +79,11 @@ class Enlight_Controller_Plugins_Json_Bootstrap extends Enlight_Plugin_Bootstrap
     /**
      * Called from the Event Manager after the dispatch process
      *
-     * @param Enlight_Event_EventArgs $args
-     *
      * @return bool
      */
     public function onPostDispatch(Enlight_Event_EventArgs $args)
     {
-        /** @var $controller Enlight_Controller_Action $controller */
+        /** @var Enlight_Controller_Action $controller $controller */
         $subject = $args->get('subject');
         $response = $subject->Response();
         $request = $subject->Request();
@@ -208,10 +206,20 @@ class Enlight_Controller_Plugins_Json_Bootstrap extends Enlight_Plugin_Bootstrap
         return $this->encoding;
     }
 
+    public function isFormatDateTime(): bool
+    {
+        return $this->formatDateTime;
+    }
+
+    public function setFormatDateTime(bool $formatDateTime): self
+    {
+        $this->formatDateTime = $formatDateTime;
+
+        return $this;
+    }
+
     /**
      * Converts data to json
-     *
-     * @param mixed $data
      *
      * @return string
      */
@@ -235,7 +243,6 @@ class Enlight_Controller_Plugins_Json_Bootstrap extends Enlight_Plugin_Bootstrap
      * Converts date time objects
      *
      * @param DateTime $value
-     * @param mixed    $key
      */
     protected static function convertDateTime(&$value, $key)
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
The variable `$formatDateTime` already exists, but cannot be set externally yet. So there is no way to not use date formatting.

### 2. What does this change do, exactly?
Add accessor methods for the variable. Also some necessary refactoring stuff to get the cs-fixer off my back.

### 3. Describe each step to reproduce the issue or behaviour.
1. 🤔 Try to use the json renderer without date formatting.
2. 😁 Be happy to see `$formatDateTime` and its usage in a condition.
3. 😭 Have all your hopes and dreams crushed by realizing there is no way to set it.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.