### PR TITLE
Fix cookie group is not existing anymore

### DIFF
--- a/engine/Shopware/Bundle/CookieBundle/Services/CookieHandler.php
+++ b/engine/Shopware/Bundle/CookieBundle/Services/CookieHandler.php
@@ -29,6 +29,7 @@ namespace Shopware\Bundle\CookieBundle\Services;
 use Shopware\Bundle\CookieBundle\CookieCollection;
 use Shopware\Bundle\CookieBundle\CookieGroupCollection;
 use Shopware\Bundle\CookieBundle\Structs\CookieGroupStruct;
+use Shopware\Bundle\CookieBundle\Exceptions\NoCookieGroupByNameKnownException;
 
 class CookieHandler implements CookieHandlerInterface
 {
@@ -74,7 +75,11 @@ class CookieHandler implements CookieHandlerInterface
                     continue;
                 }
 
-                $cookieGroupStruct = $this->cookieGroupCollection->getGroupByName($cookieGroup['name']);
+                try {
+                    $cookieGroupStruct = $this->cookieGroupCollection->getGroupByName($cookieGroup['name']);
+                } catch (NoCookieGroupByNameKnownException $e) {
+                    continue;
+                }
 
                 return $cookieGroupStruct->isRequired() ?: $cookie['active'];
             }


### PR DESCRIPTION
### 1. Why is this change necessary?
No more existing cookie group which is remembered in the cookie cookiePreferences causes error.

### 2. What does this change do, exactly?
Fix the error which occures if a cookie group don't exists anymore.

### 3. Describe each step to reproduce the issue or behaviour.
1. A plugin adds a new cookie and cookie group "tracking".
2. The users go inside the shop and accept the cookies -> the cookies and groups are saved inside the browser cookie "cookiePreferences". Including the new cookie group "tracking" from the plugin.
3. The shop owner deactivats the plugin.
4. When the user comes back to the page, he gets an error, cause of his stored cookie "cookiePreferences", where the cookie group "tracking" is still inside.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-26481

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.