### PR TITLE
Fixed the author itemprop for reviews

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/comment/entry.tpl
+++ b/themes/Frontend/Bare/frontend/detail/comment/entry.tpl
@@ -22,7 +22,9 @@
 
                     {* Author content *}
                     {block name='frontend_detail_comment_author_content'}
-                        <span class="content--field" itemprop="author">{if $vote.name}{$vote.name}{else}{s name="DetailCommentAnonymousName"}{/s}{/if}</span>
+                        <span class="content--field" itemprop="author" itemscope itemtype="https://schema.org/Person">
+                            <span itemprop="name">{if $vote.name}{$vote.name}{else}{s name="DetailCommentAnonymousName"}{/s}{/if}</span>
+                        </span>
                     {/block}
                 {/block}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
This change is necessary because the the snippet is not valid and google (and other search engines) will notice that!

### 2. What does this change do, exactly?
This change wrappes the author name in a new span and mark the name with the correct itemprop `name`.

### 3. Describe each step to reproduce the issue or behaviour.
Setup a shop, add a new review and check the source code (and/or google analytics).

### 4. Please link to the relevant issues (if any).
https://forum.shopware.com/t/google-ungueltiger-objekttyp-fuer-feld-author/91016

### 5. Which documentation changes (if any) need to be made because of this PR?
I don't think so.