### PR TITLE
Fix issue with selected_articles field in article slider component

### DIFF
--- a/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php
+++ b/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php
@@ -116,7 +116,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
                 break;
 
             case self::TYPE_STATIC_PRODUCT:
-                $products = $element->getConfig()->get('selected_articles', []);
+                $products = $element->getConfig()->get('selected_articles', '');
                 $productNumbers = array_filter(explode('|', $products));
                 if (empty($productNumbers)) {
                     $productNumbers = [];
@@ -156,7 +156,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
                 break;
 
             case self::TYPE_STATIC_PRODUCT:
-                $products = $element->getConfig()->get('selected_articles', []);
+                $products = $element->getConfig()->get('selected_articles', '');
                 $productNumbers = array_filter(explode('|', $products));
                 $listProducts = $collection->getBatchResult()->get($key);
 


### PR DESCRIPTION
Fetching "selected_articles" config should return a string, which will be given over to "explode". But default value is an empty array. That results in an error.