### PR TITLE
SW-24821 / Disable submit button to prevent multiple form submits

### DIFF
--- a/themes/Frontend/Bare/frontend/register/index.tpl
+++ b/themes/Frontend/Bare/frontend/register/index.tpl
@@ -215,7 +215,7 @@
                     {block name='frontend_register_index_form_submit'}
                         {* Submit button *}
                         <div class="register--action">
-                            <button type="submit" class="register--submit btn is--primary is--large is--icon-right" name="Submit">{s name="RegisterIndexNewActionSubmit"}{/s} <i class="icon--arrow-right"></i></button>
+                            <button type="submit" class="register--submit btn is--primary is--large is--icon-right" name="Submit" data-preloader-button="true">{s name="RegisterIndexNewActionSubmit"}{/s} <i class="icon--arrow-right"></i></button>
                         </div>
                     {/block}
                 </form>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
This change is necessary to prevent multiple submit from the registration form. This change fixes the issue https://issues.shopware.com/issues/SW-24821.

### 2. What does this change do, exactly?
This change disables the submit button after the first form submit was triggered.

### 3. Describe each step to reproduce the issue or behaviour.
Click the registration submit button more than one time, the user is created on the first request but the request will be canceled after the next click. This results in an error, because the user email address now already exists in the database, created by the first request.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-24821

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.