### PR TITLE
Fix id mapping when copying emotions and their translations

### DIFF
--- a/engine/Shopware/Controllers/Backend/Emotion.php
+++ b/engine/Shopware/Controllers/Backend/Emotion.php
@@ -1514,7 +1514,20 @@ EOD;
      */
     private function getElementIdentifier(Element $el)
     {
-        return $el->getStartCol() . $el->getStartRow() . $el->getEndCol() . $el->getEndRow();
+        $identifier = '';
+
+        foreach ($el->getViewports() as $viewport) {
+            /** @var \Shopware\Models\Emotion\ElementViewport $viewport */
+            $identifier .= $viewport->getAlias()
+                .$viewport->getStartRow()
+                .$viewport->getStartCol()
+                .$viewport->getEndRow()
+                .$viewport->getEndCol();
+        }
+
+        $identifier .= $el->getStartCol().$el->getStartRow().$el->getEndCol().$el->getEndRow();
+
+        return $identifier;
     }
 
     private function generateEmotionSeoUrls(Emotion $emotion)


### PR DESCRIPTION
### 1. Why is this change necessary?
The fields start_row, start_col, end_row, end_col are always set to '1' in s_emotion_element. This leads to a non unique key that is used to map and copy the translation objects. All translation objects will be saved with the key 1111 in copyElementTranslations::$oldObjectKeys.
When an emotion is copied then all element translations except of one are getting lost.

### 2. What does this change do, exactly?
My change reads all the viewport positioning elements and concatinates the values into an identifier string. Each element gets its own unique key again.
The change is also backward compatible with emotions without an exact viewport positioning.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a new emotion with two different text elements.
- Translate each element with different texts
- Copy the emotion
- Review the copied emotion. The translations are either completely lost or mapped incorrectly.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [✅] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [✅] I have read the contribution requirements and fulfil them.