### PR TITLE
added ignoredExceptionClasses also to testkernel config due to fatal …

### DIFF
--- a/tests/Functional/config.php
+++ b/tests/Functional/config.php
@@ -30,6 +30,17 @@ return array_replace_recursive($this->loadConfig($this->AppPath() . 'Configs/Def
     ],
     'errorhandler' => [
         'throwOnRecoverableError' => true,
+        'ignoredExceptionClasses' => [
+            // Disable logging for defined exceptions by class, eg. to disable any logging for CSRF exceptions add this:
+            // \Shopware\Components\CSRFTokenValidationException::class
+            \Shopware\Components\Api\Exception\BatchInterfaceNotImplementedException::class,
+            \Shopware\Components\Api\Exception\CustomValidationException::class,
+            \Shopware\Components\Api\Exception\NotFoundException::class,
+            \Shopware\Components\Api\Exception\OrmException::class,
+            \Shopware\Components\Api\Exception\ParameterMissingException::class,
+            \Shopware\Components\Api\Exception\PrivilegeException::class,
+            \Shopware\Components\Api\Exception\ValidationException::class,
+        ],
     ],
     'session' => [
         'unitTestEnabled' => true,


### PR DESCRIPTION
…through non-existent parameter

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Executing PHPUnit will cause a fatal error otherwise due to missing config parameters, which were recently added to the default config.

`Fatal error: Uncaught Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException: The service "errorsubscriber" has a dependency on a non-existent parameter "shopware.errorHandler.ignoredExceptionClasses".`

### 2. What does this change do, exactly?
Add the missing config parameter also in the test kernel config.

### 3. Describe each step to reproduce the issue or behaviour.
Just execute PHPUnit in the doc root. Make sure that the cache is cleared.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ - ] I have written tests and verified that they fail without my change (not neccessary)
- [ x ] I have squashed any insignificant commits
- [ - ] This change has comments for package types, values, functions, and non-obvious lines of code (not neccessary)
- [ x ] I have read the contribution requirements and fulfil them.