### PR TITLE
Allow filtering log files by name in backend

### DIFF
--- a/engine/Shopware/Controllers/Backend/Log.php
+++ b/engine/Shopware/Controllers/Backend/Log.php
@@ -191,7 +191,7 @@ class Shopware_Controllers_Backend_Log extends Shopware_Controllers_Backend_ExtJ
         // filter against input
         $query = trim($this->Request()->getParam('query', ''));
         foreach ($files as $k => $file) {
-            if (!empty($query) && mb_stripos($file[0], $query) === false) {
+            if ($query !== '' && mb_stripos($file[0], $query) === false) {
                 continue;
             }
             $files[$k] = [

--- a/engine/Shopware/Controllers/Backend/Log.php
+++ b/engine/Shopware/Controllers/Backend/Log.php
@@ -189,23 +189,19 @@ class Shopware_Controllers_Backend_Log extends Shopware_Controllers_Backend_ExtJ
         $defaultFile = $this->getDefaultLogFile($files);
 
         // filter against input
-        $query = $this->Request()->getParam('query');
-        if (!empty($query)) {
-            $query = trim($query);
-            $files = array_filter($files, static function ($file) use ($query) {
-                return mb_stripos($file[0], $query) !== false;
-            });
-        }
-
-        $files = array_map(static function ($file) use ($defaultFile) {
-            return [
+        $query = trim($this->Request()->getParam('query', ''));
+        foreach ($files as $k => $file) {
+            if (!empty($query) && mb_stripos($file[0], $query) === false) {
+                continue;
+            }
+            $files[$k] = [
                 'name' => $file[0],
                 'channel' => $file['channel'],
                 'environment' => $file['environment'],
                 'date' => $file['date'],
                 'default' => $file[0] === $defaultFile,
             ];
-        }, $files);
+        }
 
         $start = $this->Request()->getParam('start', 0);
         $limit = $this->Request()->getParam('limit', 100);

--- a/engine/Shopware/Controllers/Backend/Log.php
+++ b/engine/Shopware/Controllers/Backend/Log.php
@@ -188,13 +188,22 @@ class Shopware_Controllers_Backend_Log extends Shopware_Controllers_Backend_ExtJ
         $files = $this->getLogFiles($logDir);
         $defaultFile = $this->getDefaultLogFile($files);
 
-        $files = array_map(function ($file) use ($defaultFile) {
+        // filter against input
+        $query = $this->Request()->getParam('query');
+        if (!empty($query)) {
+            $query = trim($query);
+            $files = array_filter($files, static function ($file) use ($query) {
+                return mb_stripos($file[0], $query) !== false;
+            });
+        }
+
+        $files = array_map(static function ($file) use ($defaultFile) {
             return [
                 'name' => $file[0],
                 'channel' => $file['channel'],
                 'environment' => $file['environment'],
                 'date' => $file['date'],
-                'default' => $file[0] == $defaultFile,
+                'default' => $file[0] === $defaultFile,
             ];
         }, $files);
 

--- a/tests/Functional/Controllers/Backend/LogTest.php
+++ b/tests/Functional/Controllers/Backend/LogTest.php
@@ -138,4 +138,56 @@ class LogTest extends \Enlight_Components_Test_Controller_TestCase
 
         Shopware()->Container()->get('dbal_connection')->rollBack();
     }
+
+    public function testSystemLogList(): void
+    {
+        $container = Shopware()->Container();
+        $pluginLogger = $container->get('pluginlogger');
+        $coreLogger = $container->get('corelogger');
+
+        // making sure that at least 1 entry for pluginlogger & corelogger are available
+        $pluginLogger->info('Running test...');
+        $coreLogger->info('Running test...');
+
+        // general settings
+        $this->Request()->setMethod('GET');
+        $this->dispatch('backend/log/getLogFileList');
+        $jsonBody = $this->View()->getAssign();
+
+        static::assertArrayHasKey('data', $jsonBody);
+        static::assertArrayHasKey('success', $jsonBody);
+        static::assertTrue($jsonBody['success']);
+        static::assertArrayHasKey('total', $jsonBody);
+        static::assertGreaterThanOrEqual(2, $jsonBody['total']);
+
+        // test against limt
+        $this->Request()->setMethod('GET')->setParams([
+            'limit' => 1,
+        ]);
+        $this->dispatch('backend/log/getLogFileList');
+        $jsonBody = $this->View()->getAssign();
+
+        static::assertArrayHasKey('data', $jsonBody);
+        static::assertArrayHasKey('success', $jsonBody);
+        static::assertTrue($jsonBody['success']);
+        static::assertArrayHasKey('total', $jsonBody);
+        static::assertGreaterThanOrEqual(2, $jsonBody['total']);
+
+        // test filtering
+        $file = sprintf('plugin_%s', $container->getParameter('kernel.environment'));
+        $this->Request()->setParams([
+            'limit' => 1,
+            'query' => $file,
+        ]);
+        $this->dispatch('backend/log/getLogFileList');
+        $jsonBody = $this->View()->getAssign();
+
+        static::assertArrayHasKey('data', $jsonBody);
+        static::assertArrayHasKey('success', $jsonBody);
+        static::assertTrue($jsonBody['success']);
+        static::assertArrayHasKey('total', $jsonBody);
+        static::assertGreaterThanOrEqual(1, $jsonBody['total']);
+        static::assertCount(1, $jsonBody['data']);
+        static::assertNotFalse(stripos($jsonBody['data'][0]['name'], $file));
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Filtering for log files in backend isn't working.

### 2. What does this change do, exactly?
Adds filtering file names by already provided `query` parameter.

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to `Settings` -> `Logfile` and then to `System log` tab
2. Try searching for a file -> won't work
3. Apply PR and try again -> will filter correctly

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.