### PR TITLE
Use more strict comparisons if possible in Shopware Components

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/Property/Set.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/Property/Set.php
@@ -31,17 +31,22 @@ class Set extends Extendable
     /**
      * Constant for the alphanumeric sort configuration of the category filters
      */
-    const SORT_ALPHANUMERIC = 0;
+    public const SORT_ALPHANUMERIC = 0;
 
     /**
      * Constant for the numeric sort configuration of the category filters
      */
-    const SORT_NUMERIC = 1;
+    public const SORT_NUMERIC = 1;
+
+    /**
+     * Constant used in older shopware versions
+     */
+    public const SORT_LEGACY = 2;
 
     /**
      * Constant for the position sort configuration of the category filters
      */
-    const SORT_POSITION = 3;
+    public const SORT_POSITION = 3;
 
     /**
      * @var int

--- a/engine/Shopware/Components/Api/Resource/Customer.php
+++ b/engine/Shopware/Components/Api/Resource/Customer.php
@@ -403,7 +403,7 @@ class Customer extends Resource
                 unset($paymentDataData['paymentMeanId']);
             }
 
-            if ($paymentData->getCustomer() == null) {
+            if ($paymentData->getCustomer() === null) {
                 $paymentData->setCustomer($customer);
             }
 

--- a/engine/Shopware/Components/Api/Resource/PropertyGroup.php
+++ b/engine/Shopware/Components/Api/Resource/PropertyGroup.php
@@ -25,6 +25,7 @@
 namespace Shopware\Components\Api\Resource;
 
 use Exception;
+use Shopware\Bundle\StoreFrontBundle\Struct\Property\Set;
 use Shopware\Components\Api\Exception as ApiException;
 use Shopware\Components\Api\Exception\NotFoundException;
 use Shopware\Components\Api\Exception\ParameterMissingException;
@@ -48,10 +49,10 @@ class PropertyGroup extends Resource
     /**
      * @param int $id
      *
-     * @return array|Group
      *@throws NotFoundException
-     *
      * @throws ParameterMissingException
+     *
+     * @return array|Group
      */
     public function getOne($id)
     {
@@ -216,18 +217,16 @@ class PropertyGroup extends Resource
 
             if (!isset($params['sortmode']) || empty($params['sortmode'])) {
                 // Set sortmode
-                $params['sortmode'] = 0;
+                $params['sortmode'] = Set::SORT_ALPHANUMERIC;
             }
 
             // Sortmode equals the old article_count sorting?
-            if ((int) $params['sortmode'] === 2) {
+            if ($params['sortmode'] === Set::SORT_LEGACY) {
                 // Fallback to the default sorting
-                $params['sortmode'] = 0;
+                $params['sortmode'] = Set::SORT_ALPHANUMERIC;
             }
-        } else {
-            if (isset($params['name']) && empty($params['name'])) {
-                throw new ApiException\CustomValidationException('Name must not be empty');
-            }
+        } elseif (isset($params['name']) && empty($params['name'])) {
+            throw new ApiException\CustomValidationException('Name must not be empty');
         }
 
         return $params;

--- a/engine/Shopware/Components/Api/Resource/PropertyGroup.php
+++ b/engine/Shopware/Components/Api/Resource/PropertyGroup.php
@@ -24,7 +24,13 @@
 
 namespace Shopware\Components\Api\Resource;
 
+use Exception;
 use Shopware\Components\Api\Exception as ApiException;
+use Shopware\Components\Api\Exception\NotFoundException;
+use Shopware\Components\Api\Exception\ParameterMissingException;
+use Shopware\Components\Api\Exception\ValidationException;
+use Shopware\Models\Property\Group;
+use Shopware\Models\Property\Repository;
 
 /**
  * Property API Resource
@@ -32,37 +38,37 @@ use Shopware\Components\Api\Exception as ApiException;
 class PropertyGroup extends Resource
 {
     /**
-     * @return \Shopware\Models\Property\Repository
+     * @return Repository
      */
     public function getRepository()
     {
-        return $this->getManager()->getRepository(\Shopware\Models\Property\Group::class);
+        return $this->getManager()->getRepository(Group::class);
     }
 
     /**
      * @param int $id
      *
-     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
-     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     * @return array|Group
+     *@throws NotFoundException
      *
-     * @return array|\Shopware\Models\Property\Group
+     * @throws ParameterMissingException
      */
     public function getOne($id)
     {
         $this->checkPrivilege('read');
 
         if (empty($id)) {
-            throw new ApiException\ParameterMissingException('id');
+            throw new ParameterMissingException('id');
         }
 
         $filters = [['property' => 'groups.id', 'expression' => '=', 'value' => $id]];
         $query = $this->getRepository()->getListGroupsQuery($filters);
 
-        /** @var \Shopware\Models\Property\Group|null $property */
+        /** @var Group|null $property */
         $property = $query->getOneOrNullResult($this->getResultMode());
 
         if (!$property) {
-            throw new ApiException\NotFoundException(sprintf('PropertyGroup by id %d not found', $id));
+            throw new NotFoundException(sprintf('PropertyGroup by id %d not found', $id));
         }
 
         return $property;
@@ -93,10 +99,10 @@ class PropertyGroup extends Resource
     }
 
     /**
-     * @throws \Shopware\Components\Api\Exception\ValidationException
-     * @throws \Exception
+     * @throws ValidationException
+     * @throws Exception
      *
-     * @return \Shopware\Models\Property\Group
+     * @return Group
      */
     public function create(array $params)
     {
@@ -104,12 +110,12 @@ class PropertyGroup extends Resource
 
         $params = $this->preparePropertyData($params);
 
-        $property = new \Shopware\Models\Property\Group();
+        $property = new Group();
         $property->fromArray($params);
 
         $violations = $this->getManager()->validate($property);
         if ($violations->count() > 0) {
-            throw new ApiException\ValidationException($violations);
+            throw new ValidationException($violations);
         }
 
         $this->getManager()->persist($property);
@@ -121,25 +127,25 @@ class PropertyGroup extends Resource
     /**
      * @param int $id
      *
-     * @throws \Shopware\Components\Api\Exception\ValidationException
-     * @throws \Shopware\Components\Api\Exception\NotFoundException
-     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
+     * @throws ValidationException
+     * @throws NotFoundException
+     * @throws ParameterMissingException
      *
-     * @return \Shopware\Models\Property\Group
+     * @return Group
      */
     public function update($id, array $params)
     {
         $this->checkPrivilege('update');
 
         if (empty($id)) {
-            throw new ApiException\ParameterMissingException('id');
+            throw new ParameterMissingException('id');
         }
 
-        /** @var \Shopware\Models\Property\Group|null $propertyGroup */
+        /** @var Group|null $propertyGroup */
         $propertyGroup = $this->getRepository()->find($id);
 
         if (!$propertyGroup) {
-            throw new ApiException\NotFoundException(sprintf('PropertyGroup by id %d not found', $id));
+            throw new NotFoundException(sprintf('PropertyGroup by id %d not found', $id));
         }
 
         $params = $this->preparePropertyData($params, $propertyGroup);
@@ -147,7 +153,7 @@ class PropertyGroup extends Resource
 
         $violations = $this->getManager()->validate($propertyGroup);
         if ($violations->count() > 0) {
-            throw new ApiException\ValidationException($violations);
+            throw new ValidationException($violations);
         }
 
         $this->flush();
@@ -158,24 +164,24 @@ class PropertyGroup extends Resource
     /**
      * @param int $id
      *
-     * @throws \Shopware\Components\Api\Exception\ParameterMissingException
-     * @throws \Shopware\Components\Api\Exception\NotFoundException
+     * @throws ParameterMissingException
+     * @throws NotFoundException
      *
-     * @return \Shopware\Models\Property\Group
+     * @return Group
      */
     public function delete($id)
     {
         $this->checkPrivilege('delete');
 
         if (empty($id)) {
-            throw new ApiException\ParameterMissingException('id');
+            throw new ParameterMissingException('id');
         }
 
-        /** @var \Shopware\Models\Property\Group|null $propertyGroup */
+        /** @var Group|null $propertyGroup */
         $propertyGroup = $this->getRepository()->find($id);
 
         if (!$propertyGroup) {
-            throw new ApiException\NotFoundException(sprintf('PropertyGroup by id %d not found', $id));
+            throw new NotFoundException(sprintf('PropertyGroup by id %d not found', $id));
         }
 
         $this->getManager()->remove($propertyGroup);
@@ -185,7 +191,7 @@ class PropertyGroup extends Resource
     }
 
     /**
-     * @param \Shopware\Models\Property\Group|null $propertyGroup
+     * @param Group|null $propertyGroup
      *
      * @throws ApiException\CustomValidationException
      *
@@ -214,7 +220,7 @@ class PropertyGroup extends Resource
             }
 
             // Sortmode equals the old article_count sorting?
-            if ($params['sortmode'] == 2) {
+            if ((int) $params['sortmode'] === 2) {
                 // Fallback to the default sorting
                 $params['sortmode'] = 0;
             }

--- a/engine/Shopware/Components/Auth.php
+++ b/engine/Shopware/Components/Auth.php
@@ -128,7 +128,7 @@ class Shopware_Components_Auth extends Enlight_Components_Auth
      */
     public function authenticate(Zend_Auth_Adapter_Interface $adapter = null)
     {
-        if ($adapter == null) {
+        if ($adapter === null) {
             $adapter = $this->_baseAdapter;
         }
 
@@ -140,7 +140,7 @@ class Shopware_Components_Auth extends Enlight_Components_Auth
      */
     public function refresh(Zend_Auth_Adapter_Interface $adapter = null)
     {
-        if ($adapter == null) {
+        if ($adapter === null) {
             $adapter = $this->getBaseAdapter();
         }
         $result = $adapter->refresh();

--- a/engine/Shopware/Components/Auth/Constraint/UserEmailValidator.php
+++ b/engine/Shopware/Components/Auth/Constraint/UserEmailValidator.php
@@ -115,6 +115,7 @@ class UserEmailValidator extends ConstraintValidator
         $builder->select(1);
         $builder->from('s_core_auth');
         $builder->andWhere('email = :email');
+        $builder->setMaxResults(1);
         $builder->setParameter('email', $value);
 
         if ($userId !== null) {
@@ -122,9 +123,7 @@ class UserEmailValidator extends ConstraintValidator
             $builder->setParameter('userId', $userId);
         }
 
-        $id = $builder->execute()->fetch(\PDO::FETCH_COLUMN);
-
-        return $id == 1;
+        return (bool) $builder->execute()->fetch(\PDO::FETCH_COLUMN);
     }
 
     /**

--- a/engine/Shopware/Components/Auth/Constraint/UserNameValidator.php
+++ b/engine/Shopware/Components/Auth/Constraint/UserNameValidator.php
@@ -115,6 +115,7 @@ class UserNameValidator extends ConstraintValidator
         $builder->select(1);
         $builder->from('s_core_auth');
         $builder->andWhere('username = :username');
+        $builder->setMaxResults(1);
         $builder->setParameter('username', $value);
 
         if ($userId !== null) {
@@ -122,9 +123,7 @@ class UserNameValidator extends ConstraintValidator
             $builder->setParameter('userId', $userId);
         }
 
-        $id = $builder->execute()->fetch(\PDO::FETCH_COLUMN);
-
-        return $id == 1;
+        return (bool) $builder->execute()->fetch(\PDO::FETCH_COLUMN);
     }
 
     /**

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -123,7 +123,7 @@ class CacheManager
 
         $this->clearDirectory($compileDir);
 
-        if ($cacheDir != $compileDir) {
+        if ($cacheDir !== $compileDir) {
             $this->clearDirectory($cacheDir);
         }
     }

--- a/engine/Shopware/Components/Captcha/CaptchaRepository.php
+++ b/engine/Shopware/Components/Captcha/CaptchaRepository.php
@@ -97,7 +97,7 @@ class CaptchaRepository
     public function getCaptchaByName($captchaName)
     {
         foreach ($this->captchas as $captcha) {
-            if ($captcha->getName() == $captchaName) {
+            if ($captcha->getName() === $captchaName) {
                 return $captcha;
             }
         }

--- a/engine/Shopware/Components/Captcha/LegacyCaptcha.php
+++ b/engine/Shopware/Components/Captcha/LegacyCaptcha.php
@@ -58,7 +58,7 @@ class LegacyCaptcha implements CaptchaInterface
             $captchaString = $request->get('sCaptcha');
             $captcha = str_replace(' ', '', strtolower($captchaString));
             $rand = $request->get('sRand');
-            if (empty($rand) || $captcha != substr(md5($rand), 0, 5)) {
+            if (empty($rand) || strpos(md5($rand), $captcha) !== 0) {
                 return false;
             }
         }

--- a/engine/Shopware/Components/CategoryHandling/CategoryDuplicator.php
+++ b/engine/Shopware/Components/CategoryHandling/CategoryDuplicator.php
@@ -191,7 +191,7 @@ class CategoryDuplicator
             $path = '|' . $path . '|';
         }
 
-        if ($categoryPath != $path) {
+        if ($categoryPath !== $path) {
             $updateStmt->execute([':path' => $path, ':categoryId' => $categoryId]);
 
             return 1;

--- a/engine/Shopware/Components/Check/Requirements.php
+++ b/engine/Shopware/Components/Check/Requirements.php
@@ -184,13 +184,9 @@ class Requirements
     /**
      * Compares the requirement with the version
      *
-     * @param string $name
-     * @param string $value
-     * @param string $requiredValue
-     *
      * @return bool
      */
-    private function compare($name, $value, $requiredValue)
+    private function compare(string $name, string $value, string $requiredValue)
     {
         $m = 'compare' . str_replace(' ', '', ucwords(str_replace(['_', '.'], ' ', $name)));
 
@@ -210,7 +206,7 @@ class Requirements
             return version_compare($requiredValue, $value, '<=');
         }
 
-        return $requiredValue == $value;
+        return $requiredValue === $value;
     }
 
     /**
@@ -356,7 +352,7 @@ class Requirements
         if (function_exists('gd_info')) {
             $gd = gd_info();
             if (preg_match('#[0-9.]+#', $gd['GD Version'], $match)) {
-                if (substr_count($match[0], '.') == 1) {
+                if (substr_count($match[0], '.') === 1) {
                     $match[0] .= '.0';
                 }
 
@@ -459,7 +455,7 @@ class Requirements
         if (function_exists('set_include_path')) {
             $old = set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__ . DIRECTORY_SEPARATOR);
 
-            return $old && get_include_path() != $old;
+            return $old && get_include_path() !== $old;
         }
 
         return false;

--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -357,7 +357,7 @@ class LegacyStructConverter
 
         if ($price->getCalculatedPseudoPrice()) {
             $discount = 0;
-            if ($price->getCalculatedPseudoPrice() != 0) {
+            if ($price->getCalculatedPseudoPrice() !== 0) {
                 $discount = round(($price->getCalculatedPrice() / $price->getCalculatedPseudoPrice() * 100) - 100, 2) * -1;
             }
 
@@ -951,10 +951,10 @@ class LegacyStructConverter
         }
 
         // Switch the template for the different configurator types.
-        if ($set->getType() == 1) {
+        if ($set->getType() === 1) {
             // Selection configurator
             $settings['template'] = 'article_config_step.tpl';
-        } elseif ($set->getType() == 2) {
+        } elseif ($set->getType() === 2) {
             // Table configurator
             $settings['template'] = 'article_config_picture.tpl';
         } else {

--- a/engine/Shopware/Components/CsvIterator.php
+++ b/engine/Shopware/Components/CsvIterator.php
@@ -236,11 +236,11 @@ class Shopware_Components_CsvIterator extends Enlight_Class implements Iterator
         $line = stream_get_line($this->_handler, self::DEFAULT_LENGTH, $this->_newline);
 
         // Remove possible utf8-bom
-        if (substr($line, 0, 3) == pack('CCC', 0xef, 0xbb, 0xbf)) {
+        if (substr($line, 0, 3) === pack('CCC', 0xef, 0xbb, 0xbf)) {
             $line = substr($line, 3);
         }
 
-        while ((empty($this->_fieldmark) || ($count = substr_count($line, $this->_fieldmark)) % 2 != 0) && !feof($this->_handler)) {
+        while ((empty($this->_fieldmark) || ($count = substr_count($line, $this->_fieldmark)) % 2 !== 0) && !feof($this->_handler)) {
             $line .= $this->_newline . stream_get_line($this->_handler, self::DEFAULT_LENGTH, $this->_newline);
         }
         if (empty($line)) {

--- a/engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
@@ -31,14 +31,14 @@ class MailTransport
      */
     public function factory(\Enlight_Loader $loader, \Shopware_Components_Config $config, array $options)
     {
-        if (!isset($options['type']) && !empty($config->MailerMailer) && $config->MailerMailer != 'mail') {
+        if (!isset($options['type']) && !empty($config->MailerMailer) && $config->MailerMailer !== 'mail') {
             $options['type'] = $config->MailerMailer;
         }
         if (empty($options['type'])) {
             $options['type'] = 'sendmail';
         }
 
-        if ($options['type'] == 'smtp') {
+        if ($options['type'] === 'smtp') {
             if (!isset($options['username']) && !empty($config->MailerUsername)) {
                 if (!empty($config->MailerAuth)) {
                     $options['auth'] = $config->MailerAuth;

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -685,7 +685,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
             WHERE `type` = ? AND userID = ? AND orderID = ? LIMIT 1
             ';
             $amount = ($this->_order->order->taxfree ? true : $this->_config['netto']) ? round($this->_order->amountNetto, 2) : round($this->_order->amount, 2);
-            if ($typID === 4) {
+            if ($typID === Document::TYPE_CANCEL) {
                 $amount *= -1;
             }
             Shopware()->Db()->query($update, [
@@ -761,7 +761,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
                     $numberRange = $this->_document['numbers'];
                 } else {
                     // The typID is indexed with base 0, so we need increase the typID
-                    if (!in_array($typID, [1, 2, 3], true)) {
+                    if (!in_array($typID, [Document::TYPE_INVOICE, Document::TYPE_SHIPPING, Document::TYPE_CREDIT], true)) {
                         ++$typID;
                     }
                     $numberRange = 'doc_' . $typID;

--- a/engine/Shopware/Components/Form/Persister/Theme.php
+++ b/engine/Shopware/Components/Form/Persister/Theme.php
@@ -244,7 +244,7 @@ class Theme implements Form\Interfaces\Persister
     {
         /** @var TemplateConfig\Element $element */
         foreach ($collection as $element) {
-            if ($element->getName() == $name) {
+            if ($element->getName() === $name) {
                 return $element;
             }
         }
@@ -261,7 +261,7 @@ class Theme implements Form\Interfaces\Persister
     {
         /** @var TemplateConfig\Layout $element */
         foreach ($collection as $element) {
-            if ($element->getName() == $name) {
+            if ($element->getName() === $name) {
                 return $element;
             }
         }

--- a/engine/Shopware/Components/HttpCache/Store.php
+++ b/engine/Shopware/Components/HttpCache/Store.php
@@ -376,7 +376,7 @@ class Store extends BaseStore
         @fwrite($fp, $data);
         @fclose($fp);
 
-        if ($data != file_get_contents($tmpFile)) {
+        if ($data !== file_get_contents($tmpFile)) {
             return false;
         }
 

--- a/engine/Shopware/Components/License/Service/LocalLicenseUnpackService.php
+++ b/engine/Shopware/Components/License/Service/LocalLicenseUnpackService.php
@@ -50,13 +50,12 @@ class LocalLicenseUnpackService implements LicenseUnpackServiceInterface
             throw new LicenseProductKeyException('License key does not match a commercial Shopware edition');
         }
 
-        if ($info['host'] != $host) {
+        if ($info['host'] !== $host) {
             throw new LicenseHostException(new LicenseInformation($info), sprintf('License key is not valid for domain %s', $request->host));
         }
 
         $info['edition'] = $info['product'];
-        unset($info['moduleLicense']);
-        unset($info['coreLicense']);
+        unset($info['moduleLicense'], $info['coreLicense']);
 
         return new LicenseInformation($info);
     }
@@ -70,8 +69,7 @@ class LocalLicenseUnpackService implements LicenseUnpackServiceInterface
      */
     public function readLicenseInfo($license)
     {
-        $license = str_replace('-------- LICENSE BEGIN ---------', '', $license);
-        $license = str_replace('--------- LICENSE END ----------', '', $license);
+        $license = str_replace(['-------- LICENSE BEGIN ---------', '--------- LICENSE END ----------'], '', $license);
         $license = preg_replace('#--.+?--#', '', (string) $license);
         $license = preg_replace('#[^A-Za-z0-9+/=]#', '', $license);
 

--- a/engine/Shopware/Components/License/Struct/ShopwareEdition.php
+++ b/engine/Shopware/Components/License/Struct/ShopwareEdition.php
@@ -61,7 +61,7 @@ class ShopwareEdition
      */
     public function isCommercial()
     {
-        return $this->edition != self::CE;
+        return $this->edition !== self::CE;
     }
 
     /**

--- a/engine/Shopware/Components/Log/Formatter/WildfireFormatter.php
+++ b/engine/Shopware/Components/Log/Formatter/WildfireFormatter.php
@@ -275,7 +275,7 @@ class WildfireFormatter extends BaseWildfireFormatter
             foreach ($members as $just_name => $value) {
                 $name = $raw_name = $just_name;
 
-                if ($name[0] == "\0") {
+                if ($name[0] === "\0") {
                     $parts = explode("\0", $name);
                     $name = $parts[2];
                 }
@@ -304,7 +304,7 @@ class WildfireFormatter extends BaseWildfireFormatter
                 // if the recursion is not reset here as it contains
                 // a reference to itself. This is the only way I have come up
                 // with to stop infinite recursion in this case.
-                if ($key == 'GLOBALS' && is_array($val) && array_key_exists('GLOBALS', $val)) {
+                if ($key === 'GLOBALS' && is_array($val) && array_key_exists('GLOBALS', $val)) {
                     $val['GLOBALS'] = '** Recursion (GLOBALS) **';
                 }
                 $return[$key] = $this->encodeObject($val, 1, $arrayDepth + 1);

--- a/engine/Shopware/Components/Log/Handler/FirePHPHandler.php
+++ b/engine/Shopware/Components/Log/Handler/FirePHPHandler.php
@@ -123,10 +123,10 @@ class FirePHPHandler extends BaseFirePHPHandler
 
         $parts = str_split($record['formatted'], $chunkSize);
         $headers = [];
-        for ($i = 0; $i < count($parts); ++$i) {
+        for ($i = 0, $iMax = count($parts); $i < $iMax; ++$i) {
             $part = $parts[$i];
-            $isFirst = ($i == 0);
-            $isLast = ($i == count($parts) - 1);
+            $isFirst = ($i === 0);
+            $isLast = ($i === $iMax - 1);
 
             if ($isFirst) {
                 $headers[] = $this->createHeader(

--- a/engine/Shopware/Components/Model/CategoryDenormalization.php
+++ b/engine/Shopware/Components/Model/CategoryDenormalization.php
@@ -238,7 +238,7 @@ class CategoryDenormalization
             $path = '|' . $path . '|';
         }
 
-        if ($categoryPath != $path) {
+        if ($categoryPath !== $path) {
             $updateStmt->execute([':path' => $path, ':categoryId' => $categoryId]);
 
             return 1;

--- a/engine/Shopware/Components/Model/DBAL/Types/AllowInvalidArrayType.php
+++ b/engine/Shopware/Components/Model/DBAL/Types/AllowInvalidArrayType.php
@@ -47,7 +47,7 @@ class AllowInvalidArrayType extends Type
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
         $val = unserialize($value, ['allowed_classes' => false]);
-        if ($val === false && $value != 'b:0;') {
+        if ($val === false && $value !== 'b:0;') {
             return null;
         }
 

--- a/engine/Shopware/Components/Model/LazyFetchModelEntity.php
+++ b/engine/Shopware/Components/Model/LazyFetchModelEntity.php
@@ -71,7 +71,7 @@ abstract class LazyFetchModelEntity extends ModelEntity
             return $object;
         }
 
-        if ($em == null) {
+        if ($em === null) {
             $em = self::$em;
         }
 

--- a/engine/Shopware/Components/Model/QueryBuilder.php
+++ b/engine/Shopware/Components/Model/QueryBuilder.php
@@ -199,7 +199,7 @@ class QueryBuilder extends BaseQueryBuilder
                 $exprKey = $this->alias . '.' . $exprKey;
             }
 
-            if ($expression == null) {
+            if ($expression === null) {
                 switch (true) {
                     case \is_string($where):
                         $expression = 'LIKE';

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Backup.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Backup.php
@@ -265,7 +265,7 @@ class Backup
         }
 
         // When done, delete the extracted files again
-        if (empty($dataFiles) || $numFiles == 1) {
+        if (empty($dataFiles) || $numFiles === 1) {
             $numFiles = 1;
 
             $files = $this->getDirectoryList($dir . '/');
@@ -278,7 +278,7 @@ class Backup
         return [
             'totalCount' => $numFiles + $offset,
             'offset' => $offset + 1,
-            'done' => $numFiles == 1,
+            'done' => $numFiles === 1,
         ];
     }
 
@@ -673,7 +673,7 @@ class Backup
         $files = scandir($path);
         foreach ($files as $key => &$file) {
             $extension = pathinfo($path . $file, PATHINFO_EXTENSION);
-            if ($file == '.' || $file == '..' || in_array($file, $blacklistName) || !in_array($extension, $findExtension)) {
+            if ($file === '.' || $file === '..' || in_array($file, $blacklistName, true) || !in_array($extension, $findExtension, true)) {
                 unset($files[$key]);
             }
             $file = $path . $file;

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/BatchProcess.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/BatchProcess.php
@@ -204,7 +204,7 @@ class BatchProcess
             }
 
             // In set mode: If column is nullable and value is "" - set it to null
-            if ($operation['operator'] === 'set' && $columnInfo[ucfirst($prefix) . ucfirst($column)]['nullable'] && $operation['value'] == '') {
+            if ($operation['operator'] === 'set' && $operation['value'] === '' && $columnInfo[ucfirst($prefix) . ucfirst($column)]['nullable']) {
                 $operationValue = 'NULL';
             } else {
                 $operationValue = $builder->expr()->literal(

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
@@ -503,7 +503,7 @@ class DqlHelper
         // Sort columns by position
         uasort(
             $result,
-            function ($a, $b) {
+            static function ($a, $b) {
                 $a = $a['position'];
                 $b = $b['position'];
                 if ($a == $b) {
@@ -534,7 +534,7 @@ class DqlHelper
     public function getColumnInfoByAlias($alias)
     {
         foreach ($this->columnInfo as $info) {
-            if ($info['alias'] == $alias) {
+            if ($info['alias'] === $alias) {
                 return $info;
             }
         }
@@ -565,28 +565,28 @@ class DqlHelper
         // Some generic searching for the association
         $metaData = $this->getEntityManager()->getClassMetadata(Detail::class);
         foreach ($metaData->associationMappings as $mapping) {
-            if ($mapping['targetEntity'] == $entity) {
+            if ($mapping['targetEntity'] === $entity) {
                 return 'detail.' . $mapping['fieldName'];
             }
         }
 
         $metaData = $this->getEntityManager()->getClassMetadata(Article::class);
         foreach ($metaData->associationMappings as $mapping) {
-            if ($mapping['targetEntity'] == $entity) {
+            if ($mapping['targetEntity'] === $entity) {
                 return 'article.' . $mapping['fieldName'];
             }
         }
 
         $metaData = $this->getEntityManager()->getClassMetadata(Set::class);
         foreach ($metaData->associationMappings as $mapping) {
-            if ($mapping['targetEntity'] == $entity) {
+            if ($mapping['targetEntity'] === $entity) {
                 return 'configuratorSet.' . $mapping['fieldName'];
             }
         }
 
         $metaData = $this->getEntityManager()->getClassMetadata(Group::class);
         foreach ($metaData->associationMappings as $mapping) {
-            if ($mapping['targetEntity'] == $entity) {
+            if ($mapping['targetEntity'] === $entity) {
                 return 'propertySet.' . $mapping['fieldName'];
             }
         }
@@ -606,7 +606,7 @@ class DqlHelper
             if ($token['type'] === 'attribute') {
                 $entity = $this->getEntityForAttribute($token['token']);
                 // Do not allow main entity to be joined
-                if ($entity == $this->getMainEntity()) {
+                if ($entity === $this->getMainEntity()) {
                     continue;
                 }
                 // In some cases, additional joins are needed - e.g. a ConfiguratorGroup does need the ConfiguratorSet
@@ -780,7 +780,7 @@ class DqlHelper
         $info = $this->getColumnsForProductListing();
         $info = $info[ucfirst($prefix) . ucfirst($field['field'])];
 
-        if ($info['nullable'] && $value == '') {
+        if ($info['nullable'] && $value === '') {
             $value = null;
         }
 

--- a/engine/Shopware/Components/MultiEdit/Resource/Product/Filter.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/Filter.php
@@ -24,7 +24,9 @@
 
 namespace Shopware\Components\MultiEdit\Resource\Product;
 
+use Doctrine\ORM\Query;
 use Shopware\Components\Model\QueryBuilder;
+use Shopware\Models\Article\Article;
 use Shopware\Models\Article\Detail;
 
 /**
@@ -77,7 +79,7 @@ class Filter
      * @param int|null   $limit
      * @param array|null $orderBy
      *
-     * @return \Doctrine\ORM\Query
+     * @return Query
      */
     public function getFilterQuery($tokens, $offset = null, $limit = null, $orderBy = null)
     {
@@ -126,7 +128,7 @@ class Filter
             $builder->leftJoin($this->getDqlHelper()->getAssociationForEntity($entity), $this->getDqlHelper()->getPrefixForEntity($entity));
         }
 
-        list($dql, $params) = $this->getDqlHelper()->getDqlFromTokens($tokens);
+        [$dql, $params] = $this->getDqlHelper()->getDqlFromTokens($tokens);
 
         foreach ($params as $key => $value) {
             $builder->setParameter($key, $value);
@@ -167,7 +169,7 @@ class Filter
     }
 
     /**
-     * @param \Doctrine\ORM\Query $query
+     * @param Query $query
      *
      * @return array
      */
@@ -204,14 +206,14 @@ class Filter
     public function filter($tokens, $offset, $limit, $orderBy)
     {
         $query = $this->getFilterQuery($tokens, $offset, $limit, $orderBy);
-        list($result, $totalCount) = $this->getPaginatedResult($query);
+        [$result, $totalCount] = $this->getPaginatedResult($query);
 
         $products = $this->getDqlHelper()->getProductsForListing($result);
 
         $sortedData = [];
         foreach ($result as $id) {
             foreach ($products as $key => $row) {
-                if ($row['Detail_id'] == $id) {
+                if ($row['Detail_id'] === $id) {
                     $sortedData[] = $row;
                     unset($products[$key]);
                     break;
@@ -235,8 +237,8 @@ class Filter
         // Remove Article-Entity
         $joinEntities = array_filter(
             $joinEntities,
-            function ($item) {
-                return $item !== 'Shopware\Models\Article\Article' && $item !== 'Shopware\Models\Article\Detail';
+            static function ($item) {
+                return $item !== Article::class && $item !== Detail::class;
             }
         );
 

--- a/engine/Shopware/Components/Password/Encoder/Sha256.php
+++ b/engine/Shopware/Components/Password/Encoder/Sha256.php
@@ -94,13 +94,13 @@ class Sha256 implements PasswordEncoderInterface
     public function isReencodeNeeded($hash)
     {
         /* @var int $interations */
-        list($iterations, $salt) = explode(':', $hash);
+        [$iterations, $salt] = explode(':', $hash);
 
-        if ($iterations != $this->options['iterations']) {
+        if ((int) $iterations !== $this->options['iterations']) {
             return true;
         }
 
-        if (strlen($salt) != $this->options['salt_len']) {
+        if (strlen($salt) !== $this->options['salt_len']) {
             return true;
         }
 

--- a/engine/Shopware/Components/Plugin/Bootstrap.php
+++ b/engine/Shopware/Components/Plugin/Bootstrap.php
@@ -107,7 +107,7 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
         }
 
         // Exception for Pre-Installed Plugins
-        if ($currentVersion == '1' && $updateVersion == '1.0.0') {
+        if ($currentVersion === '1' && $updateVersion === '1.0.0') {
             return false;
         }
 
@@ -794,7 +794,7 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
                 $translationArray = $translationSet['plugin_form'];
                 foreach ($form->getTranslations() as $existingTranslation) {
                     // Check if translation for this locale already exists
-                    if ($existingTranslation->getLocale()->getLocale() != $localeCode) {
+                    if ($existingTranslation->getLocale()->getLocale() !== $localeCode) {
                         continue;
                     }
                     if (array_key_exists('label', $translationArray)) {
@@ -826,7 +826,7 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
                 $element = $form->getElement($targetName);
                 foreach ($element->getTranslations() as $existingTranslation) {
                     // Check if translation for this locale already exists
-                    if ($existingTranslation->getLocale()->getLocale() != $localeCode) {
+                    if ($existingTranslation->getLocale()->getLocale() !== $localeCode) {
                         continue;
                     }
                     if (array_key_exists('label', $translationArray)) {

--- a/engine/Shopware/Components/Plugin/ConfigWriter.php
+++ b/engine/Shopware/Components/Plugin/ConfigWriter.php
@@ -88,7 +88,7 @@ class ConfigWriter
             throw new \Exception(sprintf('Config element "%s" not found.', $name));
         }
 
-        if ($element->getScope() == 0 && $shop->getId() !== 1) {
+        if ($element->getScope() === 0 && $shop->getId() !== 1) {
             throw new \InvalidArgumentException(sprintf("Element '%s' is not writeable for shop %s", $element->getName(), $shop->getId()));
         }
 

--- a/engine/Shopware/Components/Plugin/ConfigWriter.php
+++ b/engine/Shopware/Components/Plugin/ConfigWriter.php
@@ -24,6 +24,9 @@
 
 namespace Shopware\Components\Plugin;
 
+use Doctrine\ORM\EntityRepository;
+use Exception;
+use InvalidArgumentException;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Config\Element;
 use Shopware\Models\Config\Form;
@@ -39,17 +42,17 @@ class ConfigWriter
     private $em;
 
     /**
-     * @var \Doctrine\ORM\EntityRepository
+     * @var EntityRepository
      */
     private $elementRepository;
 
     /**
-     * @var \Doctrine\ORM\EntityRepository
+     * @var EntityRepository
      */
     private $formRepository;
 
     /**
-     * @var \Doctrine\ORM\EntityRepository
+     * @var EntityRepository
      */
     private $valueRepository;
 
@@ -73,11 +76,9 @@ class ConfigWriter
     }
 
     /**
-     * @param string $name
-     *
      * @throws \Exception
      */
-    public function saveConfigElement(Plugin $plugin, $name, $value, Shop $shop)
+    public function saveConfigElement(Plugin $plugin, string $name, $value, Shop $shop)
     {
         /** @var Form $form */
         $form = $this->formRepository->findOneBy(['pluginId' => $plugin->getId()]);
@@ -85,11 +86,11 @@ class ConfigWriter
         /** @var Element|null $element */
         $element = $this->elementRepository->findOneBy(['form' => $form, 'name' => $name]);
         if (!$element) {
-            throw new \Exception(sprintf('Config element "%s" not found.', $name));
+            throw new Exception(sprintf('Config element "%s" not found.', $name));
         }
 
-        if ($element->getScope() === 0 && $shop->getId() !== 1) {
-            throw new \InvalidArgumentException(sprintf("Element '%s' is not writeable for shop %s", $element->getName(), $shop->getId()));
+        if ($element->getScope() === Element::SCOPE_LOCALE && $shop->getId() !== 1) {
+            throw new InvalidArgumentException(sprintf("Element '%s' is not writeable for shop %s", $element->getName(), $shop->getId()));
         }
 
         $defaultValue = $element->getValue();

--- a/engine/Shopware/Components/Plugin/FormSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/FormSynchronizer.php
@@ -255,7 +255,7 @@ class FormSynchronizer
                 $element = $form->getElement($targetName);
                 foreach ($element->getTranslations() as $existingTranslation) {
                     // Check if translation for this locale already exists
-                    if ($existingTranslation->getLocale()->getLocale() != $locale->getLocale()) {
+                    if ($existingTranslation->getLocale()->getLocale() !== $locale->getLocale()) {
                         continue;
                     }
 
@@ -290,7 +290,7 @@ class FormSynchronizer
         $isUpdate = false;
         foreach ($form->getTranslations() as $existingTranslation) {
             // Check if translation for this locale already exists
-            if ($existingTranslation->getLocale()->getLocale() != $locale->getLocale()) {
+            if ($existingTranslation->getLocale()->getLocale() !== $locale->getLocale()) {
                 continue;
             }
             if (array_key_exists('label', $translationArray)) {

--- a/engine/Shopware/Components/ProductStream/Repository.php
+++ b/engine/Shopware/Components/ProductStream/Repository.php
@@ -30,6 +30,7 @@ use Shopware\Bundle\SearchBundle\ConditionInterface;
 use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\SearchBundle\SortingInterface;
 use Shopware\Components\LogawareReflectionHelper;
+use Shopware\Models\ProductStream\ProductStream;
 
 class Repository implements RepositoryInterface
 {
@@ -56,13 +57,13 @@ class Repository implements RepositoryInterface
     {
         $productStream = $this->getStreamById($productStreamId);
 
-        if ($productStream['type'] == 1) {
+        if ((int) $productStream['type'] === ProductStream::TYPE_FILTERED) {
             $this->prepareConditionStream($productStream, $criteria);
 
             return;
         }
 
-        if ($productStream['type'] == 2) {
+        if ((int) $productStream['type'] === ProductStream::TYPE_SELECTION) {
             $this->prepareSelectionStream($productStream, $criteria);
 
             return;
@@ -117,13 +118,11 @@ class Repository implements RepositoryInterface
     }
 
     /**
-     * @param int $productStreamId
-     *
      * @return array
      */
-    private function getStreamById($productStreamId)
+    private function getStreamById(int $productStreamId)
     {
-        $row = $this->conn->fetchAssoc(
+        return $this->conn->fetchAssoc(
             'SELECT streams.*, customSorting.sortings as customSortings
              FROM s_product_streams streams
              LEFT JOIN s_search_custom_sorting customSorting
@@ -132,8 +131,6 @@ class Repository implements RepositoryInterface
              LIMIT 1',
             ['productStreamId' => $productStreamId]
         );
-
-        return $row;
     }
 
     private function assignSortings(array $productStream, Criteria $criteria)

--- a/engine/Shopware/Components/Routing/Matchers/RewriteMatcher.php
+++ b/engine/Shopware/Components/Routing/Matchers/RewriteMatcher.php
@@ -95,7 +95,7 @@ class RewriteMatcher implements MatcherInterface
         if ($statement->execute() && $statement->rowCount() > 0) {
             $route = $statement->fetch(\PDO::FETCH_ASSOC);
             $query = $this->getQueryFormOrgPath($route['orgPath']);
-            if (empty($route['main']) || $route['shopId'] != $context->getShopId()) {
+            if (empty($route['main']) || (int) $route['shopId'] !== $context->getShopId()) {
                 $query['rewriteAlias'] = true;
             } else {
                 $query['rewriteUrl'] = true;

--- a/engine/Shopware/Components/SitePageMenu.php
+++ b/engine/Shopware/Components/SitePageMenu.php
@@ -80,16 +80,7 @@ class SitePageMenu
         $links = [];
 
         foreach ($data as $site) {
-            if (isset($site['mapping'])) {
-                /**
-                 * If there's a mapping present, we're dealing with one of the
-                 * english legacy groups, so rename it to make it usable in the frontend.
-                 */
-                $key = $site['mapping'];
-            } else {
-                /** group either contains the new or the legacy group key */
-                $key = $site['group'];
-            }
+            $key = $site['mapping'] ?? $site['group'];
 
             if ($this->overrideExisting($menu, $key, $site)) {
                 $menu[$key] = [];
@@ -100,7 +91,7 @@ class SitePageMenu
 
                 if ($translations) {
                     foreach ($translations as $property => $translation) {
-                        if (strlen($translation) > 0) {
+                        if ($translation !== '') {
                             $site[$property] = $translation;
                         }
                     }
@@ -161,9 +152,9 @@ class SitePageMenu
     {
         $result = [];
         foreach ($sites as $index => $site) {
-            $site['active'] = ($site['id'] == $activeId);
+            $site['active'] = ((int) $site['id'] === $activeId);
 
-            if ($site['parentID'] != $parentId) {
+            if ((int) $site['parentID'] !== $parentId) {
                 continue;
             }
             $id = (int) $site['id'];

--- a/engine/Shopware/Components/Snippet/DatabaseHandler.php
+++ b/engine/Shopware/Components/Snippet/DatabaseHandler.php
@@ -78,7 +78,7 @@ class DatabaseHandler
     {
         $snippetsDir = $snippetsDir ?: $this->kernelRoot . '/snippets/';
         if (!file_exists($snippetsDir)) {
-            if ($snippetsDir == ($this->kernelRoot . '/snippets/')) {
+            if ($snippetsDir === ($this->kernelRoot . '/snippets/')) {
                 $this->printWarning('<info>No snippets folder found in Shopware core, skipping</info>');
             }
 
@@ -103,7 +103,7 @@ class DatabaseHandler
 
         foreach ($finder as $file) {
             $filePath = $file->getRelativePathname();
-            if (strpos($filePath, '.ini') == strlen($filePath) - 4) {
+            if (strpos($filePath, '.ini') === strlen($filePath) - 4) {
                 $namespace = substr($filePath, 0, -4);
                 $namespace = str_replace('\\', '/', $namespace);
             } else {
@@ -118,7 +118,7 @@ class DatabaseHandler
             ]);
 
             foreach ($namespaceData->read()->toArray() as $index => $values) {
-                if ($index == 'default') {
+                if ($index === 'default') {
                     $locale = $defaultLocale;
                 } else {
                     $locale = $localeRepository->findOneBy(['locale' => $index]);
@@ -169,13 +169,13 @@ class DatabaseHandler
         ]);
 
         $namespaces = array_map(
-            function ($result) {
+            static function ($result) {
                 return $result['namespace'];
             },
             $snippetRepository->getDistinctNamespacesQuery($locale->getId())->getArrayResult()
         );
 
-        if (count($namespaces) == 0) {
+        if (empty($namespaces)) {
             $this->printWarning('<error>No snippets found for the given locale(s)</error>');
 
             return;
@@ -233,7 +233,7 @@ class DatabaseHandler
 
         foreach ($finder as $file) {
             $filePath = $file->getRelativePathname();
-            if (strpos($filePath, '.ini') == strlen($filePath) - 4) {
+            if (strpos($filePath, '.ini') === strlen($filePath) - 4) {
                 $namespace = substr($filePath, 0, -4);
                 $namespace = str_replace('\\', '/', $namespace);
             } else {
@@ -248,7 +248,7 @@ class DatabaseHandler
             ]);
 
             foreach ($namespaceData->read()->toArray() as $index => $values) {
-                if ($index == 'default') {
+                if ($index === 'default') {
                     $locale = $defaultLocale;
                 } else {
                     $locale = $localeRepository->findOneBy(['locale' => $index]);

--- a/engine/Shopware/Components/Snippet/QueryHandler.php
+++ b/engine/Shopware/Components/Snippet/QueryHandler.php
@@ -70,7 +70,7 @@ class QueryHandler
         $finder->files()->in($snippetsDir);
         foreach ($finder as $file) {
             $filePath = $file->getRelativePathname();
-            if (strpos($filePath, '.ini') == strlen($filePath) - 4) {
+            if (strpos($filePath, '.ini') === strlen($filePath) - 4) {
                 $namespace = substr($filePath, 0, -4);
             } else {
                 continue;

--- a/engine/Shopware/Components/Snippet/Writer/DatabaseWriter.php
+++ b/engine/Shopware/Components/Snippet/Writer/DatabaseWriter.php
@@ -197,16 +197,11 @@ class DatabaseWriter
         $this->db->insert('s_core_snippets', $queryData);
     }
 
-    /**
-     * @param string $name
-     * @param string $value
-     * @param array  $row
-     */
-    private function updateRecord($name, $value, $row)
+    private function updateRecord(string $name, string $value, array $row)
     {
         $hasSameValue = $name === $row['name'] && $value === $row['value'];
 
-        $isDirty = $row['dirty'] == 1;
+        $isDirty = (int) $row['dirty'] === 1;
 
         // snippet was never touched after insert
         if (!$this->force && $hasSameValue && !$isDirty) {

--- a/engine/Shopware/Components/Snippet/Writer/QueryWriter.php
+++ b/engine/Shopware/Components/Snippet/Writer/QueryWriter.php
@@ -145,7 +145,7 @@ class QueryWriter
             ];
 
             $values[] = '(' . implode(', ', array_values($queryData)) . ')';
-            if (++$counter % 50 == 0) {
+            if (++$counter % 50 === 0) {
                 $this->queries[] = $insertSql . implode(', ', $values) . ';';
                 $values = [];
             }

--- a/engine/Shopware/Components/StringCompiler.php
+++ b/engine/Shopware/Components/StringCompiler.php
@@ -131,7 +131,7 @@ class Shopware_Components_StringCompiler
      */
     public function compileString($value, $context = null)
     {
-        if (strlen($value) == 0) {
+        if ($value === '') {
             return $value;
         }
 

--- a/engine/Shopware/Components/Theme/Service.php
+++ b/engine/Shopware/Components/Theme/Service.php
@@ -450,7 +450,7 @@ class Service
                 ->setParameter('shopId', $shop->getId());
         }
 
-        if ($parentId == null) {
+        if ($parentId === null) {
             $builder->andWhere('layout.parentId IS NULL');
         } else {
             $builder->andWhere('layout.parentId = :parentId')
@@ -574,15 +574,13 @@ class Service
      * value collection.
      * If no shop value exist, the function creates a new value object.
      *
-     * @param int $shopId
-     *
      * @return Shop\TemplateConfig\Value
      */
-    private function getElementShopValue(Collection $collection, $shopId)
+    private function getElementShopValue(Collection $collection, int $shopId)
     {
         /** @var Shop\TemplateConfig\Value $value */
         foreach ($collection as $value) {
-            if ($value->getShop() && $value->getShop()->getId() == $shopId) {
+            if ($value->getShop() && $value->getShop()->getId() === $shopId) {
                 return $value;
             }
         }

--- a/engine/Shopware/Components/Thumbnail/Generator/Basic.php
+++ b/engine/Shopware/Components/Thumbnail/Generator/Basic.php
@@ -244,11 +244,11 @@ class Basic implements GeneratorInterface
         $processWidth = $newSize['width'] + 0;
         for ($y = 0; $y < ($processHeight); ++$y) {
             for ($x = 0; $x < ($processWidth); ++$x) {
-                $colorat = imagecolorat($newImage, $x, $y);
-                $r = ($colorat >> 16) & 0xFF;
-                $g = ($colorat >> 8) & 0xFF;
-                $b = $colorat & 0xFF;
-                if (($r == 253 && $g == 253 && $b == 253) || ($r == 254 && $g == 254 && $b == 254)) {
+                $colorAt = imagecolorat($newImage, $x, $y);
+                $r = ($colorAt >> 16) & 0xFF;
+                $g = ($colorAt >> 8) & 0xFF;
+                $b = $colorAt & 0xFF;
+                if (($r === 253 && $g === 253 && $b === 253) || ($r === 254 && $g === 254 && $b === 254)) {
                     imagesetpixel($newImage, $x, $y, $colorWhite);
                 }
             }
@@ -276,8 +276,7 @@ class Basic implements GeneratorInterface
                 break;
         }
 
-        $content = ob_get_contents();
-        ob_end_clean();
+        $content = ob_get_clean();
 
         $this->mediaService->write($destination, $content);
     }

--- a/engine/Shopware/Models/Config/Element.php
+++ b/engine/Shopware/Models/Config/Element.php
@@ -34,8 +34,8 @@ use Shopware\Components\Model\ModelEntity;
  */
 class Element extends ModelEntity
 {
-    const SCOPE_LOCALE = 0;
-    const SCOPE_SHOP = 1;
+    public const SCOPE_LOCALE = 0;
+    public const SCOPE_SHOP = 1;
 
     /**
      * INVERSE SIDE

--- a/engine/Shopware/Models/Document/Document.php
+++ b/engine/Shopware/Models/Document/Document.php
@@ -37,6 +37,11 @@ use Shopware\Components\Model\ModelEntity;
  */
 class Document extends ModelEntity
 {
+    public const TYPE_INVOICE = 1;
+    public const TYPE_SHIPPING = 2;
+    public const TYPE_CREDIT = 3;
+    public const TYPE_CANCEL = 4;
+
     /**
      * The id property is an identifier property which means
      * doctrine associations can be defined over this field

--- a/engine/Shopware/Models/ProductStream/ProductStream.php
+++ b/engine/Shopware/Models/ProductStream/ProductStream.php
@@ -34,6 +34,9 @@ use Shopware\Models\Attribute\ProductStream as ProductStreamAttribute;
  */
 class ProductStream extends ModelEntity
 {
+    public const TYPE_FILTERED = 1;
+    public const TYPE_SELECTION = 2;
+
     /**
      * INVERSE SIDE
      *

--- a/tests/Functional/Components/Api/PropertyGroupTest.php
+++ b/tests/Functional/Components/Api/PropertyGroupTest.php
@@ -24,8 +24,13 @@
 
 namespace Shopware\Tests\Functional\Components\Api;
 
+use Shopware\Bundle\StoreFrontBundle\Struct\Property\Set;
+use Shopware\Components\Api\Exception\CustomValidationException;
+use Shopware\Components\Api\Exception\NotFoundException;
+use Shopware\Components\Api\Exception\ParameterMissingException;
 use Shopware\Components\Api\Resource\PropertyGroup;
 use Shopware\Components\Api\Resource\Resource;
+use Shopware\Models\Property\Group;
 
 class PropertyGroupTest extends TestCase
 {
@@ -44,11 +49,11 @@ class PropertyGroupTest extends TestCase
 
     public function testCreateShouldThrowCustomValidationException()
     {
-        $this->expectException('Shopware\Components\Api\Exception\CustomValidationException');
+        $this->expectException(CustomValidationException::class);
         $testData = [
             'position' => 1,
             'comparable' => 1,
-            'sortmode' => 2,
+            'sortmode' => Set::SORT_LEGACY,
         ];
 
         $this->resource->create($testData);
@@ -60,12 +65,12 @@ class PropertyGroupTest extends TestCase
             'name' => 'Eigenschaft1',
             'position' => 1,
             'comparable' => 1,
-            'sortmode' => 0,
+            'sortmode' => Set::SORT_ALPHANUMERIC,
         ];
 
         $group = $this->resource->create($testData);
 
-        static::assertInstanceOf('\Shopware\Models\Property\Group', $group);
+        static::assertInstanceOf(Group::class, $group);
         static::assertGreaterThan(0, $group->getId());
 
         static::assertEquals($group->getPosition(), $testData['position']);
@@ -92,7 +97,7 @@ class PropertyGroupTest extends TestCase
         $this->resource->setResultMode(1);
         $group = $this->resource->getOne($id);
 
-        static::assertInstanceOf('\Shopware\Models\Property\Group', $group);
+        static::assertInstanceOf(Group::class, $group);
         static::assertGreaterThan(0, $group->getId());
     }
 
@@ -124,7 +129,7 @@ class PropertyGroupTest extends TestCase
         static::assertGreaterThanOrEqual(1, $result['total']);
         static::assertGreaterThanOrEqual(1, $result['data']);
 
-        static::assertInstanceOf('\Shopware\Models\Property\Group', $result['data'][0]);
+        static::assertInstanceOf(Group::class, $result['data'][0]);
     }
 
     /**
@@ -133,13 +138,13 @@ class PropertyGroupTest extends TestCase
     public function testUpdateShouldBeSuccessful($id)
     {
         $testData = [
-            'name' => uniqid(rand()) . 'testProperty',
+            'name' => uniqid(mt_rand(), true) . 'testProperty',
             'sortmode' => 99,
         ];
 
         $group = $this->resource->update($id, $testData);
 
-        static::assertInstanceOf('\Shopware\Models\Property\Group', $group);
+        static::assertInstanceOf(Group::class, $group);
         static::assertEquals($id, $group->getId());
 
         static::assertEquals($group->getName(), $testData['name']);
@@ -150,13 +155,13 @@ class PropertyGroupTest extends TestCase
 
     public function testUpdateWithInvalidIdShouldThrowNotFoundException()
     {
-        $this->expectException('Shopware\Components\Api\Exception\NotFoundException');
+        $this->expectException(NotFoundException::class);
         $this->resource->update(9999999, []);
     }
 
     public function testUpdateWithMissingIdShouldThrowParameterMissingException()
     {
-        $this->expectException('Shopware\Components\Api\Exception\ParameterMissingException');
+        $this->expectException(ParameterMissingException::class);
         $this->resource->update('', []);
     }
 
@@ -167,19 +172,19 @@ class PropertyGroupTest extends TestCase
     {
         $group = $this->resource->delete($id);
 
-        static::assertInstanceOf('\Shopware\Models\Property\Group', $group);
+        static::assertInstanceOf(Group::class, $group);
         static::assertEquals(null, $group->getId());
     }
 
     public function testDeleteWithInvalidIdShouldThrowNotFoundException()
     {
-        $this->expectException('Shopware\Components\Api\Exception\NotFoundException');
+        $this->expectException(NotFoundException::class);
         $this->resource->delete(9999999);
     }
 
     public function testDeleteWithMissingIdShouldThrowParameterMissingException()
     {
-        $this->expectException('Shopware\Components\Api\Exception\ParameterMissingException');
+        $this->expectException(ParameterMissingException::class);
         $this->resource->delete('');
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Code quality in `/engine/Shopware/Components`

### 2. What does this change do, exactly?
Use strict comparisons if possible, and replace magic numbers with more vocal consts.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/pull/2271

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.