### PR TITLE
Replace "beliebig" in Price with const

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/ListingPriceTable.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/ListingPriceTable.php
@@ -26,6 +26,7 @@ namespace Shopware\Bundle\SearchBundleDBAL;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
+use Shopware\Models\Article\Price;
 
 class ListingPriceTable implements ListingPriceTableInterface
 {
@@ -76,7 +77,8 @@ class ListingPriceTable implements ListingPriceTableInterface
         $query->andWhere('prices.articledetailsID = availableVariant.id');
 
         if ($this->config->get('useLastGraduationForCheapestPrice')) {
-            $query->andWhere("IF(priceGroup.id IS NOT NULL, prices.from = 1, prices.to = 'beliebig')");
+            $query->andWhere('IF(priceGroup.id IS NOT NULL, prices.from = 1, prices.to = :toPrice)');
+            $query->setParameter(':toPrice', Price::NO_PRICE_LIMIT);
         } else {
             $query->andWhere('prices.from = 1');
         }

--- a/engine/Shopware/Bundle/SearchBundleDBAL/VariantHelper.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/VariantHelper.php
@@ -32,6 +32,7 @@ use Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\FieldHelper;
 use Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\Hydrator\CustomListingHydrator;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Components\ReflectionHelper;
+use Shopware\Models\Article\Price;
 
 class VariantHelper implements VariantHelperInterface
 {
@@ -379,7 +380,8 @@ class VariantHelper implements VariantHelperInterface
         }
 
         if ($this->config->get('useLastGraduationForCheapestPrice')) {
-            $query->andWhere("IF(priceGroup.id IS NOT NULL, prices.from = 1, prices.to = 'beliebig')");
+            $query->andWhere('IF(priceGroup.id IS NOT NULL, prices.from = 1, prices.to = :toPrice)');
+            $query->setParameter(':toPrice', Price::NO_PRICE_LIMIT);
         } else {
             $query->andWhere('prices.from = 1');
         }

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CheapestPriceGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CheapestPriceGateway.php
@@ -186,6 +186,7 @@ class CheapestPriceGateway implements Gateway\CheapestPriceGatewayInterface
         $graduation = 'prices.from = 1';
         if ($this->config->get('useLastGraduationForCheapestPrice')) {
             $graduation = 'IF(priceGroup.id IS NOT NULL, prices.from = 1, prices.to = :toPrice)';
+            $subQuery->setParameter(':toPrice', Price::NO_PRICE_LIMIT);
         }
 
         $subQuery->where('prices.pricegroup = :customerGroup')
@@ -226,11 +227,12 @@ class CheapestPriceGateway implements Gateway\CheapestPriceGatewayInterface
          * select multiple cheapest product prices.
          */
         $query = $this->connection->createQueryBuilder();
-        $query->setParameter(':customerGroup', $customerGroup->getKey());
 
-        if ($this->config->get('useLastGraduationForCheapestPrice')) {
-            $query->setParameter(':toPrice', Price::NO_PRICE_LIMIT);
+        foreach ($subQuery->getParameters() as $key => $parameter) {
+            $query->setParameter($key, $parameter, $subQuery->getParameterType($key));
         }
+
+        $query->setParameter(':customerGroup', $customerGroup->getKey());
 
         $query->select('(' . $subQuery->getSQL() . ') as priceId')
             ->from('s_articles_prices', 'outerPrices')

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CheapestPriceGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CheapestPriceGateway.php
@@ -27,6 +27,7 @@ namespace Shopware\Bundle\StoreFrontBundle\Gateway\DBAL;
 use Doctrine\DBAL\Connection;
 use Shopware\Bundle\StoreFrontBundle\Gateway;
 use Shopware\Bundle\StoreFrontBundle\Struct;
+use Shopware\Models\Article\Price;
 
 class CheapestPriceGateway implements Gateway\CheapestPriceGatewayInterface
 {
@@ -184,7 +185,7 @@ class CheapestPriceGateway implements Gateway\CheapestPriceGatewayInterface
 
         $graduation = 'prices.from = 1';
         if ($this->config->get('useLastGraduationForCheapestPrice')) {
-            $graduation = "IF(priceGroup.id IS NOT NULL, prices.from = 1, prices.to = 'beliebig')";
+            $graduation = 'IF(priceGroup.id IS NOT NULL, prices.from = 1, prices.to = :toPrice)';
         }
 
         $subQuery->where('prices.pricegroup = :customerGroup')
@@ -226,6 +227,10 @@ class CheapestPriceGateway implements Gateway\CheapestPriceGatewayInterface
          */
         $query = $this->connection->createQueryBuilder();
         $query->setParameter(':customerGroup', $customerGroup->getKey());
+
+        if ($this->config->get('useLastGraduationForCheapestPrice')) {
+            $query->setParameter(':toPrice', Price::NO_PRICE_LIMIT);
+        }
 
         $query->select('(' . $subQuery->getSQL() . ') as priceId')
             ->from('s_articles_prices', 'outerPrices')

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/GraduatedPricesGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/GraduatedPricesGateway.php
@@ -27,6 +27,7 @@ namespace Shopware\Bundle\StoreFrontBundle\Gateway\DBAL;
 use Doctrine\DBAL\Connection;
 use Shopware\Bundle\StoreFrontBundle\Gateway;
 use Shopware\Bundle\StoreFrontBundle\Struct;
+use Shopware\Models\Article\Price;
 
 class GraduatedPricesGateway implements Gateway\GraduatedPricesGatewayInterface
 {
@@ -100,11 +101,12 @@ class GraduatedPricesGateway implements Gateway\GraduatedPricesGatewayInterface
             ->leftJoin('price', 's_articles_prices_attributes', 'priceAttribute', 'priceAttribute.priceID = price.id')
             ->where('price.articledetailsID IN (:products)')
             ->andWhere('price.pricegroup = :customerGroup')
-            ->andWhere($query->expr()->orX('price.to >= variants.minpurchase', 'price.to = "beliebig"'))
+            ->andWhere($query->expr()->orX('price.to >= variants.minpurchase', 'price.to = :toPrice'))
             ->orderBy('price.articledetailsID', 'ASC')
             ->addOrderBy('price.from', 'ASC')
             ->setParameter(':products', $ids, Connection::PARAM_INT_ARRAY)
-            ->setParameter(':customerGroup', $customerGroup->getKey());
+            ->setParameter(':customerGroup', $customerGroup->getKey())
+            ->setParameter(':toPrice', Price::NO_PRICE_LIMIT);
 
         $this->fieldHelper->addPriceTranslation($query, $context);
 

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/PriceHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/PriceHydrator.php
@@ -25,6 +25,7 @@
 namespace Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\Hydrator;
 
 use Shopware\Bundle\StoreFrontBundle\Struct;
+use Shopware\Models\Article\Price;
 
 class PriceHydrator extends Hydrator
 {
@@ -72,7 +73,7 @@ class PriceHydrator extends Hydrator
         $price->setPrice((float) $data['__price_price']);
         $price->setPseudoPrice((float) $data['__price_pseudoprice']);
 
-        if (strtolower($data['__price_to']) == 'beliebig') {
+        if (strtolower($data['__price_to']) === Price::NO_PRICE_LIMIT) {
             $price->setTo(null);
         } else {
             $price->setTo((int) $data['__price_to']);

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/VariantCheapestPriceGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/VariantCheapestPriceGateway.php
@@ -322,6 +322,7 @@ class VariantCheapestPriceGateway implements Gateway\VariantCheapestPriceGateway
         $cheapestPriceIdQuery->from('s_articles_details', 'details');
         $cheapestPriceIdQuery->innerJoin('details', '(' . $cheapestPriceQuery->getSQL() . ')', 'cheapestPrices', $joinCondition);
         $cheapestPriceIdQuery->where('details.id = mainDetail.id');
+        $cheapestPriceIdQuery->setParameter(':toPrice', Price::NO_PRICE_LIMIT);
 
         if ($this->config->get('calculateCheapestPriceWithMinPurchase')) {
             /*
@@ -353,8 +354,11 @@ class VariantCheapestPriceGateway implements Gateway\VariantCheapestPriceGateway
         $baseQuery->from('s_articles_details', 'mainDetail');
         $baseQuery->where('mainDetail.id IN (:variants)');
 
-        if ($this->config->get('useLastGraduationForCheapestPrice')) {
-            $baseQuery->setParameter(':toPrice', Price::NO_PRICE_LIMIT);
+        foreach ($countSubQuery->getParameters() as $key => $parameter) {
+            $baseQuery->setParameter($key, $parameter, $countSubQuery->getParameterType($key));
+        }
+        foreach ($cheapestPriceIdQuery->getParameters() as $key => $parameter) {
+            $baseQuery->setParameter($key, $parameter, $cheapestPriceIdQuery->getParameterType($key));
         }
 
         return $baseQuery;

--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -899,7 +899,7 @@ class Variant extends Resource implements BatchInterface
             $priceData['to'] = (int) $priceData['to'];
             // if the "to" value isn't numeric, set the place holder "beliebig"
             if ($priceData['to'] <= 0) {
-                $priceData['to'] = 'beliebig';
+                $priceData['to'] = Price::NO_PRICE_LIMIT;
             }
         }
 

--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -4063,7 +4063,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
 
             // If the "to" value isn't numeric, set the place holder "beliebig"
             if ($priceData['to'] <= 0) {
-                $priceData['to'] = 'beliebig';
+                $priceData['to'] = Price::NO_PRICE_LIMIT;
             }
 
             if ($customerGroup->getTaxInput()) {

--- a/engine/Shopware/Models/Article/Configurator/Template/Price.php
+++ b/engine/Shopware/Models/Article/Configurator/Template/Price.php
@@ -89,7 +89,7 @@ class Price extends LazyFetchModelEntity
      *
      * @ORM\Column(name="`to`", type="string", nullable=true)
      */
-    private $to = 'beliebig';
+    private $to = \Shopware\Models\Article\Price::NO_PRICE_LIMIT;
 
     /**
      * @var float
@@ -179,7 +179,7 @@ class Price extends LazyFetchModelEntity
     public function setTo($to)
     {
         if ($to === null) {
-            $to = 'beliebig';
+            $to = \Shopware\Models\Article\Price::NO_PRICE_LIMIT;
         }
         $this->to = $to;
 

--- a/engine/Shopware/Models/Article/Price.php
+++ b/engine/Shopware/Models/Article/Price.php
@@ -35,6 +35,8 @@ use Shopware\Models\Customer\Group as CustomerGroup;
  */
 class Price extends LazyFetchModelEntity
 {
+    public const NO_PRICE_LIMIT = 'beliebig';
+
     /**
      * OWNING SIDE
      *
@@ -107,7 +109,7 @@ class Price extends LazyFetchModelEntity
      *
      * @ORM\Column(name="`to`", type="string", nullable=true)
      */
-    private $to = 'beliebig';
+    private $to = self::NO_PRICE_LIMIT;
 
     /**
      * @var float
@@ -217,7 +219,7 @@ class Price extends LazyFetchModelEntity
     public function setTo($to)
     {
         if ($to === null) {
-            $to = 'beliebig';
+            $to = static::NO_PRICE_LIMIT;
         }
         $this->to = $to;
 

--- a/tests/Functional/Bundle/SearchBundle/Condition/PriceConditionTest.php
+++ b/tests/Functional/Bundle/SearchBundle/Condition/PriceConditionTest.php
@@ -26,6 +26,7 @@ namespace Shopware\Tests\Functional\Bundle\SearchBundle\Condition;
 
 use Shopware\Bundle\SearchBundle\Condition\PriceCondition;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContext;
+use Shopware\Models\Article\Price;
 use Shopware\Models\Category\Category;
 use Shopware\Tests\Functional\Bundle\StoreFrontBundle\TestCase;
 
@@ -219,7 +220,7 @@ class PriceConditionTest extends TestCase
 
             $product['mainDetail']['prices'][] = [
                  'from' => 1,
-                 'to' => 'beliebig',
+                 'to' => Price::NO_PRICE_LIMIT,
                  'price' => $price,
                  'customerGroupKey' => $customerGroup,
             ];

--- a/tests/Functional/Bundle/SearchBundle/Condition/VariantConditionOnSaleTest.php
+++ b/tests/Functional/Bundle/SearchBundle/Condition/VariantConditionOnSaleTest.php
@@ -29,6 +29,7 @@ use Shopware\Bundle\SearchBundle\Sorting\PriceSorting;
 use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContext;
 use Shopware\Models\Article\Configurator\Group;
+use Shopware\Models\Article\Price;
 use Shopware\Models\Category\Category;
 use Shopware\Tests\Functional\Bundle\StoreFrontBundle\TestCase;
 
@@ -647,7 +648,7 @@ class VariantConditionOnSaleTest extends TestCase
                         ];
                         $priceCount += 9;
                     }
-                    $variant['prices'][count($variant['prices']) - 1]['to'] = 'beliebig';
+                    $variant['prices'][count($variant['prices']) - 1]['to'] = Price::NO_PRICE_LIMIT;
                 }
 
                 ++$variantCount;

--- a/tests/Functional/Bundle/SearchBundle/Condition/VariantConditionWithCurrencyFactor.php
+++ b/tests/Functional/Bundle/SearchBundle/Condition/VariantConditionWithCurrencyFactor.php
@@ -28,6 +28,7 @@ use Shopware\Bundle\SearchBundle\Condition\VariantCondition;
 use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContext;
 use Shopware\Models\Article\Configurator\Group;
+use Shopware\Models\Article\Price;
 use Shopware\Models\Category\Category;
 use Shopware\Tests\Functional\Bundle\StoreFrontBundle\TestCase;
 use Shopware\Tests\Functional\Bundle\StoreFrontBundle\TestContext;
@@ -381,7 +382,7 @@ class VariantConditionWithCurrencyFactor extends TestCase
                         ];
                         $priceCount += 9;
                     }
-                    $variant['prices'][count($variant['prices']) - 1]['to'] = 'beliebig';
+                    $variant['prices'][count($variant['prices']) - 1]['to'] = Price::NO_PRICE_LIMIT;
                 }
 
                 ++$variantCount;

--- a/tests/Functional/Bundle/SearchBundle/Condition/VariantConditionWithGraduationTest.php
+++ b/tests/Functional/Bundle/SearchBundle/Condition/VariantConditionWithGraduationTest.php
@@ -29,6 +29,7 @@ use Shopware\Bundle\SearchBundle\Sorting\PriceSorting;
 use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContext;
 use Shopware\Models\Article\Configurator\Group;
+use Shopware\Models\Article\Price;
 use Shopware\Models\Category\Category;
 use Shopware\Tests\Functional\Bundle\StoreFrontBundle\TestCase;
 
@@ -602,7 +603,7 @@ class VariantConditionWithGraduationTest extends TestCase
                         ];
                         $priceCount += 9;
                     }
-                    $variant['prices'][count($variant['prices']) - 1]['to'] = 'beliebig';
+                    $variant['prices'][count($variant['prices']) - 1]['to'] = Price::NO_PRICE_LIMIT;
                 }
 
                 ++$variantCount;

--- a/tests/Functional/Bundle/SearchBundle/Condition/VariantConditionWithPriceGroupTest.php
+++ b/tests/Functional/Bundle/SearchBundle/Condition/VariantConditionWithPriceGroupTest.php
@@ -28,6 +28,7 @@ use Shopware\Bundle\SearchBundle\Condition\PriceCondition;
 use Shopware\Bundle\SearchBundle\Condition\VariantCondition;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContext;
 use Shopware\Models\Article\Configurator\Group;
+use Shopware\Models\Article\Price;
 use Shopware\Models\Category\Category;
 use Shopware\Tests\Functional\Bundle\StoreFrontBundle\TestCase;
 
@@ -339,7 +340,7 @@ class VariantConditionWithPriceGroupTest extends TestCase
     {
         return [
             'from' => 1,
-            'to' => 'beliebig',
+            'to' => Price::NO_PRICE_LIMIT,
             'price' => $price,
             'customerGroupKey' => $group,
             'pseudoPrice' => $price + 10,

--- a/tests/Functional/Bundle/StoreFrontBundle/CheapestPriceTest.php
+++ b/tests/Functional/Bundle/StoreFrontBundle/CheapestPriceTest.php
@@ -26,6 +26,7 @@ namespace Shopware\Tests\Functional\Bundle\StoreFrontBundle;
 
 use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
+use Shopware\Models\Article\Price;
 
 class CheapestPriceTest extends TestCase
 {
@@ -439,7 +440,7 @@ class CheapestPriceTest extends TestCase
             foreach ($data['variants'] as &$variant) {
                 $variant['prices'] = [[
                     'from' => 1,
-                    'to' => 'beliebig',
+                    'to' => Price::NO_PRICE_LIMIT,
                     'price' => 100,
                     'customerGroupKey' => $context->getCurrentCustomerGroup()->getKey(),
                     'pseudoPrice' => 10,
@@ -448,7 +449,7 @@ class CheapestPriceTest extends TestCase
             $last = array_pop($data['variants']);
             $last['prices'] = [[
                 'from' => 1,
-                'to' => 'beliebig',
+                'to' => Price::NO_PRICE_LIMIT,
                 'price' => $cheapestVariantPrice,
                 'customerGroupKey' => $context->getCurrentCustomerGroup()->getKey(),
                 'pseudoPrice' => 10,

--- a/tests/Functional/Bundle/StoreFrontBundle/Helper.php
+++ b/tests/Functional/Bundle/StoreFrontBundle/Helper.php
@@ -852,7 +852,7 @@ class Helper
             ],
             [
                 'from' => 21,
-                'to' => 'beliebig',
+                'to' => Models\Article\Price::NO_PRICE_LIMIT,
                 'price' => $priceOffset + 50.00,
                 'customerGroupKey' => $group,
                 'pseudoPrice' => $priceOffset + 60,

--- a/tests/Functional/Components/DependencyInjection/Compiler/ConfigureContainerAwareCommandsTest.php
+++ b/tests/Functional/Components/DependencyInjection/Compiler/ConfigureContainerAwareCommandsTest.php
@@ -35,7 +35,7 @@ class ConfigureContainerAwareCommandsTest extends TestCase
      */
     public function testCompilerAwareIsInitialized(ShopwareCommand $containerAwareCommand): void
     {
-        $this->assertNotNull($containerAwareCommand->getContainer());
+        static::assertNotNull($containerAwareCommand->getContainer());
     }
 
     public function getShopwareCommands(): array


### PR DESCRIPTION
### 1. Why is this change necessary?
`beliebig` is a really bad value as it isn't descriptive, messing with type (`string` instead of `int`), repetitive (-> typo prone) and should be removed for better i18n.

### 2. What does this change do, exactly?
This PR isn't replacing the value `beliebig` yet but at least adds an abstraction by replacing all instances (in PHP) with a reference to a newly introduced const `Shopware\Models\Article\Price:: NO_PRICE_LIMIT`. This way the change isn't breaking.
In the future another PR should replace the default value of `Shopware\Models\Article\Price::$to` with `null` as this is a better fit.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
Using the const instead of default value is recommended.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.