### PR TITLE
Add parentheses to purchasesteps-condition

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -2958,7 +2958,7 @@ SQL;
                 $additionalInfo['purchasesteps'] = 1;
             }
 
-            if (($quantity / $additionalInfo['purchasesteps']) != (int) $quantity / $additionalInfo['purchasesteps']) {
+            if (($quantity / $additionalInfo['purchasesteps']) != (int) ($quantity / $additionalInfo['purchasesteps'])) {
                 $quantity = (int) ($quantity / $additionalInfo['purchasesteps']) * $additionalInfo['purchasesteps'];
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the integer cast only targets the `$quantity` variable instead of the result of the calculation `$quantity / $additionalInfo['purchasesteps']`. This is clearly not the intention of this code as quantities are always integer.

### 2. What does this change do, exactly?
The integer cast not targets the calculations result. This makes the thing work.

### 3. Describe each step to reproduce the issue or behaviour.
Look at the code. It wouldn't make sense this way.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.