### PR TITLE
Added support to display unit and unit name in article list component

### DIFF
--- a/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
+++ b/engine/Shopware/Components/MultiEdit/Resource/Product/DqlHelper.php
@@ -124,6 +124,7 @@ class DqlHelper
         'Supplier_link',
         'Attribute_articleId',
         'Attribute_articleDetailId',
+        'Unit_id',
     ];
 
     /**
@@ -341,6 +342,9 @@ class DqlHelper
             LEFT JOIN `s_core_tax`
             ON s_core_tax.id = s_articles.taxID
 
+            LEFT JOIN `s_core_units`
+            ON s_core_units.id = s_articles_details.unitID
+
             WHERE s_articles_details.id IN (:ids)
         ";
 
@@ -435,7 +439,7 @@ class DqlHelper
                 $result[$key] = [
                     'entity' => $entityShort,
                     'field' => $name,
-                    'editable' => substr($name, -2) !== 'Id' && $name !== 'id' && substr($name, -2) !== 'ID' && $entity !== Tax::class && $entity !== Supplier::class,
+                    'editable' => substr($name, -2) !== 'Id' && $name !== 'id' && substr($name, -2) !== 'ID' && $entity !== Tax::class && $entity !== Unit::class && $entity !== Supplier::class,
                     'type' => $config['type'],
                     'precision' => $config['precision'],
                     'nullable' => (bool) $config['nullable'],
@@ -700,7 +704,7 @@ class DqlHelper
                 // Non-numeric tokens will become their quotes removed:
                 if (!is_numeric($token['token'])) {
                     $params[] = substr($token['token'], 1, -1);
-                // Numeric tokens can simple be appended to the params array
+                    // Numeric tokens can simple be appended to the params array
                 } else {
                     $params[] = $token['token'];
                 }
@@ -1068,6 +1072,7 @@ class DqlHelper
             'Detail',
             'Supplier',
             'Attribute',
+            'Unit'
         ];
 
         // By default show the main entities

--- a/themes/Backend/ExtJs/backend/article_list/view/main/grid.js
+++ b/themes/Backend/ExtJs/backend/article_list/view/main/grid.js
@@ -117,7 +117,9 @@ Ext.define('Shopware.apps.ArticleList.view.main.Grid', {
         'Price_price': '{s name=columns/product/Price_price}Price_price{/s}',
         'Price_netPrice': '{s name=columns/product/Price_netPrice}Price_netPrice{/s}',
         'Supplier_name': '{s name=columns/product/Supplier_name}Supplier{/s}',
-        'Tax_name': '{s name=columns/product/Tax_name}Tax{/s}'
+        'Tax_name': '{s name=columns/product/Tax_name}Tax{/s}',
+        'Unit_name': '{s name=columns/product/Unit_name}Unit Name{/s}',
+        'Unit_unit': '{s name=columns/product/Unit_unit}Unit{/s}'
     },
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
customers want to see units in the product list

### 2. What does this change do, exactly?
display unit and unit name of each product

### 3. Describe each step to reproduce the issue or behaviour.
if you want to select the units in the article list there are any.

### 4. Please link to the relevant issues (if any).
- 

### 5. Which documentation changes (if any) need to be made because of this PR?
- 

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.