### PR TITLE
append DIRECTORY_SEPARATOR to the registerNamespace path, in the HttpCache plugin

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -180,7 +180,7 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
     public function afterInit()
     {
-        $this->get('loader')->registerNamespace('ShopwarePlugins\\HttpCache', __DIR__);
+        $this->get('loader')->registerNamespace('ShopwarePlugins\\HttpCache', __DIR__ . DIRECTORY_SEPARATOR);
         parent::afterInit();
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If the 'ShopwarePlugins\HttpCache\CacheControl' is used the followeing error occured:
**PHP Fatal error:  Class 'ShopwarePlugins\\HttpCache\\CacheControl' not found** 
The reason is a missing DIRECTORY_SEPARATOR on the end of the registerNamespace path, given in the HttpCache plugin.

### 2. What does this change do, exactly?
add a DIRECTORY_SEPARATOR on the end of path parameter, given to the enlight loader registerNamespace method, in the HttpCache plugin.

### 3. Describe each step to reproduce the issue or behaviour.
The CacheControl class seams to be used only if ESI-Tags are used/supported.
If the shopware is hosted behind a reverse proxy, this error may occure

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
nothing

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.