### PR TITLE
SW-26345 - fix sorting logic for categories

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CategoryGateway.php
@@ -120,10 +120,10 @@ class CategoryGateway implements Gateway\CategoryGatewayInterface
         //use php usort instead of running mysql order by to prevent file-sort and temporary table statement
         usort($data, function ($a, $b) {
             if ($a['__category_position'] === $b['__category_position']) {
-                return $a['__category_id'] > $b['__category_id'] ? 1 : 0;
+                return $a['__category_id'] > $b['__category_id'] ? 1 : -1;
             }
 
-            return $a['__category_position'] > $b['__category_position'] ? 1 : 0;
+            return $a['__category_position'] > $b['__category_position'] ? 1 : -1;
         });
 
         $categories = [];


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
PHP8 changes the behaviour of usort() in a way that the implementation of category sorting is not working reliably.

### 2. What does this change do, exactly?
It changes the result of the comparison from "greater than or equal" to "greater than or less than" resulting in categories always being sorted. Before PHP8 using usort, "equal" values could be shuffled (basically "luck" that it worked before), with PHP 8 equal values will always keep their relative order.

### 3. Describe each step to reproduce the issue or behaviour.
See ticket.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-26345

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ x ] I have not written any tests and if it gets stuck because of that:  ¯\_(ツ)_/¯
- [ x ] I have squashed any insignificant commits
- [ x ] This change has no additional comments because obvious stuff is obvious
- [ x ] I have read the contribution requirements and am not sure if I fulfil them.