### PR TITLE
Fix shopId in PluginConfigSetCommand

### DIFF
--- a/engine/Shopware/Commands/PluginConfigSetCommand.php
+++ b/engine/Shopware/Commands/PluginConfigSetCommand.php
@@ -188,7 +188,7 @@ class PluginConfigSetCommand extends ShopwareCommand implements CompletionAwareI
 
         if ($shopId) {
             /** @var Shop|null $shop */
-            $shop = $em->getRepository(Shop::class)->find($input->getOption('shop'));
+            $shop = $em->getRepository(Shop::class)->find($shopId);
 
             if (!$shop) {
                 $output->writeln(sprintf('Could not find shop with id %s.', $shopId));


### PR DESCRIPTION
Why is this change necessary?

When the console command
sw:plugin:config:set --shopId=ID
is executed, an error occurs: "The identifier id is missing for a query of Shopware\Models\Shop\Shop"