### PR TITLE
Fix empty changelog in DOM parser

### DIFF
--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLocalService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLocalService.php
@@ -278,7 +278,7 @@ class PluginLocalService
     {
         $html = strip_tags($html, '<br><i><b><strong><em><del><u><div><span><ul><li><ll><ol><p><a>');
 
-        if (empty($html)) {
+        if ($html === '') {
             return '';
         }
 

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLocalService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLocalService.php
@@ -278,6 +278,10 @@ class PluginLocalService
     {
         $html = strip_tags($html, '<br><i><b><strong><em><del><u><div><span><ul><li><ll><ol><p><a>');
 
+        if (empty($html)) {
+            return '';
+        }
+
         $dom = new \DOMDocument();
         $dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
 


### PR DESCRIPTION
### 1. Why is this change necessary?
With PHP8, trim and strip_tags the changelog can be empty and 'DOM->load` needs content or it throws an exception.

### 2. What does this change do, exactly?
Check if the changelog is empty and returns on empty

### 3. Describe each step to reproduce the issue or behavior.
Changelog entry from a Store plugin like this
```
    <changelog version="2.3.3">
        <changes lang="de"><![CDATA[]]></changes>
        <changes lang="en"><![CDATA[]]></changes>
    </changelog>
```

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.