### PR TITLE
Allow the cache to be invalided by subnets

### DIFF
--- a/engine/Shopware/Components/HttpCache/AppCache.php
+++ b/engine/Shopware/Components/HttpCache/AppCache.php
@@ -306,6 +306,8 @@ class AppCache extends HttpCache
     }
 
     /**
+     * @deprecated Since this method does not respect subnet definitions, please use IpUtils::checkIp instead
+     *
      * Checks if $ip is allowed for Http PURGE requests
      *
      * @param string $ip

--- a/engine/Shopware/Components/HttpCache/AppCache.php
+++ b/engine/Shopware/Components/HttpCache/AppCache.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Components\HttpCache;
 
+use Symfony\Component\HttpFoundation\IpUtils;
 use Shopware\Bundle\CookieBundle;
 use Shopware\Bundle\CookieBundle\CookieGroupCollection;
 use Shopware\Components\Privacy\CookieRemoveSubscriber;
@@ -301,7 +302,7 @@ class AppCache extends HttpCache
             }
         }
 
-        return $this->isPurgeIPAllowed($request->getClientIp());
+        return IpUtils::checkIp($request->getClientIp(), $this->getPurgeAllowedIPs());
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

If you have a dynamic environment you can't invalidate the cache. That's because AppCache will check if the request is allowed. At the moment you can only add IP addresses and you can't add subnets.

If you run a cronjob in a Kubernetes cluster then the cronjob runs in a different pod than the webserver. So if the cronjob pod sends a BAN request to the web server, the IP address is not allowed. You can't add the IP address of the pod because it's dynamic and will change.

### 2. What does this change do, exactly?

Add the possibility to add subnets to the Shopware config file ("app/config/config.php" => purge_allowed_ips).

### 3. Describe each step to reproduce the issue or behaviour.

Setup a dynamic environment for example with Kubernetes. Run a cronjob that updates doctrine entities (e.g. Articles).

### 4. Please link to the relevant issues (if any).

None.

### 5. Which documentation changes (if any) need to be made because of this PR?

https://developers.shopware.com/developers-guide/http-cache/#cluster-environments

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.