### PR TITLE
Fix robots.txt allow directive

### DIFF
--- a/themes/Frontend/Bare/frontend/robots_txt/index.tpl
+++ b/themes/Frontend/Bare/frontend/robots_txt/index.tpl
@@ -23,7 +23,7 @@
 {/block}
 
 {block name="frontend_robots_txt_allows"}
-    {$robotsTxt->setAllow('/widgets/index/refreshStatistic')}
+    {$robotsTxt->setAllow('/widgets/emotion')}
     {block name="frontend_robots_txt_allows_output"}
         {foreach $robotsTxt->getAllows() as $allow}
             {$allow}

--- a/themes/Frontend/Bare/frontend/robots_txt/index.tpl
+++ b/themes/Frontend/Bare/frontend/robots_txt/index.tpl
@@ -23,7 +23,7 @@
 {/block}
 
 {block name="frontend_robots_txt_allows"}
-    {$robotsTxt->setAllow('/widgets')}
+    {$robotsTxt->setAllow('/widgets/index/refreshStatistic')}
     {block name="frontend_robots_txt_allows_output"}
         {foreach $robotsTxt->getAllows() as $allow}
             {$allow}


### PR DESCRIPTION
### 1. Why is this change necessary?
The current allow entry has no effect because a disallow entry for the same route exists and is output previously.

### 2. What does this change do, exactly?
It changes the conflicting directive `Allow: /widgets` to a more specific directive `Allow: /widgets/emotion`.

### 3. Describe each step to reproduce the issue or behaviour.
As explained here the second directive will be ignored if conflicting directives exist:
https://developers.google.com/search/reference/robots_txt#order-of-precedence-for-group-member-lines

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.