### PR TITLE
Autoload Resources/templates directory

### DIFF
--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -88,7 +88,7 @@ abstract class Plugin extends Bundle implements SubscriberInterface
         return $this->isActive;
     }
 
-    public function isAutoloadViews(): bool
+    public function hasAutoloadViews(): bool
     {
         return $this->autoloadViews;
     }

--- a/engine/Shopware/Components/Plugin.php
+++ b/engine/Shopware/Components/Plugin.php
@@ -47,6 +47,8 @@ abstract class Plugin extends Bundle implements SubscriberInterface
      */
     protected $pluginNamespace;
 
+    protected $autoloadViews = false;
+
     /**
      * @var bool
      */
@@ -84,6 +86,11 @@ abstract class Plugin extends Bundle implements SubscriberInterface
     final public function isActive()
     {
         return $this->isActive;
+    }
+
+    public function isAutoloadViews(): bool
+    {
+        return $this->autoloadViews;
     }
 
     /**

--- a/engine/Shopware/Components/Plugin/ResourceSubscriber.php
+++ b/engine/Shopware/Components/Plugin/ResourceSubscriber.php
@@ -111,13 +111,15 @@ class ResourceSubscriber implements SubscriberInterface
 
         $viewsDirectory = $this->pluginPath . '/Resources/views';
 
-        if (@is_dir($viewsDirectory)) {
-            $templates = (array) $args->getReturn();
+        if (!(@is_dir($viewsDirectory))) {
+            return;
+        }
 
-            if (!in_array($viewsDirectory, $templates, true)) {
-                $templates[] = $viewsDirectory;
-                $args->setReturn($templates);
-            }
+        $templates = (array)$args->getReturn();
+
+        if (!in_array($viewsDirectory, $templates, true)) {
+            $templates[] = $viewsDirectory;
+            $args->setReturn($templates);
         }
     }
 

--- a/engine/Shopware/Components/Plugin/ResourceSubscriber.php
+++ b/engine/Shopware/Components/Plugin/ResourceSubscriber.php
@@ -37,18 +37,15 @@ class ResourceSubscriber implements SubscriberInterface
      */
     private $pluginPath;
 
-    /**
-     * @var bool
-     */
-    private $loadViewsDirectory;
+    private $loadViewsDirectory = false;
 
     /**
      * @param string $pluginPath
      */
