### PR TITLE
Update birthday for backend ElasticSearch indexing

### DIFF
--- a/engine/Shopware/Bundle/AttributeBundle/Repository/CustomerRepository.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Repository/CustomerRepository.php
@@ -87,7 +87,7 @@ class CustomerRepository extends GenericRepository implements EsAwareRepository
                 'lastLogin' => TypeMappingInterface::MAPPING_DATE_TIME_FIELD,
                 'firstLogin' => TypeMappingInterface::MAPPING_DATE_TIME_FIELD,
                 'newsletter' => TypeMappingInterface::MAPPING_BOOLEAN_FIELD,
-                'birthday' => TypeMappingInterface::MAPPING_DATE_FIELD,
+                'birthday' => TypeMappingInterface::MAPPING_DATE_TIME_FIELD,
                 'lockedUntil' => TypeMappingInterface::MAPPING_DATE_TIME_FIELD,
                 'accountMode' => TypeMappingInterface::MAPPING_LONG_FIELD,
                 'shopId' => TypeMappingInterface::MAPPING_LONG_FIELD,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
without these changes you have indexing errors

Start indexing: customer
 215/215 [============================] 100%  1 sec/1 sec 

 Evaluation:
  Total: 215 items
  Error: 199 items
  Success: 16 items

with the correct mapping it works again
Start indexing: customer
 215/215 [============================] 100% < 1 sec/< 1 sec

 Evaluation:
  Total: 215 items
  Error: 0 items
  Success: 215 items

### 2. What does this change do, exactly?
Changed to the correct mapping field for the birthday

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.