### PR TITLE
Add command for zip files

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Commands/PluginZipImportCommand.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Commands/PluginZipImportCommand.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\PluginInstallerBundle\Commands;
+
+use Shopware\Bundle\PluginInstallerBundle\Service\DownloadService;
+use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
+use Shopware\Commands\ShopwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PluginZipImportCommand extends ShopwareCommand
+{
+    /**
+     * @var DownloadService
+     */
+    private $downloadService;
+
+    /**
+     * @var InstallerService
+     */
+    private $installerService;
+
+    public function __construct(DownloadService $downloadService, InstallerService $installerService)
+    {
+        parent::__construct();
+        $this->downloadService = $downloadService;
+        $this->installerService = $installerService;
+    }
+
+    protected function configure()
+    {
+        parent::configure();
+        $this
+            ->setName('sw:plugin:zip-import')
+            ->setDescription('Imports a plugin zip file.')
+            ->addArgument(
+                'zip-file',
+                InputArgument::REQUIRED,
+                'File of the plugin to be imported.'
+            )
+            ->addOption(
+                'no-refresh',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not refresh plugin list.'
+            )
+            ->setHelp(
+                <<<'EOF'
+The <info>%command.name%</info> imports a plugin zip file.
+EOF
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $zipFile = $input->getArgument('zip-file');
+
+        if (!file_exists($zipFile)) {
+            $output->writeln('File does not exist');
+
+            return 1;
+        }
+
+        $information = pathinfo($zipFile);
+        $pluginFileName = $information['basename'];
+
+        $this->downloadService->extractPluginZip($zipFile, $pluginFileName);
+        $output->writeln('Plugin zip file ' . $pluginFileName . ' has been successfully imported');
+
+        if (!$input->getOption('no-refresh')) {
+            $this->installerService->refreshPluginList();
+            $output->writeln('Successfully refreshed');
+        }
+
+        return 0;
+    }
+}

--- a/engine/Shopware/Bundle/PluginInstallerBundle/DependencyInjection/services.xml
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/DependencyInjection/services.xml
@@ -7,6 +7,12 @@
     <services>
         <defaults public="true" />
 
+        <service id="Shopware\Bundle\PluginInstallerBundle\Commands\PluginZipImportCommand">
+            <tag name="console.command" command="sw:plugin:zip-import"/>
+            <argument id="shopware_plugininstaller.plugin_download_service" type="service"/>
+            <argument id="shopware_plugininstaller.plugin_manager" type="service"/>
+        </service>
+
         <service id="shopware_plugininstaller.http_client" class="Shopware\Components\HttpClient\GuzzleHttpClient">
             <argument type="service" id="guzzle_http_client_factory"/>
             <argument type="collection">


### PR DESCRIPTION
### 1. Why is this change necessary?
There is still no really good way to version community store plugins.
1. sw:store:download has a bad versioning support and requires credentials
2. packages.friendsofshopware.com is not officially supported

Now you can at least version a downloaded plugin file and simply do:
`bin/console sw:plugin:zip-import SwagBundle.zip && bin/console sw:plugin:install --activate --clear-cache SwagBundle`

### 2. What does this change do, exactly?
Add a new command to import plugin zip files.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a previously downloaded plugin zip file
2. Open /backend
3. Open plugin manager
4. Upload zip file
5. Install plugin
6. Activate plugin
7. Be annoyed that it is not possible via CLI in an easy way to do the same

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.