### PR TITLE
Fix update method so the existing component can be found

### DIFF
--- a/engine/Shopware/Components/Emotion/ComponentInstaller.php
+++ b/engine/Shopware/Components/Emotion/ComponentInstaller.php
@@ -68,7 +68,7 @@ class ComponentInstaller
         $repo = $this->em->getRepository(Component::class);
         /** @var Component|null $component */
         $component = $repo->findOneBy([
-            'name' => $componentName,
+            'name' => $data['name'],
             'pluginId' => $plugin->getId(),
         ]);
         if (!$component) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
When you want to update a EKW element, you should use the createOrUpdate Method showed here (https://developers.shopware.com/developers-guide/custom-shopping-world-elements/#registering-a-new-element) - this will sadly not work since the component model ist not saving the component Name given in the method, but the name in the $data Array (see DB Table -> s_library_component).

The name therefore can never be matched and it will never update. 

### 2. What does this change do, exactly?
It will change the findOneBy search for name from $componentName to $data['name']. The update works fine afterwards. 

$componentName seems to be unused after that. So it could be removed afterwards (I can change the PR) Please give a short feedback.

### 3. Describe each step to reproduce the issue or behaviour.
Install a Plugin with the usage of the ComponentInstaller -> update the fields / or add one -> a new element will be created.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
https://developers.shopware.com/developers-guide/custom-shopping-world-elements/#registering-a-new-element -> maybe when the $componentName will be removed.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.