### PR TITLE
Update Entity Insertions

### DIFF
--- a/engine/Shopware/Bundle/EsBackendBundle/Subscriber/OrmBacklogSubscriber.php
+++ b/engine/Shopware/Bundle/EsBackendBundle/Subscriber/OrmBacklogSubscriber.php
@@ -133,10 +133,9 @@ class OrmBacklogSubscriber implements EventSubscriber
         // Entity Insertions
         foreach ($uow->getScheduledEntityInsertions() as $entity) {
             $backlog = $this->getBacklog($entity);
-            if (!$backlog) {
-                continue;
+            if ($backlog && $backlog->toArray()['entity_id']){
+                $queue[$this->getBacklogKey($backlog)] = $backlog;
             }
-            $queue[$this->getBacklogKey($backlog)] = $backlog;
         }
 
         // Entity updates


### PR DESCRIPTION
this resolves this error:
An exception occurred while executing 'INSERT INTO s_es_backend_backlog (entity, entity_id, time) VALUES (?, ?, ?)' with params ("Shopware\\Models\\Customer\\Customer", null, "2020-09-04 13:11:38"):

SQLSTATE(23000): Integrity constraint violation: 1048 Column 'entity_id' cannot be null

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.