### PR TITLE
fixed x-content-type-options policy with "nosniff" refreshstatics

### DIFF
--- a/engine/Shopware/Controllers/Widgets/Index.php
+++ b/engine/Shopware/Controllers/Widgets/Index.php
@@ -47,6 +47,9 @@ class Shopware_Controllers_Widgets_Index extends Enlight_Controller_Action
         /** @var Shopware_Plugins_Frontend_Statistics_Bootstrap $plugin */
         $plugin = Shopware()->Plugins()->Frontend()->Statistics();
         $plugin->updateLog($request, $response);
+        
+        /** Setting mime type for jsonp request */
+        $this->Response()->setHeader('Content-type', 'application/javascript', true);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
on every site in the frontend comes the mime type error text/html for refreshstatics url ->
<script async="" id="refresh-statistic" src="//www.mystore.de/widgets/index/refreshStatistic?requestPage=/store/&amp;requestController=listing&sCategoryId=410"></script>

### 2. What does this change do, exactly?
fixed the error for chrome and edge

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.