### PR TITLE
Action overriding profit from Enlight_Controller_ActionEventArgs

### DIFF
--- a/engine/Library/Enlight/Controller/Action.php
+++ b/engine/Library/Enlight/Controller/Action.php
@@ -177,13 +177,11 @@ abstract class Enlight_Controller_Action extends Enlight_Class implements Enligh
 
         if ($this->Request()->isDispatched() && !$this->Response()->isRedirect()) {
             $action_name = $this->Front()->Dispatcher()->getFullActionName($this->Request());
-            if (!$event = Shopware()->Events()->notifyUntil(
-                __CLASS__ . '_' . $action_name,
-                ['subject' => $this]
-            )
-            ) {
+
+            if (!$event = Shopware()->Events()->notifyUntil(__CLASS__ . '_' . $action_name, $args)) {
                 $this->$action(...$this->getActionArguments($action));
             }
+            
             $this->postDispatch();
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Every dispatched event from `Enlight_Controller_Action` passes an instance of `Enlight_Controller_ActionEventArgs` as argument except the overriding notifyUntil. This should profit from it as well as it provides better typehinting.

### 2. What does this change do, exactly?
Replaces `['subject' => $this]` with `$args` which has the value of `['subject' => $this, 'request' => $this->Request(), 'response' => $this->Response()]`

### 3. Describe each step to reproduce the issue or behaviour.
1. Subscribe different module or controller dispatch event
2. Override one action and use the same argument typehint
3. `TypeError: Argument 1 must be an instance of Enlight_Controller_ActionEventArgs, instance of Enlight_Event_EventArgs given`

### 4. Which documentation changes (if any) need to be made because of this PR?
A change in haehnchens idea plugin could be made

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.