### PR TITLE
Remove deprecation comments for version 6.0 in favor of stability

### DIFF
--- a/engine/Library/Enlight/Application.php
+++ b/engine/Library/Enlight/Application.php
@@ -24,7 +24,6 @@
  * the configuration automatically. It loads the different resources, for example classes, loader or the
  * managers for the different packages (Hook, Plugin, Event).
  *
- * @deprecated since 5.2, to be removed in 6.0
  * @category   Enlight
  * @package    Enlight_Application
  * @copyright  Copyright (c) 2011, shopware AG (http://www.shopware.de)
@@ -33,19 +32,16 @@
 class Enlight_Application
 {
     /**
-     * @deprecated since 5.2, to be removed in 6.0
      * @var string
      */
     protected $path;
 
     /**
-     * @deprecated since 5.2, to be removed in 6.0
      * @var string
      */
     protected $core_path;
 
     /**
-     * @deprecated since 5.2, to be removed in 6.0
      * @var Enlight_Application Instance of the Enlight application.
      * Will be set in the class constructor.
      */
@@ -61,7 +57,7 @@ class Enlight_Application
 
     /**
      * Returns directory separator
-     * @deprecated since 5.2, to be removed in 6.0
+     *
      * @return string
      */
     public static function DS()
@@ -74,7 +70,6 @@ class Enlight_Application
     /**
      * Returns the instance of the application
      *
-     * @deprecated since 5.2, to be removed in 6.0
      * @return Enlight_Application
      */
     public static function Instance()
@@ -87,7 +82,6 @@ class Enlight_Application
     /**
      * Returns the enlight path: <projectroot>/engine/Library/Enlight/
      *
-     * @deprecated since 5.2, to be removed in 6.0
      * @param string $path
      * @return string
      */
@@ -101,7 +95,6 @@ class Enlight_Application
     /**
      * Returns the enlight components path: <projectroot>/engine/Library/Enlight/Components/
      *
-     * @deprecated since 5.2, to be removed in 6.0
      * @param string $path
      * @return string
      */
@@ -116,7 +109,6 @@ class Enlight_Application
     /**
      * Returns the library path: <projectroot>/engine/Library/
      *
-     * @deprecated since 5.2, to be removed in 6.0
      * @param string $path
      * @return string
      */
@@ -147,7 +139,6 @@ class Enlight_Application
 /**
  * Proxy to Shopware()
  *
- * @deprecated since 5.2, to be removed in 6.0
  * @param   Enlight_Application $newInstance
  * @return  Enlight_Application
  */

--- a/engine/Shopware/Application.php
+++ b/engine/Shopware/Application.php
@@ -86,8 +86,6 @@ class Shopware extends Enlight_Application
     /**
      * Returns the name of the application
      *
-     * @deprecated since 5.2, to be removed in 6.0
-     *
      * @return string
      */
     public function App()
@@ -100,8 +98,6 @@ class Shopware extends Enlight_Application
     /**
      * Returns the application environment method
      *
-     * @deprecated since 5.2, to be removed in 6.0
-     *
      * @return string
      */
     public function Environment()
@@ -112,8 +108,6 @@ class Shopware extends Enlight_Application
     }
 
     /**
-     * @deprecated since 5.2, to be removed in 6.0. Use Shopware()->DocPath() instead.
-     *
      * @param string $path
      *
      * @return string
@@ -319,8 +313,6 @@ class Shopware extends Enlight_Application
      * plugin specified event manager.
      * The passed manager has to be an instance of the Enlight_Event_EventManager,
      * otherwise the function throws an exception.
-     *
-     * @deprecated since 5.2, to be removed in 6.0
      */
     public function setEventManager(Enlight_Event_EventManager $manager)
     {
@@ -331,8 +323,6 @@ class Shopware extends Enlight_Application
 
     /**
      * Returns the instance of the application bootstrap
-     *
-     * @deprecated since 5.2, to be removed in 6.0
      *
      * @return Shopware_Bootstrap
      */

--- a/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandlerInterface.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/FacetHandlerInterface.php
@@ -29,9 +29,6 @@ use Shopware\Bundle\SearchBundle\FacetInterface;
 use Shopware\Bundle\SearchBundle\FacetResultInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct;
 
-/**
- * @deprecated since version 5.3, to be removed in 6.0 - Use \Shopware\Bundle\SearchBundleDBAL\PartialFacetHandlerInterface instead
- */
 interface FacetHandlerInterface
 {
     /**

--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/ContextServiceInterface.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/ContextServiceInterface.php
@@ -29,7 +29,6 @@ use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 interface ContextServiceInterface
 {
     /**
-     * @deprecated since version 5.2, to be removed in 6.0 - Use getShopContext instead
      * The \Shopware\Bundle\StoreFrontBundle\Struct\Context class contains
      * all information about the current state.
      *
@@ -62,7 +61,6 @@ interface ContextServiceInterface
     public function getShopContext();
 
     /**
-     * @deprecated since version 5.2, to be removed in 6.0 - Use `getShopContext` instead
      * Requires the following data:
      * - Current shop
      * - Current customer group
@@ -76,7 +74,6 @@ interface ContextServiceInterface
     public function getProductContext();
 
     /**
-     * @deprecated since version 5.2, to be removed in 6.0 - Use `getShopContext` instead
      * Requires the following data:
      * - Location data of the current state. (area, country, state)
      *
@@ -85,8 +82,6 @@ interface ContextServiceInterface
     public function getLocationContext();
 
     /**
-     * @deprecated since version 5.2, to be removed in 6.0 - Use `initializeShopContext` instead
-     *
      * Initials a global context class which contains
      * all information about the current request state.
      */
@@ -99,24 +94,18 @@ interface ContextServiceInterface
     public function initializeShopContext();
 
     /**
-     * @deprecated since version 5.2, to be removed in 6.0 - Use `initializeShopContext` instead
-     *
      * Initials a location context class which contains
      * the information about the country state
      */
     public function initializeLocationContext();
 
     /**
-     * @deprecated since version 5.2, to be removed in 6.0 - Use `initializeShopContext` instead
-     *
      * Initials a product context class which contains
      * all required information to calculate a product.
      */
     public function initializeProductContext();
 
     /**
-     * @deprecated since version 5.2, to be removed in 6.0 - Use createShopContext instead
-     *
      * @param int         $shopId
      * @param int|null    $currencyId
      * @param string|null $customerGroupKey

--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/LocationContextInterface.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/LocationContextInterface.php
@@ -27,9 +27,6 @@ namespace Shopware\Bundle\StoreFrontBundle\Struct;
 use Shopware\Bundle\StoreFrontBundle\Struct\Country\Area;
 use Shopware\Bundle\StoreFrontBundle\Struct\Country\State;
 
-/**
- * @deprecated since version 5.2, to be removed in 6.0 - Use ShopContextInterface instead
- */
 interface LocationContextInterface
 {
     /**

--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/ProductContext.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/ProductContext.php
@@ -24,9 +24,6 @@
 
 namespace Shopware\Bundle\StoreFrontBundle\Struct;
 
-/**
- * @deprecated since version 5.2, to be removed in 6.0 - Use ShopContext instead
- */
 class ProductContext extends ShopContext
 {
 }

--- a/engine/Shopware/Bundle/StoreFrontBundle/Struct/ProductContextInterface.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Struct/ProductContextInterface.php
@@ -24,9 +24,6 @@
 
 namespace Shopware\Bundle\StoreFrontBundle\Struct;
 
-/**
- * @deprecated since version 5.2, to be removed in 6.0 - Use ShopContextInterface instead
- */
 interface ProductContextInterface extends ShopContextInterface
 {
 }

--- a/engine/Shopware/Commands/PluginConfigListCommand.php
+++ b/engine/Shopware/Commands/PluginConfigListCommand.php
@@ -69,7 +69,6 @@ class PluginConfigListCommand extends ShopwareCommand implements CompletionAware
         $this
             ->setName('sw:plugin:config:list')
             ->setDescription('Lists plugin configuration.')
-            /* @deprecated since 5.6, to be removed in 6.0 */
             ->addOption(
                 'shop',
                 null,

--- a/engine/Shopware/Commands/PluginConfigSetCommand.php
+++ b/engine/Shopware/Commands/PluginConfigSetCommand.php
@@ -141,7 +141,6 @@ class PluginConfigSetCommand extends ShopwareCommand implements CompletionAwareI
                 InputArgument::REQUIRED,
                 'Configuration value. Can be true, false, null, an integer or an array specified with brackets: [value,anothervalue]. Everything else will be interpreted as string.'
             )
-            /* @deprecated since 5.6, to be removed in 6.0 */
             ->addOption(
                 'shop',
                 null,

--- a/engine/Shopware/Commands/RebuildSeoIndexCommand.php
+++ b/engine/Shopware/Commands/RebuildSeoIndexCommand.php
@@ -119,7 +119,6 @@ class RebuildSeoIndexCommand extends ShopwareCommand implements CompletionAwareI
         $this
             ->setName('sw:rebuild:seo:index')
             ->setDescription('Rebuild the SEO index')
-            /* @deprecated since 5.6, to be removed in 6.0 */
             ->addArgument('shopId', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The Id of the shop (deprecated)')
             ->addOption('shopId', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The Id of the shop (multiple Ids -> shopId={1,2})')
             ->setHelp('The <info>%command.name%</info> rebuilds the SEO index')

--- a/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
+++ b/engine/Shopware/Commands/WarmUpHttpCacheCommand.php
@@ -74,7 +74,6 @@ class WarmUpHttpCacheCommand extends ShopwareCommand implements CompletionAwareI
         $this
             ->setName('sw:warm:http:cache')
             ->setDescription('Warm up http cache (everything by default)')
-            /* @deprecated since 5.6, to be removed in 6.0 */
             ->addArgument('shopId', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The Id of the shop (deprecated)')
             ->addOption('shopId', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The Id of the shop (multiple Ids -> shopId={1,2})')
             ->addOption('clear-cache', 'c', InputOption::VALUE_NONE, 'Clear complete httpcache before warmup')

--- a/engine/Shopware/Core/sMarketing.php
+++ b/engine/Shopware/Core/sMarketing.php
@@ -55,8 +55,6 @@ class sMarketing implements \Enlight_Hook
     public $customerGroupId;
 
     /**
-     * @deprecated in Shopware 5.5.4, to be removed in 6.0
-     *
      * @var \Shopware\Models\Category\Category
      */
     private $category;

--- a/engine/Shopware/Models/ProductStream/ProductStream.php
+++ b/engine/Shopware/Models/ProductStream/ProductStream.php
@@ -74,8 +74,6 @@ class ProductStream extends ModelEntity
     private $type;
 
     /**
-     * @deprecated since version 5.3, to be removed in 6.0 - Use \Shopware\Models\ProductStream\ProductStream::$sortingId instead
-     *
      * @var string
      *
      * @ORM\Column(name="sorting", type="string", nullable=false)
@@ -168,17 +166,12 @@ class ProductStream extends ModelEntity
         $this->type = $type;
     }
 
-    /**
-     * @deprecated since version 5.3, to be removed in 6.0 - Use \Shopware\Models\ProductStream\ProductStream::$sortingId instead
-     */
     public function getSorting()
     {
         return $this->sorting;
     }
 
     /**
-     * @deprecated since version 5.3, to be removed in 6.0 - Use \Shopware\Models\ProductStream\ProductStream::$sortingId instead
-     *
      * @param string $sorting
      */
     public function setSorting($sorting)


### PR DESCRIPTION
### 1. Why is this change necessary?
This project will never reach version 6.0 in favor of [shopware/platform](https://github.com/shopware/platform). That means, these deprecations will never be removed unless the target version for their removal is reduced. Without this change these deprecations are meaningless.

### 2. What does this change do, exactly?
Change the target version of deprecations from 6.0 to 5.8.

### 3. Describe each step to reproduce the issue or behaviour.
None.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.