### PR TITLE
Fix: CLI product feed generation cacheDir path

### DIFF
--- a/engine/Shopware/Commands/GenerateProductFeedCommand.php
+++ b/engine/Shopware/Commands/GenerateProductFeedCommand.php
@@ -108,9 +108,9 @@ class GenerateProductFeedCommand extends ShopwareCommand implements CompletionAw
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
-        $cacheDir = $this->container->getParameter('shopware.product_export.cache_dir');
+        $this->cacheDir = $this->container->getParameter('shopware.product_export.cache_dir');
 
-        if (!\is_string($cacheDir)) {
+        if (!\is_string($this->cacheDir)) {
             throw new RuntimeException('Parameter shopware.product_export.cache_dir has to be a string');
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Before the property in class was null and tried to create a directory with path and  named `null`.

### 2. What does this change do, exactly?
Set the path do existing variable.

### 3. Describe each step to reproduce the issue or behaviour.
Generate a Product feed on CLI

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.