### PR TITLE
API improvement

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -2350,9 +2350,17 @@ class Article extends Resource implements BatchInterface
             );
 
             if (isset($imageData['link'])) {
+
+                $albumId = -1;
+                if (isset($imageData['albumId']))
+                {
+                    $albumId = $imageData['albumId'];
+                }
+                
                 /** @var MediaModel $media */
                 $media = $this->getMediaResource()->internalCreateMediaByFileLink(
-                    $imageData['link']
+                    $imageData['link'],
+                    $albumId
                 );
 
                 $image = $this->updateArticleImageWithMedia(


### PR DESCRIPTION
When adding products with image(s), also apply a albumId to each (albumId -1 if not provided)



### 1. Why is this change necessary?
When filling/updating the shop via Article API all images were put into the main album (-1).
Sorting them by hand with 1000's of pictures was taking too long.
And the function internalCreateMediaByFileLink already was accepting an albumId as parameter.

### 2. What does this change do, exactly?
If a albumId is provided in the Article POST (inside the Image object besides the link parameter) the image will be put into the correct album

### 3. Describe each step to reproduce the issue or behaviour.
Add a Article via POST and provide a image with it. For now you can't provide the albumId.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
REST-API https://developers.shopware.com/developers-guide/rest-api/examples/article/
Adding a complete example for a new product with an image would be nice.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits 
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.