### PR TITLE
Fix parameter passed to SeoIndex->setCachedTime()

### DIFF
--- a/engine/Shopware/Commands/RebuildSeoIndexCommand.php
+++ b/engine/Shopware/Commands/RebuildSeoIndexCommand.php
@@ -181,7 +181,7 @@ class RebuildSeoIndexCommand extends ShopwareCommand implements CompletionAwareI
 
             list($cachedTime, $elementId, $shopId) = $this->seoIndex->getCachedTime();
 
-            $this->seoIndex->setCachedTime($currentTime->format('Y-m-d h:m:i'), $elementId, $shopId);
+            $this->seoIndex->setCachedTime($currentTime->format('Y-m-d H:i:s'), $elementId, $shopId);
             $this->rewriteTable->baseSetup();
 
             $limit = 10000;
@@ -193,7 +193,7 @@ class RebuildSeoIndexCommand extends ShopwareCommand implements CompletionAwareI
                 $lastId = $this->rewriteTable->getRewriteArticleslastId();
             } while ($lastId !== null);
 
-            $this->seoIndex->setCachedTime($currentTime->format('Y-m-d h:m:i'), $elementId, $shopId);
+            $this->seoIndex->setCachedTime($currentTime->format('Y-m-d H:i:s'), $elementId, $shopId);
 
             $context = $this->container->get('shopware_storefront.context_service')->createShopContext($shopId);
 

--- a/engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php
@@ -152,7 +152,7 @@ class Shopware_Plugins_Core_RebuildIndex_Bootstrap extends Shopware_Components_P
             Shopware()->Modules()->Categories()->baseId = $shop->getCategory()->getId();
 
             list($cachedTime, $elementId, $shopId) = $this->SeoIndex()->getCachedTime();
-            $this->SeoIndex()->setCachedTime($currentTime->format('Y-m-d h:m:i'), $elementId, $shopId);
+            $this->SeoIndex()->setCachedTime($currentTime->format('Y-m-d H:i:s'), $elementId, $shopId);
 
             $this->RewriteTable()->baseSetup();
 
@@ -165,7 +165,7 @@ class Shopware_Plugins_Core_RebuildIndex_Bootstrap extends Shopware_Components_P
                 $lastId = $this->RewriteTable()->getRewriteArticleslastId();
             } while ($lastId !== null);
 
-            $this->SeoIndex()->setCachedTime($currentTime->format('Y-m-d h:m:i'), $elementId, $shopId);
+            $this->SeoIndex()->setCachedTime($currentTime->format('Y-m-d H:i:s'), $elementId, $shopId);
 
             $context = $this->get('shopware_storefront.context_service')->createShopContext($shopId);
 

--- a/engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php
+++ b/engine/Shopware/Plugins/Default/Core/RebuildIndex/Controllers/Seo.php
@@ -193,7 +193,7 @@ class Shopware_Controllers_Backend_Seo extends Shopware_Controllers_Backend_ExtJ
             $shop
         );
 
-        $this->SeoIndex()->setCachedTime($currentTime->format('Y-m-d h:m:i'), $elementId, $shopId);
+        $this->SeoIndex()->setCachedTime($currentTime->format('Y-m-d H:i:s'), $elementId, $shopId);
 
         $this->View()->assign([
             'success' => true,


### PR DESCRIPTION
1. Why is this change necessary?
The current timestamp passed to SeoIndex->setCachedTime(...) was
generated using a broken format string (12h instead of 24h time format
and 'number of month' instead of 'minute of hour') resulting in the
last update time not being properly utilized.

2. What does this change do, exactly?
Fix the format string being used to pass the current timestamp to SeoIndex->setCachedTime(...)

6. Checklist
[x] I have read the contribution requirements and fulfil them.