### PR TITLE
Remove facebook plugin (deprecated 5.0) completely

### DIFF
--- a/_sql/migrations/1705-remove-facebook-plugin.php
+++ b/_sql/migrations/1705-remove-facebook-plugin.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+class Migrations_Migration1705 extends Shopware\Components\Migrations\AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+SET @pluginId = (SELECT id FROM s_core_plugins WHERE name = 'Facebook' and namespace = 'Frontend' and `source` = 'Default' LIMIT 1);
+SET @formId = (SELECT id FROM s_core_config_forms WHERE plugin_id = @pluginId);
+
+DELETE FROM s_core_config_elements WHERE form_id = @formId;
+DELETE FROM s_core_config_forms WHERE id = @formId;
+DELETE FROM s_core_plugins WHERE id = @pluginId'
+EOD;
+        $this->addSql($sql);
+    }
+}

--- a/_sql/migrations/1705-remove-facebook-plugin.php
+++ b/_sql/migrations/1705-remove-facebook-plugin.php
@@ -29,9 +29,9 @@ class Migrations_Migration1705 extends Shopware\Components\Migrations\AbstractMi
 SET @pluginId = (SELECT id FROM s_core_plugins WHERE name = 'Facebook' and namespace = 'Frontend' and `source` = 'Default' LIMIT 1);
 SET @formId = (SELECT id FROM s_core_config_forms WHERE plugin_id = @pluginId);
 
-DELETE FROM s_core_config_elements WHERE form_id = @formId;
-DELETE FROM s_core_config_forms WHERE id = @formId;
-DELETE FROM s_core_plugins WHERE id = @pluginId'
+DELETE FROM s_core_config_elements WHERE form_id = @formId AND form_id IS NOT NULL;
+DELETE FROM s_core_config_forms WHERE id = @formId AND id IS NOT NULL;
+DELETE FROM s_core_plugins WHERE id = @pluginId AND id IS NOT NULL'
 EOD;
         $this->addSql($sql);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
As in migration 630 a deprecated plugin can be safely removed.

### 2. What does this change do, exactly?
Copies migration 630 and replace Google with Facebook. It **deletes** an s_core_plugin entry that has been [deprecated since 5.0](https://github.com/shopware/shopware/blame/406925fbb6a8e98beb94e71ceca1fd473a6edc31/UPGRADE-5.0.md#L500).
That could've been done almost 4 years ago with migration 630 (deprecated since April 2015).

### 3. Describe each step to reproduce the issue or behaviour.
1. Look for not installed plugins in backend plugin manager
2. Look for not installed plugins via SQL as it is easier to copy into a script
3. Be confused why you get one more result in SQL than in plugin manager
4. :male_detective: 

### 4. Please link to the relevant issues (if any).
Finally I can link an [issue](https://issues.shopware.com/issues/SW-13025).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.