### PR TITLE
Added filter event to allow file name change

### DIFF
--- a/UPGRADE-5.7.md
+++ b/UPGRADE-5.7.md
@@ -36,6 +36,7 @@ This changelog references changes done in Shopware 5.7 patch versions.
 * Added support for MySQL 8 `sql_require_primary_key`
 * Added `attribute` to users listing in API
 * Added new blocks `document_index_head_logo` and `document_index_head_wrapper` to `themes/Frontend/Bare/documents/index.tpl`
+* Added filter event `Shopware_Controllers_Order_OpenPdf_FilterName` to `Shopware_Controllers_Backend_Order::openPdfAction()`
 
 ### Changes
 

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1208,12 +1208,17 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
 
         $orderModel = Shopware()->Models()->getRepository(Document::class)->findBy(['hash' => $this->Request()->getParam('id')]);
         $orderModel = Shopware()->Models()->toArray($orderModel);
-        $orderId = $orderModel[0]['documentId'];
+
+        $fileName = $this->container->get('events')->filter(
+            'Shopware_Controllers_Order_OpenPdf_FilterName',
+            $orderModel[0]['documentId'],
+            ['data' => $orderModel[0]]
+        );
 
         $response = $this->Response();
         $response->headers->set('cache-control', 'public', true);
         $response->headers->set('content-description', 'File Transfer');
-        $response->headers->set('content-disposition', 'attachment; filename=' . $orderId . '.pdf');
+        $response->headers->set('content-disposition', 'attachment; filename=' . $fileName . '.pdf');
         $response->headers->set('content-type', 'application/pdf');
         $response->headers->set('content-transfer-encoding', 'binary');
         $response->headers->set('content-length', $filesystem->getSize($file));


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
It is currently not possible to customize PDF document download file names.
Shopware users with heavy use of those documents are having problems to organize locally downloaded files.
They have to rename files manually to add information like company, customer name or date.
By adding a filter event, it is possible to create an automatic solution with a plugin.

### 2. What does this change do, exactly?
Instead of just applying the document ID as file name, this value is now emitted in a filter event. Therefore it is possible to return a custom file name when subscribing to this event. Additional information to be used in the custom file name can be taken form the document model, which is available as 'data' argument inside the event.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.