### PR TITLE
Remove useless deprecation hint in Bootstrap.php

### DIFF
--- a/engine/Shopware/Bootstrap.php
+++ b/engine/Shopware/Bootstrap.php
@@ -24,9 +24,6 @@
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * @deprecated since 5.2 will be removed in 6.0
- */
 class Shopware_Bootstrap
 {
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
The deprecation hint has no benefit because Shopware 6.0 is a new product and there will be no upgrade from 5.x to 6.0.

### 2. What does this change do, exactly?
Removes the PHP hint inside Bootstrap.php to remove the deprecation highlight in IDEs:
<img width="195" alt="Bildschirmfoto 2020-10-21 um 11 29 12" src="https://user-images.githubusercontent.com/754074/96702020-95d6cc80-1391-11eb-9b88-33bdc63a9013.png">


### 3. Describe each step to reproduce the issue or behaviour.
1. Work with your favorite IDE and stumble over a marked file inside the folder list.
2. Get triggered and open the file.
3. Notice that this is an irrelevant deprecation hint.
4. (╯°□°)╯︵ ┻━┻ (or maybe a less destructive reaction).
5. Forget this incident.
6. Repeat...

### 4. Please link to the relevant issues (if any).
No issue.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.