### PR TITLE
Convert state types to lowercase before accessing them

### DIFF
--- a/engine/Shopware/Components/StateTranslatorService.php
+++ b/engine/Shopware/Components/StateTranslatorService.php
@@ -47,7 +47,7 @@ class StateTranslatorService implements StateTranslatorServiceInterface
         ]
     ) {
         $this->snippetManager = $snippetManager;
-        $this->availableTypes = $types;
+        $this->availableTypes = array_change_key_case($types, CASE_LOWER);
     }
 
     /**
@@ -57,6 +57,8 @@ class StateTranslatorService implements StateTranslatorServiceInterface
      */
     public function translateState($type, array $state)
     {
+        $type = strtolower($type);
+
         if (!$this->availableTypes[$type]) {
             throw new \RuntimeException(sprintf('Invalid type \'%s\' given.', $type));
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
This adds compatibility for states that (for whatever reason) have uppercase letters in their type field.

### 2. What does this change do, exactly?
Make `$type` and all keys of `$this->availableTypes` lowercase before `$this->availableTypes[$type]` is accessed.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have `SwagImportExport` and `BestitAmazonPay` installed.
2. Export with the profile `default_order_main_data`.
3. See the error `Invalid type 'Payment' given.`.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.