### PR TITLE
remove event Shopware_Controllers_Widgets_Emotion_AddElement from removed list

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -830,7 +830,6 @@ return [
 * Removed following unnecessary Subscriber:
     * `Shopware\Bundle\EsBackendBundle\Subscriber\ServiceSubscriber`
     * `Shopware\Bundle\ESIndexingBundle\Subscriber\ServiceSubscriber`
-* Removed event `Shopware_Controllers_Widgets_Emotion_AddElement`
 * Removed Ioncube checks from PluginManager
 * Removed `SwagLicense` dependency in plugin licenses
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The event was deprecated in 5.3.0 and still exists in /engine/Shopware/Bundle/EmotionBundle/ComponentHandler/EventComponentHandler.php

### 2. What does this change do, exactly?
Removes the hint that the event was removed

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.