### PR TITLE
Add more blocks to frontend/_includes/emotion

### DIFF
--- a/themes/Frontend/Bare/frontend/_includes/emotion.tpl
+++ b/themes/Frontend/Bare/frontend/_includes/emotion.tpl
@@ -1,11 +1,19 @@
-<div class="emotion--wrapper" style="display: none"
-     data-controllerUrl="{url module=widgets controller=emotion action=index emotionId=$emotion.id secret=$previewSecret controllerName=$Controller}"
-     data-availableDevices="{$emotion.devices}"
-     data-ajax="{if $theme.ajaxEmotionLoading}true{else}false{/if}"
-     {if isset($showListing)} data-showListing="{if $showListing == 1}true{else}false{/if}"{/if}{block name="frontend_emotion_include_attributes"}{/block}>
-     {if !$theme.ajaxEmotionLoading}
-         <template style="display: none">
-         {action module=widgets controller=emotion action=index emotionId=$emotion.id secret=$previewSecret controllerName=$Controller}
-         </template>
-     {/if}
-</div>
+{block name="frontend_includes_emotion"}
+    <div class="emotion--wrapper" style="display: none"
+         data-controllerUrl="{url module=widgets controller=emotion action=index emotionId=$emotion.id secret=$previewSecret controllerName=$Controller}"
+         data-availableDevices="{$emotion.devices}"
+         data-ajax="{if $theme.ajaxEmotionLoading}true{else}false{/if}"
+         {if isset($showListing)} data-showListing="{if $showListing == 1}true{else}false{/if}"{/if}{block name="frontend_emotion_include_attributes"}{/block}>
+        {block name="frontend_includes_emotion_inner"}
+            {if !$theme.ajaxEmotionLoading}
+                {block name="frontend_includes_emotion_template"}
+                    <template style="display: none">
+                        {block name="frontend_includes_emotion_template_inner"}
+                            {action module=widgets controller=emotion action=index emotionId=$emotion.id secret=$previewSecret controllerName=$Controller}
+                        {/block}
+                    </template>
+                {/block}
+            {/if}
+        {/block}
+    </div>
+{/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
In case of adding customizations here I have to overwrite the complete template. Not so cool.

### 2. What does this change do, exactly?
Adds more smarty blocks

### 3. Describe each step to reproduce the issue or behaviour.
* Add rich snippets
* Make attribute/free text field
* Choose a central point for emotion worlds
* Want to add meta-data
* Has! To! Override! Complete! Template! :anger: 

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.