### PR TITLE
Wrap mail template preview in iframe

### DIFF
--- a/themes/Backend/ExtJs/backend/mail/controller/main.js
+++ b/themes/Backend/ExtJs/backend/mail/controller/main.js
@@ -383,11 +383,21 @@ Ext.define('Shopware.apps.Mail.controller.Main', {
                 var status = Ext.decode(response.responseText);
                 if (status.success) {
 
-                    if (isHtml) {
-                        htmlString =  "<div style=\"margin: 15px\">" + status.message + "</div>"
-                    } else {
-                        htmlString =  "<div style=\"margin: 15px\"><pre>" + status.message + "</pre></div>"
+                    if (!isHtml) {
+                        status.message = "<pre>" + status.message + "</pre>";
                     }
+
+                    status.message = status.message.replace(/[&<>"']/g, function (char) {
+                        return {
+                            '&': '&amp;',
+                            '<': '&lt;',
+                            '>': '&gt;',
+                            '"': '&quot;',
+                            "'": '&#039;'
+                        }[char];
+                    });
+
+                    htmlString = "<iframe srcdoc=\"" + status.message + "\" sandbox></iframe>";
 
                     Ext.create('Enlight.app.Window', {
                         title : '{s name="title"}Email templates{/s}',
@@ -396,7 +406,11 @@ Ext.define('Shopware.apps.Mail.controller.Main', {
                         subApp: me.subApplication,
                         items: [{
                             xtype: 'container',
-                            html: htmlString
+                            html: htmlString,
+                            style: {
+                                height: '100%',
+                                background: '#fff'
+                            }
                         }]
                     }).show();
                 } else {


### PR DESCRIPTION
### 1. Why is this change necessary?

This helps separating the styles of the mail from the styles of the backend. Without it, the styles from the backend would also take effect in the mail preview.

### 2. What does this change do, exactly?

Instead of including the rendered mail body in the dom directly, this generates an iframe with a `srcdoc` attribute that holds the mail body.

### 3. Describe each step to reproduce the issue or behavior.

1. Open a mail template.
2. Click the preview button.

### 4. Please link to the relevant issues (if any).

- [Html code as IFRAME source rather than a URL - Stack Overflow](https://stackoverflow.com/questions/6102636/html-code-as-iframe-source-rather-than-a-url/6102829#6102829)
- [html - HtmlSpecialChars equivalent in Javascript? - Stack Overflow](https://stackoverflow.com/questions/1787322/htmlspecialchars-equivalent-in-javascript/4835406#4835406)

### 5. Which documentation changes (if any) need to be made because of this PR?

None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.