### PR TITLE
Check against valid category ID in Shopware_Controllers_Backend_Category::saveDetail

### DIFF
--- a/engine/Shopware/Controllers/Backend/Category.php
+++ b/engine/Shopware/Controllers/Backend/Category.php
@@ -536,6 +536,12 @@ class Shopware_Controllers_Backend_Category extends Shopware_Controllers_Backend
             $categoryModel = $this->getRepository()->find($categoryId);
         }
 
+        if (!$categoryModel) {
+            $this->View()->assign(['success' => false, 'message' => 'Invalid categoryId']);
+
+            return;
+        }
+
         $categoryModel->setStream(null);
         if ($params['streamId']) {
             $params['stream'] = Shopware()->Models()->find(\Shopware\Models\ProductStream\ProductStream::class, (int) $params['streamId']);

--- a/tests/Functional/Controllers/Backend/CategoryTest.php
+++ b/tests/Functional/Controllers/Backend/CategoryTest.php
@@ -206,6 +206,23 @@ class CategoryTest extends \Enlight_Components_Test_Controller_TestCase
         static::assertEquals(null, $categoryModel);
     }
 
+    public function testUpdatingInvalidCategory(): void
+    {
+        $params = $this->dummyData;
+        unset($params['parentId']);
+        $params['id'] = -10000;
+        $params['articles'] = [];
+        $params['customerGroups'] = [];
+
+        // Test new category
+        $this->Request()->setParams($params);
+        $this->dispatch('backend/Category/createDetail');
+        static::assertFalse($this->View()->success);
+        static::assertNotEmpty($this->View()->message);
+
+        static::assertEquals('Invalid categoryId', $this->View()->message);
+    }
+
     /**
      * Creates the dummy data
      *


### PR DESCRIPTION
### 1. Why is this change necessary?
Trying to update a category that has been removed by another user will result in an uncatched error.

### 2. What does this change do, exactly?
Check if a category could be found and otherwise return a more descriptive error to the end user.

### 3. Describe each step to reproduce the issue or behaviour.
- Use 2 tabs/windows with the backend and open the same category
- modify something in first tab
- delete category in second tab
- try saving in first tab
-> error

### 4. Please link to the relevant issues (if any).
This is #2322 but without refactoring & translation. I will add a follow up PR with that changes.

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.