### PR TITLE
Encode arrays passed to routing assembly which are otherwise lost

### DIFF
--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -30,6 +30,9 @@ This changelog references changes done in Shopware 5.6 patch versions.
 * Changed `\Shopware_Controllers_Backend_Base::getPaymentsAction` to optionally list all payment methods
 * Changed `\Shopware\Components\Cart\CartPersistService` to also persist cart item attributes
 * Changed blog statistics to work also with active http cache
+* Changed `\Shopware\Components\Routing\Router::assemble` and `\Shopware\Components\Routing\Router::match` default implementation handling arrays and encoded strings
+    * `Shopware\Components\Routing\Generators\DefaultGenerator::generate` will encode arrays as strings with `http_build_query`; objects result in an user error in 5.6 and Exception in 5.7
+    * `Shopware\Components\Routing\Matchers\DefaultMatcher::match` will try to convert encoded string values back to array representation
 
 ### Removals
 

--- a/engine/Shopware/Components/Routing/Generators/DefaultGenerator.php
+++ b/engine/Shopware/Components/Routing/Generators/DefaultGenerator.php
@@ -63,17 +63,9 @@ class DefaultGenerator implements GeneratorInterface
             unset($params['_seo']);
         }
 
-        $module = isset($params[$context->getModuleKey()])
-            ? $params[$context->getModuleKey()]
-            : $this->dispatcher->getDefaultModule();
-
-        $controller = isset($params[$context->getControllerKey()])
-            ? $params[$context->getControllerKey()]
-            : $this->dispatcher->getDefaultControllerName();
-
-        $action = isset($params[$context->getActionKey()])
-            ? $params[$context->getActionKey()]
-            : $this->dispatcher->getDefaultAction();
+        $module = $params[$context->getModuleKey()] ?? $this->dispatcher->getDefaultModule();
+        $controller = $params[$context->getControllerKey()] ?? $this->dispatcher->getDefaultControllerName();
+        $action = $params[$context->getActionKey()] ?? $this->dispatcher->getDefaultAction();
 
         unset($params[$context->getModuleKey()],
             $params[$context->getControllerKey()],
@@ -94,7 +86,7 @@ class DefaultGenerator implements GeneratorInterface
 
         foreach ($params as $key => $value) {
             $route[] = $key;
-            $route[] = $value;
+            $route[] = is_array($value) || is_object($value) ? http_build_query($value) : $value;
         }
 
         $route = array_map('urlencode', $route);

--- a/engine/Shopware/Components/Routing/Generators/DefaultGenerator.php
+++ b/engine/Shopware/Components/Routing/Generators/DefaultGenerator.php
@@ -85,8 +85,12 @@ class DefaultGenerator implements GeneratorInterface
         }
 
         foreach ($params as $key => $value) {
+            if (is_object($value)) {
+                trigger_error(sprintf('Using objects as params in %s:%s is deprecated since Shopware 5.6 and will result in an exception with 5.7.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
+            }
+
             $route[] = $key;
-            $route[] = is_array($value) || is_object($value) ? http_build_query($value) : $value;
+            $route[] = is_array($value) ? http_build_query($value) : $value;
         }
 
         $route = array_map('urlencode', $route);

--- a/engine/Shopware/Components/Routing/Matchers/DefaultMatcher.php
+++ b/engine/Shopware/Components/Routing/Matchers/DefaultMatcher.php
@@ -79,7 +79,9 @@ class DefaultMatcher implements MatcherInterface
             $chunks = array_chunk($params, 2, false);
             foreach ($chunks as $chunk) {
                 if (isset($chunk[1])) {
-                    $query[$chunk[0]] = $chunk[1];
+                    // check if the parameter is a valid array or just a simple value
+                    parse_str($chunk[1], $parsed);
+                    $query[$chunk[0]] = (count($parsed) === 1 && reset($parsed) === '') ? $chunk[1] : $parsed;
                 } else {
                     $query[$chunk[0]] = '';
                 }

--- a/tests/Functional/Components/Router/RouterTest.php
+++ b/tests/Functional/Components/Router/RouterTest.php
@@ -24,17 +24,20 @@
 
 namespace Shopware\Tests\Components\Router;
 
-class RouterTest extends \Enlight_Components_Test_TestCase
+use Enlight_Components_Test_TestCase;
+use Shopware\Components\Routing\Context;
+
+class RouterTest extends Enlight_Components_Test_TestCase
 {
     /**
      * Tests if a generated SEO route is the same with or without the _seo parameters
      */
-    public function testSeoRouteGeneration()
+    public function testSeoRouteGeneration(): void
     {
         $router = Shopware()->Container()->get('router');
         $localRouter = clone $router;
 
-        $context = new \Shopware\Components\Routing\Context();
+        $context = new Context();
         $context->setShopId(1);
         $localRouter->setContext($context);
 
@@ -47,12 +50,12 @@ class RouterTest extends \Enlight_Components_Test_TestCase
     /**
      * Tests that the seo route generation can be deactivated
      */
-    public function testDeactivatingSeoRouteGeneration()
+    public function testDeactivatingSeoRouteGeneration(): void
     {
         $router = Shopware()->Container()->get('router');
         $localRouter = clone $router;
 
-        $context = new \Shopware\Components\Routing\Context();
+        $context = new Context();
         $context->setShopId(1);
         $localRouter->setContext($context);
 
@@ -65,12 +68,12 @@ class RouterTest extends \Enlight_Components_Test_TestCase
     /**
      * Tests if a nonexisting seo route is the same with or without the _seo parameters
      */
-    public function testNoneExistingSeoRouteGeneration()
+    public function testNoneExistingSeoRouteGeneration(): void
     {
         $router = Shopware()->Container()->get('router');
         $localRouter = clone $router;
 
-        $context = new \Shopware\Components\Routing\Context();
+        $context = new Context();
         $context->setShopId(1);
         $localRouter->setContext($context);
 
@@ -88,12 +91,12 @@ class RouterTest extends \Enlight_Components_Test_TestCase
     /**
      * Tests if the default action is being ignored
      */
-    public function testDefaultActionDoesntMatter()
+    public function testDefaultActionDoesntMatter(): void
     {
         $router = Shopware()->Container()->get('router');
         $localRouter = clone $router;
 
-        $context = new \Shopware\Components\Routing\Context();
+        $context = new Context();
         $context->setShopId(1);
         $localRouter->setContext($context);
 
@@ -101,5 +104,55 @@ class RouterTest extends \Enlight_Components_Test_TestCase
         $withoutAction = $localRouter->assemble(['controller' => 'doesnotexist']);
 
         static::assertEquals($withAction, $withoutAction);
+    }
+
+    /**
+     * tests for complex arrays.
+     */
+    public function testArrayParams(): void
+    {
+        $router = Shopware()->Container()->get('router');
+        $localRouter = clone $router;
+
+        $context = new Context();
+        $context->setShopId(1);
+        $localRouter->setContext($context);
+
+        $paramList = [
+            ['foo' => 'bar'],
+            ['foo' => ['bar' => 'baz']],
+            ['foo' => [1, 2]],
+            ['foo' => [1, 3 => 2, 2 => 1]],
+            ['param1', 'param2' => ['an', 'array']],
+            [0 => 1, 'foo'],
+            ['test' => ['often'], 'tests', 'moreTests' => 'value'],
+            ['go' => ['deeper' => ['and' => ['even' => 'deeper']]]],
+        ];
+
+        foreach ($paramList as $params) {
+            $url = $localRouter->assemble($params);
+            $match = $localRouter->match($url);
+            static::assertEquals(array_intersect($match, $params), $params);
+        }
+    }
+
+    /**
+     * tests for passing an object to assembly (will be returned as array)
+     */
+    public function testArrayParamsWithObject(): void
+    {
+        $router = Shopware()->Container()->get('router');
+        $localRouter = clone $router;
+
+        $context = new Context();
+        $context->setShopId(1);
+        $localRouter->setContext($context);
+
+        $cls = new \stdClass();
+        $cls->test = 'It\'s a class';
+
+        $url = $localRouter->assemble([$cls]);
+        $match = $localRouter->match($url);
+        static::assertEquals(array_intersect($match, [(array) $cls]), [(array) $cls]);
     }
 }

--- a/tests/Functional/Components/Router/RouterTest.php
+++ b/tests/Functional/Components/Router/RouterTest.php
@@ -135,24 +135,4 @@ class RouterTest extends Enlight_Components_Test_TestCase
             static::assertEquals(array_intersect($match, $params), $params);
         }
     }
-
-    /**
-     * tests for passing an object to assembly (will be returned as array)
-     */
-    public function testArrayParamsWithObject(): void
-    {
-        $router = Shopware()->Container()->get('router');
-        $localRouter = clone $router;
-
-        $context = new Context();
-        $context->setShopId(1);
-        $localRouter->setContext($context);
-
-        $cls = new \stdClass();
-        $cls->test = 'It\'s a class';
-
-        $url = $localRouter->assemble([$cls]);
-        $match = $localRouter->match($url);
-        static::assertEquals(array_intersect($match, [(array) $cls]), [(array) $cls]);
-    }
 }

--- a/tests/Functional/Components/Router/RouterTestObject.php
+++ b/tests/Functional/Components/Router/RouterTestObject.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Functional\Components\Router;
+
+use Enlight_Components_Test_TestCase;
+use InvalidArgumentException;
+use Shopware\Components\Routing\Context;
+use stdClass;
+
+class RouterTestObject extends Enlight_Components_Test_TestCase
+{
+    protected $errorHandler;
+
+    /**
+     * @before
+     */
+    public function prepareUserAsException(): void
+    {
+        $this->errorHandler = set_error_handler(static function (int $errno, string $errstr) {
+            throw new InvalidArgumentException($errstr, $errno);
+        }, E_USER_DEPRECATED);
+    }
+
+    /**
+     * @after
+     */
+    public function restoreErrorHandler(): void
+    {
+        restore_error_handler();
+    }
+
+    /**
+     * tests for passing an object to assemble
+     */
+    public function testArrayParamsWithObject(): void
+    {
+        $router = Shopware()->Container()->get('router');
+        $localRouter = clone $router;
+
+        $context = new Context();
+        $context->setShopId(1);
+        $localRouter->setContext($context);
+
+        $cls = new stdClass();
+        $cls->test = 'It\'s a class';
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $url = $localRouter->assemble([$cls]);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Try passing an array to the Router assemble method. Using the default generator & matcher the array values will be lost.

### 2. What does this change do, exactly?
Encode array values

### 3. Describe each step to reproduce the issue or behaviour.
Run `Shopware()->Container()->get('router')->assemble(['foo' => ['test' => 'value']]);`
The resulting url will be looking something like this: `https://example.tld/index/index/foo/`
The value of foo is lost.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.