### PR TITLE
fixed issue SW-23798: Duplicated smarty block in box-basic.tpl, box-emotion.tpl and product-badges.tpl

### DIFF
--- a/themes/Frontend/Bare/frontend/listing/product-box/box-basic.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/box-basic.tpl
@@ -10,7 +10,7 @@
             <div class="box--content is--rounded">
 
                 {* Product box badges - highlight, newcomer, ESD product and discount *}
-                {block name='frontend_listing_box_article_badges'}
+                {block name='frontend_listing_box_article_badges_container'}
                     {include file="frontend/listing/product-box/product-badges.tpl"}
                 {/block}
 

--- a/themes/Frontend/Bare/frontend/listing/product-box/box-emotion.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/box-emotion.tpl
@@ -14,7 +14,7 @@
             <div class="box--content">
 
                 {* Product badges *}
-                {block name='frontend_listing_box_article_badges'}
+                {block name='frontend_listing_box_article_badges_container'}
                     {if !$imageOnly}
                         {include file="frontend/listing/product-box/product-badges.tpl"}
                     {/if}


### PR DESCRIPTION
There is a smarty block named **frontend_listing_box_article_badges** in
_frontend/listing/product-box/box-basic.tpl_,
_frontend/listing/product-box/box-emotion.tpl_ and also in
_frontend/listing/product-box/product-badges.tpl_
which is in included by **box-basic.tpl** and **box-emotion.tpl**.

Please rename **frontend_listing_box_article_badges** in
_frontend/listing/product-box/box-basic.tpl and_
_frontend/listing/product-box/box-emotion.tpl_.
For example like this:

`frontend_listing_box_article_badges_container`

### 1. Why is this change necessary?
Extending the product box and prepending or appending the block **frontend_listing_box_article_badges** will result in content being displayed twice.

### 2. What does this change do, exactly?
Renaming the smarty block **frontend_listing_box_article_badges** in
_frontend/listing/product-box/box-basic.tpl and_
_frontend/listing/product-box/box-emotion.tpl_.
to **frontend_listing_box_article_badges_container**.

### 3. Describe each step to reproduce the issue or behaviour.
Extend template _frontend/listing/product-box/box-basic.tpl_ and append the block **frontend_listing_box_article_badges** for example like this:

`{extends file='parent:frontend/listing/product-box/box-basic.tpl'}`
`{block name='frontend_listing_box_article_badges'}`
    `My Badge`
    `{$smarty.block.parent}`
`{/block}`

### 4. Please link to the relevant issues (if any).
[https://issues.shopware.com/issues/SW-23798](https://issues.shopware.com/issues/SW-23798)

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.