### PR TITLE
OrderDetailID set to 0 instead of null for non-article items in order_details

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -696,7 +696,7 @@ class sOrder implements Enlight_Hook
                 pack_unit,
                 articleDetailID
                 )
-                VALUES (%d, %s, %d, %s, %f, %d, %s, %d, %s, %d, %d, %d, %f, %s, %s, %s, %d)
+                VALUES (%d, %s, %d, %s, %f, %d, %s, %d, %s, %d, %d, %d, %f, %s, %s, %s, %s)
             ';
 
             $sql = sprintf(
@@ -717,7 +717,7 @@ class sOrder implements Enlight_Hook
                 $this->db->quote((string) $basketRow['ean']),
                 $this->db->quote((string) $basketRow['itemUnit']),
                 $this->db->quote((string) $basketRow['packunit']),
-                $basketRow['additional_details']['articleDetailsID']
+                !\is_null($basketRow['additional_details']['articleDetailsID']) ?: 'null'
             );
 
             $sql = $this->eventManager->filter('Shopware_Modules_Order_SaveOrder_FilterDetailsSQL', $sql, [

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -717,7 +717,7 @@ class sOrder implements Enlight_Hook
                 $this->db->quote((string) $basketRow['ean']),
                 $this->db->quote((string) $basketRow['itemUnit']),
                 $this->db->quote((string) $basketRow['packunit']),
-                !\is_null($basketRow['additional_details']['articleDetailsID']) ?: 'null'
+                !\is_null($basketRow['additional_details']['articleDetailsID']) ? $basketRow['additional_details']['articleDetailsID'] : 'null'
             );
 
             $sql = $this->eventManager->filter('Shopware_Modules_Order_SaveOrder_FilterDetailsSQL', $sql, [


### PR DESCRIPTION
### 1. Why is this change necessary?

For non-articles, the orderDetaildID column of order items (s_order_details) is to set to 0 instead of null. It is not a correct behavior as surcharges or discount have no article details and therefore should contain a null value. The issue comes from string conversion in a sprintf that cast a null value into a 0.  

### 2. What does this change do, exactly?

This changes will properly make the articleDetailID being null when necessary. Thought it's important to notice that there is not migration involved for existing order_details and I am not sure it's even wished to do that. 

### 3. Describe each step to reproduce the issue or behaviour.

Create an order that includes a discount (or a surcharge) and go through the entire checkout

Without the current PR:
- in s_order_details, for the discount item, the column articleDetailID contains 0
With the current PR:
- in s_order_details, for the discount item, the column articleDetailID contains null :+1: 