### PR TITLE
README: note the filter extension is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Visit the forum at <https://forum.shopware.com/>
 -   <a href="https://php.net/manual/en/book.ctype.php" target="_blank">ctype</a>
 -   <a href="https://php.net/manual/en/book.curl.php" target="_blank">curl</a>
 -   <a href="https://php.net/manual/en/book.dom.php" target="_blank">dom</a>
+-   <a href="https://php.net/manual/en/book.filter.php" target="_blank">filter</a>
 -   <a href="https://php.net/manual/en/book.hash.php" target="_blank">hash</a>
 -   <a href="https://php.net/manual/en/book.iconv.php" target="_blank">iconv</a>
 -   <a href="https://php.net/manual/en/book.image.php" target="_blank">gd</a> (with freetype and libjpeg)

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "ext-curl": "*",
         "ext-date": "*",
         "ext-dom": "*",
+        "ext-filter": "*",
         "ext-gd": "*",
         "ext-hash": "*",
         "ext-iconv": "*",


### PR DESCRIPTION
### 1. Why is this change necessary?

Symfony uses the filter_var function.

### 2. What does this change do, exactly?

Add a note the README, and require the `ext-filter` extension in the composer file.

### 3. Describe each step to reproduce the issue or behaviour.

You use PHP without enabling the filter extension. Then, start the builtin server (for example) and request a page. You see 500 error in your browser.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.