### PR TITLE
Change EventSuffix to be unique for each plugin

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.plugin-base.js
@@ -77,7 +77,7 @@
         /**
          * @property {string} eventSuffix - Suffix which will be appended to the eventType to get namespaced events
          */
-        me.eventSuffix = '.' + name;
+        me.eventSuffix = '.' + name + '-' + $.guid++;
 
         /**
          * @property {Array} _events Registered events listeners. See {@link PluginBase._on} for registration


### PR DESCRIPTION
### 1. Why is this change necessary?
Make registered jQuery-plugin events unique


### 2. What does this change do, exactly?
Add a GUID to the eventSuffix of jQuery-plugins

### 3. Describe each step to reproduce the issue or behaviour.
1. Have multiple instances of the same plugin on the page
2. Which add event-listeners to the same element (e.g. body)
3. Destroy one instance
4. Both plugins will have their event-listeners removed

Code (simplified):

```html
<html>
<body>
<div data-demo-plugin="true" data-id="1"></div>
<div data-demo-plugin="true" data-id="2"></div>
</body>
</html>
```

```js
$.plugin('demoPlugin', {
  init: function(){
    this._on($('body'), 'click', function(){ console.log('foo'); });
  },
  [...]
});
```

Clicking the body will print `foo` twice.

Somewhere in your code:

```js
StateManager.destroyPlugin('[data-id="1"]', 'demoPlugin');
```

Now clicking the body won't print `foo` anymore, because destroying one plugin caused a call like this:

```js
$('body').off('click.demoPlugin');
```

Which removes both listeners.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.