### PR TITLE
Update with displayOnlySubShopBlogComments

### DIFF
--- a/engine/Shopware/Models/Blog/Repository.php
+++ b/engine/Shopware/Models/Blog/Repository.php
@@ -108,8 +108,8 @@ class Repository extends ModelRepository
 
         if ($shopId && Shopware()->Config()->get('displayOnlySubShopBlogComments')) {
             $builder
-                ->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1 AND (comments.shopId IS NULL OR comments.shopId = :shopId)')
-                ->setParameter('shopId', $shopId);
+                ->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1 AND (comments.shopId IS NULL OR comments.shopId = :shopId2)')
+                ->setParameter('shopId2', $shopId);
         } else {
             $builder->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1');
         }
@@ -465,8 +465,8 @@ class Repository extends ModelRepository
 
         if ($shopId && Shopware()->Config()->get('displayOnlySubShopBlogComments')) {
             $builder
-                ->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1 AND (comments.shopId IS NULL OR comments.shopId = :shopId)')
-                ->setParameter('shopId', $shopId);
+                ->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1 AND (comments.shopId IS NULL OR comments.shopId = :shopId2)')
+                ->setParameter('shopId2', $shopId);
         } else {
             $builder->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1');
         }

--- a/engine/Shopware/Models/Blog/Repository.php
+++ b/engine/Shopware/Models/Blog/Repository.php
@@ -108,8 +108,8 @@ class Repository extends ModelRepository
 
         if ($shopId && Shopware()->Config()->get('displayOnlySubShopBlogComments')) {
             $builder
-                ->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1 AND (comments.shopId IS NULL OR comments.shopId = :shopId2)')
-                ->setParameter('shopId2', $shopId);
+                ->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1 AND (comments.shopId IS NULL OR comments.shopId = :commentShopId)')
+                ->setParameter('commentShopId', $shopId);
         } else {
             $builder->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1');
         }
@@ -465,8 +465,8 @@ class Repository extends ModelRepository
 
         if ($shopId && Shopware()->Config()->get('displayOnlySubShopBlogComments')) {
             $builder
-                ->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1 AND (comments.shopId IS NULL OR comments.shopId = :shopId2)')
-                ->setParameter('shopId2', $shopId);
+                ->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1 AND (comments.shopId IS NULL OR comments.shopId = :commentShopId)')
+                ->setParameter('commentShopId', $shopId);
         } else {
             $builder->leftJoin('blog.comments', 'comments', Join::WITH, 'comments.active = 1');
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If you have a main shop in German and two other languages ​​in English and French and only activate the comments here for the respective shops, the blog posts which should only be displayed in one language shop are missing.

### 2. What does this change do, exactly?
If the comments should only be displayed per language shop, then all contributions that were limited by shop limitation are now displayed again.


### 3. Describe each step to reproduce the issue or behaviour.
Activate the blog comments in the configuration for each language shop only. Create a blog post which should only be displayed in German (shop limitation).
Create another blog post which should be displayed in all languages ​​and translate it accordingly.

The result is that we only see the blog post which is available in all languages.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.