### PR TITLE
Make the limit of emotion product stream sliders configurable

### DIFF
--- a/themes/Backend/ExtJs/backend/emotion/view/components/article_slider.js
+++ b/themes/Backend/ExtJs/backend/emotion/view/components/article_slider.js
@@ -95,7 +95,7 @@ Ext.define('Shopware.apps.Emotion.view.components.ArticleSlider', {
             me.streamSelection.allowBlank = true;
             me.categoryFilter.allowBlank = true;
         } else if (me.articleType.getValue() == 'product_stream') {
-            me.maxCountField.hide();
+            me.maxCountField.show();
             me.categoryFilter.hide();
             me.articleGrid.hide();
             me.variantGrid.hide();
@@ -175,7 +175,7 @@ Ext.define('Shopware.apps.Emotion.view.components.ArticleSlider', {
             me.streamSelection.allowBlank = true;
             me.categoryFilter.allowBlank = true;
         } else if (newValue == 'product_stream') {
-            me.maxCountField.hide();
+            me.maxCountField.show();
             me.categoryFilter.hide();
             me.articleGrid.hide();
             me.variantGrid.hide();


### PR DESCRIPTION
### 1. Why is this change necessary?
The number of products which are shown in an emotion product stream slider is limited by the default limit (`25`), see here: 
https://github.com/shopware/shopware/blob/406925fbb6a8e98beb94e71ceca1fd473a6edc31/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php#L225-L231
But one cannot change this limit, although it might be wanted.

### 2. What does this change do, exactly?
Add the possibility to configure this limit, by showing the necessary configuration fields.

### 3. Describe each step to reproduce the issue or behaviour.
Try to show a long product stream in a shopping world.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-23779

### 5. Which documentation changes (if any) need to be made because of this PR?
https://docs.shopware.com/en/shopware-5-en/products-and-categories/product-streams#stream-in-a-shopping-world
maybe this picture should be changed.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.