### PR TITLE
Filter orders by any payment

### DIFF
--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -136,9 +136,18 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
         // Load shop repository
         /** @var \Shopware\Models\Payment\Repository $repository */
         $repository = Shopware()->Models()->getRepository(\Shopware\Models\Payment\Payment::class);
+        $filter = $this->Request()->getParam('filter', []);
+        $hasActiveFilter = in_array('active', array_column($filter, 'property'));
+
+        if (!$hasActiveFilter) {
+            $filter[] = [
+                'property' => 'active',
+                'value' => true
+            ];
+        }
 
         $query = $repository->getAllPaymentsQuery(
-            $this->Request()->getParam('filter', []),
+            $filter,
             $this->Request()->getParam('sort', []),
             $this->Request()->getParam('start'),
             $this->Request()->getParam('limit')

--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -137,7 +137,7 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
         /** @var \Shopware\Models\Payment\Repository $repository */
         $repository = Shopware()->Models()->getRepository(\Shopware\Models\Payment\Payment::class);
 
-        $query = $repository->getActivePaymentsQuery(
+        $query = $repository->getAllPaymentsQuery(
             $this->Request()->getParam('filter', []),
             $this->Request()->getParam('sort', []),
             $this->Request()->getParam('start'),

--- a/themes/Backend/ExtJs/backend/base/store/payment.js
+++ b/themes/Backend/ExtJs/backend/base/store/payment.js
@@ -45,6 +45,11 @@ Ext.define('Shopware.apps.Base.store.Payment', {
         direction: 'ASC'
     }],
 
+    filters: [{
+        property: 'active',
+        value: true
+    }],
+
     proxy:{
         type:'ajax',
         url:'{url action="getPayments"}',

--- a/themes/Backend/ExtJs/backend/base/store/payment.js
+++ b/themes/Backend/ExtJs/backend/base/store/payment.js
@@ -45,11 +45,6 @@ Ext.define('Shopware.apps.Base.store.Payment', {
         direction: 'ASC'
     }],
 
-    filters: [{
-        property: 'active',
-        value: true
-    }],
-
     proxy:{
         type:'ajax',
         url:'{url action="getPayments"}',

--- a/themes/Backend/ExtJs/backend/order/view/list/filter.js
+++ b/themes/Backend/ExtJs/backend/order/view/list/filter.js
@@ -234,7 +234,17 @@ Ext.define('Shopware.apps.Order.view.list.Filter', {
             name: 'orders.paymentId',
             pageSize: 7,
             queryMode: 'remote',
-            store: Ext.create('Shopware.store.Payment', { pageSize: 7 }),
+            store: Ext.create('Shopware.store.Payment', {
+                pageSize: 7,
+                filters: [],
+                sorters: [{
+                    property: 'active',
+                    direction: 'DESC'
+                }, {
+                    property: 'position',
+                    direction: 'ASC'
+                }]
+            }),
             valueField: 'id',
             displayField: 'description',
             emptyText: me.snippets.empty,

--- a/themes/Backend/ExtJs/backend/order/view/list/filter.js
+++ b/themes/Backend/ExtJs/backend/order/view/list/filter.js
@@ -236,7 +236,10 @@ Ext.define('Shopware.apps.Order.view.list.Filter', {
             queryMode: 'remote',
             store: Ext.create('Shopware.store.Payment', {
                 pageSize: 7,
-                filters: [],
+                filters: [{
+                    property: 'active',
+                    value: [true, false]
+                }],
                 sorters: [{
                     property: 'active',
                     direction: 'DESC'


### PR DESCRIPTION
### 1. Why is this change necessary?
Orders can be placed in the past using a nowadays inactive payment. But you can't filter these orders by them.

### 2. What does this change do, exactly?
It allows to retrieve all payments from the server side, but the ExtJs store always send the same filter that has been applied by the server at first. Then this filter gets overwritten for this specific store to allow choosing inactive payments as well. The order is kept the same as inactive payments are just added below the active ones. It shouldn't be breaking as the store is working the same like before.

### 3. Describe each step to reproduce the issue or behaviour.
1. A payment fails to work properly
2. Payment gets disabled so no further orders using this payment get created
3. Now all failed orders have to be manually processed
4. Open orders
5. Set payment filter to (now inactive) faulty payment
6. You can't do step 5 without this pull request :anger: 

### 4. Which documentation changes (if any) need to be made because of this PR?
The store change has to be part of an UPGRADE file I assume as if anyone uses the exact endpoint manually it has a different outcome (for now).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.