### PR TITLE
fix sExport sql error unknown column EK

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -291,7 +291,7 @@ class sExport implements \Enlight_Hook
             $this->sSettings['categoryID'] = $this->shopData['category_id'];
         }
         if (empty($this->sSettings['customergroupID'])) {
-            $this->sSettings['customergroupID'] = $shop->getCustomerGroup()->getKey();
+            $this->sSettings['customergroupID'] = $shop->getCustomerGroup()->getId();
         } else {
             $this->sSettings['customergroupID'] = (int) $this->sSettings['customergroupID'];
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
without this change, man can not export products if he didn't chose a customer group by the export settings in backend.

### 2. What does this change do, exactly?
I just get the customer group id instead of the customer group key, this will adjust the default value to macht the code behaviour.

### 3. Describe each step to reproduce the issue or behaviour.

simply create a product export und don't chose a customer group in the setting and try to run the export then you will get the following error:

```
`PDOException: SQLSTATE(42S22): Column not found: 1054 Unknown column 'EK' in 'on clause' in /engine/Library/Zend/Db/Statement/Pdo.php:219 Stack trace:
#0 /engine/Library/Zend/Db/Statement/Pdo.php(219): PDOStatement->execute()
#1 /engine/Library/Zend/Db/Statement.php(297): Zend_Db_Statement_Pdo->_execute()
#2 /engine/Library/Zend/Db/Adapter/Abstract.php(472): Zend_Db_Statement->execute()
#3 /engine/Library/Zend/Db/Adapter/Pdo/Abstract.php(232): Zend_Db_Adapter_Abstract->query()
#4 /engine/Library/Enlight/Components/Db/Adapter/Pdo/Mysql.php(83): Zend_Db_Adapter_Pdo_Abstract->query()
#5 /engine/Shopware/Core/sExport.php(1044): Enlight_Components_Db_Adapter_Pdo_Mysql->query()
#6 /engine/Shopware/Plugins/Default/Core/CronProductExport/Bootstrap.php(102): sExport->executeExport()
#7 /engine/Shopware/Plugins/Default/Core/CronProductExport/Bootstrap.php(50): Shopware_Plugins_Core_CronProductExport_Bootstrap->exportProductFiles()
#8 /engine/Library/Enlight/Event/Handler/Plugin.php(145): Shopware_Plugins_Core_CronProductExport_Bootstrap->onRun()
#9 /engine/Library/Enlight/Event/EventManager.php(251): Enlight_Event_Handler_Plugin->execute()
#10 /engine/Library/Enlight/Components/Cron/Manager.php(275): Enlight_Event_EventManager->notifyUntil()
#11 /engine/Shopware/Plugins/Default/Core/Cron/Cron.php(53): Enlight_Components_Cron_Manager->runJob()
#12 /engine/Library/Enlight/Controller/Action.php(192): Shopware_Controllers_Backend_Cron->indexAction()
#13 /engine/Library/Enlight/Controller/Dispatcher/Default.php(478): Enlight_Controller_Action->dispatch()
#14 /engine/Library/Enlight/Controller/Front.php(228): Enlight_Controller_Dispatcher_Default->dispatch()
#15 /engine/Shopware/Kernel.php(188): Enlight_Controller_Front->dispatch()
#16 /vendor/symfony/http-kernel/HttpCache/SubRequestHandler.php(102): Shopware\Kernel->handle()
#17 /vendor/symfony/http-kernel/HttpCache/HttpCache.php(453): Symfony\Component\HttpKernel\HttpCache\SubRequestHandler::handle()
#18 /engine/Shopware/Components/HttpCache/AppCache.php(261): Symfony\Component\HttpKernel\HttpCache\HttpCache->forward()
#19 /vendor/symfony/http-kernel/HttpCache/HttpCache.php(238): Shopware\Components\HttpCache\AppCache->forward()
#20 /engine/Shopware/Components/HttpCache/AppCache.php(102): Symfony\Component\HttpKernel\HttpCache\HttpCache->pass()
#21 /var/www/clients/client1/web1/web/shopware.php(122): Shopware\Components\HttpCache\AppCache->handle()
#22`
```

### 4. Please link to the relevant issues (if any).
there are no issue.

### 5. Which documentation changes (if any) need to be made because of this PR?
nothing

### Note:
this problem related to this [commit](https://github.com/shopware/shopware/commit/47b5304c403c8e3355df16968e119704e70c0ae3) , so I think this problem is there ab version 5.5.5

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.