### PR TITLE
Fix category sorting on PHP8

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
@@ -120,10 +120,10 @@ class CategoryGateway implements Gateway\CategoryGatewayInterface
         //use php usort instead of running mysql order by to prevent file-sort and temporary table statement
         usort($data, function ($a, $b) {
             if ($a['__category_position'] === $b['__category_position']) {
-                return $a['__category_id'] > $b['__category_id'] ? 1 : 0;
+                return $a['__category_id'] <=> $b['__category_id'];
             }
 
-            return $a['__category_position'] > $b['__category_position'] ? 1 : 0;
+            return $a['__category_position'] <=> $b['__category_position'];
         });
 
         $categories = [];


### PR DESCRIPTION
### 1. Why is this change necessary?
PHP8 changed the behavior of sort functions, [RFC stable sorting](https://wiki.php.net/rfc/stable_sorting) Illegal comparison functions:
> This works, because PHP currently only checks whether the comparison result is “greater than” or not, and never explicitly distinguishes the “equal” and “smaller than” cases. This breaks down with the approach proposed here, because we now do need to know whether values are equal or not, in order to use the fallback sorting criterion.

### 2. What does this change do, exactly?
Return `-1` instead of `0` if left is smaller than right.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.