-    public function __construct($pluginPath, ?bool $loadViewsDirectory = null)
+    public function __construct($pluginPath, bool $loadViewsDirectory)
     {
         $this->pluginPath = $pluginPath;
-        $this->loadViewsDirectory = $loadViewsDirectory ?? false;
+        $this->loadViewsDirectory = $loadViewsDirectory;
     }
 
     /**

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -256,7 +256,7 @@ class Kernel extends SymfonyKernel
             $this->container->get('events')->addSubscriber($bundle);
             $this->container->get('events')->addSubscriber(new Plugin\ResourceSubscriber(
                 $bundle->getPath(),
-                $bundle instanceof Plugin && $bundle->isAutoloadViews()
+                $bundle instanceof Plugin && $bundle->hasAutoloadViews()
             ));
         }
 

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -254,7 +254,10 @@ class Kernel extends SymfonyKernel
             }
 
             $this->container->get('events')->addSubscriber($bundle);
-            $this->container->get('events')->addSubscriber(new Plugin\ResourceSubscriber($bundle->getPath()));
+            $this->container->get('events')->addSubscriber(new Plugin\ResourceSubscriber(
+                $bundle->getPath(),
+                $bundle instanceof Plugin && $bundle->isAutoloadViews()
+            ));
         }
 
         $this->booted = true;

--- a/tests/Unit/Components/Plugin/ResourceSubscriberTest.php
+++ b/tests/Unit/Components/Plugin/ResourceSubscriberTest.php
@@ -37,6 +37,17 @@ class ResourceSubscriberTest extends TestCase
         static::assertNull($subscriber->onCollectCss());
         static::assertNull($subscriber->onCollectJavascript());
         static::assertNull($subscriber->onCollectLess());
+        $templateEventArgs = new \Enlight_Event_EventArgs();
+        $templateEventArgs->setReturn([]);
+        $subscriber->onRegisterTemplate($templateEventArgs);
+        static::assertTrue(is_array($templateEventArgs->getReturn()));
+        static::assertEmpty($templateEventArgs->getReturn());
+
+        $subscriberWithViews = new ResourceSubscriber(__DIR__ . '/examples/EmptyPlugin', true);
+        $templateEventArgs->setReturn([]);
+        $subscriberWithViews->onRegisterTemplate($templateEventArgs);
+        static::assertTrue(is_array($templateEventArgs->getReturn()));
+        static::assertEmpty($templateEventArgs->getReturn());
     }
 
     public function testFoo()
@@ -64,6 +75,22 @@ class ResourceSubscriberTest extends TestCase
                 __DIR__ . '/examples/TestPlugin/Resources/frontend/less/all.less',
             ]),
             $subscriber->onCollectLess()
+        );
+        $templateEventArgs = new \Enlight_Event_EventArgs();
+        $templateEventArgs->setReturn([]);
+        $subscriber->onRegisterTemplate($templateEventArgs);
+        static::assertTrue(is_array($templateEventArgs->getReturn()));
+        static::assertEmpty($templateEventArgs->getReturn());
+
+        $subscriberWithViews = new ResourceSubscriber(__DIR__ . '/examples/TestPlugin', true);
+        $templateEventArgs->setReturn([]);
+        $subscriberWithViews->onRegisterTemplate($templateEventArgs);
+        static::assertTrue(is_array($templateEventArgs->getReturn()));
+        static::assertSame(
+            [
+                __DIR__ . '/examples/TestPlugin/Resources/views',
+            ],
+            $templateEventArgs->getReturn()
         );
     }
 }

--- a/tests/Unit/Components/Plugin/ResourceSubscriberTest.php
+++ b/tests/Unit/Components/Plugin/ResourceSubscriberTest.php
@@ -32,7 +32,7 @@ class ResourceSubscriberTest extends TestCase
 {
     public function testEmptyPlugin()
     {
-        $subscriber = new ResourceSubscriber(__DIR__ . '/examples/EmptyPlugin');
+        $subscriber = new ResourceSubscriber(__DIR__ . '/examples/EmptyPlugin', false);
 
         static::assertNull($subscriber->onCollectCss());
         static::assertNull($subscriber->onCollectJavascript());
@@ -52,7 +52,7 @@ class ResourceSubscriberTest extends TestCase
 
     public function testFoo()
     {
-        $subscriber = new ResourceSubscriber(__DIR__ . '/examples/TestPlugin');
+        $subscriber = new ResourceSubscriber(__DIR__ . '/examples/TestPlugin', false);
 
         static::assertSame(
             [


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1133593/70347580-216e6a00-1861-11ea-9a38-bbef638343ab.png)
[![image](https://user-images.githubusercontent.com/1133593/70347546-0c91d680-1861-11ea-978e-21a56af208f7.png)](https://github.com/shopware/shopware/pull/2258)
### 0. Why do you post this again?
The previous [pull request 2258](https://github.com/shopware/shopware/pull/2258) just expired.

### 1. Why is this change necessary?
Once upon a time it was common to put js and less files under `Resources/views/frontend/_public/src` and register the files manually via subscriber. A wise man automatically loads these source files now from `Resources/frontend`. But why are the template files in `Resources/views` not automatically loaded?
To reduce the chance of a breaking change I chose the directory `Resources/templates` as these are template files that needs to be loaded. In case of specific reasons to not load them automatically one can still load them from elsewhere conditionally.

### 2. What does this change do, exactly?
Subscribe `Enlight_Controller_Action_PreDispatch` and tell the controller template manager to use the plugins path.

### 3. Describe each step to reproduce the issue or behaviour.
1. Put `all.less` in `Resources/frontend/less`
2. Style is online
3. Put `foobar.js` into `Resources/frontend/js`
4. Dynamic DOM is online
5. Put `tpl` files into `Resources/views`
6. Nothing happens
7. Adds subscriber class as one does not want to pollute the bootstrap file
8. Add reference to subscriber service in `Resources/services.xml` (which gets loaded automatically!)

### 4. Which documentation changes (if any) need to be made because of this PR?
The information about this new directory has to be propagated somewhere.

### 5. Checklist
* [x]  I have written tests and verified that they fail without my change
* [x]  I have squashed any insignificant commits
* [ ]  This change has comments for package types, values, functions, and non-obvious lines of code
* [x]  I have read the contribution requirements and fulfil them.
