### PR TITLE
Pre-check selector condition in swPanelAutoResizer to prevent endless resize recursion

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.panel-auto-resizer.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.panel-auto-resizer.js
@@ -205,9 +205,18 @@
 
             // shortcut to resize all
             if (typeof selector === 'undefined') {
-                me.resize(me.opts.panelHeaderSelector);
-                me.resize(me.opts.panelBodySelector);
-                me.resize(me.opts.panelFooterSelector);
+                if (typeof me.opts.panelHeaderSelector !== 'undefined') {
+                    me.resize(me.opts.panelHeaderSelector);
+                }
+
+                if (typeof me.opts.panelBodySelector !== 'undefined') {
+                    me.resize(me.opts.panelBodySelector);
+                }
+
+                if (typeof me.opts.panelFooterSelector !== 'undefined') {
+                    me.resize(me.opts.panelFooterSelector);
+                }
+
                 return;
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Prevent an Uncaught RangeError: Maximum call stack size exceeded.

### 2. What does this change do, exactly?
In a case that a `panelHeaderSelector`, `panelBodySelector` or `panelFooterSelector` are an invalid parameter don't invoke a recursive call.

### 3. Describe each step to reproduce the issue or behaviour.
Register the `swPanelAutoResizer` plugin with a partially filled configuration like this:
```js
$.subscribe('plugin/swEmotionLoader/onDeviceChange', function(event, plugin) {
    StateManager.addPlugin(plugin.$el.find('.foo-bar'), 'swPanelAutoResizer', {
        panelBodySelector: '.foo-bar--sub-element'
    });
});
```

### 4. Please link to the relevant issues (if any).
This might be more a problem with an initialization problem but one can forcefully unset the values and still run into the error. So better check it in any case.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x]  I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.