### PR TITLE
Change exit code of sw:plugin:activate to 0 when plugin is already installed

### DIFF
--- a/engine/Shopware/Commands/PluginActivateCommand.php
+++ b/engine/Shopware/Commands/PluginActivateCommand.php
@@ -107,7 +107,7 @@ EOF
         if ($plugin->getActive()) {
             $output->writeln(sprintf('The plugin %s is already activated.', $pluginName));
 
-            return 1;
+            return 0;
         }
 
         if (!$plugin->getInstalled()) {


### PR DESCRIPTION
### 1. Why is this change necessary?
When I run `sw:plugin:activate` the expected result is that the plugin is active afterwards. If it was active already before I ran this command, it is still my expected result. This is not an error, so the exit code should be 0.

### 2. What does this change do, exactly?
Change exit code of sw:plugin:activate to 0 when plugin is already installed.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have an active plugin.
2. Run `sw:plugin:activate` on that plugin.
3. Get exit code 1.

### 4. Please insert the relevant meme (if any).
![meme](https://user-images.githubusercontent.com/11394739/91670002-c4ff5900-eb19-11ea-90f8-9edc68525858.png)

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.