### PR TITLE
Add database session config field in configuration

### DIFF
--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -156,6 +156,9 @@ return array_replace_recursive([
             'charset' => 'utf8',
             'collate' => 'utf8_unicode_ci',
         ],
+        // Session variables that are set after connection initialization e.g. 'wait_timeout' => 180
+        'session' => [
+        ],
     ],
     'es' => [
         'prefix' => 'sw_shop',


### PR DESCRIPTION
### 1. Why is this change necessary?
In case you need to change e.g. `wait_timeout` for shopware but your hosting environment does not offer the choice of editing the my.cnf. Just add a `'db' => [ 'session' => [ 'wait_timeout' => 1 << 16 ] ]` to wait for a decent amount of seconds before your database or hosting partner is about to die.

### 2. What does this change do, exactly?
Simply sets these values on the database as well everytime a connection is created.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have inperformant SQL query
2. MySQL gone away
3. Increase timeout in my.cnf
4. my.cnf is readonly

### 4. Which documentation changes (if any) need to be made because of this PR?
Maybe a hint in the dev cheatsheet or hosting docs?

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.