### PR TITLE
Add translations to attributes with type=combo to their values

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/AttributeData.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/AttributeData.php
@@ -115,7 +115,7 @@ class Shopware_Controllers_Backend_AttributeData extends Shopware_Controllers_Ba
     /**
      * @param ConfigurationStruct[] $columns
      */
-    private function translateColumns($columns)
+    private function translateColumns(array $columns): void
     {
         $snippets = $this->container->get('snippets')->getNamespace('backend/attribute_columns');
 
@@ -130,6 +130,16 @@ class Shopware_Controllers_Backend_AttributeData extends Shopware_Controllers_Ba
             }
             if ($snippet = $snippets->get($key . 'helpText')) {
                 $column->setHelpText($snippet);
+            }
+
+            $arrayStore = json_decode($column->getArrayStore(), true);
+            if (!empty($arrayStore)) {
+                foreach ($arrayStore as &$option) {
+                    $optionKey = sprintf('%s_options_store_%s', $key, strtolower($option['key']));
+                    $option['value'] = $snippets->get($optionKey, $option['value'], true);
+                }
+                unset($option);
+                $column->setArrayStore(json_encode($arrayStore));
             }
         }
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
While you can translate labels of an attribute field you can't translate the values itself on a combo field.

### 2. What does this change do, exactly?
Iterate over `arrayStore` in `options` and try to translate those based on their key 

### 3. Describe each step to reproduce the issue or behaviour.
Create a new attribute like 
```
$crudService = $this->container->get('shopware_attribute.crud_service');
        $crudService->update(
            's_articles_attributes',
            'my_cool_plugin',
            'combobox',
            [
                'label' => 'Dropdown',
                'displayInBackend' => true,
                'arrayStore' => [
                    ['key' => 1, 'value' => 'Value 1'],
                    ['key' => 2, 'value' => 'Value 2'],
                    ['key' => 3, 'value' => 'Value 3'],
                ],
            ]
        );
```
Afterwards you can translate or import translations for the label but not its values. With this PR those will be translated

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.