### PR TITLE
Remove customer id limitation from shipping address (SW5.7.3 & B2B-Suite)

### DIFF
--- a/engine/Shopware/Core/sAdmin.php
+++ b/engine/Shopware/Core/sAdmin.php
@@ -4335,10 +4335,6 @@ SQL;
             return null;
         }
 
-        if ($shippingAddress->getCustomer()->getId() !== $customer->getId()) {
-            throw new \UnexpectedValueException('Address did not match the user');
-        }
-
         $shippingAddressArray = $this->convertToLegacyAddressArray($shippingAddress);
 
         $shippingAddressArray['attributes'] = $this->attributeLoader->load(


### PR DESCRIPTION
### 1. Why is this change necessary?
B2B-Suite contact ids differ from the user_id stored in the address (debtor id).

### 2. What does this change do, exactly?
Remove check for matching customer id, added in [SW-25778](https://github.com/shopware/shopware/commit/ad174f77d3881bde501dbb6e0d71a0de4b3162ee#diff-ccef450af51163136d58b2a86d0624de543261e45ce16710130d81430b150ba4R4349-R4351).

### 3. Describe each step to reproduce the issue or behaviour.
Install B2B-Suite on SW5.7.3 and call `sAdmin::sGetUserData()` on a contact with default shipping address.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.