### PR TITLE
Make ListProductService interchangeable with ProductService

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/ProductServiceInterface.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/ProductServiceInterface.php
@@ -27,7 +27,7 @@ namespace Shopware\Bundle\StoreFrontBundle\Service;
 use Shopware\Bundle\StoreFrontBundle\Struct\Product;
 use Shopware\Bundle\StoreFrontBundle\Struct\ProductContextInterface;
 
-interface ProductServiceInterface
+interface ProductServiceInterface extends ListProductServiceInterface
 {
     /**
      * @see \Shopware\Bundle\StoreFrontBundle\Service\ProductServiceInterface::get()


### PR DESCRIPTION
### 1. Why is this change necessary?
When I have a service that normally uses a `ListProductService` and now I need more detailed information in the resulting structs, I now have the option to change the service definition to use a `ProductService` for the exact same code. E.g. the `ProductSearch` could then have `Product` instances instead of `ListProduct` instances in its results. That will not break anything, because `Product` extends `ListProduct`, so it can be used in the same way. The difference is that now I can decorate the `ProductSearch` and work with the information of `Product` structs.

### 2. What does this change do, exactly?
`interface ProductServiceInterface extends ListProductServiceInterface`

### 3. Describe each step to reproduce the issue or behaviour.
See 1.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.