### PR TITLE
use major version option (--1) for composer self-update

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -90,7 +90,7 @@
         <exec executable="${script.php}">
             <arg value="composer.phar"/>
             <arg value="self-update"/>
-            <arg value="1"/>
+            <arg value="--1"/>
             <arg value="--no-interaction"/>
         </exec>
     </target>


### PR DESCRIPTION
use major version option (--1) for composer self-update, instead of explicit using version 1, because version 1 doesn't exists.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
because `composer self-update` in **ant** failed with:
`The "https://getcomposer.org/download/1/composer.phar.sig" file could not be downloaded (HTTP/1.1 404 Not Found)  
`

### 2. What does this change do, exactly?
change argument for **ant** target **update-composer-binary**

### 3. Describe each step to reproduce the issue or behaviour.
run **ant** target **update-composer-binary**

### 4. Please link to the relevant issues (if any).
none

### 5. Which documentation changes (if any) need to be made because of this PR?
nothing

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.