### PR TITLE
Move usage of useShortDescriptionInListing from sArticles to LegacyStructConverter

### DIFF
--- a/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
+++ b/engine/Shopware/Components/Compatibility/LegacyStructConverter.php
@@ -334,6 +334,10 @@ class LegacyStructConverter
         $promotion['linkVariant'] = $this->config->get('baseFile') .
             '?sViewport=detail&sArticle=' . $promotion['articleID'] . '&number=' . $promotion['ordernumber'];
 
+        if ($this->config->get('useShortDescriptionInListing') && strlen($promotion['description']) > 5) {
+            $promotion['description_long'] = $promotion['description'];
+        }
+
         return $this->eventManager->filter('Legacy_Struct_Converter_Convert_List_Product', $promotion, [
             'product' => $product,
         ]);

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -2439,9 +2439,6 @@ class sArticles implements \Enlight_Hook
                 $product['linkDetails'] .= "&sCategory=$categoryId";
             }
 
-            if ($this->config->get('useShortDescriptionInListing') && strlen($product['description']) > 5) {
-                $product['description_long'] = $product['description'];
-            }
             $product['description_long'] = $this->sOptimizeText($product['description_long']);
 
             $products[$product['ordernumber']] = $product;


### PR DESCRIPTION
### 1. Why is this change necessary?
The config value `useShortDescriptionInListing` is only honored when requesting the listing via the `frontend/listing` controller. When the user starts scrolling or applies a filter to the listing, the new result is loaded from the `widgets/listing` controller. Because the frontend controller uses `sAdmin` and the widget controller does not, the description will be different.

### 2. What does this change do, exactly?
I moved the condition on whether to use the description or the short description from `sArticles` into the `LegacyStructConverter`. This way the condition is applied in both situations.

### 3. Describe each step to reproduce the issue or behaviour.
1. Set `useShortDescriptionInListing` to true.
2. Have a product with a description and a short description (that has more than 5 characters).
3. Open a listing with said product. Notice that you will see the short description.
4. Apply a filter that will match with said product and let ajax load the filter results. Notice that you will see the long description.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.