### PR TITLE
Bump less.php to version 3.1.0 for better PHP 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "symfony/serializer": "~4.4.14",
         "symfony/validator": "~4.4.14",
         "symfony/web-link": "~4.4.14",
-        "wikimedia/less.php": "3.0.0"
+        "wikimedia/less.php": "3.1.0"
     },
     "replace": {
         "paragonie/random_compat": "2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca3bc8a70284ae71c4075c09386e4b10",
+    "content-hash": "02b67279c078f1580a9911e0a8a26a77",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -7307,24 +7307,26 @@
         },
         {
             "name": "wikimedia/less.php",
-            "version": "v3.0.0",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikimedia/less.php.git",
-                "reference": "5e2a4fba9304915c4cbf98cc9cb665a5c365c351"
+                "reference": "a486d78b9bd16b72f237fc6093aa56d69ce8bd13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/5e2a4fba9304915c4cbf98cc9cb665a5c365c351",
-                "reference": "5e2a4fba9304915c4cbf98cc9cb665a5c365c351",
+                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/a486d78b9bd16b72f237fc6093aa56d69ce8bd13",
+                "reference": "a486d78b9bd16b72f237fc6093aa56d69ce8bd13",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.9"
             },
             "require-dev": {
-                "jakub-onderka/php-parallel-lint": "1.0.0",
+                "mediawiki/mediawiki-codesniffer": "34.0.0",
                 "mediawiki/minus-x": "1.0.0",
+                "php-parallel-lint/php-console-highlighter": "0.5.0",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
                 "phpunit/phpunit": "^8.5"
             },
             "bin": [
@@ -7368,9 +7370,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wikimedia/less.php/issues",
-                "source": "https://github.com/wikimedia/less.php/tree/v3.0.0"
+                "source": "https://github.com/wikimedia/less.php/tree/v3.1.0"
             },
-            "time": "2020-03-11T23:01:29+00:00"
+            "time": "2020-12-11T19:33:31+00:00"
         }
     ],
     "packages-dev": [
@@ -10987,5 +10989,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
To improve PHP8 support.

### 2. What does this change do, exactly?
Bump version of less.php library.

### 3. Describe each step to reproduce the issue or behaviour.
Try to compile the theme on PHP8.0.
Error: <b>Deprecated</b>:  Required parameter $rules follows optional parameter $value in <b>/vagrant/www/vendor/wikimedia/less.php/lib/Less/Tree/Directive.php</b> on line <b>20</b>

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.