### PR TITLE
Fix cookie group is not existing anymore

### DIFF
--- a/engine/Shopware/Bundle/CookieBundle/Services/CookieRemoveHandler.php
+++ b/engine/Shopware/Bundle/CookieBundle/Services/CookieRemoveHandler.php
@@ -32,6 +32,7 @@ use Shopware\Bundle\CookieBundle\Structs\CookieStruct;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Shopware\Bundle\CookieBundle\Exceptions\NoCookieGroupByNameKnownException;
 
 class CookieRemoveHandler extends CookieHandler implements CookieRemoveHandlerInterface
 {
@@ -114,7 +115,12 @@ class CookieRemoveHandler extends CookieHandler implements CookieRemoveHandlerIn
 
         foreach ($preferences['groups'] as $group) {
             foreach ($group['cookies'] as $cookie) {
-                $cookieCollection = $allowedCookies->getGroupByName($group['name'])->getCookies();
+                try {
+                    $cookieCollection = $allowedCookies->getGroupByName($group['name'])->getCookies();
+                } catch (NoCookieGroupByNameKnownException $e) {
+                    unset($preferences['groups'][$group['name']]);
+                    continue;
+                }
 
                 if ($this->hasCookieWithTechnicalName($cookieCollection, $cookie['name'])) {
                     continue;


### PR DESCRIPTION
### 1. Why is this change necessary?
No more existing cookie group which is remembered in the cookie cookiePreferences causes error.

### 2. What does this change do, exactly?
Fix the error which occures if a cookie group don't exists anymore.

### 3. Describe each step to reproduce the issue or behaviour.
1. A plugin adds a new cookie and cookie group "tracking".
2. The users go inside the shop and accept the cookies -> the cookies and groups are saved inside the browser cookie "cookiePreferences". Including the new cookie group "tracking" from the plugin.
3. The shop owner deactivats the plugin.
4. When the user comes back to the page, he gets an error, cause of his stored cookie "cookiePreferences", where the cookie group "tracking" is still inside.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-26481

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.