### PR TITLE
'Cron Product Export' plugin, export only the unvalidated Cache files

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/CronProductExport/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/CronProductExport/Bootstrap.php
@@ -77,8 +77,19 @@ class Shopware_Plugins_Core_CronProductExport_Bootstrap extends Shopware_Compone
         $activeFeeds = $productFeedRepository->getActiveListQuery()->getResult();
         foreach ($activeFeeds as $feedModel) {
             /** @var Shopware\Models\ProductFeed\ProductFeed $feedModel */
+            $fileName = $feedModel->getHash() . '_' . $feedModel->getFileName();
+            $filePath = $cacheDir . $fileName;
             if ($feedModel->getInterval() === 0) {
                 continue;
+            }elseif($feedModel->getInterval() > 0) {
+                $diffInterval = time();
+                if ($feedModel->getCacheRefreshed()) {
+                    $diffInterval = $diffInterval - $feedModel->getCacheRefreshed()->getTimestamp();
+                }
+
+                if ($diffInterval < $feedModel->getInterval() && file_exists($filePath)) {
+                    continue;
+                }
             }
 
             $export->sFeedID = $feedModel->getId();
@@ -87,8 +98,7 @@ class Shopware_Plugins_Core_CronProductExport_Bootstrap extends Shopware_Compone
             $export->sSmarty = clone $sSmarty;
             $export->sInitSmarty();
 
-            $fileName = $feedModel->getHash() . '_' . $feedModel->getFileName();
-            $handleResource = fopen($cacheDir . $fileName, 'w');
+            $handleResource = fopen($filePath, 'w');
             $export->executeExport($handleResource);
         }
 

--- a/engine/Shopware/Plugins/Default/Core/CronProductExport/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/CronProductExport/Bootstrap.php
@@ -79,9 +79,10 @@ class Shopware_Plugins_Core_CronProductExport_Bootstrap extends Shopware_Compone
             /** @var Shopware\Models\ProductFeed\ProductFeed $feedModel */
             $fileName = $feedModel->getHash() . '_' . $feedModel->getFileName();
             $filePath = $cacheDir . $fileName;
+
             if ($feedModel->getInterval() === 0) {
                 continue;
-            }elseif($feedModel->getInterval() > 0) {
+            } elseif ($feedModel->getInterval() > 0) {
                 $diffInterval = time();
                 if ($feedModel->getCacheRefreshed()) {
                     $diffInterval = $diffInterval - $feedModel->getCacheRefreshed()->getTimestamp();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
without this change the Export cronjob will create a new Export feed every time I call it.
for example: 
Feed_1 interval : 1 day
Feed_2 interval: 30 minutes
Export cronjob interval: 15 minutes
with the current logic every time I call the cronjob it will ignore the feed interval and create a new feed file.  

### 2. What does this change do, exactly?
after this change the cronjob will recreate only the unvalidated cache files. 

### 3. Describe each step to reproduce the issue or behaviour.
simply create the feeds with the interval in my example and run the cronjob

### 4. Please link to the relevant issues (if any).
there are no issues

### 5. Which documentation changes (if any) need to be made because of this PR?
no need

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.