### PR TITLE
fixed to relative path

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_components/fonts.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_components/fonts.less
@@ -1,4 +1,4 @@
-@OpenSansPath: "./fonts";
+@OpenSansPath: "../../../vendors/fonts/open-sans-fontface";
 
 /* BEGIN Light */
 @font-face {


### PR DESCRIPTION
because grunt error -> Running "less:development" (less) task
>> ../themes/Frontend/Responsive/frontend/_public/src/less/_components/fonts.less: [L5:C33] error evaluating function `swhash`: ENOENT: no such file or directory, open '../themes/Frontend/Responsive/frontend/_public/src/less/_components/./fonts/Light/OpenSans-Light.woff2'

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.