### PR TITLE
Always show cookie banner if preference hash was changed

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-permission.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-permission.js
@@ -239,6 +239,9 @@
                 if ($.getCookie('cookiePreferences') && !this.hasPreferencesHashChanged()) {
                     callback(false);
                     return;
+                } else {
+                    callback(true);
+                    return;
                 }
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The cookie permissions are not shown, event if there was a new cookie added to the cookie manager. 

### 2. What does this change do, exactly?
Always show the cookie permissions if the preferences hash has changed. Not sure if this is a good approach since this is also triggered if a cookie has been removed.

### 3. Describe each step to reproduce the issue or behaviour.
Accept all cookies, and add a new cookie in the `CookieCollector_Collect_Cookies` afterwards the cookie permissions are not shown again, and the new cookie is never be accepted.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.