### PR TITLE
SSL fix from http to https for schema.org and facebook.com

### DIFF
--- a/themes/Frontend/Bare/frontend/_includes/rating.tpl
+++ b/themes/Frontend/Bare/frontend/_includes/rating.tpl
@@ -81,9 +81,9 @@
 {* Microdata depending on type *}
 {block name='frontend_rating_microdata_type'}
     {if $isType === 'single'}
-        {$data='itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating"'}
+        {$data='itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating"'}
     {else}
-        {$data='itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating"'}
+        {$data='itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating"'}
     {/if}
 {/block}
 

--- a/themes/Frontend/Bare/frontend/blog/bookmarks.tpl
+++ b/themes/Frontend/Bare/frontend/blog/bookmarks.tpl
@@ -17,7 +17,7 @@
                 {* Facebook *}
                 {block name='frontend_blog_bookmarks_facebook'}
                     {s name="BookmarkFacebookShare" assign="snippetBookmarkFacebookShare"}{/s}
-                    <a href="http://www.facebook.com/share.php?v=4&amp;src=bm&amp;u={url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}&amp;t={$sArticle.title|escape:'url'}"
+                    <a href="https://www.facebook.com/share.php?v=4&amp;src=bm&amp;u={url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}&amp;t={$sArticle.title|escape:'url'}"
                         title="{$snippetBookmarkFacebookShare|escape}"
                         class="blog--bookmark icon--facebook2"
                         rel="nofollow"

--- a/themes/Frontend/Bare/frontend/blog/comment/entry.tpl
+++ b/themes/Frontend/Bare/frontend/blog/comment/entry.tpl
@@ -7,7 +7,7 @@
         <ul class="comments--list list--unstyled">
 
             {foreach $sArticle.comments as $vote}
-                <li class="list--entry" itemscope itemtype="http://schema.org/UserComments">
+                <li class="list--entry" itemscope itemtype="https://schema.org/UserComments">
 
                     {* Comment meta data *}
                     {block name='frontend_blog_comments_comment_meta'}

--- a/themes/Frontend/Bare/frontend/blog/detail.tpl
+++ b/themes/Frontend/Bare/frontend/blog/detail.tpl
@@ -19,9 +19,9 @@
                     <meta itemprop="description" content="{$sArticle.shortDescription}">
                     <meta itemprop="mainEntityOfPage" content="{url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}">
 
-                    <div itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+                    <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
                         <meta itemprop="name" content="{{config name=sShopname}|escapeHtml}">
-                        <div itemprop="logo" itemscope itemtype="http://schema.org/ImageObject">
+                        <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
                             <meta itemprop="url" content="{link file=$theme.desktopLogo fullPath}">
                         </div>
                     </div>

--- a/themes/Frontend/Bare/frontend/detail/block_price.tpl
+++ b/themes/Frontend/Bare/frontend/detail/block_price.tpl
@@ -39,14 +39,14 @@
                             {block name="frontend_detail_data_block_prices_table_body_inner"}
                                 {foreach $sArticle.sBlockPrices as $blockPrice}
                                     {block name='frontend_detail_data_block_prices'}
-                                        <tr class="block-prices--row {cycle values="is--primary,is--secondary"}" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+                                        <tr class="block-prices--row {cycle values="is--primary,is--secondary"}" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
                                             {block name="frontend_detail_data_block_prices_table_body_row"}
                                                 {block name="frontend_detail_data_block_prices_table_body_cell_quantity"}
                                                     <td class="block-prices--cell">
 
                                                         <meta itemprop="priceCurrency" content="{$Shop->getCurrency()->getCurrency()}" />
                                                         <meta itemprop="price" content="{$blockPrice.price}" />
-                                                        <link itemprop="availability" href="http://schema.org/InStock" />
+                                                        <link itemprop="availability" href="https://schema.org/InStock" />
 
                                                         {if $blockPrice.from == 1}
                                                             {s namespace="frontend/detail/data" name="DetailDataInfoUntil"}{/s}

--- a/themes/Frontend/Bare/frontend/detail/comment/entry.tpl
+++ b/themes/Frontend/Bare/frontend/detail/comment/entry.tpl
@@ -1,6 +1,6 @@
 {namespace name="frontend/detail/comment"}
 
-<div class="review--entry{if $isLast} is--last{/if}{if $vote.answer} has--answer{/if}" itemprop="review" itemscope itemtype="http://schema.org/Review">
+<div class="review--entry{if $isLast} is--last{/if}{if $vote.answer} has--answer{/if}" itemprop="review" itemscope itemtype="https://schema.org/Review">
 
     {* Review content - Title and content *}
     {block name='frontend_detail_comment_header'}

--- a/themes/Frontend/Bare/frontend/detail/content.tpl
+++ b/themes/Frontend/Bare/frontend/detail/content.tpl
@@ -1,5 +1,5 @@
 {block name='frontend_index_content_inner'}
