### PR TITLE
Remove superfluous # from woff2 icon font path to fix font preloading

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/icon-set.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/icon-set.less
@@ -1297,7 +1297,7 @@ Example: `<i class="icon--cart"></i>`
 
     font-family: @sw-icon-fontname;
     font-display: block;
-    src:url('@{font-directory}/shopware.woff2?#@{hash-shopware-woff-2}') format('woff2'),
+    src:url('@{font-directory}/shopware.woff2?@{hash-shopware-woff-2}') format('woff2'),
         url('@{font-directory}/shopware.woff?@{hash-shopware-woff}') format('woff'),
         url('@{font-directory}/shopware.ttf?@{hash-shopware-ttf}') format('truetype'),
         url('@{font-directory}/shopware.svg?@{hash-shopware-svg}') format('svg');


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#` prevents the preloading of the font resource.

### 2. What does this change do, exactly?

Remove a superfluous hash character.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a preload hint for the font file `shopware.woff2`:
`<link rel="preload" as="font" type="font/woff2" crossorigin href="/themes/Frontend/Responsive/frontend/_public/src/fonts/shopware.woff2" />`
2. Validate preloading, e.g. with Google Pagespeed (https://developers.google.com/speed/pagespeed/insights/).
3. The analysis shows that the preload doesn't work because the url inside the css file doesn't match the one from the preload hint. For all the other font files (without the # inside the path) preloading works as expected.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.