### PR TITLE
Allow only unique attributes for each entity

### DIFF
--- a/_sql/migrations/1651-enforce-unique-attributes.php
+++ b/_sql/migrations/1651-enforce-unique-attributes.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+use Shopware\Components\Migrations\AbstractMigration;
+
+class Migrations_Migration1651 extends AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = 'ALTER TABLE `s_attribute_configuration` ADD UNIQUE INDEX `table_column_unique` (`table_name`, `column_name`)';
+
+        $this->addSql($sql);
+    }
+}

--- a/engine/Shopware/Models/Attribute/Configuration.php
+++ b/engine/Shopware/Models/Attribute/Configuration.php
@@ -28,7 +28,9 @@ use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
 
 /**
- * @ORM\Table(name="s_attribute_configuration")
+ * @ORM\Table(name="s_attribute_configuration",
+ *     uniqueConstraints={@ORM\UniqueConstraint(name="table_column_unique", columns={"table_name", "column_name"})}
+ * )
  * @ORM\Entity()
  */
 class Configuration extends ModelEntity

--- a/tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
+++ b/tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
@@ -24,9 +24,16 @@
 
 namespace Shopware\Tests\Functional\Bundle\AttributeBundle;
 
-class SchemaOperatorTest extends \PHPUnit\Framework\TestCase
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Shopware\Bundle\AttributeBundle\Service\ConfigurationStruct;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
+
+class SchemaOperatorTest extends TestCase
 {
-    public function testDefaultValues()
+    use DatabaseTransactionBehaviour;
+
+    public function testDefaultValues(): void
     {
         $types = [
             'string' => 'test123',
@@ -45,7 +52,7 @@ class SchemaOperatorTest extends \PHPUnit\Framework\TestCase
         $this->iterateTypeArray($types);
     }
 
-    public function testNullDefaultValues()
+    public function testNullDefaultValues(): void
     {
         $types = [
             'string' => null,
@@ -64,7 +71,7 @@ class SchemaOperatorTest extends \PHPUnit\Framework\TestCase
         $this->iterateTypeArray($types);
     }
 
-    public function testNullStringDefaultValues()
+    public function testNullStringDefaultValues(): void
     {
         $types = [
             'string' => 'NULL',
@@ -84,9 +91,9 @@ class SchemaOperatorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @throws \Exception
+     * @throws Exception
      */
-    public function testDefaultValuesBoolean()
+    public function testDefaultValuesBoolean(): void
     {
         $this->iterateTypeArray(['boolean' => 1]);
         $this->iterateTypeArray(['boolean' => 0]);
@@ -100,12 +107,45 @@ class SchemaOperatorTest extends \PHPUnit\Framework\TestCase
         $this->iterateTypeArray(['boolean' => 'null']);
     }
 
+    public function testUpdateConfiguration(): void
+    {
+        $service = Shopware()->Container()->get('shopware_attribute.crud_service');
+        $tableMapping = Shopware()->Container()->get('shopware_attribute.table_mapping');
+        $table = 's_articles_attributes';
+        $columnName = 'attr_' . uniqid(mt_rand(), false);
+
+        $service->update($table, $columnName, 'bool');
+        static::assertTrue($tableMapping->isTableColumn($table, $columnName));
+        $service->update($table, $columnName, 'date');
+        static::assertTrue($tableMapping->isTableColumn($table, $columnName));
+
+        /** @var ConfigurationStruct|null $column */
+        $column = $service->get($table, $columnName);
+        static::assertInstanceOf(ConfigurationStruct::class, $column);
+        static::assertEquals('date', $column->getColumnType());
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\DBALException
+     */
+    public function testReinsertColumnConfigurationShouldFail(): void
+    {
+        $connection = Shopware()->Container()->get('dbal_connection');
+        $attributeData = [
+            'table_name' => 's_articles_attributes',
+            'column_name' => 'attr_' . uniqid(mt_rand(), false),
+            'column_type' => 'bool',
+        ];
+        $connection->insert('s_attribute_configuration', $attributeData);
+        $connection->insert('s_attribute_configuration', $attributeData);
+    }
+
     /**
      * @param array $types
      *
-     * @throws \Exception
+     * @throws Exception
      */
-    private function iterateTypeArray($types)
+    private function iterateTypeArray($types): void
     {
         $service = Shopware()->Container()->get('shopware_attribute.crud_service');
         $tableMapping = Shopware()->Container()->get('shopware_attribute.table_mapping');
@@ -118,7 +158,7 @@ class SchemaOperatorTest extends \PHPUnit\Framework\TestCase
                 $service->delete($table, $name);
             }
 
-            $service->update('s_articles_attributes', $name, $type, [], null, false, $default);
+            $service->update($table, $name, $type, [], null, false, $default);
 
             static::assertTrue($tableMapping->isTableColumn($table, $name));
             $service->delete($table, $name);


### PR DESCRIPTION
### 1. Why is this change necessary?
It is possible to create several attributes with the same name for the same entity. This results in strange problems like attributes not appearing etc. as the newest attribute entry will win.

### 2. What does this change do, exactly?
Enforce the combination of entity and attribute to be unique via Doctrine Entity Annotation (+ migration)

### 3. Describe each step to reproduce the issue or behaviour.

1. Run
```
INSERT INTO `s_attribute_configuration` (`table_name`, `column_name`, `column_type`, `display_in_backend`)
VALUES ('s_articles_attributes', 'attr5', 'text', TRUE), ('s_articles_attributes', 'attr5', 'boolean', FALSE);
```
on a clean installation.
2. Regenerate models
3. Try to modify new attr5 on a product. You won't find its entry.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.