### PR TITLE
"html compression" use a very slow regex-only approach

### DIFF
--- a/engine/Shopware/Components/Template/HtmlMinCompressor.php
+++ b/engine/Shopware/Components/Template/HtmlMinCompressor.php
@@ -49,8 +49,8 @@ class HtmlMinCompressor implements HtmlCompressorInterface
             $content
         );
 
-        // Remove whitespace (spaces, newlines and tabs)
-        $content = trim(preg_replace('/[ \n\t]{2,}|[\n\t]/m', ' ', $content));
+        // Remove whitespace (spaces, newlines and tabs) at the beginning of a line and complete empty lines
+        $content = trim(preg_replace('!^[ \t]*\r?\n|^[ \t]+!m', '', $content));
 
         // Replace the placeholders with the original content.
         $content = preg_replace_callback(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The current implementation is VERY slow for bigger pages. I.e. on our shop only the minify take ~3 seconds on some pages.

### 2. What does this change do, exactly?
It replace the regex-only approach to erase whitespaces with an algorithm that in first place replace every untouchable HTML-tags with placeholders, then replace all whitespaces and then refill the placeholders with the original content.

The change itself did not change anything else. The results from this new algorithm is identical to the previous implementation.

### 3. Describe each step to reproduce the issue or behaviour.
Enable html compression on a bigger shop. Worst results are when the filters are enabled and your products have many attributes, so the page has ~700.000 removable whitespaces in it.

After some benchmarking this new algorithm drop the CPU time for our usecase from ~3seconds to 1.3ms.
Original contentsize was 940.000 bytes with ~710.000 unnecessary whitespaces.


### 4. Please link to the relevant issues (if any).
https://forum.shopware.com/discussion/66883/


### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.