### PR TITLE
fix CronJob EndDate Parsing 

### DIFF
--- a/engine/Library/Enlight/Components/Cron/Job.php
+++ b/engine/Library/Enlight/Components/Cron/Job.php
@@ -324,7 +324,7 @@ class Enlight_Components_Cron_Job
     public function setStart($start = null)
     {
         if (!$start instanceof Zend_Date) {
-            $start = new Zend_Date($start);
+            $start = new Zend_Date($start, is_string($start) ? Zend_Date::ISO_8601 : null);
         }
         $this->start = $start;
 
@@ -344,14 +344,14 @@ class Enlight_Components_Cron_Job
     /**
      * Sets the date and time when the cronjob stopped its run.
      *
-     * @param null|Zend_Date $end
+     * @param string|null|Zend_Date $end
      *
      * @return Enlight_Components_Cron_Job
      */
     public function setEnd($end = null)
     {
         if ($end !== null && !$end instanceof Zend_Date) {
-            $end = new Zend_Date($end);
+            $end = new Zend_Date($end, is_string($end) ? Zend_Date::ISO_8601 : null);
         }
         $this->end = $end;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

The end-date in the Shopware-Crons is not parsed correctly. I my Case 1st April will parsed as the 4th January. That happen in a cron that used the getEnd function and in the command sw:cron:list

### 2. What does this change do, exactly?

It checks the param is a string and give the Zend_Date the parsing format ISO_8601.
The same code is used in the setNext function some lines above.  

### 3. Describe each step to reproduce the issue or behaviour.

This happen in sw:cron:list or when you use the getEnd function in your CronJob.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.