### PR TITLE
Fix a typo.

### DIFF
--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -40,6 +40,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
 * Changed `Shopware\Models\Customer\Customer`, set correct return type for `getregisterOptInId`
 * Changed the `TemplateMail_CreateMail_MailContext` filter to work correctly.
 * Changed `ProductServiceInterface` to extend from `ListProductServiceInterface`
+* Changed additionAddressLine1 in `themes/Frontend/Bare/frontend/register/shipping_fieldset.tpl` to fix a typo.
 
 ### Removals
 

--- a/themes/Frontend/Bare/frontend/register/shipping_fieldset.tpl
+++ b/themes/Frontend/Bare/frontend/register/shipping_fieldset.tpl
@@ -97,7 +97,7 @@
                         <div class="register--additional-line1">
                             <input autocomplete="section-shipping shipping address-line2"
                                    name="register[shipping][additionalAddressLine1]"
-                                   type="text"{if {config name=requireAdditionAddressLine2}} required="required" aria-required="true"{/if}
+                                   type="text"{if {config name=requireAdditionAddressLine1}} required="required" aria-required="true"{/if}
                                    placeholder="{s name='RegisterLabelAdditionalAddressLine1'}{/s}{if {config name=requireAdditionAddressLine1}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                    id="additionalAddressLine21"
                                    value="{$form_data.additionalAddressLine1|escape}"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Because it fixes a bug in the register-form.

### 2. What does this change do, exactly?
Fix a bug/ typo.

### 3. Describe each step to reproduce the issue or behaviour.
1. In the basic settings, go to the "Login / registration"-page.
2. Here, set "Show additional address line 1" and "Show additional address line 1" to "Yes".
3. Next, set only "Treat additional address line 2 as required" to "Yes".
4. Now, go to the register-page of your shop (f.ex. www.shop.de/account). Fill out all required inputs, while keeping the "The shipping address does not match the billing address"-Checkbox unset.
5. After that, click on the submit button. => Nothing happens, the responsible JS-Plugin could not set the hidden shipping-additionalAddressLine2-field to not-required.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.