### PR TITLE
Set empty string as default for missing password reset hash

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -501,7 +501,7 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
      */
     public function resetPasswordAction()
     {
-        $hash = $this->Request()->getParam('hash');
+        $hash = $this->Request()->getParam('hash', '');
         $this->View()->assign('hash', $hash);
         $customer = null;
 

--- a/tests/Functional/Controllers/Frontend/AccountTest.php
+++ b/tests/Functional/Controllers/Frontend/AccountTest.php
@@ -134,6 +134,14 @@ class AccountTest extends Enlight_Components_Test_Plugin_TestCase
         static::assertEquals($before, $changed);
     }
 
+    public function testNoServerErrorOnMissingHashParameter(): void
+    {
+        $this->Request()->setMethod('GET');
+        $response = $this->dispatch('account/resetPassword');
+
+        static::assertNotNull($response);
+    }
+
     private function getConnection(): Connection
     {
         return Shopware()->Container()->get('dbal_connection');


### PR DESCRIPTION
### 1. Why is this change necessary?
Completly removing the hash parameter from the password reset url results in a server error.

### 2. What does this change do, exactly?
Set the default for the password hash to an empty string so it can't be NULL anymore.
An empty string is than handled by an (already existing) exception.

### 3. Describe each step to reproduce the issue or behaviour.
Call resetPasswordAction in Account frontend controller without hash parameter ("/account/resetPassword").
An empty hash ("/account/resetPassword/hash") or invalid hashes ("/account/resetPassword/hash/abc") were already handled correctly. Server error only occurs if hash parameter is missing, since getCustomerByResetHash() method does not accept NULL as parameter.

### 4. Please link to the relevant issues (if any).
/

### 5. Which documentation changes (if any) need to be made because of this PR?
/

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.