### PR TITLE
Added new events so sBasket:sAddVoucher

### DIFF
--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -24,6 +24,9 @@ This changelog references changes done in Shopware 5.6 patch versions.
 * Added new Smarty blocks `frontend_index_left_categories_wrapper` and `frontend_index_left_subcategory_config` to `frontend/index/sidebar.tpl`
 * Added `Shopware\Bundle\CookieBundle`, which takes care of the new cookie consent manager. If you're using cookies in your plugin, make sure
 to read [this documentation](https://developers.shopware.com/developers-guide/cookie-consent-manager/)!
+* Added a filter event 'Shopware_Modules_Basket_AddVoucher_FilterSqlParams' to `sBasket::sAddVoucher` to modify sql params
+* Added a notify event 'Shopware_Modules_Basket_AddVoucher_Inserted' to `sBasket::sAddVoucher` to execute code after a voucher was inserted
+
 
 
 ### Changes

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -969,7 +969,37 @@ SQL;
             ]
         );
 
-        return (bool) $this->db->query($sql, $params);
+        $params = $this->eventManager->filter(
+            'Shopware_Modules_Basket_AddVoucher_FilterSqlParams',
+            $params,
+            [
+                'subject' => $this,
+                'voucher' => $voucherDetails,
+                'vouchername' => $voucherName,
+                'shippingfree' => $freeShipping,
+                'tax' => $tax,
+            ]
+        );
+
+        $isInserted = (bool) $this->db->query($sql, $params);
+
+        if($isInserted) {
+            $insertId = $this->db->lastInsertId('s_order_basket');
+
+            $this->eventManager->notify(
+                'Shopware_Modules_Basket_AddVoucher_Inserted',
+                [
+                    'subject' => $this,
+                    'basketId' => $insertId,
+                    'voucher' => $voucherDetails,
+                    'vouchername' => $voucherName,
+                    'shippingfree' => $freeShipping,
+                    'tax' => $tax,
+                ]
+            );
+        }
+
+        return $isInserted;
     }
 
     /**


### PR DESCRIPTION
New events:
Shopware_Modules_Basket_AddVoucher_FilterSqlParams (filter)
Shopware_Modules_Basket_AddVoucher_Inserted (notify)

### 1. Why is this change necessary?
To handle vouchers based on voucher attributes.

### 2. What does this change do, exactly?
It just adds two new events:

1. Shopware_Modules_Basket_AddVoucher_FilterSqlParams (filter), can be used to modify the SQL params, for example the voucher name which is about to be inserted.
2. Shopware_Modules_Basket_AddVoucher_Inserted (notify)  allows to execute code after a voucher was added to the cart

### 3. Describe each step to reproduce the issue or behaviour.
New feature.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.