### PR TITLE
Make the Produkt-Export Cache Directory configurable

### DIFF
--- a/engine/Shopware/Commands/GenerateProductFeedCommand.php
+++ b/engine/Shopware/Commands/GenerateProductFeedCommand.php
@@ -108,13 +108,11 @@ class GenerateProductFeedCommand extends ShopwareCommand implements CompletionAw
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
-        $cacheDir = $this->container->getParameter('kernel.cache_dir');
+        $cacheDir = $this->container->getParameter('kernel.cache_dir.product_export');
 
         if (!\is_string($cacheDir)) {
-            throw new \RuntimeException('Parameter kernel.cache_dir has to be an string');
+            throw new \RuntimeException('Parameter kernel.cache_dir.product_export has to be an string');
         }
-
-        $this->cacheDir = $cacheDir . '/productexport/';
 
         if (!is_dir($this->cacheDir)) {
             if (@mkdir($this->cacheDir, 0777, true) === false) {

--- a/engine/Shopware/Controllers/Backend/Export.php
+++ b/engine/Shopware/Controllers/Backend/Export.php
@@ -184,7 +184,7 @@ class Shopware_Controllers_Backend_Export extends Enlight_Controller_Action impl
     /**
      * @return string Path to new output directory
      */
-    private function createOutputDirectory()
+    protected function createOutputDirectory()
     {
         $dirName = $this->container->getParameter('kernel.cache_dir');
         if (!\is_string($dirName)) {

--- a/engine/Shopware/Controllers/Backend/Export.php
+++ b/engine/Shopware/Controllers/Backend/Export.php
@@ -184,7 +184,7 @@ class Shopware_Controllers_Backend_Export extends Enlight_Controller_Action impl
     /**
      * @return string Path to new output directory
      */
-    protected function createOutputDirectory()
+    private function createOutputDirectory()
     {
         $dirName = $this->container->getParameter('kernel.cache_dir.product_export');
         if (!\is_string($dirName)) {

--- a/engine/Shopware/Controllers/Backend/Export.php
+++ b/engine/Shopware/Controllers/Backend/Export.php
@@ -186,12 +186,11 @@ class Shopware_Controllers_Backend_Export extends Enlight_Controller_Action impl
      */
     protected function createOutputDirectory()
     {
-        $dirName = $this->container->getParameter('kernel.cache_dir');
+        $dirName = $this->container->getParameter('kernel.cache_dir.product_export');
         if (!\is_string($dirName)) {
-            throw new \RuntimeException('Parameter kernel.cache_dir has to be an string');
+            throw new \RuntimeException('Parameter kernel.cache_dir.product_export has to be an string');
         }
 
-        $dirName .= '/productexport/';
         if (!file_exists($dirName)) {
             mkdir($dirName);
         }

--- a/engine/Shopware/Controllers/Backend/ProductFeed.php
+++ b/engine/Shopware/Controllers/Backend/ProductFeed.php
@@ -194,12 +194,11 @@ class Shopware_Controllers_Backend_ProductFeed extends Shopware_Controllers_Back
         $productFeed->setLastChange(new DateTime());
 
         // Clear feed cache
-        $cacheDir = $this->container->getParameter('kernel.cache_dir');
+        $cacheDir = $this->container->getParameter('kernel.cache_dir.product_export');
         if (!\is_string($cacheDir)) {
-            throw new \RuntimeException('Parameter kernel.cache_dir has to be an string');
+            throw new \RuntimeException('Parameter kernel.cache_dir.product_export has to be an string');
         }
 
-        $cacheDir .= '/productexport/';
         if (!is_dir($cacheDir)) {
             if (@mkdir($cacheDir, 0777, true) === false) {
                 throw new \RuntimeException(sprintf("Unable to create the %s directory (%s)\n", 'Productexport', $cacheDir));

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -741,6 +741,7 @@ class Kernel extends SymfonyKernel
             'kernel.debug' => $this->debug,
             'kernel.name' => $this->name,
             'kernel.cache_dir' => $this->getCacheDir(),
+            'kernel.cache_dir.product_export' => $this->getCacheDir().'/productexport',
             'kernel.logs_dir' => $this->getLogDir(),
             'kernel.bundles' => $bundles,
             'kernel.bundles_metadata' => $bundlesMetadata,

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -741,7 +741,7 @@ class Kernel extends SymfonyKernel
             'kernel.debug' => $this->debug,
             'kernel.name' => $this->name,
             'kernel.cache_dir' => $this->getCacheDir(),
-            'kernel.cache_dir.product_export' => $this->getCacheDir().'/productexport/',
+            'kernel.cache_dir.product_export' => $this->getCacheDir() . '/productexport/',
             'kernel.logs_dir' => $this->getLogDir(),
             'kernel.bundles' => $bundles,
             'kernel.bundles_metadata' => $bundlesMetadata,

--- a/engine/Shopware/Kernel.php
+++ b/engine/Shopware/Kernel.php
@@ -741,7 +741,7 @@ class Kernel extends SymfonyKernel
             'kernel.debug' => $this->debug,
             'kernel.name' => $this->name,
             'kernel.cache_dir' => $this->getCacheDir(),
-            'kernel.cache_dir.product_export' => $this->getCacheDir().'/productexport',
+            'kernel.cache_dir.product_export' => $this->getCacheDir().'/productexport/',
             'kernel.logs_dir' => $this->getLogDir(),
             'kernel.bundles' => $bundles,
             'kernel.bundles_metadata' => $bundlesMetadata,

--- a/engine/Shopware/Plugins/Default/Core/CronProductExport/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/CronProductExport/Bootstrap.php
@@ -62,8 +62,7 @@ class Shopware_Plugins_Core_CronProductExport_Bootstrap extends Shopware_Compone
     public function exportProductFiles()
     {
         /** @var string $cacheDir */
-        $cacheDir = Shopware()->Container()->getParameter('kernel.cache_dir');
-        $cacheDir .= '/productexport/';
+        $cacheDir = Shopware()->Container()->getParameter('kernel.cache_dir.product_export');
         if (!is_dir($cacheDir)) {
             if (@mkdir($cacheDir, 0777, true) === false) {
                 throw new \RuntimeException(sprintf("Unable to create the %s directory (%s)\n", 'Productexport', $cacheDir));

--- a/tests/Functional/Core/sExportTest.php
+++ b/tests/Functional/Core/sExportTest.php
@@ -75,9 +75,8 @@ class sExportTest extends PHPUnit\Framework\TestCase
         $this->template = $this->container->get('template');
 
         /** @var string $cacheDir */
-        $cacheDir = $this->container->getParameter('kernel.cache_dir');
+        $this->cacheDir = $this->container->getParameter('kernel.cache_dir.product_export');
 
-        $this->cacheDir = $cacheDir . '/productexport/';
         $this->testDir = __DIR__ . '/fixtures/productexport/';
 
         if (!is_dir($this->cacheDir)) {

--- a/tests/Functional/Core/sExportTest.php
+++ b/tests/Functional/Core/sExportTest.php
@@ -74,7 +74,6 @@ class sExportTest extends PHPUnit\Framework\TestCase
         $this->repository = $this->container->get('models')->getRepository(ProductFeed::class);
         $this->template = $this->container->get('template');
 
-        /** @var string $cacheDir */
         $this->cacheDir = $this->container->getParameter('kernel.cache_dir.product_export');
 
         $this->testDir = __DIR__ . '/fixtures/productexport/';


### PR DESCRIPTION
This change is needed, if you want to store your product_exports not in the cache directory.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
I want to store the product exports outside the cache directory to save them on a nfs volume. Without this change, I have to replace the whole controller - yeah!

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.