### PR TITLE
Update jquery.image-gallery.js

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
@@ -459,6 +459,7 @@
                 img = $('<img>', {
                     'class': 'image--element',
                     'src': $el.attr('data-img-original'),
+                    'alt': $el.attr('data-alt'),
                     'data-extension': $mediaEl.hasClass('image--svg') ? 'svg' : ''
                 });
 


### PR DESCRIPTION
add alt attribute to gallery image element

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

the alt attribute is missing in the gallery img element

### 2. What does this change do, exactly?

add alt attribute in the gallery img element

### 3. Describe each step to reproduce the issue or behaviour.

- go to product detail page
- click on product image
- check in gallery image element in developer console

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.