### PR TITLE
Update rss.tpl

### DIFF
--- a/themes/Frontend/Bare/frontend/blog/rss.tpl
+++ b/themes/Frontend/Bare/frontend/blog/rss.tpl
@@ -5,7 +5,7 @@
         <atom:link href="{$sCategoryContent.rssFeed}" rel="self" type="application/rss+xml"/>
         <title>{block name='frontend_atom_title'}{s name="BlogRssFeedHeader"}{$sCategoryContent.description|escape:'hexentity'}{/s}{/block}</title>
         <link>{url controller='index'}</link>
-        <description>{$sShopname|escapeHtml} - {$sCategoryContent.description}</description>
+        <description>{$sShopname|escapeHtml} - {$sCategoryContent.description|escape}</description>
         <language>{$rssChannelLanguage|strtolower}</language>
         <lastBuildDate>{time()|date:rss}</lastBuildDate>
         {foreach from=$sBlogArticles item=sArticle key=key name="counter"}
@@ -14,7 +14,7 @@
                 <guid>{block name='frontend_blog_listing_rss_guid'}{url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}{/block}</guid>
                 <link>{block name='frontend_blog_listing_rss_link'}{url controller=blog action=detail sCategory=$sArticle.categoryId blogArticle=$sArticle.id}{/block}</link>
                 <description>{block name='frontend_blog_listing_rss_description'}{$sArticle.shortDescription|strip_tags|strip|truncate:280:"...":true|escape}{/block}</description>
-                <category>{block name='frontend_blog_listing_rss_category'}{$sCategoryContent.description}{/block}</category>
+                <category>{block name='frontend_blog_listing_rss_category'}{$sCategoryContent.description|escape}{/block}</category>
                 {if $sArticle.displayDate}
                     <pubDate>{block name='frontend_blog_listing_rss_date'}{$sArticle.displayDate|date:rss}{/block}</pubDate>
                 {/if}


### PR DESCRIPTION
Without escape it seems that some characters can cause rss feed break

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Without escape some characters ma break the rss feed.

### 2. What does this change do, exactly?
it escapes the sCategoryContentdescription value in the view

### 3. Describe each step to reproduce the issue or behaviour.
use some weird polish characters in the description

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.