### PR TITLE
Fix session id when switching between sessions

### DIFF
--- a/engine/Library/Enlight/Components/Session/Namespace.php
+++ b/engine/Library/Enlight/Components/Session/Namespace.php
@@ -140,4 +140,58 @@ class Enlight_Components_Session_Namespace extends Session implements ArrayAcces
         parent::clear();
         $this->set('sessionId', $this->getId());
     }
+
+    public function start()
+    {
+        // Generally `start()` is called by Shopware's session factories
+        // - Shopware_Plugins_Backend_Auth_Bootstrap::onInitResourceBackendSession()
+        // - Shopware\Components\DependencyInjection\Bridge\Session::createSession()
+        // In case the session is started somewhere else we need to ensure no other session is active. The same logic as
+        // in Shopware's factories is used here.
+        // This behaviour is analogue to Zend: https://github.com/shopware/shopware/blob/cbc212ca4642878cac62193d3a2f41e08f4849a2/engine/Library/Zend/Session.php#L413
+        $container = Shopware()->Container();
+        self::ensureFrontendSessionClosed($container);
+        self::ensureBackendSessionClosed($container);
+
+        // When the session cookie is present but no session id is currently set, set its value as session id as
+        // otherwise a new session id is generated when a session was active before. This is required to resume a
+        // previously active session after switching back from another session. This behaviour is analogue to Zend:
+        // https://github.com/shopware/shopware/blob/cbc212ca4642878cac62193d3a2f41e08f4849a2/engine/Library/Zend/Session.php#L421-L423
+        // The session id can be empty on first start or when it has been set to an empty string, for example by
+        // `ensureSessionClosed()`.
+        if (!$this->getId() && ini_get('session.use_cookies') === '1' && !empty($_COOKIE[$this->getName()])) {
+            $this->setId($_COOKIE[$this->getName()]);
+        }
+
+        return parent::start();
+    }
+
+    public static function ensureFrontendSessionClosed($container)
+    {
+        self::ensureSessionClosed($container, 'session');
+    }
+
+    public static function ensureBackendSessionClosed($container)
+    {
+        self::ensureSessionClosed($container, 'backendsession');
+    }
+
+    /**
+     * Saves the session and ensures it can be reused.
+     *
+     * This method can be used to ensure other sessions are closed before starting a new session, because the other
+     * sessions would use the session id of the new session and thus write their data into the wrong session.
+     *
+     * @param $container
+     * @param $sessionServiceName
+     */
+    private static function ensureSessionClosed($container, $sessionServiceName)
+    {
+        $session = $container->initialized($sessionServiceName) ? $container->get($sessionServiceName) : null;
+        if ($session && $session->isStarted()) {
+            $session->save();
+            // The empty session id signals that upon starting a session the session cookie is used.
+            $session->setId('');
+        }
+    }
 }

--- a/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
@@ -67,6 +67,19 @@ class Session
      */
     public function createSession(Container $container, \SessionHandlerInterface $saveHandler = null)
     {
+        // If another session is already started, save and close it before starting the frontend session below.
+        // We need to do this, because the other session would use the session id of the frontend session and thus write
+        // its data into the wrong session.
+        \Enlight_Components_Session_Namespace::ensureBackendSessionClosed($container);
+        // Ensure no session is active before starting the frontend session below. We need to do this because there
+        // could be another session with inconsistent/invalid state in the container.
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+            // The empty session id signals to `Enlight_Components_Session_Namespace::start()` that the session cookie
+            // should be used as session id.
+            session_id('');
+        }
+
         $sessionOptions = $container->getParameter('shopware.session');
 
         /** @var \Shopware\Models\Shop\Shop $shop */


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently with SW 5.7 when switching between sessions (Frontend/Backend) the session id is not updated with the correct session id for the respective session based on the cookie values. With SW <= 5.6 Zend took care of this: https://github.com/shopware/shopware/blob/cbc212ca4642878cac62193d3a2f41e08f4849a2/engine/Library/Zend/Session.php#L421-L423
Additionally any active session was closed before starting a new one with Zend: https://github.com/shopware/shopware/blob/cbc212ca4642878cac62193d3a2f41e08f4849a2/engine/Shopware/Components/DependencyInjection/Bridge/Session.php#L77-L79.

### 2. What does this change do, exactly?
This change replicates the Zend logic to set the session id to the session cookies value if there is none set currently. As such when creating e.g. a Frontend session after using a Backend session the session id is set to the Frontend Session cookie value and thus correct, instead of still being the Backend session id. The backend session is also saved and closed before starting the frontend session to ensure clean switches between each other. The same is true vice versa.


### 3. Describe each step to reproduce the issue or behaviour.
1) Call a Backend Controller Action with a Frontend and Backend session cookie set (`SHOPWAREBACKEND` and `session-1` for a shop with id 1)
2) Close the Backend session:
```php
$backendSession = $container->get('backendsession');
$backendSession->save();
$backendSession->getId();
```
3) Register a Shop and request the Frontend session:
```php
$shop->registerResources();
$session = $container->get('session');
$session->getId();
```
4) Observe the session id from the Frontend session is the same as the session id from the Backend session.


### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.