### PR TITLE
Set phone to model when creating fromAddress()

### DIFF
--- a/engine/Shopware/Models/Order/Shipping.php
+++ b/engine/Shopware/Models/Order/Shipping.php
@@ -641,6 +641,7 @@ class Shipping extends ModelEntity
         $this->setAdditionalAddressLine1((string) $address->getAdditionalAddressLine1());
         $this->setAdditionalAddressLine2((string) $address->getAdditionalAddressLine2());
         $this->setCountry($address->getCountry());
+        $this->setPhone($address->getPhone());
         $this->setTitle($address->getTitle());
         if ($address->getState()) {
             $this->setState($address->getState());


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Using the plugin "Shopware Backend Order", the billing address phone number will not get copied to shipping address.

### 2. What does this change do, exactly?
Set phone number from a given address object into the shipping model

### 3. Describe each step to reproduce the issue or behaviour.
- Install Backend Order Plugin
- Place backend order and tick "use billing address" for the shipping address. Ensure, that the customer has a phone number within his billing address.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [model has no tests] I have written tests and verified that they fail without my change
- [yes] I have squashed any insignificant commits
- [?] This change has comments for package types, values, functions, and non-obvious lines of code
- [yes] I have read the contribution requirements and fulfil them.