### PR TITLE
Remove second non integer exception parameter

### DIFF
--- a/engine/Library/Zend/Mail/Protocol/Abstract.php
+++ b/engine/Library/Zend/Mail/Protocol/Abstract.php
@@ -414,10 +414,11 @@ abstract class Zend_Mail_Protocol_Abstract
         } while (strpos($more, '-') === 0); // The '-' message prefix indicates an information string instead of a response string.
 
         if ($errMsg !== '') {
+            $message = sprintf('errMsg: %s , cmd: %s', $errMsg, $cmd); 
             /**
              * @see Zend_Mail_Protocol_Exception
              */
-            throw new Zend_Mail_Protocol_Exception($errMsg, $cmd);
+            throw new Zend_Mail_Protocol_Exception($message);
         }
 
         return $msg;


### PR DESCRIPTION
### 1. Why is this change necessary?
The second parameter of an exception should be an integer, if this exception is thrown the $cmd variable contains an non numeric string and leads to an php error:
```Wrong parameters for Zend_Mail_Protocol_Exception([string $message [, long $code [, Throwable $previous = NULL]]])```

### 2. What does this change do, exactly?
removed the second code parameter and pass the $cmd variable in the exception message

### 3. Describe each step to reproduce the issue or behaviour.
return code of the mail server did not match the expected codes

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.