### PR TITLE
fix related slider block

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/tabs/related.tpl
+++ b/themes/Frontend/Bare/frontend/detail/tabs/related.tpl
@@ -2,9 +2,12 @@
 
 {if $sArticle.sRelatedArticles && !$sArticle.crossbundlelook}
     {* Related products - Content *}
-    {block name="frontend_detail_index_similar_slider_content"}
-        <div class="related--content">
-            {include file="frontend/_includes/product_slider.tpl" articles=$sArticle.sRelatedArticles sliderInitOnEvent="onShowContent-related"}
-        </div>
+    {block name="frontend_detail_index_related_slider_content"}
+        {* @deprecated block frontend_detail_index_similar_slider_content will be removed in 5.7 *}
+        {block name="frontend_detail_index_similar_slider_content"}
+            <div class="related--content">
+                {include file="frontend/_includes/product_slider.tpl" articles=$sArticle.sRelatedArticles sliderInitOnEvent="onShowContent-related"}
+            </div>
+        {/block}
     {/block}
 {/if}


### PR DESCRIPTION
### 1. Why is this change necessary?
the frontend_detail_index_similar_slider_content block belongs to the similar.tpl

### 2. What does this change do, exactly?
changes the frontend_detail_index_similar_slider_content in the related.tpl to frontend_detail_index_related_slider_content

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.