### PR TITLE
Update product.tpl - add block inside of form-tag

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/items/product.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/items/product.tpl
@@ -176,6 +176,8 @@
                         title="{$snippetCartItemLinkDelete|escape}">
                     <i class="icon--cross"></i>
                 </button>
+                {block name='frontend_checkout_cart_item_delete_article_form_inner'}        
+                {/block}
             </form>
         </div>
     {/block}

--- a/themes/Frontend/Bare/frontend/checkout/items/product.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/items/product.tpl
@@ -171,12 +171,12 @@
         <div class="panel--td column--actions">
             <form action="{url action='deleteArticle' sDelete=$sBasketItem.id sTargetAction=$sTargetAction}"
                   method="post">
-                {s name="CartItemLinkDelete" assign="snippetCartItemLinkDelete"}{/s}
-                <button type="submit" class="btn is--small column--actions-link"
-                        title="{$snippetCartItemLinkDelete|escape}">
-                    <i class="icon--cross"></i>
-                </button>
-                {block name='frontend_checkout_cart_item_delete_article_form_inner'}        
+                {block name='frontend_checkout_cart_item_delete_article_form_submit'}   
+                    {s name="CartItemLinkDelete" assign="snippetCartItemLinkDelete"}{/s}
+                    <button type="submit" class="btn is--small column--actions-link"
+                            title="{$snippetCartItemLinkDelete|escape}">
+                        <i class="icon--cross"></i>
+                    </button>
                 {/block}
             </form>
         </div>


### PR DESCRIPTION
As a plugin manufacturer, I want to be able to add additional inputs within the form. Right now, this can only be done by replacing the block "frontend_checkout_cart_item_delete_article" completely, which may lead to incompatibilities with other plugins. A new block would be of much help.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

As a plugin manufacturer, I want to be able to add additional inputs within the form. Right now, this can only be done by replacing the block "frontend_checkout_cart_item_delete_article" completely, which may lead to incompatibilities with other plugins. A new block would be of much help.

### 2. What does this change do, exactly?

Adds a new block inside the form tag.

### 3. Describe each step to reproduce the issue or behaviour.

n/a

### 4. Please link to the relevant issues (if any).

n/a

### 5. Which documentation changes (if any) need to be made because of this PR?

n/a

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.