### PR TITLE
Fix image zoom in webkit/blink engine based browsers

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/image.tpl
+++ b/themes/Frontend/Bare/frontend/detail/image.tpl
@@ -26,6 +26,8 @@
                                    data-img-large="{$sArticle.image.thumbnails[2].source}"
                                    data-img-small="{$sArticle.image.thumbnails[0].source}"
                                    data-img-original="{$sArticle.image.source}"
+                                   data-img-width="{$sArticle.image.width}"
+                                   data-img-height="{$sArticle.image.height}"
                                   {/if}
                                    data-alt="{$alt}">
 
@@ -78,6 +80,8 @@
                                       data-img-large="{$image.thumbnails[2].source}"
                                       data-img-small="{$image.thumbnails[0].source}"
                                       data-img-original="{$image.source}"
+                                      data-img-width="{$image.image.width}"
+                                      data-img-height="{$image.image.height}"
                                       data-alt="{$alt}">
 
                                     {block name='frontend_detail_images_image_media'}

--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.image-gallery.js
@@ -460,6 +460,8 @@
                     'class': 'image--element',
                     'src': $el.attr('data-img-original'),
                     'alt': $el.attr('data-alt'),
+                    'width': $el.attr('data-img-width'),
+                    'height': $el.attr('data-img-height'),
                     'data-extension': $mediaEl.hasClass('image--svg') ? 'svg' : ''
                 });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Zoom won't work on safari or chromium based browsers

Demo from a random website
https://demoshops.splendid-internet.de/shopware/demoshop-shopwared//lebensmittel/suesses/10/hauptartikel-mit-grundpreisberechnung


### 2. What does this change do, exactly?
Fix the zoom issue

### 3. Describe each step to reproduce the issue or behaviour.

The `+` is gray until the image is moved a little to left or right, looks like the zoom possible is calculated before the image is loaded and without a size and so no zoom is possible.
![image](https://user-images.githubusercontent.com/1295633/125078932-58eb6b00-e0c3-11eb-9e1d-eb0eb1f5748c.png)


(In general a lot of sizes for proper ratio are missing in  detail view and that results in unnecessary repaints and CLS.)

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.