### PR TITLE
add option to specifiy if just SEO-URLs should be printed

### DIFF
--- a/_sql/migrations/1650-add-hreflang-just-seo-option.php
+++ b/_sql/migrations/1650-add-hreflang-just-seo-option.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+use Shopware\Components\Migrations\AbstractMigration;
+
+class Migrations_Migration1650 extends AbstractMigration
+{
+    public function up($modus)
+    {
+        $this->addSql('SET @formId = (SELECT id FROM s_core_config_forms WHERE name = "Frontend100")');
+
+        $sql = "INSERT INTO `s_core_config_elements` (`form_id`, `name`, `value`, `label`, `description`, `type`, `required`, `position`, `scope`, `options`)
+                    VALUES (@formId, 'hrefLangJustSeoUrl', 'b:1;', 'nur SEO-Urls in href-lang ausgeben', 'Wenn aktiv, werden in den Meta Tags \"href-lang\" nur SEO-Urls ausgegeben', 'boolean', '0', '0', '0', NULL);";
+        $this->addSql($sql);
+
+        $this->addSql('SET @elementId = LAST_INSERT_ID();');
+
+        $sql = "INSERT IGNORE INTO `s_core_config_element_translations` (`element_id`, `locale_id`, `label`, `description`)
+                   VALUES (@elementId, '2', 'Just output href-lang with SEO URLs', 'If active, just SEO URLs are displayed in the meta tags \"href-lang\"');";
+        $this->addSql($sql);
+
+    }
+}

--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/HrefLangService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/HrefLangService.php
@@ -110,7 +110,7 @@ class HrefLangService implements HrefLangServiceInterface
                 $href->setLocale('x-default');
             }
 
-            if (!$this->isSeoUrl($parameters, $href->getLink(), $routingContext)) {
+            if ($this->config->get('hrefLangJustSeoUrl') && !$this->isSeoUrl($parameters, $href->getLink(), $routingContext)) {
                 continue;
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Grown historically and product related we have some products containing the same name. The SEO-URLs just contains the name, so not every product has its SEO-URLs. Currently, non-SEO-URLs are filtered out of the hreflang. Sure, these links aren't looking nice, but these links are printed into sitemap and so on. So this restriction should be adjustable.

### 2. What does this change do, exactly?
Adds option to specify, if just SEO-URLs should be printed into href-lang.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.