### PR TITLE
Fix analytics csv export strlen() argument

### DIFF
--- a/engine/Shopware/Controllers/Backend/Analytics.php
+++ b/engine/Shopware/Controllers/Backend/Analytics.php
@@ -972,7 +972,7 @@ class Shopware_Controllers_Backend_Analytics extends Shopware_Controllers_Backen
             $shopNames = $this->getShopNames();
 
             foreach ($fields as $field => $shopId) {
-                $suffix = substr($field, 0, \strlen($fields) - \strlen($shopId));
+                $suffix = substr($field, 0, \strlen($field) - \strlen($shopId));
                 $data = $this->switchArrayKeys($data, $shopNames[$shopId] . ' (' . $suffix . ')', $field);
             }
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
`TypeError: strlen(): Argument #1 ($str) must be of type string, array given`

### 2. What does this change do, exactly?
Passes correct argument to `strlen()`.

### 3. Describe each step to reproduce the issue or behaviour.
Backend: Marketing -> Analysis -> Analysis -> Item detail viewing (/ any statistic with shop selection) -> select shop -> Export (as csv)

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.