### PR TITLE
Missing controller attribute check used the same message as the missi…

### DIFF
--- a/engine/Shopware/Bundle/ControllerBundle/DependencyInjection/Compiler/ControllerCompilerPass.php
+++ b/engine/Shopware/Bundle/ControllerBundle/DependencyInjection/Compiler/ControllerCompilerPass.php
@@ -42,7 +42,7 @@ class ControllerCompilerPass implements CompilerPassInterface
             }
 
             if (!isset($options['controller'])) {
-                throw new \RuntimeException(sprintf('Attribute "module" is required for "shopware.controller" tagged service with id "%s"', $id));
+                throw new \RuntimeException(sprintf('Attribute "controller" is required for "shopware.controller" tagged service with id "%s"', $id));
             }
 
             $controllers[strtolower(sprintf('%s_%s', $options['module'], $options['controller']))] = $id;


### PR DESCRIPTION
### 1. Why is this change necessary?
Wrong error message for a missing controller attribute in the "shopware.controllers" tag was displayed.

### 2. What does this change do, exactly?
Displays the correct error message.

### 3. Describe each step to reproduce the issue or behaviour.
Tag an controller without the controller attribute and you see the same error message that you get by not providing the module attribute.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.