### PR TITLE
Remove Webmozart dependency

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
@@ -29,7 +29,7 @@ use PDO;
 use Shopware\Bundle\StoreFrontBundle\Gateway;
 use Shopware\Bundle\StoreFrontBundle\Service\MediaServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct;
-use Webmozart\Assert\Assert;
+use Assert\Assertion;
 
 class CategoryGateway implements Gateway\CategoryGatewayInterface
 {
@@ -63,7 +63,7 @@ class CategoryGateway implements Gateway\CategoryGatewayInterface
      */
     public function get($id, Struct\ShopContextInterface $context)
     {
-        Assert::integer($id);
+        Assertion::integer($id);
         $categories = $this->getList([$id], $context);
 
         return array_shift($categories);


### PR DESCRIPTION
### 1. Why is this change necessary?
Since Webmozart is not included in the project's dependencies it should be replaced with the actually present library for assertions. 
This is the only place where Webmozart was referenced.

### 2. What does this change do, exactly?
Replace the Webmozart assertion with an alternative assertion.

### 3. Describe each step to reproduce the issue or behaviour.
Any filter actions in the store frontend will fail with:
`PHP Fatal error:  Uncaught Error: Class 'Webmozart\\Assert\\Assert' not found in engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php:66`

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.