### PR TITLE
Notepad fix, when in cookie preferences comfort function is disabled.

### DIFF
--- a/tests/Functional/Core/sBasketTest.php
+++ b/tests/Functional/Core/sBasketTest.php
@@ -2134,6 +2134,9 @@ class sBasketTest extends PHPUnit\Framework\TestCase
     public function testsAddNote()
     {
         $_COOKIE['sUniqueID'] = Random::getAlphanumericString(32);
+        
+        $this->module->sSYSTEM->sSESSION_ID = uniqid(rand(), true);
+        $this->session->offsetSet('sessionId', $this->module->sSYSTEM->sSESSION_ID);    
 
         // Add one article to the basket with low amount
         $randomArticle = $this->db->fetchRow(


### PR DESCRIPTION
### 1. Why is this change necessary?
With disabled comfort cookies (sUniqueID) the notepad doesn't work as intended. It creates a new unique Id every time. A fallback to sessionId is more appropriate here.
At the moment, the table s_order_notes is filling with different unique Id's for customers who didn't activate the comfort cookies.

### 2. What does this change do, exactly?
In sAddNote it checks if the comfort cookie sUniqueID is set to true -> behaviour as is, false -> use sessionId as $uniqueId. There might be a better way to access the cookiePreferences, edit as needed.

### 3. Describe each step to reproduce the issue or behaviour.
Disable comfort cookie sUniqueID in cookie preferences and click on the notepad link in the detail page of a article. Do it multiple times, the count on the icon goes up, since every entry has a unique Id. Also to remove all of them, the customer has to delete the same article over and over again for each unique Id. 
Note: in the notepad only one entry is shown, despite there can be multiple of them.

### 4. Please link to the relevant issues (if any).
Probably (or partly) https://issues.shopware.com/issues/SW-24776

### 5. Which documentation changes (if any) need to be made because of this PR?
Probably none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.