### PR TITLE
Check for invalid cache result

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
@@ -166,7 +166,9 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
 
         if ($this->Config()->get('caching') && $cache->test($cacheKey)) {
             $menu = $cache->load($cacheKey, true);
-        } else {
+        }
+
+        if (empty($menu) || !is_array($menu)) {
             $ids = $this->getCategoryIdsOfDepth($category, $depth);
             $categories = Shopware()->Container()->get(\Shopware\Bundle\StoreFrontBundle\Service\CategoryServiceInterface::class)->getList($ids, $context);
             $categoriesArray = $this->convertCategories($categories);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
In certain circumstances - i.e. when using Redis-Backend with LRU-Eviction active - loading a cached menu can return false, despite a successful test in the condition prior. 

### 2. What does this change do, exactly?
Check if we actually received a proper menu-array from cache

### 3. Describe each step to reproduce the issue or behaviour.
- Set up Shopware to use redis backend.
- Load any page once.
- Remove the cache item from redis using cli, but keep the set containing tags.
- Reload the page. $menu will be "false" 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.