### PR TITLE
Updated grunt-contrib-uglify to version 5 so you can compile JS with …

### DIFF
--- a/themes/package-lock.json
+++ b/themes/package-lock.json
@@ -371,12 +371,6 @@
                 "delayed-stream": "~1.0.0"
             }
         },
-        "commander": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-            "dev": true
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -530,9 +524,9 @@
             }
         },
         "duplexer": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
         },
         "eachr": {
@@ -1346,9 +1340,9 @@
             }
         },
         "grunt-contrib-uglify": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-4.0.1.tgz",
-            "integrity": "sha512-dwf8/+4uW1+7pH72WButOEnzErPGmtUvc8p08B0eQS/6ON0WdeQu0+WFeafaPTbbY1GqtS25lsHWaDeiTQNWPg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-5.0.0.tgz",
+            "integrity": "sha512-rIFFPJMWKnh6oxDe2b810Ysg5SKoiI0u/FvuvAVpvJ7VHILkKtGqA4jgJ1JWruWQ+1m5FtB1lVSK81YyzIgDUw==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.1",
@@ -1868,9 +1862,9 @@
             },
             "dependencies": {
                 "lodash": {
-                    "version": "4.17.20",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
                     "dev": true
                 }
             }
@@ -3067,22 +3061,10 @@
             }
         },
         "uglify-js": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-            "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
-            "dev": true,
-            "requires": {
-                "commander": "~2.20.0",
-                "source-map": "~0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.0.tgz",
+            "integrity": "sha512-8lBMSkFZuAK7gGF8LswsXmir8eX8d2AAMOnxSDWjKBx/fBR6MypQjs78m6ML9zQVp1/hD4TBdfeMZMC7nW1TAA==",
+            "dev": true
         },
         "underscore.string": {
             "version": "3.3.5",

--- a/themes/package.json
+++ b/themes/package.json
@@ -19,7 +19,7 @@
         "grunt-chokidar": "^1.0.2",
         "grunt-contrib-eslint": "0.0.5",
         "grunt-contrib-less": "2.0.0",
-        "grunt-contrib-uglify": "4.0.1",
+        "grunt-contrib-uglify": "5.0.0",
         "grunt-file-exists": "0.1.4",
         "grunt-subgrunt": "1.3.0",
         "gruntify-eslint": "5.0.0",


### PR DESCRIPTION
Currently if you have a let statement in any JS file, it will fail when you compile JS with Grunt. Updating to version 5 for the grunt-contrb-uglify npm package fixes this.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

To fix a bug with compiling JS with Grunt.

### 2. What does this change do, exactly?

Allows you to add let statements in a JS file and compile with grunt.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a let statement in any JS file that is in a theme or active plugin
2. Setup grunt as per docs
3. Run grunt and the uglify process for compiling JS should work

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.