### PR TITLE
Make position reset for product slider optional

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js
@@ -291,7 +291,15 @@
              * @property initOnEvent
              * @type {String}
              */
-            initOnEvent: null
+            initOnEvent: null,
+            
+            /**
+             * On update reset the slider position to the first element
+             *
+             * @property resetPositionOnUpdate
+             * @type {Boolean}
+             */
+            resetPositionOnUpdate: true
         },
 
         /**
@@ -380,9 +388,12 @@
             }
 
             /**
-             * Always set back to the first item on update
+             * Set back to the first item on update
              */
-            me.setPosition(0);
+            if (me.opts.resetPositionOnUpdate) {
+                me.setPosition(0);
+            }
+
             me.trackArrows();
 
             $.publish('plugin/swProductSlider/onUpdate', [ me ]);


### PR DESCRIPTION
### 1. Why is this change necessary?
In case of an update on a page the sliders can occasionally be updated. This will slide them to the first item. This also can reset the position although no change happened. Either situation is appreciatable so it is now optionally disablable.

### 2. What does this change do, exactly?
Add an option to deactivate that setPosition call. The default is behaving like before so no real change in bahaviour unless configured differently.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a product slider at the top of the page
2. Slide to the right
3. Scroll down where an update is triggered to product sliders
4. Scroll up and the slider is back to the start
5. What product was I looking again? 😖 
6. Have @Yarisade in your team debugging it down to the problematic area

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.