### PR TITLE
Add svg format to $fileUploadBlacklist

### DIFF
--- a/engine/Shopware/Controllers/Backend/MediaManager.php
+++ b/engine/Shopware/Controllers/Backend/MediaManager.php
@@ -56,6 +56,7 @@ class Shopware_Controllers_Backend_MediaManager extends Shopware_Controllers_Bac
         'py',
         'rb',
         'exe',
+        'svg',
     ];
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The .svg file format allows the insertion and execution of arbitrary javascript leading to XSS attacks

### 2. What does this change do, exactly?
Do not allow uploading .svg image files to the server

### 3. Describe each step to reproduce the issue or behaviour.
The step to reproduce the issue is described in detail in the report: [https://huntr.dev/bounties/778474ad-8ee4-48a6-8562-7c56ee222d44/](https://huntr.dev/bounties/778474ad-8ee4-48a6-8562-7c56ee222d44/)

### 4. Please link to the relevant issues (if any).
[https://huntr.dev/bounties/778474ad-8ee4-48a6-8562-7c56ee222d44/](https://huntr.dev/bounties/778474ad-8ee4-48a6-8562-7c56ee222d44/)

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.