### PR TITLE
Add sw:admin:login for instant backend login

### DIFF
--- a/_sql/migrations/1650-add-otp-fields-to-auth.php
+++ b/_sql/migrations/1650-add-otp-fields-to-auth.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+class Migrations_Migration1650 extends Shopware\Components\Migrations\AbstractMigration
+{
+    const UP = <<<'SQL'
+set sql_mode = '';
+
+alter table s_core_auth
+	add otp varchar(255) null;
+
+alter table s_core_auth
+	add otp_activation datetime null;
+
+SQL;
+
+
+    public function up($modus)
+    {
+        $this->addSql(self::UP);
+    }
+}

--- a/engine/Shopware/Commands/AdminLoginCommand.php
+++ b/engine/Shopware/Commands/AdminLoginCommand.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Commands;
+
+use Shopware\Components\Model\ModelManager;
+use Shopware\Components\Password\Manager;
+use Shopware\Components\Random;
+use Shopware\Components\Routing\Context;
+use Shopware\Components\Routing\RouterInterface;
+use Shopware\Models\Shop\Shop;
+use Shopware\Models\User\Role;
+use Shopware\Models\User\User;
+use Shopware_Components_Config;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+class AdminLoginCommand extends ShopwareCommand
+{
+    /**
+     * @var Manager
+     */
+    private $passwordRegistry;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var ModelManager
+     */
+    private $modelManager;
+
+    /**
+     * @var Shopware_Components_Config
+     */
+    private $config;
+
+    public function __construct(
+        Manager $passwordRegistry,
+        RouterInterface $router,
+        ModelManager $modelManager,
+        Shopware_Components_Config $config
+    ) {
+        parent::__construct();
+
+        $this->passwordRegistry = $passwordRegistry;
+        $this->router = $router;
+        $this->modelManager = $modelManager;
+        $this->config = $config;
+    }
+
+    protected function configure()
+    {
+        $this->addArgument('username', InputArgument::OPTIONAL);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $criteria = [
+            'active' => true,
+        ];
+
+        if ($input->getArgument('username')) {
+            // find user by username from input
+            $criteria['username'] = $input->getArgument('username');
+        } else {
+            // fallback: find user by role "local_admins"
+            $role = $this->modelManager->getRepository(Role::class)->findOneBy([
+                'name' => 'local_admins',
+            ]);
+
+            if (!$role instanceof Role) {
+                $output->writeln('No role called "local_admins" could be found.');
+
+                return 1;
+            }
+
+            $criteria['roleId'] = $role->getId();
+        }
+
+        $user = $this->modelManager->getRepository(User::class)->findOneBy($criteria);
+
+        if (!$user instanceof User) {
+            $output->writeln('No matching user could be found.');
+
+            return 1;
+        }
+
+        // generate a cryptographically secure one-time-password
+        $otp = Random::getString(32);
+
+        try {
+            $encoder = $this->passwordRegistry->getEncoderByName($user->getEncoder());
+        } catch (Throwable $exception) {
+            $output->writeln(sprintf('Password encoder %s could not be found.', $user->getEncoder()));
+
+            return 1;
+        }
+
+        // prepare the user for a successful authentication
+        $user->setLockedUntil(null)
+            ->setFailedLogins(0)
+            ->setOtp($encoder->encodePassword($otp))
+            ->setOtpActivation(date_create());
+
+        $this->modelManager->flush();
+
+        // a request context is needed to generate the url for the correct host
+        $shop = $this->modelManager->getRepository(Shop::class)->getActiveDefault();
+        $this->router->setContext(Context::createFromShop($shop, $this->config));
+
+        $url = $this->router->assemble([
+            'module' => 'backend',
+            'controller' => 'login',
+            'action' => 'login',
+            'username' => $user->getUsername(),
+            'password' => $otp,
+            'fullPath' => true,
+        ]);
+
+        $output->writeln($url);
+
+        return 0;
+    }
+}

