### PR TITLE
Remove unnecessary parameter

### DIFF
--- a/engine/Library/Enlight/Template/Plugins/function.compileLess.php
+++ b/engine/Library/Enlight/Template/Plugins/function.compileLess.php
@@ -39,12 +39,8 @@ function smarty_function_compileLess($params, $template)
         \Doctrine\ORM\AbstractQuery::HYDRATE_OBJECT
     );
 
-    /** @var Enlight_Controller_Front $front */
-    $front = Shopware()->Front();
-    $secure = $front->Request()->isSecure();
-
     $file = $pathResolver->getCssFilePath($shop, $time);
-    $url = $pathResolver->formatPathToUrl($file, $shop, $secure);
+    $url = $pathResolver->formatPathToUrl($file, $shop);
 
     if (!$settings->getForceCompile() && file_exists($file)) {
         // see: http://stackoverflow.com/a/9473886


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The `compileLess` Smarty function still uses a nonexistent third parameter of `$pathResolver->formatPathToUrl()`.

### 2. What does this change do, exactly?
It removes the unnecessary parameter. :)

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.