### PR TITLE
fix analytics conversion export

### DIFF
--- a/engine/Shopware/Controllers/Backend/Analytics.php
+++ b/engine/Shopware/Controllers/Backend/Analytics.php
@@ -279,11 +279,17 @@ class Shopware_Controllers_Backend_Analytics extends Shopware_Controllers_Backen
             }
         }
 
+        // Sets the correct limit
+        $limit = 25;
+        if (strtolower($this->format) === 'csv') {
+            $limit = \count($data);
+        }
+
         $values = array_values($data);
         $splice = array_splice(
             $values,
-            (int) $this->Request()->getParam('start', 0),
-            (int) $this->Request()->getParam('limit', 25)
+            $this->Request()->getParam('start', 0),
+            $this->Request()->getParam('limit', $limit)
         );
 
         $this->send($splice, \count($data));

--- a/engine/Shopware/Controllers/Backend/Analytics.php
+++ b/engine/Shopware/Controllers/Backend/Analytics.php
@@ -212,8 +212,8 @@ class Shopware_Controllers_Backend_Analytics extends Shopware_Controllers_Backen
         $values = array_values($data);
         $splice = array_splice(
             $values,
-            $this->Request()->getParam('start', 0),
-            $this->Request()->getParam('limit', $limit)
+            (int) $this->Request()->getParam('start', 0),
+            (int) $this->Request()->getParam('limit', $limit)
         );
 
         $this->send($splice, \count($data));

--- a/engine/Shopware/Controllers/Backend/Analytics.php
+++ b/engine/Shopware/Controllers/Backend/Analytics.php
@@ -288,8 +288,8 @@ class Shopware_Controllers_Backend_Analytics extends Shopware_Controllers_Backen
         $values = array_values($data);
         $splice = array_splice(
             $values,
-            $this->Request()->getParam('start', 0),
-            $this->Request()->getParam('limit', $limit)
+            (int) $this->Request()->getParam('start', 0),
+            (int) $this->Request()->getParam('limit', $limit)
         );
 
         $this->send($splice, \count($data));


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently, only the entries from the first page are exported from the "Conversion Overview" report type.
This PR fix the csv export of this report type.

### 2. What does this change do, exactly?
The change export all entries.

### 3. Describe each step to reproduce the issue or behaviour.
1.) Go into the backend.
2.) Open the window marketing > evaluations > evaluations.
3.) Select the type "Conversion Overview"
4.) Filter for more then 3 month, for example.
5.) Click on export

=> in the export is only the result of the first page included.

With this fix, all entries are exported as csv now.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.