### PR TITLE
Autoload Resources/templates directory

### DIFF
--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -47,6 +47,8 @@ abstract class Plugin extends Bundle implements SubscriberInterface
      */
     protected $pluginNamespace;
 
+    protected $autoloadViews = false;
+
     /**
      * @var bool
      */
@@ -84,6 +86,11 @@ abstract class Plugin extends Bundle implements SubscriberInterface
     final public function isActive()
     {
         return $this->isActive;
+    }
+
+    public function isAutoloadViews(): bool
+    {
+        return $this->autoloadViews;
     }
 
     /**

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -254,7 +254,10 @@ class Kernel extends SymfonyKernel
             }
 
             $this->container->get('events')->addSubscriber($bundle);
-            $this->container->get('events')->addSubscriber(new Plugin\ResourceSubscriber($bundle->getPath()));
+            $this->container->get('events')->addSubscriber(new Plugin\ResourceSubscriber(
+                $bundle->getPath(),
+                $bundle instanceof Plugin && $bundle->isAutoloadViews()
+            ));
         }
 
         $this->booted = true;

--- a/tests/Unit/Components/Plugin/ResourceSubscriberTest.php
+++ b/tests/Unit/Components/Plugin/ResourceSubscriberTest.php
@@ -37,6 +37,17 @@ class ResourceSubscriberTest extends TestCase
         static::assertNull($subscriber->onCollectCss());
         static::assertNull($subscriber->onCollectJavascript());
         static::assertNull($subscriber->onCollectLess());
+        $templateEventArgs = new \Enlight_Event_EventArgs();
+        $templateEventArgs->setReturn([]);
+        $subscriber->onRegisterTemplate($templateEventArgs);
+        static::assertTrue(is_array($templateEventArgs->getReturn()));
+        static::assertEmpty($templateEventArgs->getReturn());
+
+        $subscriberWithViews = new ResourceSubscriber(__DIR__ . '/examples/EmptyPlugin', true);
+        $templateEventArgs->setReturn([]);
+        $subscriberWithViews->onRegisterTemplate($templateEventArgs);
+        static::assertTrue(is_array($templateEventArgs->getReturn()));
+        static::assertEmpty($templateEventArgs->getReturn());
     }
 
     public function testFoo()
@@ -64,6 +75,22 @@ class ResourceSubscriberTest extends TestCase
                 __DIR__ . '/examples/TestPlugin/Resources/frontend/less/all.less',
             ]),
             $subscriber->onCollectLess()
+        );
+        $templateEventArgs = new \Enlight_Event_EventArgs();
+        $templateEventArgs->setReturn([]);
+        $subscriber->onRegisterTemplate($templateEventArgs);
+        static::assertTrue(is_array($templateEventArgs->getReturn()));
+        static::assertEmpty($templateEventArgs->getReturn());
+
+        $subscriberWithViews = new ResourceSubscriber(__DIR__ . '/examples/TestPlugin', true);
+        $templateEventArgs->setReturn([]);
+        $subscriberWithViews->onRegisterTemplate($templateEventArgs);
+        static::assertTrue(is_array($templateEventArgs->getReturn()));
+        static::assertSame(
+            [
+                __DIR__ . '/examples/TestPlugin/Resources/views',
+            ],
+            $templateEventArgs->getReturn()
         );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Once upon a time it was common to put js and less files under `Resources/views/frontend/_public/src` and register the files manually via subscriber. A wise man automatically loads these source files now from `Resources/frontend`. But why are the template files in `Resources/views` not automatically loaded?
To reduce the chance of a breaking change I chose the directory `Resources/templates` as these are template files that needs to be loaded. In case of specific reasons to not load them automatically one can still load them from elsewhere conditionally.

### 2. What does this change do, exactly?
Subscribe `Enlight_Controller_Action_PreDispatch` and tell the controller template manager to use the plugins path.

### 3. Describe each step to reproduce the issue or behaviour.
1. Put `all.less` in `Resources/frontend/less`
2. Style is online
3. Put `foobar.js` into `Resources/frontend/js`
4. Dynamic DOM is online
5. Put `tpl` files into `Resources/views`
6. Nothing happens
7. Adds subscriber class as one does not want to pollute the bootstrap file
8. Add reference to subscriber service in `Resources/services.xml` (which gets loaded automatically!)

### 4. Which documentation changes (if any) need to be made because of this PR?
The information about this new directory has to be propagated somewhere.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.