### PR TITLE
Fix the inconsistent format processing of "orderCount" for subshop entries

### DIFF
--- a/engine/Shopware/Controllers/Backend/Analytics.php
+++ b/engine/Shopware/Controllers/Backend/Analytics.php
@@ -946,6 +946,7 @@ class Shopware_Controllers_Backend_Analytics extends Shopware_Controllers_Backen
 
             if (!empty($shopIds)) {
                 foreach ($shopIds as $shopId) {
+                    $row['orderCount' . $shopId] = (int) $row['orderCount' . $shopId];
                     $row['turnover' . $shopId] = (float) $row['turnover' . $shopId];
                 }
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The subshop values for the number of orders (orderCount +$shopID) are not properly casted as numerical (int) values and prevent further processing when creating new statistics (e.g. new statistics based on the number of orders).

Example of the current JSON result:
`"data":[
	{
		"orderCount":63,
		"turnover":53196.00999999999,
		"displayDate":"Monday",
		"turnover1":24252.190000000002,
		"orderCount1":"36",
		"turnover2":25998.73,
		"orderCount2":"24",
		"date":1606950000,
		"normal":"2020-12-03"
	}
]`

### 2. What does this change do, exactly?
It casts the subshop values for the number of orders to int.

Example of the corrected JSON result:
`"data":[
	{
		"orderCount":63,
		"turnover":53196.00999999999,
		"displayDate":"Monday",
		"turnover1":24252.190000000002,
		"orderCount1":36,
		"turnover2":25998.73,
		"orderCount2":24,
		"date":1606950000,
		"normal":"2020-12-03"
	}
]`
### 3. Describe each step to reproduce the issue or behaviour.
Create an additional evaluation based on the data values from {url controller = analytics action = getXXX} (every getXXXAction that uses the formatOrderAnalyticsData method) and use the subshop values for the number of orders (orderCount + $shopID). The values are visible in the table view, but cannot be sorted. In the diagram view, the values are not processed .

### 4. Please link to the relevant issues (if any).
/

### 5. Which documentation changes (if any) need to be made because of this PR?
I haven't found any part of the documentation that needs to be adjusted.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 7. Remarks
- I couldn't find a suitable ticket in the tracker.
- I have no idea what "I have squashed any insignificant commits" means.
- I didn't write a test for the one-liner, but I can confirm that all additional statistics now work properly.
- I have not made an entry in upgrade.md.
- I tried to follow the coding guidelines.