### PR TITLE
unlimit searchable orders

### DIFF
--- a/engine/Shopware/Models/Order/Repository.php
+++ b/engine/Shopware/Models/Order/Repository.php
@@ -793,8 +793,6 @@ class Repository extends ModelRepository
             $query->setParameter(':exclude', $excludeOrders, Connection::PARAM_INT_ARRAY);
         }
 
-        $query->setMaxResults(self::SEARCH_TERM_LIMIT);
-
         return $query->execute()->fetchAll(\PDO::FETCH_COLUMN);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
In the backend, you can not search for all orders of a certain customer, if that customer has more than 400 orders.

### 2. What does this change do, exactly?
Remove the result limit in \Shopware\Models\Order\Repository::searchCustomers

### 3. Describe each step to reproduce the issue or behaviour.
- Have a customer with more than 400 orders.
- search for that customer's email in the search-mask in Backend -> Orders

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.