### PR TITLE
fix cookie removal for www domains

### DIFF
--- a/engine/Shopware/Bundle/CookieBundle/Services/CookieRemoveHandler.php
+++ b/engine/Shopware/Bundle/CookieBundle/Services/CookieRemoveHandler.php
@@ -91,13 +91,14 @@ class CookieRemoveHandler extends CookieHandler implements CookieRemoveHandlerIn
 
         foreach ($requestCookies as $cookieKey => $cookieName) {
             if (!$validationFunction($cookieKey)) {
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookieBasePath));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookiePath));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $currentPath));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $currentPathWithoutSlash));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $request->getBaseUrl()));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookieBasePath . $request->getBaseUrl()));
+                $host = preg_replace('/^www./', '', $request->getHost());
+                $response->headers->setCookie(new Cookie($cookieKey, null, 0, '/', $host));
+                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookieBasePath, $host));
+                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookiePath, $host));
+                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $currentPath, $host));
+                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $currentPathWithoutSlash, $host));
+                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $request->getBaseUrl(), $host));
+                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookieBasePath . $request->getBaseUrl(), $host));
             }
         }
     }

--- a/engine/Shopware/Bundle/CookieBundle/Services/CookieRemoveHandler.php
+++ b/engine/Shopware/Bundle/CookieBundle/Services/CookieRemoveHandler.php
@@ -92,13 +92,15 @@ class CookieRemoveHandler extends CookieHandler implements CookieRemoveHandlerIn
         foreach ($requestCookies as $cookieKey => $cookieName) {
             if (!$validationFunction($cookieKey)) {
                 $host = preg_replace('/^www./', '', $request->getHost());
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, '/', $host));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookieBasePath, $host));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookiePath, $host));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $currentPath, $host));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $currentPathWithoutSlash, $host));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $request->getBaseUrl(), $host));
-                $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookieBasePath . $request->getBaseUrl(), $host));
+                foreach([$host, null] as $cookieHost) {
+                    $response->headers->setCookie(new Cookie($cookieKey, null, 0, '/', $cookieHost));
+                    $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookieBasePath, $cookieHost));
+                    $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookiePath, $cookieHost));
+                    $response->headers->setCookie(new Cookie($cookieKey, null, 0, $currentPath, $cookieHost));
+                    $response->headers->setCookie(new Cookie($cookieKey, null, 0, $currentPathWithoutSlash, $cookieHost));
+                    $response->headers->setCookie(new Cookie($cookieKey, null, 0, $request->getBaseUrl(), $cookieHost));
+                    $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookieBasePath . $request->getBaseUrl(), $cookieHost));
+                }
             }
         }
     }

--- a/engine/Shopware/Bundle/CookieBundle/Services/CookieRemoveHandler.php
+++ b/engine/Shopware/Bundle/CookieBundle/Services/CookieRemoveHandler.php
@@ -92,7 +92,7 @@ class CookieRemoveHandler extends CookieHandler implements CookieRemoveHandlerIn
         foreach ($requestCookies as $cookieKey => $cookieName) {
             if (!$validationFunction($cookieKey)) {
                 $host = preg_replace('/^www./', '', $request->getHost());
-                foreach([$host, null] as $cookieHost) {
+                foreach ([$host, null] as $cookieHost) {
                     $response->headers->setCookie(new Cookie($cookieKey, null, 0, '/', $cookieHost));
                     $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookieBasePath, $cookieHost));
                     $response->headers->setCookie(new Cookie($cookieKey, null, 0, $cookiePath, $cookieHost));


### PR DESCRIPTION
## 1. Why is this change necessary?
Cookies that are set on .domain.tld currently do not get removed by the cookie removal service, if the shop runs on www.domain.tld
Since major cookies by tracking services (e.g. Google Analytics, Hotjar, ...) use cookies on .domain.tld the user's cookie preferences are bypassed. **This is currently causing serious privacy issues!**

### 2. What does this change do, exactly?
It adds a www-stripped domain to the overwriting cookie, thereby making sure that both www and non-www domains are addressed. (https://stackoverflow.com/questions/1062963/how-do-browser-cookie-domains-work)


### 3. Describe each step to reproduce the issue or behaviour.

1. The shop has to run on a www domain and the Shopware cookie settings shall be set to either not allow any cookies before giving consent or only allow technically required cookies
2. Manually set a cookie on .yourdomain.tld
3. Open any shop page without accepting cookies
4. Notice that the cookie does not get removed

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.