### PR TITLE
Fix migration for shop pages in update to 5.6

### DIFF
--- a/_sql/migrations/1404-remove-language-distinction-from-shop-pages.php
+++ b/_sql/migrations/1404-remove-language-distinction-from-shop-pages.php
@@ -43,7 +43,8 @@ SQL;
 
         if ($modus === self::MODUS_INSTALL) {
             $this->addSql($dropEnglish);
-            $this->addSql($renameGerman);
         }
+
+        $this->addSql($renameGerman);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The new template files use the new template keys. When the keys are only changed during a fresh install, the shop pages will not be displayed after an update. This has become a common problem that many face while updating from earlier versions to 5.6.

### 2. What does this change do, exactly?
This change moves the sql to rename the german shop pages out of the condition for the migration mode to be `update`, because with that condition the shop pages are not displayed after the update.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a shopware shop in version `< 5.6`
2. Update to `5.6`
3. See no shop pages in the footer

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.