### PR TITLE
Fix ES indexing query skipping property groups

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/Property/PropertyQueryFactory.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Property/PropertyQueryFactory.php
@@ -60,6 +60,7 @@ class PropertyQueryFactory
         $query->select(['propertyGroups.id', 'propertyGroups.id'])
             ->from('s_filter_options', 'propertyGroups')
             ->where('propertyGroups.id > :lastId')
+            ->orderBy('propertyGroups.id')
             ->setParameter(':lastId', 0);
 
         if ($limit !== null) {


### PR DESCRIPTION
### 1. Why is this change necessary?
The ES property query relies on the order in which property groups are returned, property groups will be skipped if they are not returned in strictly ascending order.

### 2. What does this change do, exactly?
Explicitly sets the order.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.