-    <div class="content product--details" itemscope itemtype="http://schema.org/Product"{if !{config name=disableArticleNavigation}} data-product-navigation="{url module="widgets" controller="listing" action="productNavigation"}" data-category-id="{$sArticle.categoryID}" data-main-ordernumber="{$sArticle.mainVariantNumber}"{/if} data-ajax-wishlist="true" data-compare-ajax="true"{if $theme.ajaxVariantSwitch} data-ajax-variants-container="true"{/if}>
+    <div class="content product--details" itemscope itemtype="https://schema.org/Product"{if !{config name=disableArticleNavigation}} data-product-navigation="{url module="widgets" controller="listing" action="productNavigation"}" data-category-id="{$sArticle.categoryID}" data-main-ordernumber="{$sArticle.mainVariantNumber}"{/if} data-ajax-wishlist="true" data-compare-ajax="true"{if $theme.ajaxVariantSwitch} data-ajax-variants-container="true"{/if}>
 
         {* The configurator selection is checked at this early point
            to use it in different included files in the detail template. *}

--- a/themes/Frontend/Bare/frontend/detail/content/buy_container.tpl
+++ b/themes/Frontend/Bare/frontend/detail/content/buy_container.tpl
@@ -58,7 +58,7 @@
 
         {* Product data *}
         {block name='frontend_detail_index_buy_container_inner'}
-            <div itemprop="offers" itemscope itemtype="{if $sArticle.sBlockPrices}http://schema.org/AggregateOffer{else}http://schema.org/Offer{/if}" class="buybox--inner">
+            <div itemprop="offers" itemscope itemtype="{if $sArticle.sBlockPrices}https://schema.org/AggregateOffer{else}https://schema.org/Offer{/if}" class="buybox--inner">
 
                 {block name='frontend_detail_index_data'}
                     {if $sArticle.sBlockPrices}
@@ -82,7 +82,7 @@
                     {/block}
 
                     {block name="frontend_detail_index_data_pricespecification"}
-                        <span itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
+                        <span itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">
                             {if $sOutputNet}
                                 <meta itemprop="valueAddedTaxIncluded" content="false"/>
                             {else}

--- a/themes/Frontend/Bare/frontend/detail/data.tpl
+++ b/themes/Frontend/Bare/frontend/detail/data.tpl
@@ -112,13 +112,13 @@
         {if ($sArticle.sConfiguratorSettings.type != 1 && $sArticle.sConfiguratorSettings.type != 2) || $activeConfiguratorSelection == true}
             {include file="frontend/plugins/index/delivery_informations.tpl" sArticle=$sArticle}
         {elseif $sArticle.sReleaseDate && $sArticle.sReleaseDate|date_format:"%Y%m%d" > $smarty.now|date_format:"%Y%m%d"}
-            <link itemprop="availability" href="http://schema.org/PreOrder" />
+            <link itemprop="availability" href="https://schema.org/PreOrder" />
         {elseif $sArticle.esd}
-            <link itemprop="availability" href="http://schema.org/InStock" />
+            <link itemprop="availability" href="https://schema.org/InStock" />
         {elseif $sArticle.instock >= $sArticle.minpurchase}
-            <link itemprop="availability" href="http://schema.org/InStock" />
+            <link itemprop="availability" href="https://schema.org/InStock" />
         {else}
-            <link itemprop="availability" href="http://schema.org/LimitedAvailability" />
+            <link itemprop="availability" href="https://schema.org/LimitedAvailability" />
         {/if}
     {/block}
 {/block}

--- a/themes/Frontend/Bare/frontend/index/breadcrumb.tpl
+++ b/themes/Frontend/Bare/frontend/index/breadcrumb.tpl
@@ -1,4 +1,4 @@
-<ul class="breadcrumb--list" role="menu" itemscope itemtype="http://schema.org/BreadcrumbList">
+<ul class="breadcrumb--list" role="menu" itemscope itemtype="https://schema.org/BreadcrumbList">
 
     {* Prefix for the breadcrumb e.g. the configured shop name *}
     {block name="frontend_index_breadcrumb_prefix"}{/block}
@@ -6,7 +6,7 @@
     {block name="frontend_index_breadcrumb_content"}
         {foreach $sBreadcrumb as $breadcrumb}
             {block name="frontend_index_breadcrumb_entry"}
-                <li role="menuitem" class="breadcrumb--entry{if $breadcrumb@last} is--active{/if}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                <li role="menuitem" class="breadcrumb--entry{if $breadcrumb@last} is--active{/if}" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
                     {if $breadcrumb.name}
                         {block name="frontend_index_breadcrumb_entry_inner"}
                             {if $breadcrumb.link}

