### PR TITLE
Fixing document showing wrong article data

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -495,7 +495,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         $articleModule = Shopware()->Modules()->Articles();
         foreach ($positions as &$position) {
             if ($position['modus'] == 0) {
-                $position['meta'] = $articleModule->sGetPromotionById('fix', 0, $position['articleordernumber']);
+                $position['meta'] = $articleModule->sGetPromotionById('fix', 0, $position['articleID']);
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
https://forum.shopware.com/discussion/67158/template-problem?new=1
https://forum.shopware.com/discussion/comment/267721/#Comment_267721

As encountered by a few users, using certain article data in templates might lead to a strange bug, where certain articles show wrong information.

Here is what I found out why this happens:
In the end, Document.php would call sGetPromotionById() with an articleordernumber, which in turn will call getOrderNumberByProductId() with this articleordernumber. The existence of the problem can already be seen with just this one sentence, as it tries to get an order number by using a product id, which in reality is already an order number.

### 2. What does this change do, exactly?
Providing the articleID instead of the articleordernumber should work around the problem. In general it does not seem smart, relying on is_numeric to determine which field should be used to query an article. I'd even go as far as calling it bad design, but I might be wrong not having much PHP and/or a lot backend coding experience.

### 3. Describe each step to reproduce the issue or behaviour.
Here is an excerpt of the data that is provided to the template in our case. You can clearly see, that the articleordernumber ends up to be the articleID in meta.

```
Array (
    [id] => 4080
    [orderID] => 1771
    [ordernumber] => 100006937
    [articleID] => 8433
    [articleordernumber] => 0006907
    [price] => 6.28
    [quantity] => 1
    [name] => Bepanthen - Wund- und Heilsalbe
    [status] => 0
    [shipped] => 0
    [shippedgroup] => 0
    [releasedate] =>
    [modus] => 0
    [esdarticle] => 0
    [taxID] => 1
    [tax_rate] => 10
    [config] => [ean] => [unit] => g
    [pack_unit] =>
    [articleDetailID] => 8434
    [articleTaxID] => 1
    [kind] => 1
    [attr1] =>
    ...
    [attr20] =>
    [attributes] => Array (
        [id] => 4080
        [detailID] => 4080
        [attribute1] =>
        ...
        [attribute6] =>
        [swag_promotion_item_discount] => 1.02
        [swag_promotion_direct_item_discount] => 1.02
        [swag_promotion_direct_promotions] => [5]
        [bundle_id] =>
        [bundle_article_ordernumber] =>
        [bundle_package_id] =>
        [pickware_canceled_quantity] => 0 
    )
    [tax] => 10
    [netto] => 5.7090909090909
    [amount_netto] => 5.71
    [amount] => 6.28
    [meta] => Array (
        [articleID] => 6907
        [articleDetailsID] => 6907
        [ordernumber] => 4575909
        [highlight] =>
        [description] => Stillt den Hustenreiz – entspannt den Rachen. Lindert sofort Hustenreiz und Reizrachen 3-fach
reizlindernde Island Formel Wirkt sofort reizlindernd Ideal für Tag und Nacht Ohne Alkohol und Zucker Rein pflanzlich
        ...
    )
```

### 4. Please link to the relevant issues (if any).
We created an issue @ shopware but it ended up getting no attention as we had an insufficient support plan. We posted in the forum and found another entry with the same problem. I think there will be more people suffering from this (the error might only be visible to the someone having a really close look at the results) with a respectable dark figure. In our case it is really bad as we are an online pharmacy.

https://forum.shopware.com/discussion/67158/template-problem?new=1
https://forum.shopware.com/discussion/comment/267721/#Comment_267721


### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [  ] I have written tests and verified that they fail without my change
I have not written any tests. I am developing on windows and have very little PHP development experience. I ran test-unit though and could not find that my changes have a negative impact.
- [X] I have squashed any insignificant commits
- [  ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.