### PR TITLE
add var sCustomPage to template paths

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Custom.php
+++ b/engine/Shopware/Controllers/Frontend/Custom.php
@@ -56,7 +56,7 @@ class Shopware_Controllers_Frontend_Custom extends Enlight_Controller_Action
         if (!empty($staticPage['html'])) {
             $this->View()->assign('sContent', $staticPage['html']);
         }
-        
+
         $this->View()->assign('sCustomPage', $staticPage);
 
         for ($i = 1; $i <= 3; ++$i) {

--- a/engine/Shopware/Controllers/Frontend/Custom.php
+++ b/engine/Shopware/Controllers/Frontend/Custom.php
@@ -56,6 +56,8 @@ class Shopware_Controllers_Frontend_Custom extends Enlight_Controller_Action
         if (!empty($staticPage['html'])) {
             $this->View()->assign('sContent', $staticPage['html']);
         }
+        
+        $this->View()->assign('sCustomPage', $staticPage);
 
         for ($i = 1; $i <= 3; ++$i) {
             if (empty($staticPage['tpl' . $i . 'variable']) || empty($staticPage['tpl' . $i . 'path'])) {

--- a/engine/Shopware/Controllers/Frontend/Custom.php
+++ b/engine/Shopware/Controllers/Frontend/Custom.php
@@ -71,7 +71,5 @@ class Shopware_Controllers_Frontend_Custom extends Enlight_Controller_Action
                 $this->View()->fetch($staticPage['tpl' . $i . 'path'])
             );
         }
-
-        $this->View()->assign('sCustomPage', $staticPage);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Actually, the data of a shop custom page, like attributes, will not be available in templates, if a template path (1-3) is configured.

### 2. What does this change do, exactly?
This PR assign the var sCustomPage to the included tpls. So this templates have access to the other fields of the custom page, like the attributes.

### 3. Describe each step to reproduce the issue or behaviour.
Add a template path
Add a template var
=> The template has no access to the var sCustomPage

Add this line in this PR
Add a template path
Add a template var
=> The template has access to the var sCustomPage

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.