### PR TITLE
Reunite ConfigureContainerAwareCommands with the other compiler passes

### DIFF
--- a/engine/Shopware/Components/Console/Application.php
+++ b/engine/Shopware/Components/Console/Application.php
@@ -184,6 +184,10 @@ class Application extends BaseApplication
             if ($command instanceof Command) {
                 $this->add($command);
             }
+
+            if ($command instanceof ContainerAwareInterface) {
+                $command->setContainer($this->getKernel()->getContainer());
+            }
         }
     }
 

--- a/engine/Shopware/Components/Console/Application.php
+++ b/engine/Shopware/Components/Console/Application.php
@@ -113,10 +113,6 @@ class Application extends BaseApplication
      */
     protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
     {
-        if ($command instanceof ContainerAwareInterface) {
-            $command->setContainer($this->kernel->getContainer());
-        }
-
         /** @var \Enlight_Event_EventManager $eventManager */
         $eventManager = $this->kernel->getContainer()->get('events');
 

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -58,6 +58,7 @@ use Shopware\Bundle\StaticContentBundle\StaticContentBundle;
 use Shopware\Bundle\StoreFrontBundle\StoreFrontBundle;
 use Shopware\Components\ConfigLoader;
 use Shopware\Components\DependencyInjection\Compiler\ConfigureApiResourcesPass;
+use Shopware\Components\DependencyInjection\Compiler\ConfigureContainerAwareCommands;
 use Shopware\Components\DependencyInjection\Compiler\DoctrineEventSubscriberCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EventListenerCompilerPass;
 use Shopware\Components\DependencyInjection\Compiler\EventSubscriberCompilerPass;
@@ -660,6 +661,7 @@ class Kernel extends SymfonyKernel
         $container->addCompilerPass(new AddConstraintValidatorsPass());
         $container->addCompilerPass(new StaticResourcesCompilerPass());
         $container->addCompilerPass(new AddConsoleCommandPass());
+        $container->addCompilerPass(new ConfigureContainerAwareCommands());
         $container->addCompilerPass(new MatcherCompilerPass());
         $container->addCompilerPass(new LegacyApiResourcesPass());
         $container->addCompilerPass(new ConfigureApiResourcesPass(), PassConfig::TYPE_OPTIMIZE, -500);

--- a/tests/Functional/Components/DependencyInjection/Compiler/ConfigureContainerAwareCommandsTest.php
+++ b/tests/Functional/Components/DependencyInjection/Compiler/ConfigureContainerAwareCommandsTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Tests\Functional\Components\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Commands\ShopwareCommand;
+use Symfony\Component\Console\Application;
+
+class ConfigureContainerAwareCommandsTest extends TestCase
+{
+    /**
+     * @dataProvider getShopwareCommands
+     */
+    public function testCompilerAwareIsInitialized(ShopwareCommand $containerAwareCommand): void
+    {
+        $this->assertNotNull($containerAwareCommand->getContainer());
+    }
+
+    public function getShopwareCommands(): array
+    {
+        /** @var Application $application */
+        $application = Shopware()->Container()->get('application');
+        $commands = [];
+
+        foreach ($application->all() as $command) {
+            if ($command instanceof ShopwareCommand) {
+                $commands[] = [$command];
+            }
+        }
+
+        return $commands;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
When using a compiler-aware-command (a command implementing the CompilerAwareInterface) from the service container it has no valid reference to the service container. So it is not properly initialized.

### 2. What does this change do, exactly?
Readd the `ConfigureContainerAwareCommands` to the service container, remove the redundant `setContainer` call in `Shopware\Components\Console\Application::doRunCommand` and add a test to check whether things stay that way.

### 3. Describe each step to reproduce the issue or behaviour.
1. Be up to use auto completion feature
2. Type `sw:pl<tab>:act<tab> <tab>`
3. Get `Call to a member function get() on null in PluginActivateCommand.php:53`
4. On null? What is happening there?
5. Find `getContainer()->get` failing
6. But why is it not initialized? When is `setContainer` called?
7. Find `Shopware\Components\Console\Application::doRunCommand` and `ConfigureContainerAwareCommands`. Wait didn't I implement the `ConfigureContainerAwareCommands`?
8. Check auto completion pull request. Yes I did. Did I forget adding it? 😳
9. [Check diff from pull request](https://github.com/niemand-online/shopware/blame/e61f879bd28302fbe7732e20c8e122651e4a1c8a/engine/Shopware/Kernel.php#L621) 🙂 I did add it back then
10. Is it still present? NO?!
[![grafik](https://user-images.githubusercontent.com/1133593/71047729-0b07be80-213d-11ea-9f28-5a1b3f4b13bd.png)](https://knowyourmeme.com/memes/confused-nick-young)

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.