### PR TITLE
Fix backend user adds

### DIFF
--- a/engine/Shopware/Models/User/User.php
+++ b/engine/Shopware/Models/User/User.php
@@ -190,6 +190,15 @@ class User extends ModelEntity
     private $role;
 
     /**
+     * Initial the date fields
+     */
+    public function __construct()
+    {
+        $this->lastLogin = new \DateTime();
+        $this->lockedUntil = new \DateTime();
+    }
+
+    /**
      * @return int
      */
     public function getId()


### PR DESCRIPTION
### 1. Why is this change necessary?
It's currently impossible to log in as a newly created backend user, unless you change the user's `s_core_auth` entry to have a non-`NULL`  `locked_until` field.

### 2. What does this change do, exactly?
Partially revert bdbf6210c52f30378da3265c60332e3e2185ff11. Specifically, this re-adds the `__construct` function of the `Models\User\User` class.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a new backend user via the user manager in the backend
2. Attempt to log in as that user

### 4. Please link to the relevant issues (if any).
None. There is a comment on [SW-26142](https://issues.shopware.com/issues/SW-26142) that mentions the problem this PR fixes, but I couldn't find any standalone issue that mentions it.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.