### PR TITLE
changed sw:es:index:populate to accept multiple shop ids

### DIFF
--- a/UPGRADE-5.7.md
+++ b/UPGRADE-5.7.md
@@ -82,6 +82,7 @@ This changelog references changes done in Shopware 5.7 patch versions.
 * Changed `\Shopware_Controllers_Backend_ProductStream::loadPreviewAction` to return formatted prices
 * Changed `sw:plugin:activate` exit code from 1 to 0, when it's already installed.
 * Changed `\Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\CategoryGateway::get` it accepts now only integers as id
+* Changed `sw:es:index:populate` to accept multiple shop ids with `--shopId={1,2}`
 
 ### Removals
 

--- a/engine/Shopware/Bundle/ESIndexingBundle/Commands/IndexPopulateCommand.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Commands/IndexPopulateCommand.php
@@ -80,7 +80,7 @@ class IndexPopulateCommand extends ShopwareCommand implements CompletionAwareInt
         $this
             ->setName('sw:es:index:populate')
             ->setDescription('Reindex all shops into a new index and switch the live-system alias after the index process.')
-            ->addOption('shopId', null, InputOption::VALUE_OPTIONAL, 'The shop to populate')
+            ->addOption('shopId', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The shop to populate (multiple Ids -> shopId={1,2})')
             ->addOption('index', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'The index to populate')
             ->addOption('no-evaluation', null, InputOption::VALUE_NONE, 'Disable evaluation for each index')
             ->addOption('stop-on-error', null, InputOption::VALUE_NONE, 'Abort indexing if an error occurs')
@@ -93,7 +93,11 @@ class IndexPopulateCommand extends ShopwareCommand implements CompletionAwareInt
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($shopId = $input->getOption('shopId')) {
-            $shops = [$this->container->get(\Shopware\Bundle\StoreFrontBundle\Gateway\ShopGatewayInterface::class)->get($shopId)];
+            $shops = [];
+
+            foreach ($input->getOption('shopId') as $shopId) {
+                $shops[] = $this->container->get(\Shopware\Bundle\StoreFrontBundle\Gateway\ShopGatewayInterface::class)->get($shopId);
+            }
         } else {
             $shops = $this->container->get(\Shopware\Bundle\ESIndexingBundle\IdentifierSelector::class)->getShops();
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
When someone doesn't want some shops to be indexed and want them to reindex in the specific order (not parallel) he doesn't have any easy option right now.

### 2. What does this change do, exactly?
The change allows someone to specify the shops that should be reindex via the `sw:es:index:populate` command.

### 3. Describe each step to reproduce the issue or behaviour.
* `bin/console sw:es:index:populate --shopId={1,2}` (just rebuilds the index for shops with the id 1 and 2)

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.