--- a/engine/Shopware/Components/Auth/Adapter/Otp.php
+++ b/engine/Shopware/Components/Auth/Adapter/Otp.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Components\Auth\Adapter;
+
+use DateInterval;
+use DateTime;
+use Shopware_Components_Auth_Adapter_Default;
+use Throwable;
+use Zend_Auth_Result;
+
+class Otp extends Shopware_Components_Auth_Adapter_Default
+{
+    public function authenticate()
+    {
+        // set one-time-password as column to hold the password-hash
+        $this->setCredentialColumn('otp');
+
+        // execute default login routine
+        $result = parent::authenticate();
+
+        try {
+            if ($this->_resultRow['otp_activation'] === null) {
+                // the otp has not been activated
+                $result = new Zend_Auth_Result(Zend_Auth_Result::FAILURE_CREDENTIAL_INVALID, $result->getIdentity());
+            } else {
+                $now = new DateTime();
+                $validUntil = (new DateTime($this->_resultRow['otp_activation']))->add(new DateInterval('PT30S'));
+
+                if ($now > $validUntil) {
+                    // the otp has expired
+                    $result = new Zend_Auth_Result(Zend_Auth_Result::FAILURE_CREDENTIAL_INVALID, $result->getIdentity());
+                }
+            }
+
+            if ($result->getCode() === Zend_Auth_Result::SUCCESS) {
+                // reset otp hash and activation if one login was successful
+                $this->_zendDb->update($this->_tableName, [
+                    'otp' => null,
+                    'otp_activation' => null,
+                ], sprintf('%s = "%s"', $this->_identityColumn, $result->getIdentity()));
+            }
+        } catch (Throwable $exception) {
+            return new Zend_Auth_Result(Zend_Auth_Result::FAILURE, $result->getIdentity());
+        }
+
+        return $result;
+    }
+}

--- a/engine/Shopware/Components/DependencyInjection/commands.xml
+++ b/engine/Shopware/Components/DependencyInjection/commands.xml
@@ -9,6 +9,14 @@
             <tag name="console.command" command="sw:admin:create"/>
         </service>
 
+        <service id="Shopware\Commands\AdminLoginCommand">
+            <tag name="console.command" command="sw:admin:login"/>
+            <argument type="service" id="passwordencoder"/>
+            <argument type="service" id="router"/>
+            <argument type="service" id="models"/>
+            <argument type="service" id="config"/>
+        </service>
+
         <service id="shopware.commands.cache_clear_command" class="Shopware\Commands\CacheClearCommand">
             <tag name="console.command" command="sw:cache:clear"/>
         </service>

--- a/engine/Shopware/Controllers/Backend/Login.php
+++ b/engine/Shopware/Controllers/Backend/Login.php
@@ -105,6 +105,19 @@ class Shopware_Controllers_Backend_Login extends Shopware_Controllers_Backend_Ex
             'locale' => isset($user->locale) ? $user->locale->toString() : null,
             'lockedUntil' => isset($lockedUntil) ? $lockedUntil : null,
         ]);
+
+        if ($this->Request()->isGet()) {
+            // GET-method indicates, that this is not the default xhr from the login form
+            // instead this request is likely to be an otp-login, so we should redirect to the backend
+            $this->redirect([
+                'module' => 'backend',
+                'controller' => 'index',
+                'action' => 'index',
+                // this is necessary, because with 302 chrome will not save the session cookie
+                // @see https://bugs.chromium.org/p/chromium/issues/detail?id=696204
+                'code' => 307,
+            ]);
+        }
     }
 
     /**

--- a/engine/Shopware/Models/User/User.php
+++ b/engine/Shopware/Models/User/User.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Models\User;
 
+use DateTimeInterface;
 use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
 
@@ -123,7 +124,7 @@ class User extends ModelEntity
     private $sessionId = '';
 
     /**
-     * @var \DateTimeInterface
+     * @var DateTimeInterface
      *
      * @ORM\Column(name="lastlogin", type="datetime", nullable=false)
      */
@@ -158,7 +159,7 @@ class User extends ModelEntity
     private $failedLogins = 0;
 
     /**
-     * @var \DateTimeInterface
+     * @var DateTimeInterface
      *
      * @ORM\Column(name="lockeduntil", type="datetime", nullable=false)
      */
