### PR TITLE
Improve installation hint for recovery/{install,update}

### DIFF
--- a/recovery/common/autoload.php
+++ b/recovery/common/autoload.php
@@ -30,10 +30,12 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
     }
 
     echo sprintf($template, 'Error');
-    echo "Please execute \"composer install\" from the command line to install the required dependencies for Shopware 5\n";
+    echo "Please execute \"composer install --working-dir=" . __DIR__ . "\" or \"composer install\" in the directory " .
+        __DIR__ . " from the command line to install the required dependencies for the install/update application for Shopware 5\n";
 
     echo sprintf($template, 'Fehler');
-    echo "Bitte führen Sie zuerst \"composer install\" aus um alle von Shopware 5 benötigten Abhängigkeiten zu installieren.\n";
+    echo "Bitte führen Sie zuerst \"composer install --working-dir=" . __DIR__ . "\" oder \"composer install\" im Verzeichnis " .
+        __DIR__ . " aus um alle von der Shopware 5 Installations-/Aktualisierungsanwendung benötigten Abhängigkeiten zu installieren.\n";
 
     exit(1);
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
On first pull from git any access to shopware states to initialize shopware. This can be done from the command line as well but a specific composer directory is not initialized. The hint states to run `composer install`. I did. In the project root. Someone has to say that it is not about running `composer install` in recovery/common. Now it does.

### 2. What does this change do, exactly?
Add the working directory option to the composer install command hint.

### 3. Describe each step to reproduce the issue or behaviour.
1. Clone shopware
2. Open webpage
3. See unclear installation instruction `Shopware 5 must be configured before use. Please run the installer.`
4. Look up instruction in code
5. See alternative CLI instructions
6. Run CLI command `recovery/install/index.php`
7. See composer install hint
8. Run composer install
9. Go to 6

### 4. Which documentation changes (if any) need to be made because of this PR?
This is a documentation change. Sort of.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.