### PR TITLE
Update sExport.php to also support no timelimit

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -2014,7 +2014,7 @@ class sExport implements Enlight_Hook
     private function ensurePHPTimeLimit(): void
     {
         $maxExecutionTime = (int) ini_get('max_execution_time');
-        if ($maxExecutionTime >= 30) {
+        if ($maxExecutionTime >= 30 || $maxExecutionTime <= 0) {
             return;
         }
 


### PR DESCRIPTION
When no timelimit is set the sExport.php sets the timelimit to 30 seconds due to max_execution_time = 0 or = -1 within the php.ini results in $maxExecutionTime >= 30 to be false.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.