### PR TITLE
Introduce Argon2 as new password encoder

### DIFF
--- a/_sql/migrations/1655-add-argon2-hashing.php
+++ b/_sql/migrations/1655-add-argon2-hashing.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+use Shopware\Components\Migrations\AbstractMigration;
+
+// see rfc for argon2 in PHP -> https://wiki.php.net/rfc/argon2_password_hash
+if (!defined('PASSWORD_ARGON2_DEFAULT_MEMORY_COST')) {
+    define('PASSWORD_ARGON2_DEFAULT_MEMORY_COST', 1 << 20); // 1MiB
+}
+
+if (!defined('PASSWORD_ARGON2_DEFAULT_TIME_COST')) {
+    define('PASSWORD_ARGON2_DEFAULT_TIME_COST', 2);
+}
+
+if (!defined('PASSWORD_ARGON2_DEFAULT_THREADS')) {
+    define('PASSWORD_ARGON2_DEFAULT_THREADS', 2);
+}
+
+class Migrations_Migration1655 extends AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('SET @parentFormId = (SELECT id FROM s_core_config_forms WHERE NAME = "Passwörter" AND parent_id=(SELECT id FROM s_core_config_forms WHERE NAME="Core") LIMIT 1)');
+
+        $sql = 'INSERT IGNORE INTO `s_core_config_elements` (`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`, `options`) VALUES ';
+        $sql .= sprintf(
+            "(@parentFormId, '%s', '%s', '%s', '%s', 'number', 1, 0, 0, '%s'),",
+            'argon2MemoryCost',
+            serialize(PASSWORD_ARGON2_DEFAULT_MEMORY_COST),
+            'Argon2-Speicher',
+            'Ein höherer Speicherverbrauch macht es einem möglichen Angreifer schwerer, ein passendes Klartext-Passwort zu erzeugen.',
+            serialize(['minValue' => (string) (1 << 20), 'maxValue' => (string) (1 << 62)])
+        );
+        $sql .= sprintf(
+            "(@parentFormId, '%s', '%s', '%s', '%s', 'number', 1, 0, 0, '%s'),",
+            'argon2TimeCost',
+            serialize(PASSWORD_ARGON2_DEFAULT_TIME_COST),
+            'Argon2-Zeit',
+            'Ein höherer Zeitaufwand macht es einem möglichen Angreifer schwerer, ein passendes Klartext-Passwort zu erzeugen.',
+            serialize(['minValue' => '1', 'maxValue' => '30'])
+        );
+        $sql .= sprintf(
+            "(@parentFormId, '%s', '%s', '%s', '%s', 'number', 1, 0, 0, '%s');",
+            'argon2Threads',
+            serialize(PASSWORD_ARGON2_DEFAULT_MEMORY_COST),
+            'Argon2-Threads',
+            'Anzahl paralleler Threads zur Erzeugung nutzen',
+            serialize(['minValue' => '1', 'maxValue' => '32'])
+        );
+
+        $this->addSql($sql);
+
+        // translation
+        $this->addSql('SET @elemArgon2MemoryCost = (SELECT id FROM s_core_config_elements WHERE name="argon2MemoryCost" AND form_id = @parentFormId LIMIT 1)');
+        $this->addSql('SET @elemargon2TimeCost = (SELECT id FROM s_core_config_elements WHERE name="argon2TimeCost" AND form_id = @parentFormId LIMIT 1)');
+        $this->addSql('SET @elemargon2Threads = (SELECT id FROM s_core_config_elements WHERE name="argon2Threads" AND form_id = @parentFormId  LIMIT 1)');
+
+        $sql = 'INSERT IGNORE INTO `s_core_config_element_translations` (`element_id`, `locale_id`, `label`, `description`) VALUES ';
+        // memory
+        $sql .= sprintf(
+            "(@elemArgon2MemoryCost, 2, '%s', '%s'),",
+            'Argon2 memory',
+            'Higher memory usage increases the security against attackers.'
+        );
+
+        // time
+        $sql .= sprintf(
+            "(@elemargon2TimeCost, 2, '%s', '%s'),",
+            'Argon2 time',
+            'Increasing the required time for hash calculation.'
+        );
+
+        // threads
+        $sql .= sprintf(
+            "(@elemargon2Threads, 2, '%s', '%s');",
+            'Argon2 threads',
+            'Use more threads for parallelism and therefore increased security against attackers, based on your setup.'
+        );
+
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Components/Password/Encoder/Argon2i.php
+++ b/engine/Shopware/Components/Password/Encoder/Argon2i.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Password\Encoder;
+
+class Argon2i implements PasswordEncoderInterface
+{
+    /**
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * @param array $options
+     */
+    public function __construct($options = null)
+    {
+        if ($options !== null) {
+            $this->options = $options;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Argon2i';
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCompatible()
+    {
+        return defined('PASSWORD_ARGON2I');
+    }
+
+    /**
+     * @param string $password
+     * @param string $hash
+     *
+     * @return bool
+     */
+    public function isPasswordValid($password, $hash)
+    {
+        return password_verify($password, $hash);
+    }
+
+    /**
+     * @param string $password
+     *
+     * @return string
+     */
+    public function encodePassword($password)
+    {
+        return password_hash($password, PASSWORD_ARGON2I, $this->options);
+    }
+
+    /**
+     * @param string $hash
+     *
+     * @return bool
+     */
+    public function isReencodeNeeded($hash)
+    {
+        return password_needs_rehash($hash, PASSWORD_ARGON2I, $this->options);
+    }
+}

--- a/engine/Shopware/Components/Password/Encoder/Argon2id.php
+++ b/engine/Shopware/Components/Password/Encoder/Argon2id.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Password\Encoder;
+
+class Argon2id implements PasswordEncoderInterface
+{
+    /**
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * @param array $options
+     */
+    public function __construct($options = null)
+    {
+        if ($options !== null) {
+            $this->options = $options;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Argon2id';
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCompatible()
+    {
+        return defined('PASSWORD_ARGON2ID');
+    }
+
+    /**
+     * @param string $password
+     * @param string $hash
+     *
+     * @return bool
+     */
+    public function isPasswordValid($password, $hash)
+    {
+        return password_verify($password, $hash);
+    }
+
+    /**
+     * @param string $password
+     *
+     * @return string
+     */
+    public function encodePassword($password)
+    {
+        return password_hash($password, PASSWORD_ARGON2ID, $this->options);
+    }
+
+    /**
+     * @param string $hash
+     *
+     * @return bool
+     */
+    public function isReencodeNeeded($hash)
+    {
+        return password_needs_rehash($hash, PASSWORD_ARGON2ID, $this->options);
+    }
+}

--- a/tests/Unit/Components/Password/Encoder/Argon2iTest.php
+++ b/tests/Unit/Components/Password/Encoder/Argon2iTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Unit\Components\Password\Encoder;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Components\Password\Encoder\Argon2i;
+
+class Argon2iTest extends TestCase
+{
+    /**
+     * @var Argon2i
+     */
+    private $hasher;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->hasher = new Argon2i([
+            // test should run fast, use minimum cost
+            'memory_cost' => 256,
+        ]);
+
+        if (!$this->hasher->isCompatible()) {
+            static::markTestSkipped(
+                'Argon2i Hasher is not compatible with current system.'
+            );
+        }
+    }
+
+    /**
+     * Test case
+     */
+    public function testIsAvailable()
+    {
+        static::assertInstanceOf(Argon2i::class, $this->hasher);
+    }
+
+    /**
+     * Test case
+     */
+    public function testGetNameShouldReturnName()
+    {
+        static::assertEquals('Argon2i', $this->hasher->getName());
+    }
+
+    /**
+     * Test case
+     */
+    public function testGenerateShouldReturnString()
+    {
+        static::assertIsString($this->hasher->encodePassword('foobar'));
+    }
+
+    /**
+     * Test case
+     */
+    public function testGenerateShouldReturnDifferentHashesForSamePlaintextString()
+    {
+        static::assertNotEquals($this->hasher->encodePassword('foobar'), $this->hasher->encodePassword('foobar'));
+    }
+
+    /**
+     * Test case
+     */
+    public function testVerifyShouldReturnTrueForMatchingHash()
+    {
+        $hash = $this->hasher->encodePassword('foobar');
+
+        static::assertTrue($this->hasher->isPasswordValid('foobar', $hash));
+    }
+
+    /**
+     * Test case
+     */
+    public function testVerifyShouldReturnFalseForNotMatchingHash()
+    {
+        $hash = $this->hasher->encodePassword('foobar');
+
+        static::assertFalse($this->hasher->isPasswordValid('notfoo', $hash));
+    }
+
+    /**
+     * Test case
+     */
+    public function testRehash()
+    {
+        $hash = $this->hasher->encodePassword('foobar');
+
+        static::assertFalse($this->hasher->isReencodeNeeded($hash));
+    }
+
+    /**
+     * Test case
+     */
+    public function testRehash2()
+    {
+        $hash = $this->hasher->encodePassword('foobar');
+        $this->hasher = new Argon2i([
+            'memory_cost' => 1024,
+        ]);
+
+        static::assertTrue($this->hasher->isReencodeNeeded($hash));
+    }
+}

--- a/tests/Unit/Components/Password/Encoder/Argon2idTest.php
+++ b/tests/Unit/Components/Password/Encoder/Argon2idTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Unit\Components\Password\Encoder;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Components\Password\Encoder\Argon2id;
+
+class Argon2idTest extends TestCase
+{
+    /**
+     * @var Argon2id
+     */
+    private $hasher;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->hasher = new Argon2id([
+            // test should run fast, use minimum cost
+            'memory_cost' => 256,
+        ]);
+
+        if (!$this->hasher->isCompatible()) {
+            static::markTestSkipped(
+                'Argon2id Hasher is not compatible with current system.'
+            );
+        }
+    }
+
+    /**
+     * Test case
+     */
+    public function testIsAvailable()
+    {
+        static::assertInstanceOf(Argon2id::class, $this->hasher);
+    }
+
+    /**
+     * Test case
+     */
+    public function testGetNameShouldReturnName()
+    {
+        static::assertEquals('Argon2id', $this->hasher->getName());
+    }
+
+    /**
+     * Test case
+     */
+    public function testGenerateShouldReturnString()
+    {
+        static::assertIsString($this->hasher->encodePassword('foobar'));
+    }
+
+    /**
+     * Test case
+     */
+    public function testGenerateShouldReturnDifferentHashesForSamePlaintextString()
+    {
+        static::assertNotEquals($this->hasher->encodePassword('foobar'), $this->hasher->encodePassword('foobar'));
+    }
+
+    /**
+     * Test case
+     */
+    public function testVerifyShouldReturnTrueForMatchingHash()
+    {
+        $hash = $this->hasher->encodePassword('foobar');
+
+        static::assertTrue($this->hasher->isPasswordValid('foobar', $hash));
+    }
+
+    /**
+     * Test case
+     */
+    public function testVerifyShouldReturnFalseForNotMatchingHash()
+    {
+        $hash = $this->hasher->encodePassword('foobar');
+
+        static::assertFalse($this->hasher->isPasswordValid('notfoo', $hash));
+    }
+
+    /**
+     * Test case
+     */
+    public function testRehash()
+    {
+        $hash = $this->hasher->encodePassword('foobar');
+
+        static::assertFalse($this->hasher->isReencodeNeeded($hash));
+    }
+
+    /**
+     * Test case
+     */
+    public function testRehash2()
+    {
+        $hash = $this->hasher->encodePassword('foobar');
+        $this->hasher = new Argon2id([
+            'memory_cost' => 1024,
+        ]);
+
+        static::assertTrue($this->hasher->isReencodeNeeded($hash));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Security

### 2. What does this change do, exactly?
Add new encoders Argon2i and Argon2id.

While `argon2` is considered more secure than `bcrypt` I hadn't enabled it by default as this would require several more code changes and is BC breaking.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
The availability of the new password encoders requires PHP 7.2/7.3 and argon2 enabled.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.