### PR TITLE
Move highfreq refresh statistics delete to lowfreq Clearing cronjob

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/CronRefresh/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/CronRefresh/Bootstrap.php
@@ -81,6 +81,11 @@ class Shopware_Plugins_Frontend_CronRefresh_Bootstrap extends Shopware_Component
         $data['referrer']['rows'] = $this->deleteOldReferrerData($this->get('config')->get('maximumReferrerAge'));
         $data['article_impression']['rows'] = $this->deleteOldArticleImpressionData($this->get('config')->get('maximumImpressionAge'));
 
+        // Delete all entries from s_statistics_pool not from the current day
+        $sql = 'DELETE FROM s_statistics_pool WHERE datum != CURDATE()';
+        $result = Shopware()->Db()->query($sql);
+        $data['statistics_pool']['rows'] = $result->rowCount();
+
         // Delete all entries from s_order_notes, which are older than a year and have no userID set
         $sql = 'DELETE FROM s_order_notes WHERE datum < DATE_SUB(NOW(), INTERVAL 1 YEAR) AND userID = 0';
         $noteResult = $connection->executeQuery($sql);

--- a/engine/Shopware/Plugins/Default/Frontend/Statistics/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Statistics/Bootstrap.php
@@ -192,8 +192,6 @@ ShopWiki;Bot;WebAlta;;abachobot;architext;ask jeeves;frooglebot;googlebot;lycos;
         if ((rand() % 10) === 0) {
             $sql = 'DELETE FROM s_statistics_currentusers WHERE time < DATE_SUB(NOW(), INTERVAL 3 MINUTE)';
             Shopware()->Db()->query($sql);
-            $sql = 'DELETE FROM s_statistics_pool WHERE datum != CURDATE()';
-            Shopware()->Db()->query($sql);
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

when enabling the refreshStatistics function for a higher traffic site the DELETE turned out to be a bottleneck

### 2. What does this change do, exactly?

it moves the 2nd DELETE in the function to the Clearing cronjob. For the pageimpression / uniquevisitor count a daily cleanup is sufficient as it filters with its own WHERE-condition in the pool table before counting to their target. For the currentuser table deleting on rand()%10 of requests does make sense, not for the daily pool though. If the cronjobs runs at the end of the day, it still keeps the pool table small for inserts.
Git will not tell the story of that code, I can find it in sw 3.5.6 still. I guess the first DELETE was present before the second was added.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

haven't found any, in general performance topics

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

Re checklist: I tested the clearing cronjob to successfully delete old entries, but didn't write tests.