### PR TITLE
SW-24987 fix empty array key in request cookies

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/InputFilter/Bootstrap.php
@@ -150,11 +150,15 @@ class Shopware_Plugins_Frontend_InputFilter_Bootstrap extends Shopware_Component
             foreach ($val as $k => $v) {
                 unset($process[$key][$k]);
                 $stripTags = in_array($k, $whiteList) ? false : $stripTagsConf;
+                $filteredKey = self::filterValue($k, $regex, $stripTags);
+                if ($filteredKey === '' || $filteredKey === null) {
+                  continue;   
+                }
                 if (is_array($v)) {
-                    $process[$key][self::filterValue($k, $regex, $stripTags)] = $v;
+                    $process[$key][$filteredKey] = $v;
                     $process[] = &$process[$key][self::filterValue($k, $regex, $stripTags)];
                 } else {
-                    $process[$key][self::filterValue($k, $regex, $stripTags)] = self::filterValue($v, $regex, $stripTags);
+                    $process[$key][$filteredKey] = self::filterValue($v, $regex, $stripTags);
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Shops break if you have a cookie that contains `.*s_user`.

### 2. What does this change do, exactly?
It prevents the `InputFilter` from generating empty array keys in the request cookies.

### 3. Describe each step to reproduce the issue or behaviour.
Set a cookie on your domain e.g. `ajs_user=something`. The shop will break with 
```
PHP message: PHP Fatal error:  Uncaught InvalidArgumentException: The cookie name cannot be empty. in /var/www/clients/client1/web14/web/vendor/symfony/http-foundation/Cookie.php:110
```

OR 

```
PHP message: PHP Fatal error:  Uncaught Zend\Diactoros\Exception\InvalidArgumentException: Invalid header value type; must be a string or numeric; received NULL in /var/www/clients/client1/web14/web/vendor/zendframework/zend-diactoros/src/HeaderSecurity.php:139
```

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-24987

### 5. Which documentation changes (if any) need to be made because of this PR?
Nothing

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.