### PR TITLE
added missing descriptions for cookie-groups

### DIFF
--- a/engine/Shopware/Bundle/CookieBundle/Services/CookieCollector.php
+++ b/engine/Shopware/Bundle/CookieBundle/Services/CookieCollector.php
@@ -107,9 +107,9 @@ class CookieCollector implements CookieCollectorInterface
 
         $cookieGroupCollection->add(new CookieGroupStruct(CookieGroupStruct::TECHNICAL, $snippetNamespace->get('technical/title'), $snippetNamespace->get('technical/description'), true));
         $cookieGroupCollection->add(new CookieGroupStruct(CookieGroupStruct::COMFORT, $snippetNamespace->get('comfort/title'), $snippetNamespace->get('comfort/description')));
-        $cookieGroupCollection->add(new CookieGroupStruct(CookieGroupStruct::PERSONALIZATION, $snippetNamespace->get('personalization/title')));
-        $cookieGroupCollection->add(new CookieGroupStruct(CookieGroupStruct::STATISTICS, $snippetNamespace->get('statistics/title')));
-        $cookieGroupCollection->add(new CookieGroupStruct(CookieGroupStruct::OTHERS, $snippetNamespace->get('others/title')));
+        $cookieGroupCollection->add(new CookieGroupStruct(CookieGroupStruct::PERSONALIZATION, $snippetNamespace->get('personalization/title'), $snippetNamespace->get('personalization/description', '')));
+        $cookieGroupCollection->add(new CookieGroupStruct(CookieGroupStruct::STATISTICS, $snippetNamespace->get('statistics/title'), $snippetNamespace->get('statistics/description', '')));
+        $cookieGroupCollection->add(new CookieGroupStruct(CookieGroupStruct::OTHERS, $snippetNamespace->get('others/title'), $snippetNamespace->get('others/description', '')));
     }
 
     private function addDefaultCookies(CookieCollection $cookieCollection): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
It was not possible to add descriptions to the groups "personalization", "statistics" and "others" in the consent-manager

### 2. What does this change do, exactly?
it *only* adds the code to include these snippets if present. Actual snippets are *not* provided.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.