### PR TITLE
Remove iframe border from lightweight backend modules

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.ModuleManager.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.ModuleManager.js
@@ -130,6 +130,7 @@ Ext.define('Shopware.ModuleManager', {
             'width': '100%',
             'height': '100%',
             'border': '0',
+            'frameBorder': 0,
             'src': (fullPath ? name : '{url module="backend" controller=""}' + name),
             'data-instance': instance
         }));


### PR DESCRIPTION
### 1. Why is this change necessary?
This isn't year 2k anymore

### 2. What does this change do, exactly?
Set `frameBorder=0` on iframe as just using `border=0` isn't sufficient enough, at least in Chrome.

![with `frameBorder`](https://user-images.githubusercontent.com/19560252/77110185-6fc90280-6a25-11ea-9b75-23be7c2c6ad3.png)
*w/ `frameBorder`*

![without `frameBorder`](https://user-images.githubusercontent.com/19560252/77110248-8ec79480-6a25-11ea-8642-97565f613aa6.png)
*w/o `frameBorder`*

### 3. Describe each step to reproduce the issue or behaviour.
Open a lightweight backend module (iframe embedding external content instead of ExtJS pain).
See borders of iframe.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.