### PR TITLE
initServiceMode: case-insensitive compare for `offlineip` addresses

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -168,7 +168,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
     protected function initServiceMode($request)
     {
         $config = $this->Application()->Config();
-        if (!empty($config->setOffline) && strpos($config->offlineIp, $request->getClientIp()) === false) {
+        if (!empty($config->setOffline) && strpos(strtolower($config->offlineIp), $request->getClientIp()) === false) {
             if ($request->getControllerName() !== 'error') {
                 $request->setControllerName('error')->setActionName('service')->setDispatched(false);
             }

--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -168,7 +168,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
     protected function initServiceMode($request)
     {
         $config = $this->Application()->Config();
-        if (!empty($config->setOffline) && strpos(strtolower($config->offlineIp), $request->getClientIp()) === false) {
+        if (!empty($config->setOffline) && stripos($config->offlineIp, $request->getClientIp()) === false) {
             if ($request->getControllerName() !== 'error') {
                 $request->setControllerName('error')->setActionName('service')->setDispatched(false);
             }


### PR DESCRIPTION
## Make the comparison of allowed IP addresses in `offlineip` to the client's IP address as reported by the web server(s) case-insensitive.

This will enhance working with IPv6 addresses, which are sometime reported with uppercase letters by some "whatismyip" sites.
The case-sensitive behavior has lead to confusion for at least one of our customers who could not access the frontend in ServiceMode despite entering their IPv6 address into the allow list.

### 1. Why is this change necessary?
IPv6 addresses contain letters, they are therefore sensitive to letter case when comparing strings.
Using an case-insensitive comparison solves this issue.

### 2. What does this change do, exactly?
This change makes the comparison of the user configuration value for `offlineIp`, which is a string of space-separated IP addresses (IPv4 or IPv6), with the HTTP client's IP address a case-insensitive one.

### 3. Describe each step to reproduce the issue or behavior.
When entering IPv6 addresses with upper-case letters for the configuration value of `offlineIp`, users connecting from those IP addresses would not be able to bypass ServiceMode and be denied access to the store frontend pages.

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
n/a

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


Please notify me if any issues appear in this PR, I'll gladly work to correct them.
