### PR TITLE
Fix translation issue in sitemap

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Sitemap.php
+++ b/engine/Shopware/Controllers/Frontend/Sitemap.php
@@ -145,7 +145,7 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
             $translationkeys[] = $data[$keyField];
 
             if (!empty($data[$recursiveField])) {
-                $translationkeys += $this->getTranslationKeys($data[$recursiveField], $keyField, $recursiveField);
+                $translationkeys = array_merge($translationkeys,$this->getTranslationKeys($data[$recursiveField], $keyField, $recursiveField));
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Translations of sub categories was not being displayed in the sitemap.

### 2. What does this change do, exactly?
It changes merging of array from $array1+$array2 to array_merge($array1,$array2)

### 3. Describe each step to reproduce the issue or behaviour.
Add few sub categories and add translations for them. Then check the sitemap of language shop.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.