### PR TITLE
SW-24901 - Assign variantID to articleDetailId in mainData attribute

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -333,6 +333,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
         if (!empty($variants)) {
             /** @var Detail $variant */
             foreach ($variants as $variant) {
+                $mainData['attribute']['articleDetailId'] = $variant->getId();
                 $variant->fromArray($mainData);
                 Shopware()->Models()->persist($variant);
             }


### PR DESCRIPTION
### 1. Why is this change necessary?
The articleDetailId from the main variant is also read out for the attributes in the mainData and therefore the duplicate entry occurs.

### 2. What does this change do, exactly?
I assigned the variantID to the articleDetailId in the mainData attribute.

### 3. Describe each step to reproduce the issue or behaviour.
Create a new variant product in the backend and enter for example a text in attr1. Now use the apply standard data function and make sure you include the apply attribute configuration option.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-24901

### 5. Which documentation changes (if any) need to be made because of this PR?
Just a bugfix

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.