### PR TITLE
keep positioning, even on mediaId

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -2361,6 +2361,9 @@ class Article extends Resource implements BatchInterface
                     $image,
                     $media
                 );
+                
+                $image->setPosition($position);
+                ++$position;
             }
 
             $image->fromArray($imageData);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If you reuse existing media on updating an article using the api, the order of the images is not as submitted.

### 2. What does this change do, exactly?
count up the position on submitting media id instead of link

### 3. Describe each step to reproduce the issue or behaviour.
update an article per api, use a mix of $imageData['link'] and $imageData['mediaId'], you'll see that the order of the images is not like you submitted

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.