### PR TITLE
SSL fix

### DIFF
--- a/themes/Frontend/Bare/frontend/index/index.tpl
+++ b/themes/Frontend/Bare/frontend/index/index.tpl
@@ -4,7 +4,7 @@
 {/block}
 
 {block name='frontend_index_html'}
-<html class="no-js" lang="{s name='IndexXmlLang'}{/s}" itemscope="itemscope" itemtype="http://schema.org/WebPage">
+<html class="no-js" lang="{s name='IndexXmlLang'}{/s}" itemscope="itemscope" itemtype="https://schema.org/WebPage">
 {/block}
 
 {block name='frontend_index_header'}


### PR DESCRIPTION
If a resource is available over SSL, then always use the https:// URI.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
**Loads page resources using protocol relative URIs**
Loading a resource using protocol relative URIs allow it to be requested over HTTP and opens the door for Man-on-the-side attacks. If a resource is available over SSL, then always use the https:// URI.

### 2. What does this change do, exactly?
change from http to https

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.