### PR TITLE
Avoid PHP8 error if the bucket in ES is null

### DIFF
--- a/engine/Shopware/Bundle/SearchBundleES/FacetHandler/ProductAttributeFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/FacetHandler/ProductAttributeFacetHandler.php
@@ -155,9 +155,11 @@ class ProductAttributeFacetHandler implements HandlerInterface, ResultHydratorIn
 
             $type = $attribute ? $attribute->getColumnType() : null;
 
-            $aggregations[$key]['buckets'] = array_filter($aggregations[$key]['buckets'], function ($item) {
-                return $item['key'] !== '';
-            });
+            if ($aggregations[$key]['buckets']) {
+                $aggregations[$key]['buckets'] = array_filter($aggregations[$key]['buckets'], function ($item) {
+                    return $item['key'] !== '';
+                });
+            }
 
             if (\in_array($type, [TypeMappingInterface::TYPE_DATE, TypeMappingInterface::TYPE_DATETIME])) {
                 $aggregations[$key] = $this->formatDates($aggregations[$key]);

--- a/engine/Shopware/Bundle/SearchBundleES/FacetHandler/ProductAttributeFacetHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/FacetHandler/ProductAttributeFacetHandler.php
@@ -155,7 +155,7 @@ class ProductAttributeFacetHandler implements HandlerInterface, ResultHydratorIn
 
             $type = $attribute ? $attribute->getColumnType() : null;
 
-            if ($aggregations[$key]['buckets']) {
+            if (\is_array($aggregations[$key]['buckets'])) {
                 $aggregations[$key]['buckets'] = array_filter($aggregations[$key]['buckets'], function ($item) {
                     return $item['key'] !== '';
                 });


### PR DESCRIPTION
### 1. Why is this change necessary?
Avoid PHP error with v8


### 2. What does this change do, exactly?
\Check if the value is null (array_filter needs an array)


### 3. Describe each step to reproduce the issue or behaviour.
Use ES, have an attribute without a value (my case a checkbox - filterable).

### 6. Checklist
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.