### PR TITLE
Show the content type entries in emotion

### DIFF
--- a/engine/Shopware/Bundle/ContentTypeBundle/Structs/Criteria.php
+++ b/engine/Shopware/Bundle/ContentTypeBundle/Structs/Criteria.php
@@ -32,7 +32,7 @@ class Criteria
     public $offset = 0;
 
     /**
-     * @var int
+     * @var int|null
      */
     public $limit = 10;
 

--- a/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ContentTypeComponentHandler.php
+++ b/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ContentTypeComponentHandler.php
@@ -82,6 +82,7 @@ class ContentTypeComponentHandler implements ComponentHandlerInterface
                 ],
             ];
         } elseif ($mode === self::MODE_SELECTED) {
+            $criteria->limit = null;
             $criteria->filter = [
                 [
                     'property' => 'id',


### PR DESCRIPTION
### 1. Why is this change necessary?
There is a limit of 5 in code without any reason. The Backend can handle many records.

### 2. What does this change do, exactly?
Remove the limit for selected records (keep it for rand() and new)

### 3. Describe each step to reproduce the issue or behaviour.
Add a list of items to emotion via content type

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
No because the behavior is undocumented anyway.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.