### PR TITLE
Add attributes to user api list action

### DIFF
--- a/engine/Shopware/Components/Api/Resource/User.php
+++ b/engine/Shopware/Components/Api/Resource/User.php
@@ -114,6 +114,9 @@ class User extends Resource
         $builder = $this->getRepository()->createQueryBuilder('user')
             ->join('user.role', 'role');
 
+        $builder->addSelect(['attribute'])
+            ->leftJoin('user.attribute', 'attribute');
+
         $builder->addFilter($criteria)
             ->addOrderBy($orderBy)
             ->setFirstResult($offset)


### PR DESCRIPTION
# 1. Why is this change necessary?
Like other API resources the user API list action should display the attributes of the users.

### 2. What does this change do, exactly?
It adds a left join to the users attributes table.

### 3. Describe each step to reproduce the issue or behaviour.
1. Open `/api/users`.
2. Look for an `attribute` field at the entries.
3. Cry because its missing 😢 

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.