@@ -188,6 +189,20 @@ class User extends ModelEntity
      * @ORM\JoinColumn(name="roleID", referencedColumnName="id")
      */
     private $role;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="otp", type="string", length=255, nullable=true)
+     */
+    private $otp;
+
+    /**
+     * @var DateTimeInterface
+     *
+     * @ORM\Column(name="otp_activation", type="datetime", nullable=true)
+     */
+    private $otpActivation;
 
     /**
      * Initial the date fields
@@ -295,13 +310,13 @@ class User extends ModelEntity
     }
 
     /**
-     * @param \DateTimeInterface|string $lastLogin
+     * @param DateTimeInterface|string $lastLogin
      *
      * @return User
      */
     public function setLastLogin($lastLogin)
     {
-        if (!$lastLogin instanceof \DateTimeInterface) {
+        if (!$lastLogin instanceof DateTimeInterface) {
             $lastLogin = new \DateTime((string) $lastLogin);
         }
         $this->lastLogin = $lastLogin;
@@ -310,7 +325,7 @@ class User extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return DateTimeInterface
      */
     public function getLastLogin()
     {
@@ -402,7 +417,7 @@ class User extends ModelEntity
      */
     public function setLockedUntil($lockedUntil)
     {
-        if (!$lockedUntil instanceof \DateTimeInterface) {
+        if (!$lockedUntil instanceof DateTimeInterface) {
             $lockedUntil = new \DateTime((string) $lockedUntil);
         }
         $this->lockedUntil = $lockedUntil;
@@ -411,7 +426,7 @@ class User extends ModelEntity
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return DateTimeInterface
      */
     public function getLockedUntil()
     {
@@ -572,5 +587,29 @@ class User extends ModelEntity
     public function getEncoder()
     {
         return $this->encoder;
+    }
+
+    public function getOtp(): ?string
+    {
+        return $this->otp;
+    }
+
+    public function setOtp(?string $otp): self
+    {
+        $this->otp = $otp;
+
+        return $this;
+    }
+
+    public function getOtpActivation(): ?DateTimeInterface
+    {
+        return $this->otpActivation;
+    }
+
+    public function setOtpActivation(?DateTimeInterface $otpActivation): self
+    {
+        $this->otpActivation = $otpActivation;
+
+        return $this;
     }
 }

--- a/engine/Shopware/Plugins/Default/Backend/Auth/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Backend/Auth/Bootstrap.php
@@ -22,6 +22,7 @@
  * our trademarks remain entirely with us.
  */
 
+use Shopware\Components\Auth\Adapter\Otp;
 use Shopware\Components\DependencyInjection\Bridge\Db;
 use Shopware\Components\DependencyInjection\Container;
 use Shopware\Components\Session\PdoSessionHandler;
@@ -391,10 +392,12 @@ class Shopware_Plugins_Backend_Auth_Bootstrap extends Shopware_Components_Plugin
         Shopware()->Container()->load('backendsession');
 
         $resource = Shopware_Components_Auth::getInstance();
-        $adapter = new Shopware_Components_Auth_Adapter_Default();
+        $defaultAdapter = new Shopware_Components_Auth_Adapter_Default();
+        $otpAdapter = new Otp();
         $storage = new Zend_Auth_Storage_Session('Shopware', 'Auth');
-        $resource->setBaseAdapter($adapter);
-        $resource->addAdapter($adapter);
+        $resource->setBaseAdapter($defaultAdapter);
+        $resource->addAdapter($defaultAdapter);
+        $resource->addAdapter($otpAdapter);
         $resource->setStorage($storage);
 
         $this->registerAclPlugin($resource);


### PR DESCRIPTION
### 1. Why is this change necessary?
It is not necessary. This is merely for convenience.

### 2. What does this change do, exactly?
A new command is introduced to the CLI: `sw:admin:login`
It generates a one-time-password for a backend user that is valid for 30 seconds. The username and the generated password are composed into a url to the backend login controller.

### 3. Describe each step to reproduce the issue or behaviour.
1. Run `sw:admin:login` in CLI.
2. Open the link.
3. You are now logged into the backend 🚀 

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
I don't know.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.