### PR TITLE
fix routing problem on nginx as reverse proxy

### DIFF
--- a/themes/Backend/ExtJs/backend/order/view/list/document.js
+++ b/themes/Backend/ExtJs/backend/order/view/list/document.js
@@ -242,7 +242,7 @@ Ext.define('Shopware.apps.Order.view.list.Document', {
         var spec = {
             tag: 'a',
             html: display,
-            href: '{url action="openPdf"}?id=' + record.get('hash'),
+            href: '{url action="openPdf"}/?id=' + record.get('hash'),
             target: '_blank'
         };
 

--- a/themes/Backend/ExtJs/backend/order/view/mail/attachment.js
+++ b/themes/Backend/ExtJs/backend/order/view/mail/attachment.js
@@ -350,7 +350,7 @@ Ext.define('Shopware.apps.Order.view.mail.Attachment', {
         var spec = {
             tag: 'a',
             html: name,
-            href: '{url action="openPdf"}?id=' + record.get('hash'),
+            href: '{url action="openPdf"}/?id=' + record.get('hash'),
             target: '_blank'
         };
 


### PR DESCRIPTION
### 1. Why is this change necessary?
This change prevents caching issues if shopware runs behind a reverse proxy like nginx. 

### 2. What does this change do, exactly?
This change force the openPdfAction to be interpreted as controller action instead of a pdf file.
This fix adds a trailing slash for the openPdfAction before request params will be added.

### 3. Describe each step to reproduce the issue or behaviour.
* Setup nginx as reverse proxy for serving static files based on the request URL
* Perform an order
* Create a document
* Open the document in the backend 
* URL will be generated: shop.com/backend/**openPdf**?id=<file-hash>
* Response will be a 404 

### 4. Please link to the relevant issues (if any).
* https://forum.shopware.com/discussion/61983/kann-pdf-belege-aus-dem-backend-heraus-nicht-aufrufen
* https://talk.plesk.com/threads/issue-with-pdf-files.353074/

### 5. Which documentation changes (if any) need to be made because of this PR?
No documentation has to be changed

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.