### PR TITLE
Fix robots.txt setAllow() and setDisallow()

### DIFF
--- a/engine/Shopware/Components/RobotsTxtGenerator.php
+++ b/engine/Shopware/Components/RobotsTxtGenerator.php
@@ -74,8 +74,6 @@ class RobotsTxtGenerator implements RobotsTxtGeneratorInterface
         if (in_array($allow, $this->disallows, true)) {
             $index = array_search($allow, $this->disallows);
             unset($this->disallows[$index]);
-
-            return;
         }
 
         if (in_array($allow, $this->allows, true)) {
@@ -90,8 +88,6 @@ class RobotsTxtGenerator implements RobotsTxtGeneratorInterface
         if (in_array($disallow, $this->allows, true)) {
             $index = array_search($disallow, $this->allows);
             unset($this->allows[$index]);
-
-            return;
         }
 
         if (in_array($disallow, $this->disallows, true)) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Calling `setAllow()` or `setDisallow()` for a route tthat is currently disallowed respectively allowed has not the expected effect.

### 2. What does this change do, exactly?
It ensures that an allowed route is output in /robots.txt even if it was previously disallowed and vice versa.

### 3. Describe each step to reproduce the issue or behaviour.
Open /robots.txt. There should be an entry `Allow /widgets/` because of https://github.com/shopware/shopware/blob/fba270614c5007167774a9ddb64b1d71eea0dee7/themes/Frontend/Bare/frontend/robots_txt/index.tpl#L26
But it is missing because it has been previously disallowed by https://github.com/shopware/shopware/blob/fba270614c5007167774a9ddb64b1d71eea0dee7/themes/Frontend/Bare/frontend/robots_txt/index.tpl#L13

The entry `{$robotsTxt->setAllow('/widgets')}` is also a bug I think and should be fixed in a separate PR.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.