### PR TITLE
Optimize Elasticsearch Index Populate Command to prevent invalid shopId

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/Commands/IndexPopulateCommand.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Commands/IndexPopulateCommand.php
@@ -97,7 +97,7 @@ class IndexPopulateCommand extends ShopwareCommand implements CompletionAwareInt
         if ($input->getOption('shopId')) {
             $shops = [];
 
-            foreach ($input->getOption('shopId') as $shopId) {                
+            foreach ($input->getOption('shopId') as $shopId) {
                 $shop = $this->container->get(ShopGatewayInterface::class)->get($shopId);
 
                 if ($shop instanceof Shop) {

--- a/engine/Shopware/Bundle/ESIndexingBundle/Commands/IndexPopulateCommand.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Commands/IndexPopulateCommand.php
@@ -94,11 +94,15 @@ class IndexPopulateCommand extends ShopwareCommand implements CompletionAwareInt
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($shopId = $input->getOption('shopId')) {
+        if ($input->getOption('shopId')) {
             $shops = [];
 
-            foreach ($input->getOption('shopId') as $shopId) {
-                $shops[] = $this->container->get(ShopGatewayInterface::class)->get($shopId);
+            foreach ($input->getOption('shopId') as $shopId) {                
+                $shop = $this->container->get(ShopGatewayInterface::class)->get($shopId);
+
+                if ($shop instanceof Shop) {
+                    $shops[] = $shop;
+                }
             }
         } else {
             $shops = $this->container->get(IdentifierSelector::class)->getShops();


### PR DESCRIPTION
Make sure that the provided shopId exists in the `sw:es:index:populate` cli command.

### 1. Why is this change necessary?
Providing an invalid shopId to the index populate command breaks it

### 2. What does this change do, exactly?
Checks if the provided shopId is valid

### 3. Describe each step to reproduce the issue or behaviour.
`bin/console sw:es:index:populate --shopId={1,22}` (test with invalid shopId)

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.