### PR TITLE
Add smarty blocks for sidebar subcategory config

### DIFF
--- a/themes/Frontend/Bare/frontend/index/sidebar.tpl
+++ b/themes/Frontend/Bare/frontend/index/sidebar.tpl
@@ -15,55 +15,59 @@
                         {/block}
                     </ul>
 
-                {* Switches for currency and language on mobile devices *}
-                {block name="frontend_index_left_switches"}
-                    <div class="mobile--switches">
-                        {action module=widgets controller=index action=shopMenu}
-                    </div>
-                {/block}
-            </div>
-        {/block}
-
-            {* if sCategoryContent is not available use sArticle.categoryID *}
-            {if isset($sCategoryContent) && $sCategoryContent.id}
-                {$subCategoryId = $sCategoryContent.id}
-            {elseif isset($sArticle) && $sArticle.categoryID}
-                {$subCategoryId = $sArticle.categoryID}
-            {elseif isset($sCustomPage) && $sCustomPage.id}
-                {$subCategoryId = $sCustomPage.id}
-            {else}
-                {$subCategoryId = 0}
-            {/if}
-
-            <div class="sidebar--categories-wrapper"
-                 data-subcategory-nav="true"
-                 data-mainCategoryId="{$sCategoryStart}"
-                 data-categoryId="{$subCategoryId}"
-                 data-fetchUrl="{if $subCategoryId}{if $sCustomPage}{url module=widgets controller=listing action=getCustomPage pageId={$subCategoryId}}{else}{url module=widgets controller=listing action=getCategory categoryId={$subCategoryId}}{/if}{/if}">
-
-                {* Sidebar category tree *}
-                {block name='frontend_index_left_categories'}
-
-                    {* Categories headline *}
-                    {block name="frontend_index_left_categories_headline"}
-                        <div class="categories--headline navigation--headline">
-                            {s namespace='frontend/index/menu_left' name="IndexSidebarCategoryHeadline"}{/s}
+                    {* Switches for currency and language on mobile devices *}
+                    {block name="frontend_index_left_switches"}
+                        <div class="mobile--switches">
+                            {action module=widgets controller=index action=shopMenu}
                         </div>
                     {/block}
+                </div>
+            {/block}
 
-                    {* Actual include of the categories *}
-                    {block name='frontend_index_left_categories_inner'}
-                        <div class="sidebar--categories-navigation">
-                            {include file='frontend/index/sidebar-categories.tpl'}
-                        </div>
+            {block name="frontend_index_left_subcategory_config"}
+                {* if sCategoryContent is not available use sArticle.categoryID *}
+                {if isset($sCategoryContent) && $sCategoryContent.id}
+                    {$subCategoryId = $sCategoryContent.id}
+                {elseif isset($sArticle) && $sArticle.categoryID}
+                    {$subCategoryId = $sArticle.categoryID}
+                {elseif isset($sCustomPage) && $sCustomPage.id}
+                    {$subCategoryId = $sCustomPage.id}
+                {else}
+                    {$subCategoryId = 0}
+                {/if}
+            {/block}
+
+            {block name='frontend_index_left_categories_wrapper'}
+                <div class="sidebar--categories-wrapper"
+                     data-subcategory-nav="true"
+                     data-mainCategoryId="{$sCategoryStart}"
+                     data-categoryId="{$subCategoryId}"
+                     data-fetchUrl="{if $subCategoryId}{if $sCustomPage}{url module=widgets controller=listing action=getCustomPage pageId={$subCategoryId}}{else}{url module=widgets controller=listing action=getCategory categoryId={$subCategoryId}}{/if}{/if}">
+
+                    {* Sidebar category tree *}
+                    {block name='frontend_index_left_categories'}
+
+                        {* Categories headline *}
+                        {block name="frontend_index_left_categories_headline"}
+                            <div class="categories--headline navigation--headline">
+                                {s namespace='frontend/index/menu_left' name="IndexSidebarCategoryHeadline"}{/s}
+                            </div>
+                        {/block}
+
+                        {* Actual include of the categories *}
+                        {block name='frontend_index_left_categories_inner'}
+                            <div class="sidebar--categories-navigation">
+                                {include file='frontend/index/sidebar-categories.tpl'}
+                            </div>
+                        {/block}
                     {/block}
-                {/block}
 
-                {* Static sites *}
-                {block name='frontend_index_left_menu'}
-                    {include file='frontend/index/sites-navigation.tpl'}
-                {/block}
-            </div>
+                    {* Static sites *}
+                    {block name='frontend_index_left_menu'}
+                        {include file='frontend/index/sites-navigation.tpl'}
+                    {/block}
+                </div>
+            {/block}
         {/block}
     </aside>
 {/block}


### PR DESCRIPTION
### 1. Why is this change necessary?
I wanted to change the value of `$subCategoryId` and there was no block to do so. Now there is. Also some indention fixes.

### 2. What does this change do, exactly?
Add two new blocks and fix some indention.

### 3. Describe each step to reproduce the issue or behaviour.
None.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.