### PR TITLE
fix typo in header.less file

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/header.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/header.less
@@ -426,7 +426,7 @@ More precise designations are commented inside the document.
     .unitize-height(16);
     position: absolute;
     display: none;
-    background-image: url('../../img/icons/loading-indicator.gif@{hash-loading-indicator}');
+    background-image: url('../../img/icons/loading-indicator.gif?@{hash-loading-indicator}');
 }
 
     // Search results modal


### PR DESCRIPTION
### 1. Why is this change necessary?
my log file was full with errors like

`[error] 27083#27083: *427446 open() "ROOT/themes/Frontend/Responsive/frontend/_public/src/img/icons/**loading-indicator.gifee21dca323a2d65314823dae370f9893**" failed (2: No such file or directory), client: 195.201.247.77, server: surf4shoes.us, request: "GET /themes/Frontend/Responsive/frontend/_public/src/img/icons/loading-indicator.gifee21dca323a2d65314823dae370f9893 HTTP/1.1", ........."`

### 2. What does this change do, exactly?

just add the missing '?' after the image name

### 3. Describe each step to reproduce the issue or behaviour.
simply open any Shopware Shop and I think you can find this error in the console

### 4. Please link to the relevant issues (if any).
there are no issue

### 5. Which documentation changes (if any) need to be made because of this PR?
nothing

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.