### PR TITLE
Fix Elasticsearch missing manualSorting position bug

### DIFF
--- a/UPGRADE-5.7.md
+++ b/UPGRADE-5.7.md
@@ -37,6 +37,7 @@ This changelog references changes done in Shopware 5.7 patch versions.
 * Added support for MySQL 8 `sql_require_primary_key`
 * Added `attribute` to users listing in API
 * Added new blocks `document_index_head_logo` and `document_index_head_wrapper` to `themes/Frontend/Bare/documents/index.tpl`
+* Added `unmapped_type` to `integer` in `engine/Shopware/Bundle/SearchBundleES/SortingHandler/ManualSortingHandler.php`
 
 ### Changes
 

--- a/engine/Shopware/Bundle/SearchBundleES/SortingHandler/ManualSortingHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/SortingHandler/ManualSortingHandler.php
@@ -63,6 +63,7 @@ class ManualSortingHandler implements HandlerInterface
         $categoryId = $categoryCondition->getCategoryIds()[0];
         $fieldSort = new FieldSort('manualSorting.position', strtolower($criteriaPart->getDirection()), [
             'nested_path' => 'manualSorting',
+            'unmapped_type' => 'integer',
         ]);
         $fieldSort->setNestedFilter(new TermsQuery('manualSorting.category_id', [$categoryId]));
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The Elasticsearch ManualSortingHandler requires filled positions in the manualSorting array. When there is no data elasticsearch throws an error:

`Fatal error: Uncaught Elasticsearch\Common\Exceptions\BadRequest400Exception: {"error":{"root_cause":[{"type":"query_shard_exception","reason":"No mapping found for [manualSorting.position] in order to sort on"...`

### 2. What does this change do, exactly?
Adds the `unmapped_type` configuration to `integer` to define a fallback logic for elasticsearch.

### 3. Describe each step to reproduce the issue or behaviour.
* Remove manualSorting configuration for all products of one given category
* Build the elasticsearch index
* Open the category page (without cache)

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.