--- a/themes/Frontend/Bare/frontend/index/main-navigation.tpl
+++ b/themes/Frontend/Bare/frontend/index/main-navigation.tpl
@@ -1,7 +1,7 @@
 {block name='frontend_index_navigation_categories'}
     <div class="navigation--list-wrapper">
         {block name='frontend_index_navigation_categories_navigation_list'}
-            <ul class="navigation--list container" role="menubar" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement">
+            <ul class="navigation--list container" role="menubar" itemscope="itemscope" itemtype="https://schema.org/SiteNavigationElement">
                 {strip}
                     {block name='frontend_index_navigation_categories_top_home'}
                         <li class="navigation--entry{if $sCategoryCurrent == $sCategoryStart && $Controller == 'index'} is--active{/if} is--home" role="menuitem">

--- a/themes/Frontend/Bare/frontend/plugins/index/delivery_informations.tpl
+++ b/themes/Frontend/Bare/frontend/plugins/index/delivery_informations.tpl
@@ -14,7 +14,7 @@
             {/if}
             {if isset($sArticle.active) && !$sArticle.active}
                 {block name='frontend_widgets_delivery_infos_not_active'}
-                    <link itemprop="availability" href="http://schema.org/LimitedAvailability" />
+                    <link itemprop="availability" href="https://schema.org/LimitedAvailability" />
                     <p class="delivery--information">
                         <span class="delivery--text  delivery--text-not-available">
                             <i class="delivery--status-icon delivery--status-not-available"></i>
@@ -24,7 +24,7 @@
                 {/block}
             {elseif $sArticle.sReleaseDate && $sArticle.sReleaseDate|date_format:"%Y%m%d" > $smarty.now|date_format:"%Y%m%d"}
                 {block name='frontend_widgets_delivery_infos_preorder'}
-                    <link itemprop="availability" href="http://schema.org/PreOrder" />
+                    <link itemprop="availability" href="https://schema.org/PreOrder" />
                     <p class="delivery--information">
                         <span class="delivery--text delivery--text-more-is-coming">
                             <i class="delivery--status-icon delivery--status-more-is-coming"></i>
@@ -34,7 +34,7 @@
                 {/block}
             {elseif $sArticle.esd}
                 {block name='frontend_widgets_delivery_infos_download'}
-                    <link itemprop="availability" href="http://schema.org/InStock" />
+                    <link itemprop="availability" href="https://schema.org/InStock" />
                     <p class="delivery--information">
                         <span class="delivery--text delivery--text-available">
                             <i class="delivery--status-icon delivery--status-available"></i>
@@ -44,7 +44,7 @@
                 {/block}
             {elseif {config name="instockinfo"} && $sArticle.modus == 0 && $sArticle.instock > 0 && $sArticle.quantity > $sArticle.instock}
                 {block name='frontend_widgets_delivery_infos_partial'}
-                    <link itemprop="availability" href="http://schema.org/LimitedAvailability" />
+                    <link itemprop="availability" href="https://schema.org/LimitedAvailability" />
                     <p class="delivery--information">
                         <span class="delivery--text delivery--text-more-is-coming">
                             <i class="delivery--status-icon delivery--status-more-is-coming"></i>
@@ -54,7 +54,7 @@
                 {/block}
             {elseif $sArticle.instock >= $sArticle.minpurchase}
                 {block name='frontend_widgets_delivery_infos_instock'}
-                    <link itemprop="availability" href="http://schema.org/InStock" />
+                    <link itemprop="availability" href="https://schema.org/InStock" />
                     <p class="delivery--information">
                         <span class="delivery--text delivery--text-available">
                             <i class="delivery--status-icon delivery--status-available"></i>
@@ -64,7 +64,7 @@
                 {/block}
             {elseif $sArticle.shippingtime}
                 {block name='frontend_widgets_delivery_infos_future_shipping'}
-                    <link itemprop="availability" href="http://schema.org/LimitedAvailability" />
+                    <link itemprop="availability" href="https://schema.org/LimitedAvailability" />
                     <p class="delivery--information">
                         <span class="delivery--text delivery--text-more-is-coming">
                             <i class="delivery--status-icon delivery--status-more-is-coming"></i>
@@ -74,7 +74,7 @@
                 {/block}
             {else}
                 {block name='frontend_widgets_delivery_infos_not_available'}
-                    <link itemprop="availability" href="http://schema.org/LimitedAvailability" />
+                    <link itemprop="availability" href="https://schema.org/LimitedAvailability" />
                     <p class="delivery--information">
                         <span class="delivery--text delivery--text-not-available">
                             <i class="delivery--status-icon delivery--status-not-available"></i>


### PR DESCRIPTION
If a resource is available over SSL, then always use the https:// URI.

### 1. Why is this change necessary?
Loads page resources using protocol relative URIs
Loading a resource using protocol relative URIs allow it to be requested over HTTP and opens the door for Man-on-the-side attacks. If a resource is available over SSL, then always use the https:// URI.

### 2. What does this change do, exactly?
change from http to https urls where https urls are available

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.