### PR TITLE
Fix office 365 autodiscover CSRF errors

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,6 +3,9 @@ RewriteEngine on
 
 #RewriteBase /shopware/
 
+# Fix for office 365 autodiscover feature to prevent CSRF errors
+RewriteRule ^autodiscover/autodiscover.xml$ - [F,L]
+
 # HTTPS config for the backend
 #RewriteCond %{HTTPS} !=on
 #RewriteRule backend/(.*) https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]

--- a/.htaccess
+++ b/.htaccess
@@ -4,7 +4,7 @@ RewriteEngine on
 #RewriteBase /shopware/
 
 # Fix for office 365 autodiscover feature to prevent CSRF errors
-RewriteRule ^autodiscover/autodiscover.xml$ - [F,L]
+RewriteRule ^autodiscover/autodiscover.xml$ - [F,L,NC]
 
 # HTTPS config for the backend
 #RewriteCond %{HTTPS} !=on


### PR DESCRIPTION
This is a recurring issue users stumble upon.
For example look here:
https://forum.shopware.com/discussion/39104/geloest-fehlermeldungen-des-shops-bzgl-outlook-und-autodiscover-nach-update-auf-5-2-wg-x-csrf


### 1. Why is this change necessary?
Outlook queries the following places in the following order. The behavior is hard-coded and therefore cannot be changed. If the requested information is obtained from one of the sources, the remaining sources are no longer queried.

Service Connection Point (SCP) from the AD
Query URL https://domain/autodiscover/autodiscover.xml
Query URL https://autodiscover.domäne/autodiscover/autodiscover.xml
Query URL http://autodiscover.domäne/autodiscover/autodiscover.xml
SRV Record _autodiscover._tcp.domain
Local autodiscover.xml

### 2. What does this change do, exactly?
Prevents "Query URL https://domain/autodiscover/autodiscover.xml" to hit shopware and trigger the error.

### 3. Describe each step to reproduce the issue or behaviour.
Some of our customers host their emails at Office365. In the process, we set the DNS entries as requested by Office365. This includes a CNAME adaptation of autodiscover @ to autodiscover.outlook.com.

However, Office first checks the main domain and not the autodiscover subdomain. Thus, autodiscover.xml POST queries come to our web server.

### 4. Please link to the relevant issues (if any).
https://forum.shopware.com/discussion/39104/geloest-fehlermeldungen-des-shops-bzgl-outlook-und-autodiscover-nach-update-auf-5-2-wg-x-csrf/p1

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [-] I have written tests and verified that they fail without my change
- [+] I have squashed any insignificant commits
- [+] This change has comments for package types, values, functions, and non-obvious lines of code
- [+] I have read the contribution requirements and fulfil them.