### PR TITLE
Remove the need to begin javascript files with a semicolon

### DIFF
--- a/engine/Shopware/Components/Theme/Compiler.php
+++ b/engine/Shopware/Components/Theme/Compiler.php
@@ -290,7 +290,7 @@ class Compiler
         $javascriptFiles = $this->javascriptCollector->collectJavascriptFiles($template, $shop);
         $content = '';
         foreach ($javascriptFiles as $jsFile) {
-            $content .= file_get_contents($jsFile) . "\n";
+            $content .= file_get_contents($jsFile) . ";\n";
         }
 
         if ($settings->getCompressJs()) {

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.add-article.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.add-article.js
@@ -1,4 +1,4 @@
-;(function ($, window) {
+(function ($, window) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.address-editor.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.address-editor.js
@@ -1,4 +1,4 @@
-;(function($, window) {
+(function($, window) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.address-selection.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.address-selection.js
@@ -1,4 +1,4 @@
-;(function($, window) {
+(function($, window) {
     'use strict';
 
     $.addressSelection = {

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-product-navigation.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-product-navigation.js
@@ -1,4 +1,4 @@
-;(function ($, Modernizr, location) {
+(function ($, Modernizr, location) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-variant.js
@@ -1,4 +1,4 @@
-;(function ($, window) {
+(function ($, window) {
     /**
      * Shopware AJAX variant
      *

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-wishlist.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.ajax-wishlist.js
@@ -1,4 +1,4 @@
-;(function ($, window, undefined) {
+(function ($, window, undefined) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.auto-submit.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.auto-submit.js
@@ -1,4 +1,4 @@
-;(function($) {
+(function($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.captcha.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.captcha.js
@@ -1,4 +1,4 @@
-;(function($, window) {
+(function($, window) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.collapse-cart.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.collapse-cart.js
@@ -1,4 +1,4 @@
-;(function ($, window) {
+(function ($, window) {
     'use strict';
 
     $.plugin('swCollapseCart', {

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.collapse-panel.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.collapse-panel.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-consent-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-consent-manager.js
@@ -1,4 +1,4 @@
-;(function ($, window, undefined) {
+(function ($, window, undefined) {
     'use strict';
 
     $.getCookiePreference = function(cookieName) {

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-permission.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-permission.js
@@ -1,4 +1,4 @@
-;(function($, window) {
+(function($, window) {
     'use strict';
 
     var $body = $('body');

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.csrf-protection.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.csrf-protection.js
@@ -1,4 +1,4 @@
-;(function($, window, document) {
+(function($, window, document) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.drop-down-menu.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.drop-down-menu.js
@@ -1,4 +1,4 @@
-;(function($) {
+(function($) {
     'use strict';
 
     $.plugin('swDropdownMenu', {

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.emotion.js
@@ -1,4 +1,4 @@
-;(function($, window, document, undefined) {
+(function($, window, document, undefined) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.filter-component.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.filter-component.js
@@ -1,4 +1,4 @@
-;(function($, window, document, undefined) {
+(function($, window, document, undefined) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.form-polyfill.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.form-polyfill.js
@@ -1,4 +1,4 @@
-;(function($) {
+(function($) {
     'use strict';
 
     $.plugin('swFormPolyfill', {

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
@@ -1,4 +1,4 @@
-;(function ($, window) {
+(function ($, window) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-slider.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-slider.js
@@ -1,4 +1,4 @@
-;(function ($, Modernizr, window, Math) {
+(function ($, Modernizr, window, Math) {
     'use strict';
 
     var transitionProperty = StateManager.getVendorProperty('transition'),

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-zoom.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-zoom.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.infinite-scrolling.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.infinite-scrolling.js
@@ -1,4 +1,4 @@
-;(function($, window) {
+(function($, window) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.invalid-tos-jump.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.invalid-tos-jump.js
@@ -1,4 +1,4 @@
-;(function($, window) {
+(function($, window) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.jump-to-tab.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.jump-to-tab.js
@@ -1,4 +1,4 @@
-;(function($, window) {
+(function($, window) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.last-seen-products.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.last-seen-products.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     var emptyObj = {};
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.lightbox.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.lightbox.js
@@ -1,4 +1,4 @@
-;(function ($, window, Math) {
+(function ($, window, Math) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.listing-actions.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.listing-actions.js
@@ -1,4 +1,4 @@
-;(function ($, window, StateManager, undefined) {
+(function ($, window, StateManager, undefined) {
     'use strict';
 
     var $body = $('body');

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.loading-indicator.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.loading-indicator.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.menu-scroller.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.menu-scroller.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.modal.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.modal.js
@@ -1,4 +1,4 @@
-;(function ($, window) {
+(function ($, window) {
     'use strict';
 
     var emptyFn = function () {},

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.newsletter.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.newsletter.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     $.plugin('swNewsletter', {

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.off-canvas-button.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.off-canvas-button.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.off-canvas-menu.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.off-canvas-menu.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     var $html = $('html');

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.offcanvas-html-panel.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.offcanvas-html-panel.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     /**
      * Shopware Offcanvas HTML Panel
      *

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.overlay.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.overlay.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.panel-auto-resizer.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.panel-auto-resizer.js
@@ -1,4 +1,4 @@
-;(function($) {
+(function($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     /*! Tiny Pub/Sub - v0.7.0 - 2013-01-29
      * https://github.com/cowboy/jquery-tiny-pubsub
      * Copyright (c) 2014 "Cowboy" Ben Alman; Licensed MIT */
@@ -16,7 +16,7 @@
     };
 }(jQuery));
 
-;(function ($, window) {
+(function ($, window) {
     'use strict';
 
     var numberRegex = /^-?\d*\.?\d*$/,

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.preloader-button.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.preloader-button.js
@@ -1,4 +1,4 @@
-;(function($, window, undefined) {
+(function($, window, undefined) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-add.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-add.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-menu.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-compare-menu.js
@@ -1,4 +1,4 @@
-;(function($) {
+(function($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js
@@ -17,7 +17,7 @@
  *     </div>
  * </div>
  */
-;(function ($, window) {
+(function ($, window) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.pseudo-text.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.pseudo-text.js
@@ -1,4 +1,4 @@
-;(function($, window) {
+(function($, window) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.range-slider.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.range-slider.js
@@ -1,4 +1,4 @@
-;(function($, window, document) {
+(function($, window, document) {
     'use strict';
 
     var $document = $(document);

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.register.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.scroll.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.scroll.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.search.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.search.js
@@ -1,4 +1,4 @@
-;(function ($, StateManager, window) {
+(function ($, StateManager, window) {
     'use strict';
 
     var msPointerEnabled = window.navigator.msPointerEnabled,

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.selectbox-replacement.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.selectbox-replacement.js
@@ -1,4 +1,4 @@
-;(function ($, window, document, undefined) {
+(function ($, window, document, undefined) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.shipping-payment.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.shipping-payment.js
@@ -1,4 +1,4 @@
-;(function($) {
+(function($) {
     'use strict';
 
     $.plugin('swShippingPayment', {

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.state-manager.js
@@ -102,7 +102,7 @@
  *                .addPlugin('.my-selector', 'pluginName', { 'foo': 'baz' }, 'm');
  * ```
  */
-;(function ($, window, document) {
+(function ($, window, document) {
     'use strict';
 
     var $html = $('html'),

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-field.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-field.js
@@ -1,4 +1,4 @@
-;(function($, window) {
+(function($, window) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-manager.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.storage-manager.js
@@ -1,4 +1,4 @@
-;(function (window, document) {
+(function (window, document) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.subcategory-nav.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.subcategory-nav.js
@@ -1,4 +1,4 @@
-;(function ($, Modernizr) {
+(function ($, Modernizr) {
     'use strict';
 
     /**

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.tab-menu.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.tab-menu.js
@@ -1,4 +1,4 @@
-;(function ($) {
+(function ($) {
     /**
      * Shopware Tab Menu Plugin
      *


### PR DESCRIPTION
### 1. Why is this change necessary?
To account for errors of others it has always been a good idea to begin a javascript file with a semicolon. That way a third party could have forgotten the last semicolon in a file and the merged code would still work. So I figured, it would be clever to have this extra semicolon be added automatically when merging the files.

### 2. What does this change do, exactly?
Remove a bunch of semicolons at the beginning of javascript files.

### 3. Describe each step to reproduce the issue or behaviour.
Not really steps but rather an explanation: see 1.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None. (I think)

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.