### PR TITLE
Fix/advanced menu delay

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
@@ -156,7 +156,7 @@
                     me._on($el, 'touchstart', $.proxy(me.onTouchStart, me, i, $el));
                 }
 
-                me._on($el, 'mouseenter', $.proxy(me.onListItemEnter, me, i, $el));
+                me._on($el, 'mouseenter touchstart', $.proxy(me.onListItemEnter, me, i, $el));
                 me._on($el, 'click', $.proxy(me.onClick, me, i, $el));
                 me._on($el, 'mouseleave', $.proxy(me.onMouseLeave, me));
             });

--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
@@ -157,6 +157,8 @@
                 me._on($el, 'click', $.proxy(me.onClick, me, i, $el));
             });
 
+            $body.on('mousemove touchstart', $.proxy(me.onMouseMove, me));
+
             me._on(me._$closeButton, 'click', $.proxy(me.onCloseButtonClick, me));
         },
 
@@ -312,8 +314,6 @@
         openMenu: function () {
             var me = this;
 
-            $body.on('mousemove touchstart', $.proxy(me.onMouseMove, me));
-
             me.$el.show();
 
             $.publish('plugin/swAdvancedMenu/onOpenMenu', [ me ]);
@@ -332,8 +332,6 @@
             me._$list.find('.' + opts.itemHoverClass).removeClass(opts.itemHoverClass);
 
             me.$el.hide();
-
-            $body.off('mousemove touchstart', $.proxy(me.onMouseMove, me));
 
             me._targetIndex = -1;
 

--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
@@ -1,8 +1,7 @@
 ;(function ($, window) {
     'use strict';
 
-    var $body = $('body'),
-        $html = $('html'),
+    var $html = $('html'),
         isTouchIE = $html.hasClass('is--ie-touch');
 
     /**
@@ -127,6 +126,9 @@
 
             // Register all needed events
             me.registerEvents();
+
+            // Fixes initial hover delay
+            me.closeMenu();
         },
 
         /**
@@ -140,7 +142,8 @@
          */
         registerEvents: function () {
             var me = this,
-                $el;
+                $el,
+                pluginEl = me.$el[0];
 
             $.each(me._$listItems, function (i, el) {
                 $el = $(el);
@@ -155,10 +158,10 @@
 
                 me._on($el, 'mouseenter', $.proxy(me.onListItemEnter, me, i, $el));
                 me._on($el, 'click', $.proxy(me.onClick, me, i, $el));
+                me._on($el, 'mouseleave', $.proxy(me.onMouseLeave, me));
             });
 
-            $body.on('mousemove touchstart', $.proxy(me.onMouseMove, me));
-
+            me._on(pluginEl, 'mouseleave', $.proxy(me.onMouseLeave, me));
             me._on(me._$closeButton, 'click', $.proxy(me.onCloseButtonClick, me));
         },
 
@@ -248,12 +251,12 @@
          * @event onMouseLeave
          * @param {jQuery.Event} event
          */
-        onMouseMove: function (event) {
+        onMouseLeave: function (event) {
             var me = this,
-                target = event.target,
+                target = event.toElement || event.relatedTarget,
                 pluginEl = me.$el[0];
 
-            if (pluginEl === target || $.contains(me.$el[0], target) || me._$listItems.has(target).length) {
+            if (pluginEl === target || $.contains(pluginEl, target) || me._$listItems.has(target).length) {
                 return;
             }
 

--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Views/frontend/_public/src/js/jquery.advanced-menu.js
@@ -269,6 +269,13 @@
         },
 
         /**
+         * Keep empty method for compatibility
+         */
+        onMouseMove: function (event) {
+            // empty
+        },
+
+        /**
          * Fired when the mouse leaves the navigation list items or advanced menu.
          *
          * @event onCloseButtonClick


### PR DESCRIPTION
### 1. Why is this change necessary?
The advanced menu hover effect does not work correctly. This pull request faces/solves multiple issues:
- The "Hover delay (ms)", that can be configured in the settings, is not respected on first hover of the navigation bar after loading a page. The advanced menu instantly opens. The delay is respected on following (2nd, 3rd, ...) hovers.
- When moving the cursor downwards moving over the navigation bar, the advanced menu always opens. Even when the cursor leaves the navigation bar in less time than configured as "Hover delay (ms)". This happens when the cursor stays in the area where the advanced menu is about to be displayed. This is an annoying behavior, because the advanced menu covers the first part of the content section - every time a user moves down the cursor from the header to the content section (without the intention to open the menu).
- The performance impact of the used mousemove function on body is bad. This problem has partially been addressed with this contribution: https://github.com/shopware/shopware/pull/2153 https://issues.shopware.com/issues/SW-24297 https://github.com/shopware/shopware/commit/06eb4d0b23548848da0b1ed011aee1790ab67408# But this "fix" broke the hover delay resulting in the issue described above.

### 2. What does this change do, exactly?
This change solves the three issues described above by
- reverting the commit https://github.com/shopware/shopware/commit/06eb4d0b23548848da0b1ed011aee1790ab67408#
- replacing the mousemove listener on the body element with mouseleave listeners only on the relevant elements
- initially calling closeMenu() to fix the first issue (hover delay not working on first hover)

### 3. Describe each step to reproduce the issue or behaviour.
Description under '1. Why is this change necessary?' should contain all information to reproduce the issues.

### 4. Please link to the relevant issues (if any).
N/A

### 5. Which documentation changes (if any) need to be made because of this PR?
N/A

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.