### PR TITLE
Remove time_limit and add rowIndex into Event

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -1191,12 +1191,11 @@ class sExport implements \Enlight_Hook
             $rows[] = $row;
 
             if ($rowIndex == $count || \count($rows) >= 50) {
-                @set_time_limit(30);
 
                 $rows = Shopware()->Container()->get('events')->filter(
                     'Shopware_Modules_Export_ExportResult_Filter_Fixed',
                     $rows,
-                    ['feedId' => $this->sFeedID, 'subject' => $this]
+                    ['feedId' => $this->sFeedID, 'rowIndex' => $rowIndex, 'subject' => $this]
                 );
 
                 $this->sSmarty->assign('sArticles', $rows);


### PR DESCRIPTION
Remove the time_limit from the sExport function and add the rowIndex into the Filter_Fixed Event


### 1. Why is this change necessary?
Easier extension of the sExport

### 2. What does this change do, exactly?
Customizing your feed through the Filter_Fixed Event can reach 30seconds really fast. 
Adding the rowIndex into the Event makes it easier to detect in which current row the event got fired.
