### PR TITLE
HttpClient: Add Guzzle 6.x compatibility

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/DependencyInjection/services.xml
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/DependencyInjection/services.xml
@@ -95,8 +95,6 @@
             <argument type="service" id="shopware_plugininstaller.plugin_installer_struct_hydrator" />
             <argument type="service" id="snippets" />
             <argument type="service" id="models" />
-            <argument type="service" id="guzzle_http_client_factory" />
-            <argument>%shopware.store.apiEndpoint%</argument>
         </service>
 
         <service id="shopware_plugininstaller.plugin_licence_service" class="Shopware\Bundle\PluginInstallerBundle\Service\PluginLicenceService">

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/AccountManagerService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/AccountManagerService.php
@@ -56,35 +56,16 @@ class AccountManagerService
      */
     private $entityManager;
 
-    /**
-     * @var ClientInterface
-     */
-    private $guzzleHttpClient;
-
-    /**
-     * @var string
-     */
-    private $apiEndPoint;
-
-    /**
-     * @param string $apiEndPoint
-     *
-     * @internal param ClientInterface $guzzleHttpClient
-     */
     public function __construct(
         StoreClient $storeClient,
         StructHydrator $structHydrator,
         \Shopware_Components_Snippet_Manager $snippetManager,
-        ModelManager $entityManager,
-        GuzzleFactory $guzzleFactory,
-        $apiEndPoint
+        ModelManager $entityManager
     ) {
         $this->storeClient = $storeClient;
         $this->hydrator = $structHydrator;
         $this->snippetManager = $snippetManager;
         $this->entityManager = $entityManager;
-        $this->guzzleHttpClient = $guzzleFactory->createClient();
-        $this->apiEndPoint = $apiEndPoint;
     }
 
     /**

--- a/engine/Shopware/Components/HttpCache/CacheWarmer.php
+++ b/engine/Shopware/Components/HttpCache/CacheWarmer.php
@@ -106,9 +106,14 @@ class CacheWarmer
             $guzzleConfig['cookies'] = ['shop' => $shopId];
         }
 
+        $requestMethod = 'createRequest';
+        if (method_exists($this->guzzleClient, 'request')) {
+            $requestMethod = 'request';
+        }
+
         $requests = [];
         foreach ($urls as $url) {
-            $requests[] = $this->guzzleClient->createRequest('GET', $url, $guzzleConfig);
+            $requests[] = $this->guzzleClient->$requestMethod('GET', $url, $guzzleConfig);
         }
 
         $events = $this->eventManager;

--- a/engine/Shopware/Components/HttpClient/GuzzleFactory.php
+++ b/engine/Shopware/Components/HttpClient/GuzzleFactory.php
@@ -34,13 +34,12 @@ class GuzzleFactory
      */
     public function createClient(array $guzzleConfig = [])
     {
-        $client = new Client($guzzleConfig);
-
         $certPath = __DIR__ . '/cacert.pem';
         if (is_file($certPath)) {
-            $client->setDefaultOption('verify', $certPath);
+            $guzzleConfig['verify'] = $certPath;
         }
 
-        return $client;
+
+        return new Client($guzzleConfig);
     }
 }


### PR DESCRIPTION
Also cleanup unused arguments to AccountManagerService.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Practically all packages require Guzzle v6.x as minimum version. Shopware 5 is stuck at v5.3.x

### 2. What does this change do, exactly?
This change add Guzzle v6.x compatibility while preserving compatibility to v5.3.x, thus not putting existing third party plugins' dependencies into danger.

### 3. Describe each step to reproduce the issue or behaviour.
Install any composer package with Guzzle v6.x requirement. Start plugin manager from backend, warm-up cache from backend.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
I guess this could be a silent change as it does not change default behaviour.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [-] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.