### PR TITLE
fix invalid datetime value error on generic entity search

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Repository/Searcher/GenericSearcher.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Repository/Searcher/GenericSearcher.php
@@ -110,9 +110,14 @@ class GenericSearcher implements SearcherInterface
     {
         $classMetaData = $this->entityManager->getClassMetadata($this->entity);
 
-        return array_map(function ($field) {
-            return 'entity.' . $field;
-        }, $classMetaData->fieldNames);
+        $searchFields = [];
+        foreach($classMetaData->fieldMappings as $key => $fieldMapping) {
+            if($fieldMapping['type'] !== 'datetime') {
+                $searchFields[] = 'entity.' . $fieldMapping['fieldName'];
+            }
+        }
+
+        return $searchFields;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The generic entity search (for example used in attribute fields with entity selection) throws exceptions regarding "General error: 1525 Incorrect DATETIME value" with MySQL 8 (MySQL 8.0.21 in my case)

### 2. What does this change do, exactly?
The change excludes all datetime fields from beeing used as search field in generic entity search

### 3. Describe each step to reproduce the issue or behaviour.
- Add a attribute with type multi selection for entity Category
- Open a category and start typing in the multiselection field
- The triggered AJAX request produces an exception as described in 1

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ X ] I have read the contribution requirements and fulfil them.