### PR TITLE
Fixed fetching of documents positions metadata

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -495,7 +495,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         $articleModule = Shopware()->Modules()->Articles();
         foreach ($positions as &$position) {
             if ($position['modus'] == 0) {
-                $position['meta'] = $articleModule->sGetPromotionById('fix', 0, $position['articleordernumber']);
+                $position['meta'] = $articleModule->sGetPromotionById('fix', 0, $position['articleID']);
             }
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
So far the fetching of the documents position metadata was done by articleordernumber, but it has to be articleID. Because later on the given value will be used to retrieves the ordernumber by searching with a given articleID.

### 2. What does this change do, exactly?
see above


### 3. Describe each step to reproduce the issue or behaviour.
The metadata for document positions has been wrong, if there was an article with an detailID which matches the given articleordernumber. Which is done in sArticles::sGetPromotionById() and sArticles::getPromotionNumberByMode().

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.