### PR TITLE
Filter order number on raw data

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleES/ConditionHandler/OrdernumberConditionHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/ConditionHandler/OrdernumberConditionHandler.php
@@ -54,7 +54,7 @@ class OrdernumberConditionHandler implements PartialConditionHandlerInterface
     ) {
         /* @var OrdernumberCondition $criteriaPart */
         $search->addQuery(
-            new TermsQuery('number', $criteriaPart->getOrdernumbers()),
+            new TermsQuery('number.raw', $criteriaPart->getOrdernumbers()),
             BoolQuery::FILTER
         );
     }
@@ -70,7 +70,7 @@ class OrdernumberConditionHandler implements PartialConditionHandlerInterface
     ) {
         /* @var OrdernumberCondition $criteriaPart */
         $search->addPostFilter(
-            new TermsQuery('number', $criteriaPart->getOrdernumbers())
+            new TermsQuery('number.raw', $criteriaPart->getOrdernumbers())
         );
     }
 }


### PR DESCRIPTION
Filtering on tokenized data will cause issues for some order numbers

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

When using the order number filter with ElasticSearch, the filtering is currently done on the tokenzied field.
This causes order numbers like A1234567 to be split up into multiple tokens, and the terms query will not match correctly when given the original value.
This is especially problematic when using ES in combination with the Doofinder plugin, as it sends back order numbers as a result of the async search call.

### 2. What does this change do, exactly?

Instead of using the tokenized field, it uses the raw value of the order number. This way, the terms query will work with any kind of order numer.

### 3. Describe each step to reproduce the issue or behaviour.

- Create article with order number "A12345678"
- Set up ElasticSearch and let it index the article
- Try to filter by order number "A12345678"
- No results are returned

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/SW-25971

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.