### PR TITLE
NTR - fix price display in net mode

### DIFF
--- a/themes/Frontend/Bare/frontend/checkout/confirm_item_product.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/confirm_item_product.tpl
@@ -13,7 +13,13 @@
             </div>
         {/block}
 
-        {if $sUserData.additional.charge_vat}{$sBasketItem.tax|currency}{else}&nbsp;{/if}
+        {if $sUserData.additional.charge_vat && !$sUserData.additional.show_net}
+            {$sBasketItem.price|currency}
+        {elseif $sUserData.additional.charge_vat}
+            {$sBasketItem.tax|currency}
+        {else}
+            &nbsp;
+        {/if}
     </div>
 {/block}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If you have a customer group with display net prices in the storefront the checkout confirm page will look like the following: 
![image](https://user-images.githubusercontent.com/4624237/98805045-4f681100-2417-11eb-9401-55b99d4ed3eb.png)
the amount of 6,40 € is the vat value not the net price of the article. With the change this display issue is fixed: 
![image](https://user-images.githubusercontent.com/4624237/98805638-2eec8680-2418-11eb-9ea6-c71105da069c.png)



### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.