### PR TITLE
Allow filtering customer groups and shops in order list

### DIFF
--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -197,8 +197,9 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
 
         $request = $this->Request();
         $filter = $request->getParam('filter', []);
-        if ($request->getParam('query')) {
-            $query = '%' . trim($request->getParam('query')) . '%';
+        $query = trim($request->getParam('query', ''));
+        if ($query !== '') {
+            $query = '%' . $query . '%';
             $filter[] = [
                 'property' => 'groups.key',
                 'value' => $query,
@@ -701,8 +702,9 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
 
         $request = $this->Request();
         $filter = $request->getParam('filter', []);
-        if ($request->getParam('query')) {
-            $query = '%' . trim($request->getParam('query')) . '%';
+        $query = trim($request->getParam('query', ''));
+        if ($query !== '') {
+            $query = '%' . $query . '%';
             $filter[] = [
                 'property' => 'shop.name',
                 'expression' => 'LIKE',

--- a/engine/Shopware/Controllers/Backend/Base.php
+++ b/engine/Shopware/Controllers/Backend/Base.php
@@ -194,11 +194,31 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
             'groups.taxInput as taxInput',
             'groups.mode as mode',
         ]);
-        $builder->addFilter($this->Request()->getParam('filter', []));
-        $builder->addOrderBy($this->Request()->getParam('sort', []));
 
-        $builder->setFirstResult($this->Request()->getParam('start'))
-            ->setMaxResults($this->Request()->getParam('limit'));
+        $request = $this->Request();
+        $filter = $request->getParam('filter', []);
+        if ($request->getParam('query')) {
+            $query = '%' . trim($request->getParam('query')) . '%';
+            $filter[] = [
+                'property' => 'groups.key',
+                'value' => $query,
+                'expression' => 'LIKE',
+                'operator' => 'OR',
+            ];
+            $filter[] = [
+                'property' => 'groups.name',
+                'value' => $query,
+                'expression' => 'LIKE',
+                'operator' => 'OR',
+            ];
+        }
+
+        $builder->addFilter($filter);
+        $builder->addOrderBy($request->getParam('sort', []));
+
+        $builder
+            ->setFirstResult($request->getParam('start'))
+            ->setMaxResults($request->getParam('limit'));
 
         $query = $builder->getQuery();
 
@@ -679,14 +699,24 @@ class Shopware_Controllers_Backend_Base extends Shopware_Controllers_Backend_Ext
         /** @var \Shopware\Models\Shop\Repository $repository */
         $repository = Shopware()->Models()->getRepository(\Shopware\Models\Shop\Shop::class);
 
+        $request = $this->Request();
+        $filter = $request->getParam('filter', []);
+        if ($request->getParam('query')) {
+            $query = '%' . trim($request->getParam('query')) . '%';
+            $filter[] = [
+                'property' => 'shop.name',
+                'expression' => 'LIKE',
+                'value' => $query,
+            ];
+        }
+
         $query = $repository->getBaseListQuery(
-            $filter = $this->Request()->getParam('filter', []),
-            $order = $this->Request()->getParam('sort', []),
-            $offset = $this->Request()->getParam('start'),
-            $limit = $this->Request()->getParam('limit'),
+            $filter,
+            $order = $request->getParam('sort', []),
+            $offset = $request->getParam('start'),
+            $limit = $request->getParam('limit'),
             true
         );
-
         // Get total result of the query
         $total = Shopware()->Models()->getQueryCount($query);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
You can't filter

### 2. What does this change do, exactly?
Allow remote filtering

### 3. Describe each step to reproduce the issue or behaviour.
* Open order list in backend
* start searching for a customer group or shop in their filters
* will still show all entries

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.