### PR TITLE
Global cronjob events

### DIFF
--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -33,7 +33,34 @@ This changelog references changes done in Shopware 5.6 patch versions.
     s_articles_attributes_my_column_options_store_1 = "Item 1 DE"
     ``` 
 * Changed cookie consent manager to work correctly when accepting all cookies
-
+* Changed `Shopware_CronJob_Error_` and `Shopware_CronJob_Finished_` events  to support all crojobs
+    * Example:
+        ```php
+        public static function getSubscribedEvents()
+        {
+            return [
+                'Shopware_CronJob_Error' => 'onCronJobError',
+                'Shopware_CronJob_Finished' => 'onCronJobFinal'
+            ];
+        }
+        public function onCronJobError(\Enlight_Event_EventArgs $args)
+        {
+            /** @var \Shopware_Components_Cron_CronJob $job */
+            $job = $args->get('job');
+            $action = $job->getAction();
+            
+            // Your code here
+        }
+        
+        public function onCronJobFinal(\Enlight_Event_EventArgs $args)
+        {
+            /** @var \Shopware_Components_Cron_CronJob $job */
+            $job = $args->get('job');
+            $action = $job->getAction();
+            
+            // Your code here
+        }
+        ```
 ## 5.6.5
 
 [View all changes from v5.6.4...v5.6.5](https://github.com/shopware/shopware/compare/v5.6.4...v5.6.5)

--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -33,7 +33,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
     s_articles_attributes_my_column_options_store_1 = "Item 1 DE"
     ``` 
 * Changed cookie consent manager to work correctly when accepting all cookies
-* Changed `Shopware_CronJob_Error_` and `Shopware_CronJob_Finished_` events  to support all crojobs
+* Added `Shopware_CronJob_Error` and `Shopware_CronJob_Finished` events  to support all crojobs
     * Example:
         ```php
         public static function getSubscribedEvents()

--- a/engine/Library/Enlight/Components/Cron/Manager.php
+++ b/engine/Library/Enlight/Components/Cron/Manager.php
@@ -282,7 +282,7 @@ class Enlight_Components_Cron_Manager
             }
 
             $this->endJob($job);
-            $this->eventManager->notify('Shopware_CronJob_Finished_' . $job->getAction(), [
+            $this->eventManager->notify('Shopware_CronJob_Finished', [
                 'subject' => $this,
                 'job' => $job,
             ]);
@@ -297,7 +297,7 @@ class Enlight_Components_Cron_Manager
                 $this->endJob($job);
             }
 
-            $this->eventManager->notify('Shopware_CronJob_Error_' . $action, [
+            $this->eventManager->notify('Shopware_CronJob_Error', [
                 'subject' => $this,
                 'job' => $job,
             ]);

--- a/engine/Library/Enlight/Components/Cron/Manager.php
+++ b/engine/Library/Enlight/Components/Cron/Manager.php
@@ -282,6 +282,11 @@ class Enlight_Components_Cron_Manager
             }
 
             $this->endJob($job);
+            $this->eventManager->notify('Shopware_CronJob_Finished_' . $job->getAction(), [
+                'subject' => $this,
+                'job' => $job,
+            ]);
+
             $this->eventManager->notify('Shopware_CronJob_Finished', [
                 'subject' => $this,
                 'job' => $job,
@@ -296,6 +301,11 @@ class Enlight_Components_Cron_Manager
             } else {
                 $this->endJob($job);
             }
+
+            $this->eventManager->notify('Shopware_CronJob_Error_' . $action, [
+                'subject' => $this,
+                'job' => $job,
+            ]);
 
             $this->eventManager->notify('Shopware_CronJob_Error', [
                 'subject' => $this,


### PR DESCRIPTION
### 1. Why is this change necessary?
It will allow each cronjob to be tracked instead of just an individual one.

### 2. What does this change do, exactly?
The current implementation allows you to subscribe to only one cronjob, by adding a cronjob action at the end of the event. If you want to track more than one or all the cronjobs, you need to subscribe to each cronjob individually through the plugin. With these changes you can subscribe to only one event and thus you can still follow all or just one cronjob.

### 3. Describe each step to reproduce the issue or behaviour.
Subscribe to all cronjobs which are present inside the shop.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
No documentation change is needed.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.