### PR TITLE
Add metadata to gcp adapter

### DIFF
--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -25,6 +25,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
 * Added new event `Shopware_Modules_Admin_SaveRegister_BeforeRegister` to cancel customer registration
 * Added new property to plugin base class `$autoloadViews` which allows pre registration of template folder
     * Its still required on backend extensions to call `extendsTemplate`
+* Added new option `metadata` to GCP Storage Adapter for e.g. per object Cache-Control header
 
 ### Changes
 

--- a/engine/Shopware/Bundle/MediaBundle/Adapters/GoogleStorageFactory.php
+++ b/engine/Shopware/Bundle/MediaBundle/Adapters/GoogleStorageFactory.php
@@ -63,12 +63,13 @@ class GoogleStorageFactory implements AdapterFactoryInterface
         $options = new OptionsResolver();
 
         $options->setRequired(['projectId', 'keyFilePath', 'bucket']);
-        $options->setDefined(['root', 'mediaUrl', 'type', 'url']);
+        $options->setDefined(['root', 'mediaUrl', 'type', 'url', 'metadata']);
 
         $options->setAllowedTypes('projectId', 'string');
         $options->setAllowedTypes('keyFilePath', 'string');
         $options->setAllowedTypes('bucket', 'string');
         $options->setAllowedTypes('root', 'string');
+        $options->setAllowedTypes('metadata', 'array');
 
         $options->setDefault('root', '');
 

--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -114,6 +114,9 @@ return array_replace_recursive([
                 'keyFilePath' => '',
                 'bucket' => '',
                 'root' => '',
+                'metadata' => [
+                    'Cache-Control' => 'public, max-age=604800'
+                ],
             ],
         ],
     ],


### PR DESCRIPTION
### 1. Why is this change necessary?

it allows to modify the objects metadata. I needed it to serve files with Cache-Control headers

### 2. What does this change do, exactly?

add a config array

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

it does for GCP what SW-24932 / shopware/shopware@bf691c24 does for AWS S3

### 5. Which documentation changes (if any) need to be made because of this PR?

none, the Default Config is self explanatory

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

Opinionated: the Cache-Control header ist set to a week, similar to the nginx "expires 1w" directive for media assets.