### PR TITLE
Fix fuzzy search also looking through inactive articles

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Search.php
+++ b/engine/Shopware/Controllers/Frontend/Search.php
@@ -135,7 +135,7 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
                 FROM s_articles_details
                   INNER JOIN s_articles
                    ON s_articles.id = s_articles_details.articleID
-                WHERE ordernumber = ? AND s_articles.active = 1
+                WHERE ordernumber = ? AND s_articles.active = 1 AND s_articles_details.active = 1
                 GROUP BY articleID
                 LIMIT 2
             ';

--- a/engine/Shopware/Controllers/Frontend/Search.php
+++ b/engine/Shopware/Controllers/Frontend/Search.php
@@ -135,7 +135,7 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
                 FROM s_articles_details
                   INNER JOIN s_articles
                    ON s_articles.id = s_articles_details.articleID
-                WHERE ordernumber = ?
+                WHERE ordernumber = ? AND s_articles.active = 1
                 GROUP BY articleID
                 LIMIT 2
             ';
@@ -151,8 +151,8 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
                 $sql = '
                     SELECT DISTINCT articleID
                     FROM s_articles_details
-                    WHERE ordernumber = ?
-                    OR ordernumber LIKE ?
+                    WHERE (ordernumber = ?
+                    OR ordernumber LIKE ?) AND active = 1
                     GROUP BY articleID
                     LIMIT 2
                 ';


### PR DESCRIPTION
### 1. Why is this change necessary?
Fuzzy search is looking at all articles, even deactivated ones (which would not appear on the frontend)


### 2. What does this change do, exactly?
Added active=1 in the where clauses

### 3. Describe each step to reproduce the issue or behaviour.
Premise:
Multiple articles which react to a keyword. The first in the default sorting is inactive.

If you then in the frontend search for this keyword, the shop lists the search results. If you press enter or click Show all, shopware tries to show the deactivated article (which of course won't show up).

### 4. Please link to the relevant issues (if any).
Dunno

### 5. Which documentation changes (if any) need to be made because of this PR?
None, it is a bug fix

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.