### PR TITLE
SW-24896 - Make intl extension required - add requirement to composer…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "ext-xml": "*",
         "ext-zip": "*",
         "ext-zlib": "*",
+        "ext-intl": "*",
         "lib-libxml": "*",
         "symfony/http-kernel": "3.4.37",
         "symfony/http-foundation": "3.4.37",


### PR DESCRIPTION
SW-24896 - Make intl extension required - add requirement to composer.json for better developer experience

until now only added in thsi commit: https://github.com/shopware/shopware/commit/59b1b65e589d5bfb9eeb081cdeec70a7e7fd2b02

### 1. Why is this change necessary?
for better developer / devops experience

### 2. What does this change do, exactly?
just add composer require of ext-intl which is required until https://github.com/shopware/shopware/commit/59b1b65e589d5bfb9eeb081cdeec70a7e7fd2b02

### 3. Describe each step to reproduce the issue or behaviour.
composer install of current 5.6 branch doesn't alert if php intl extension is not installed

### 4. Please link to the relevant issues (if any).
SW-24896 - Make intl extension required

### 5. Which documentation changes (if any) need to be made because of this PR?
nothing

### 6. Checklist

- [ x ] I have written tests and verified that they fail without my change
- [ x ] I have squashed any insignificant commits
- [ x ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.