### PR TITLE
Update jquery.image-slider.js

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-slider.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-slider.js
@@ -635,8 +635,8 @@
             }
 
             if (opts.arrowControls) {
-                me._on(me._$arrowLeft, 'click touchstart', $.proxy(me.onLeftArrowClick, me));
-                me._on(me._$arrowRight, 'click touchstart', $.proxy(me.onRightArrowClick, me));
+                me._on(me._$arrowLeft, 'click touchend', $.proxy(me.onLeftArrowClick, me));
+                me._on(me._$arrowRight, 'click touchend', $.proxy(me.onRightArrowClick, me));
             }
 
             if (opts.thumbnails) {


### PR DESCRIPTION
Prevent mobile browsers from throwing errors like `Unable to preventDefault inside passive event listener invocation.` and calling the event twice.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Prevent mobile browsers from throwing errors like `Unable to preventDefault inside passive event listener invocation.` and calling the event twice.

### 2. What does this change do, exactly?
It changes the eventlistener from touchstart to touchend.

### 3. Describe each step to reproduce the issue or behaviour.
On some devices and projects it's calling the image slider twice when clicking the arrow on mobile devices. To prevent this behaviour it's necessary to call `touchend` and not `touchstart` 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.