### PR TITLE
[SW-24808] Fix for duplicate names in plugin defined menu

### DIFF
--- a/engine/Shopware/Components/Plugin/MenuSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/MenuSynchronizer.php
@@ -81,6 +81,11 @@ class MenuSynchronizer
             $items[] = $this->createMenuItem($plugin, $parent, $menuItem);
         }
 
+        foreach ($menuNames as &$menuName) {
+            $menuName = $plugin->getName() . '_' . $menuName;
+        }
+        unset($menuName);
+
         $this->em->flush($items);
         $this->removeNotExistingEntries($plugin->getId(), $menuNames);
     }
@@ -121,7 +126,7 @@ class MenuSynchronizer
             /** @var Menu $item */
             $item = $this->menuRepository->findOneBy([
                 'pluginId' => $plugin->getId(),
-                'label' => $menuItem['name'],
+                'label' => $plugin->getName() . '_' . $menuItem['name'],
             ]);
         }
 
@@ -135,7 +140,7 @@ class MenuSynchronizer
         if (!isset($menuItem['label']['en']) || empty($menuItem['label']['en'])) {
             throw new \RuntimeException('Label with lang en required');
         }
-        $item->setLabel($menuItem['name']);
+        $item->setLabel($plugin->getName() . '_' . $menuItem['name']);
 
         $item->setController(
             isset($menuItem['controller']) ? $menuItem['controller'] : null


### PR DESCRIPTION
### 1. Why is this change necessary?
If you want to install two plugins with the same menu entry

### 2. What does this change do, exactly?
Removes an index on `name` inside
 `s_core_menu`

### 3. Describe each step to reproduce the issue or behaviour.
Use the provided plugins and try to install (activate) both
[examplePlugins.zip](https://github.com/shopware/shopware/files/3788431/examplePlugins.zip)

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-24808

### 5. Which documentation changes (if any) need to be made because of this PR?
///

### 6. Checklist
- [ ] I have written tests and verified that they fail without my change
  - Tested the backend accessibility
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.