### PR TITLE
Fix for wrong listing of shop name in the shipping

### DIFF
--- a/themes/Backend/ExtJs/backend/shipping/view/main/list.js
+++ b/themes/Backend/ExtJs/backend/shipping/view/main/list.js
@@ -244,7 +244,7 @@ Ext.define('Shopware.apps.Shipping.view.main.List', {
      */
     multishopIdColumn : function(value, obj, record) {
         var me = this,
-            shop = me.shopStore.findRecord('id', record.get('multiShopId'));
+            shop = me.shopStore.findRecord('id', record.get('multiShopId'),0,false,false,true);
 
         // if we have an empty or a zero value show default empty text
         if (null === record.get('multiShopId') || 0 === record.get('multiShopId')) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently shipping table lists wrong shop name, if there is another shop with id that has same starting pattern.
eg 1,11,  2,25, etc 

### 2. What does this change do, exactly?
This fix adds whole string matching restriction. So 1 will match only 1 and 10 will match only 10.

### 3. Describe each step to reproduce the issue or behaviour.
Add shops with same pattern id's like 1,11,12,123 etc assign shipping method to each shop.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.