### PR TITLE
Add webp as image type to media extension whitelist

### DIFF
--- a/engine/Shopware/Bundle/MediaBundle/MediaExtensionMappingService.php
+++ b/engine/Shopware/Bundle/MediaBundle/MediaExtensionMappingService.php
@@ -50,6 +50,7 @@ class MediaExtensionMappingService implements MediaExtensionMappingServiceInterf
         'png' => Media::TYPE_IMAGE,
         'tif' => Media::TYPE_IMAGE,
         'tiff' => Media::TYPE_IMAGE,
+        'webp' => Media::TYPE_IMAGE,
         'eps' => Media::TYPE_VECTOR,
         'pbm' => Media::TYPE_IMAGE,
         'psd' => Media::TYPE_UNKNOWN,


### PR DESCRIPTION
### 1. Why is this change necessary?
You can't upload webp files. Webp is a image format for web related images. You want to be able to upload webp images.

### 2. What does this change do, exactly?
Add webp as extension with the type IMAGE.

### 3. Describe each step to reproduce the issue or behaviour.
1. Open media manager
2. Select webp file
3. Click upload
4. See error message that webp is not allowed

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.