### PR TITLE
Use correct config-form key

### DIFF
--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Backup.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Backup.php
@@ -154,7 +154,7 @@ class Backup
     public function create($detailIds, $operations, $newBackup, $id)
     {
         // When backups are disabled, return
-        if (!$this->getConfig()->getByNamespace('SwagMultiEdit', 'enableBackup', true)) {
+        if (!$this->getConfig()->getByNamespace('MultiEdit', 'enableBackup', true)) {
             return;
         }
 
@@ -181,7 +181,7 @@ class Backup
     public function finishBackup($filterString, $operations, $items, $id)
     {
         // When backups are disabled, return
-        if (!$this->getConfig()->getByNamespace('SwagMultiEdit', 'enableBackup', true)) {
+        if (!$this->getConfig()->getByNamespace('MultiEdit', 'enableBackup', true)) {
             return;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
the config-form for multi editing was renamed in migration 503, in e922b6d5c9fb05e3fcefe69a5ee740db6051f0a. Setting "enableBackup" there has no effect, since we checked for the old form's name here.

### 2. What does this change do, exactly?
Read the config from the correct form name

### 3. Describe each step to reproduce the issue or behaviour.
- Set enableBackup for multi editing to false. 
- Queue any multiedit action
- Shopware still tries to create a backup

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.