### PR TITLE
#Fix Google Lighthouse Links do not have a discernible name

### DIFF
--- a/themes/Frontend/Bare/widgets/emotion/components/component_video.tpl
+++ b/themes/Frontend/Bare/widgets/emotion/components/component_video.tpl
@@ -26,7 +26,7 @@
                 <a href="#play-video"
                    class="video--cover"
                    style="background-image: url('{link file=$Data.fallback_picture}');">
-                    <i class="video--play-icon icon--play"></i>
+                    <i class="video--play-icon icon--play"></i> 
                 </a>
             {/if}
         {/block}
@@ -37,7 +37,7 @@
                    class="video--play-btn"
                    data-playIconCls="icon--play"
                    data-pauseIconCls="icon--pause">
-                    <i class="video--play-icon icon--play"></i>
+                    <i class="video--play-icon icon--play"></i> 
                 </a>
             {/if}
         {/block}


### PR DESCRIPTION


### 1. Why is this change necessary?

To prevent a message on Google Lighthouse test "Links do not have a discernible name" 

https://web.dev/link-name/?utm_source=lighthouse&utm_medium=lr

### 2. What does this change do, exactly?

Removes the "Links do not have a discernible name" Lighthouse audit fails if you use a video with play button  (6 Points more at the Best Practices score.  

### 3. Describe each step to reproduce the issue or behaviour.

Just added a space to the hrefs tags where no title is. (Play Button Icon)

### 4. Please link to the relevant issues (if any).

https://web.dev/link-name/?utm_source=lighthouse&utm_medium=lr

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.