### PR TITLE
Fix widgets/listing/listingCount for facets containing html tags

### DIFF
--- a/themes/Frontend/Bare/widgets/listing/listing_count.tpl
+++ b/themes/Frontend/Bare/widgets/listing/listing_count.tpl
@@ -13,7 +13,7 @@
 
     {if $facets}
         <div id="facets">
-            {$facets|@json_encode}
+            {$facets|@json_encode|escape}
         </div>
     {/if}
 </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
widgets/listing/listingCount returns broken json if `$facets` contains html tags.

### 2. What does this change do, exactly?
HTML-escapes the json-encoded facets.

### 3. Describe each step to reproduce the issue or behaviour.
Config:
\- enable ES
Plugins:
\- TestPlugin (see below, alternatively use SwagEnterpriseSearch and test on search listing)
Backend settings:
\- enable filter_ajax_reload

<details>
<summary>TestPlugin/TestPlugin.php</summary>

```php
<?php
namespace TestPlugin;

use Shopware\Bundle\SearchBundle\Criteria;
use Shopware\Bundle\SearchBundle\FacetResultInterface;
use Shopware\Bundle\SearchBundle\ProductNumberSearchResult;
use Shopware\Bundle\SearchBundleES\ResultHydratorInterface;
use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
use Shopware\Components\Plugin;
use Symfony\Component\DependencyInjection\ContainerBuilder;

class TestPlugin extends Plugin {
    public function build(ContainerBuilder $container) {
        parent::build($container);
        $container->register(TestHydrator::class)
            ->addTag('shopware_search_es.search_handler')
        ;
    }
}

class TestHydrator implements ResultHydratorInterface {
    public function hydrate(array $elasticResult, ProductNumberSearchResult $result, Criteria $criteria, ShopContextInterface $context) {
        $result->addFacet(new class implements FacetResultInterface {
            
            public string $_ = '<b>';

            public function getFacetName() { return self::class; }
            public function isActive() { return false; }
            public function getLabel() { return self::class; }
            public function getTemplate() { return null; }
        });
    }
}
```
</details>

Steps:
\- Open category or search listing (e.g. `/genusswelten/?p=1`)
\- Apply one of the available filters (e.g. "Farbe" "goldig")

Page hangs at reloading, caused by broken json in `#facets` due to `<b>` tag.


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.