### PR TITLE
Support composer installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,8 @@
         "superbalist/flysystem-google-storage": "6.0.0",
         "stecman/symfony-console-completion": "0.10.1",
         "beberlei/doctrineextensions": "1.2.1",
-        "phpstan/phpstan-shim": "0.11.19"
+        "phpstan/phpstan-shim": "0.11.19",
+        "oomphinc/composer-installers-extender": "~1.1.2"
     },
     "suggest": {
         "ext-apcu": "*",
@@ -149,5 +150,8 @@
         "post-update-cmd": "./build/composer-post-update-cmd.sh",
         "test": "phpunit -c tests/ --colors=always",
         "test-unit": "phpunit -c tests/phpunit_unit.xml.dist --colors=always"
+    },
+    "extra": {
+        "installer-name": "shopware"
     }
 }


### PR DESCRIPTION
Allow installing shopware as dependency and to overwrite the install path and name

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Sometimes you need to install shopware as dependency and integrate it in an existing project

### 2. What does this change do, exactly?
Enables support for composer installers, so that you can change the install path/name

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.