### PR TITLE
Fixed Newsletter Double-opt-in bug when comparing lowercase "nocaptcha" with camelcase "noCaptcha"

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Newsletter.php
+++ b/engine/Shopware/Controllers/Frontend/Newsletter.php
@@ -63,7 +63,7 @@ class Shopware_Controllers_Frontend_Newsletter extends Enlight_Controller_Action
         $config = $this->container->get(\Shopware_Components_Config::class);
         $noCaptchaAfterLogin = $config->get('noCaptchaAfterLogin');
         // redirect user if captcha is active and request is sent from the footer
-        if ($config->get('newsletterCaptcha') !== 'noCaptcha'
+        if (strtolower($config->get('newsletterCaptcha')) !== 'nocaptcha'
             && $this->Request()->getPost('redirect') !== null
             && !($noCaptchaAfterLogin && Shopware()->Modules()->Admin()->sCheckUser())) {
             return;


### PR DESCRIPTION
Bug: $config->get('newsletterCaptcha') returns 'nocaptcha' and never matches 'noCaptcha'.
Solution: Make comparism case insensitive. 

### 1. Why is this change necessary?
indexAction in Shopware_Controllers_Frontend_Newsletter never reaches the Double-Optin procedure because
lowercase 'nocaptcha'  doesn't match camelcase 'noCaptcha' and just returns.

### 2. What does this change do, exactly?
Makes old comparism  `$config->get('newsletterCaptcha') !== "noCaptcha"` case insensitive.

### 3. Describe each step to reproduce the issue or behaviour.
Bug happened with a client. It might happen to more people without knowing why and it won't be a problem to make this comparison case insensitive.
