### PR TITLE
Fix PHPStan error in Acl component

### DIFF
--- a/engine/Shopware/Components/Acl.php
+++ b/engine/Shopware/Components/Acl.php
@@ -73,9 +73,9 @@ class Shopware_Components_Acl extends Zend_Acl
         $repository = $this->em->getRepository(Role::class);
         $roles = $repository->findAll();
 
-        /** @var \Shopware\Models\User\Role $role */
+        /** @var Role $role */
         foreach ($roles as $role) {
-            /** @var \Shopware\Models\User\Role|null $parent */
+            /** @var Role|null $parent */
             $parent = $role->getParent();
 
             // Parent exist and not already added?
@@ -104,7 +104,7 @@ class Shopware_Components_Acl extends Zend_Acl
     {
         $rules = $this->em->getRepository(Rule::class)->findAll();
 
-        /** @var \Shopware\Models\User\Rule $rule */
+        /** @var Rule $rule */
         foreach ($rules as $rule) {
             $role = $rule->getRole();
 
@@ -144,12 +144,14 @@ class Shopware_Components_Acl extends Zend_Acl
      * @param string     $resourceName - unique identifier or resource key
      * @param array|null $privileges   - optionally array [a,b,c] of new privileges
      * @param null       $menuItemName - optionally s_core_menu.name item to link to this resource
-     * @param null       $pluginID     - optionally pluginID that implements this resource
-     *
-     * @throws Enlight_Exception
+     * @param int|null   $pluginID     - optionally pluginID that implements this resource
      */
-    public function createResource($resourceName, array $privileges = null, $menuItemName = null, $pluginID = null)
-    {
+    public function createResource(
+        $resourceName,
+        array $privileges = null,
+        /* @noinspection PhpUnusedParameterInspection */ $menuItemName = null,
+        $pluginID = null
+    ){
         // Check if resource already exists
         if ($this->hasResourceInDatabase($resourceName)) {
             throw new Enlight_Exception(sprintf('Resource "%s" already exists', $resourceName));
@@ -206,7 +208,7 @@ class Shopware_Components_Acl extends Zend_Acl
     {
         $repository = $this->em->getRepository(Resource::class);
 
-        /** @var \Shopware\Models\User\Resource|null $resource */
+        /** @var Resource|null $resource */
         $resource = $repository->findOneBy(['name' => $resourceName]);
         if ($resource === null) {
             return false;


### PR DESCRIPTION
We must add integer to the hinted types of optional $pluginID arg.
Else PHPstan level 5 check fails with:

------ --------------------------------------------------------------------
  Line   Bootstrap/Acl.php
 ------ --------------------------------------------------------------------
  53     Parameter #4 $pluginID of method
         Shopware_Components_Acl::createResource() expects null, int given.
 ------ --------------------------------------------------------------------

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
PHPStan level 5 check in our plugin fails.

### 2. What does this change do, exactly?
We just add int to the hinted types of the optional $pluginID argument to createResource().

### 3. Describe each step to reproduce the issue or behaviour.
Use createResource(), run a PHPStan check level 5 to trigger an error like:
------ --------------------------------------------------------------------
  Line   Bootstrap/Acl.php
 ------ --------------------------------------------------------------------
  53     Parameter #4 $pluginID of method
         Shopware_Components_Acl::createResource() expects null, int given.
 ------ --------------------------------------------------------------------

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.