### PR TITLE
Removes the always empty first entry of the visitor overview

### DIFF
--- a/engine/Shopware/Controllers/Backend/Widgets.php
+++ b/engine/Shopware/Controllers/Backend/Widgets.php
@@ -358,7 +358,7 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
 
         $data = Shopware()->Container()->get('db')->fetchAll($sql, [$timeBack]);
 
-        $result[] = [];
+        $result = [];
         foreach ($data as $row) {
             $result[] = [
                 'timestamp' => strtotime($row['date']),


### PR DESCRIPTION
(the graph always have a start point at zero)

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The "Visitors online" statistics on the dashboard always shows the first entry in the graph with zero visitors.

Example of the current JSON result (data shortened):
`"data":{"customers":[…],"visitors":[[],{"timestamp":1606518000,"date":"28.11.2020","visitors":"3066"},…],"currentUsers":"12"}`
Explanation: First entry of Visitors is an empty array and not an valid object.

### 2. What does this change do, exactly?
The controller method was adapted so that the first entry - the empty array - is no longer generated.

Example of the corrected JSON result (data shortened):
`"data":{"customers":[…],"visitors":[{"timestamp":1606518000,"date":"28.11.2020","visitors":"3066"},…],"currentUsers":"12"}`

### 3. Describe each step to reproduce the issue or behaviour.
Activate the dashboard widget "Visitors online". Regardless of whether the shop had visitors or not, the first point is always displayed with zero hits.

### 4. Please link to the relevant issues (if any).
/

### 5. Which documentation changes (if any) need to be made because of this PR?
I haven't found any part of the documentation that needs to be adjusted.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 7. Remarks
- I couldn't find a suitable ticket in the tracker.
- I have no idea what "I have squashed any insignificant commits" means.
- I didn't write a test for the one-liner, but I tested in my shops and a clean shopware installation, with no problems.
- I have not made an entry in upgrade.md.
- I tried to follow the coding guidelines.