### PR TITLE
Adapt conditional logic on cookie permission

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-permission.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.cookie-permission.js
@@ -382,7 +382,9 @@
         hideElement: function() {
             this.$el.addClass(this.opts.isHiddenClass);
             $body.css('padding-bottom', 0);
-            $.modal.close();
+            if(window.cookieRemoval === 2) {
+                $.modal.close();
+            }
         },
 
         getBasePath: function () {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
In the jquery.cookie-permission.js a modal is opened only when cookieRemoval === 2. But on the hide method for this module the $.modal.close() method is called without any conditional logic which leads to a closing modal if you have added one from third party code and this modal uses Shopware built-in modal component. When the same logic for opening is used for closing it other initial modals can survive on the page. 

### 2. What does this change do, exactly?
The logic for closing the modal is now exactly same for opening the modal, so only when cookieRemoval equals 2 the $.modal.close() method is called. 

### 3. Describe each step to reproduce the issue or behaviour.
Spin up an initial modal from a plugin or theme (e.g. age verification or newsletter popup) and configure Shopware to display cookie note and use cookie consent tool or only the simple note (setting equals window.cookieRemoval either 0 or 1). In this case your modal will get closed when you confirm any button in the cookie note. 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.