### PR TITLE
Zend: Update HTTP version check regex for HTTP/2

### DIFF
--- a/engine/Library/Zend/Http/Response.php
+++ b/engine/Library/Zend/Http/Response.php
@@ -175,7 +175,7 @@ class Zend_Http_Response
         $this->body = $body;
 
         // Set the HTTP version
-        if (! preg_match('|^\d\.\d$|', $version)) {
+        if (!preg_match('|^\d(\.\d)?$|', $version)) {
             throw new Zend_Http_Exception("Invalid HTTP response version: $version");
         }
 


### PR DESCRIPTION
I'm seeing more sites use HTTP/2 now, his causes our Zend
implementation to fail. Use a different regex that makes
the dot and the word (digit) after optional.

Tests: Zuora API calls do not raise an exception. All other sites still work.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Sites that use HTTP/2 protocol raise an exception because a regex check fails.

### 2. What does this change do, exactly?
The regex is updated insofar the dot and following word (digit) is optional.
That way we can use all the versions that exist in the wild (1.1, 1.2, 2) but also 3.

### 3. Describe each step to reproduce the issue or behaviour.
Create a zend client and call a site that uses protocol version 2
(we observed this with Zuora).

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ x ] I have written tests and verified that they fail without my change
- [ - ] I have squashed any insignificant commits
- [ - ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.