### PR TITLE
Attribute wurden nicht korrekt beim Logout nicht korrekt weggeschrieb…

### DIFF
--- a/engine/Shopware/Components/Cart/CartPersistService.php
+++ b/engine/Shopware/Components/Cart/CartPersistService.php
@@ -72,11 +72,13 @@ class CartPersistService implements CartPersistServiceInterface
 
         $ids = array_keys($this->cart);
 
+        $qb = $this->connection->createQueryBuilder();
         $this->cartAttributes = $qb->from('s_order_basket_attributes', 'cartAttributes')
             ->addSelect('cartAttributes.basketID')
             ->addSelect('cartAttributes.*')
-            ->andWhere('cartAttributes.basketID IN(:ids)')
-            ->setParameter('ids', $ids)
+            ->andWhere(
+                $qb->expr()->in('cartAttributes.basketID', $ids)
+            )
             ->execute()
             ->fetchAll(\PDO::FETCH_GROUP | \PDO::FETCH_UNIQUE | \PDO::FETCH_ASSOC);
     }


### PR DESCRIPTION

Kam u.a. durch die Weiterverwendung derselben Querybuilder Instanz


### 1. Why is this change necessary?
Attribute wurden nicht korrekt beim Logout nicht korrekt weggeschrieben, so dass diese Informationen verloren gingenAttribute wurden nicht korrekt beim Logout nicht korrekt weggeschrieben, so dass diese Informationen verloren gingen.


### 2. What does this change do, exactly?
Dafür sorgen, das die Attribute beim "persistenten Warenkorb" Feature mit weggespeichert werden, bei Logout, sodass diese auch beim Login wiederhergestellt werden können

### 3. Describe each step to reproduce the issue or behaviour.
Basket Items mit Attributen haben
Konfiguration des persistenten Warenkorbs aktiv haben
Ausloggen
Einloggen und gucken was mit den Attributen passiert ist

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.