### PR TITLE
Normalize validation of agreements between finishAction and paymentAction in checkout

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -502,10 +502,18 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
             $this->session['sComment'] = trim(strip_tags($this->Request()->getParam('sComment')));
         }
 
-        if (!Shopware()->Config()->get('IgnoreAGB') && !$this->Request()->getParam('sAGB')) {
-            $this->View()->assign('sAGBError', true);
+        $basket = $this->getBasket();
+        $agreements = $this->getInvalidAgreements($basket, $this->Request());
 
-            return $this->forward('confirm');
+        if (!empty($agreements)) {
+            $this->View()->assign('sAGBError', array_key_exists('agbError', $agreements));
+
+            return $this->forward(
+                'confirm',
+                null,
+                null,
+                ['agreementErrors' => $agreements]
+            );
         }
 
         $this->View()->assign($this->session['sOrderVariables']->getArrayCopy());


### PR DESCRIPTION
### 1. Why is this change necessary?
Until now the agreements are validated differently depending on the payment method. If the selected payment method has a payment action, only the terms of service (`sAGB`) are validated. If the payment action has no payment action, the validation checks for terms of service (`sAGB`), esd (`esdAgreementChecked`) and service agreements (`serviceAgreementChecked `).

### 2. What does this change do, exactly?
This change uses the same method for agreement validation in the paymentAction as in the finishAction.

### 3. Describe each step to reproduce the issue or behaviour.
1. Set the config value `serviceAttrField` to "attr1".
2. Enter a truthy value into `attr1` of a product.
3. Configure a payment method with a payment action (e. g. PayPal).
4. Add said product to the cart and go to `/checkout/confirm`.
5. Open your browser's inspector and remove the `required` attribute from the checkbox for `serviceAgreementChecked`.
6. Leave the checkbox for `serviceAgreementChecked` unticked and click the finish-button.
7. See that the checkbox has not been validated and you can actually proceed to the external payment service provider.

If you would choose a payment method that has no payment action (e. g. prepayment), the checkbox would have been validated and the order cannot be finished without ticking it.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.