### PR TITLE
Add cms attribute translations

### DIFF
--- a/engine/Shopware/Core/sCms.php
+++ b/engine/Shopware/Core/sCms.php
@@ -111,7 +111,15 @@ class sCms implements \Enlight_Hook
                 $fallbackId = Shopware()->Shop()->getFallback()->getId();
             }
 
-            $translations = $this->translationComponent->readWithFallback($shopId, $fallbackId, 'page', $staticId);
+            $translations = \array_merge(
+                $this->translationComponent->readWithFallback($shopId, $fallbackId, 'page', $staticId),
+                $this->translationComponent->readWithFallback(
+                    $shopId,
+                    $fallbackId,
+                    's_cms_static_attributes',
+                    $staticId
+                )
+            );
         }
 
         // Load static page data from database


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Because attribute translations are not being read in the frontend for custom pages (CMS).

### 2. What does this change do, exactly?

It reads the attribute translations and merges them with the base data translations before they are being prepared for the frontend view.

### 3. Describe each step to reproduce the issue or behaviour.

* Add a new translatable attribute field for custom pages (display in backend = true)
* Create/edit a custom page and set a translation value for the custom page attribute
* Open the page in the frontend using the proper shop for the entered translation

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.