### PR TITLE
Fix - Set SearchBundleDBAL condition handler public

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleDBAL/DependencyInjection/Compiler/DBALHandlerCompilerPass.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/DependencyInjection/Compiler/DBALHandlerCompilerPass.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\SearchBundleDBAL\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DBALHandlerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $taggedServicesIds = [];
+        $taggedServicesIds += array_keys($container->findTaggedServiceIds(
+            'condition_handler_dbal'
+        ));
+        $taggedServicesIds += array_keys($container->findTaggedServiceIds(
+            'sorting_handler_dbal'
+        ));
+        $taggedServicesIds += array_keys($container->findTaggedServiceIds(
+            'facet_handler_dbal'
+        ));
+
+        if (empty($taggedServicesIds)) {
+            return;
+        }
+
+        foreach ($taggedServicesIds as $id) {
+            $def = $container->getDefinition($id);
+            $def->setPublic(true);
+        }
+    }
+}

--- a/engine/Shopware/Bundle/SearchBundleES/DependencyInjection/Compiler/ESHandlerCompilerPass.php
+++ b/engine/Shopware/Bundle/SearchBundleES/DependencyInjection/Compiler/ESHandlerCompilerPass.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+namespace Shopware\Bundle\SearchBundleES\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ESHandlerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $taggedServicesIds = array_keys($container->findTaggedServiceIds(
+            'shopware_search_es.search_handler'
+        ));
+
+        if (empty($taggedServicesIds)) {
+            return;
+        }
+
+        foreach ($taggedServicesIds as $id) {
+            $def = $container->getDefinition($id);
+            $def->setPublic(true);
+        }
+    }
+}

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -51,7 +51,9 @@ use Shopware\Bundle\OrderBundle\OrderBundle;
 use Shopware\Bundle\PluginInstallerBundle\PluginInstallerBundle;
 use Shopware\Bundle\PluginInstallerBundle\Service\PluginInitializer;
 use Shopware\Bundle\SearchBundle\SearchBundle;
+use Shopware\Bundle\SearchBundleDBAL\DependencyInjection\Compiler\DBALHandlerCompilerPass;
 use Shopware\Bundle\SearchBundleDBAL\SearchBundleDBAL;
+use Shopware\Bundle\SearchBundleES\DependencyInjection\Compiler\ESHandlerCompilerPass;
 use Shopware\Bundle\SearchBundleES\SearchBundleES;
 use Shopware\Bundle\SitemapBundle\SitemapBundle;
 use Shopware\Bundle\StaticContentBundle\StaticContentBundle;
@@ -673,6 +675,8 @@ class Kernel extends SymfonyKernel
         $container->addCompilerPass(new ControllerCompilerPass());
         $container->addCompilerPass(new RegisterControllerArgumentLocatorsPass('argument_resolver.service', 'shopware.controller'));
         $container->addCompilerPass(new VersionCompilerPass());
+        $container->addCompilerPass(new DBALHandlerCompilerPass());
+        $container->addCompilerPass(new ESHandlerCompilerPass());
 
         $container->setParameter('active_plugins', $this->activePlugins);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Otherwise one needs to manually set the condition handlers public when adding the tag `condition_handler_dbal`, see:
https://github.com/shopware/shopware/blob/5.7/engine/Shopware/Bundle/SearchBundleDBAL/QueryBuilderFactory.php#L74-L75

### 2. What does this change do, exactly?
Automatically sets all condition handler which are added public.

### 3. Describe each step to reproduce the issue or behaviour.
Write a plugin, add a condition handler.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.