### PR TITLE
Fix blog statistic with enabled http cache

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Blog.php
+++ b/engine/Shopware/Controllers/Frontend/Blog.php
@@ -363,22 +363,6 @@ class Shopware_Controllers_Frontend_Blog extends Enlight_Controller_Action
         $avgVoteQuery = $this->repository->getAverageVoteQuery($blogArticleId, $shop->getId());
         $blogArticleData['sVoteAverage'] = $avgVoteQuery->getOneOrNullResult(AbstractQuery::HYDRATE_SINGLE_SCALAR);
 
-        // Count the views of this blog item
-        $visitedBlogItems = Shopware()->Session()->visitedBlogItems;
-        if (!Shopware()->Session()->Bot && !in_array($blogArticleId, $visitedBlogItems)) {
-            // Update the views count
-            /* @var Shopware\Models\Blog\Blog $blogModel */
-            $blogModel = $this->getRepository()->find($blogArticleId);
-            if ($blogModel) {
-                $blogModel->setViews($blogModel->getViews() + 1);
-                Shopware()->Models()->flush($blogModel);
-
-                // Save it to the session
-                $visitedBlogItems[] = $blogArticleId;
-                Shopware()->Session()->visitedBlogItems = $visitedBlogItems;
-            }
-        }
-
         // Generate breadcrumb
         $breadcrumb = $this->getCategoryBreadcrumb($blogArticleData['categoryId']);
         $blogDetailLink = $this->Front()->Router()->assemble([

--- a/themes/Frontend/Bare/widgets/index/statistic_include.tpl
+++ b/themes/Frontend/Bare/widgets/index/statistic_include.tpl
@@ -52,6 +52,9 @@
             {if $sArticle.articleID}
             url += '&articleId=' + encodeURI("{$sArticle.articleID}");
             {/if}
+            {if $sArticle.id && $Controller === 'blog'}
+            url += '&blogId=' + encodeURI("{$sArticle.id}");
+            {/if}
 
             {* Early simple device detection for statistics, duplicated in StateManager for resizes *}
             if (isDeviceCookieAllowed()) {


### PR DESCRIPTION
### 1. Why is this change necessary?

blog statistic doesn't work if http cache is enabled.

### 2. What does this change do, exactly?

Move code from controller to statistic plugin.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.