### PR TITLE
Fix ES with product attribute boolean

### DIFF
--- a/engine/Shopware/Bundle/SearchBundle/Condition/ProductAttributeCondition.php
+++ b/engine/Shopware/Bundle/SearchBundle/Condition/ProductAttributeCondition.php
@@ -39,7 +39,7 @@ class ProductAttributeCondition implements ConditionInterface, JsonSerializable
     protected $field;
 
     /**
-     * @var array|int|string|null
+     * @var array|boolean|int|string|null
      */
     protected $value;
 
@@ -86,7 +86,7 @@ class ProductAttributeCondition implements ConditionInterface, JsonSerializable
     }
 
     /**
-     * @return array|int|string|null $value
+     * @return array|boolean|int|string|null
      */
     public function getValue()
     {
@@ -94,7 +94,7 @@ class ProductAttributeCondition implements ConditionInterface, JsonSerializable
     }
 
     /**
-     * @param array|int|string|null $value
+     * @param array|boolean|int|string|null $value
      */
     public function setValue($value)
     {

--- a/engine/Shopware/Bundle/SearchBundleES/ConditionHandler/ProductAttributeConditionHandler.php
+++ b/engine/Shopware/Bundle/SearchBundleES/ConditionHandler/ProductAttributeConditionHandler.php
@@ -97,6 +97,10 @@ class ProductAttributeConditionHandler implements PartialConditionHandlerInterfa
             $attribute = $this->attributeService->get('s_articles_attributes', $criteriaPart->getField());
             if ($attribute instanceof ConfigurationStruct) {
                 $type = $attribute->getElasticSearchType()['type'];
+                
+                if ($type === 'boolean') {
+                    $criteriaPart->setValue((bool) $criteriaPart->getValue());
+                }
             }
         } catch (Exception $e) {
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
DBAL wants `1` or `0` as value and doesn't work with `true` or `false`.
ES is the other way around. Switching between then, needs Manuel backend changes from an editor.
Without the search ends in an exception.

ES v7.10.1


### 2. What does this change do, exactly?
Cast bool vales 1/0 to true or false


### 3. Describe each step to reproduce the issue or behaviour.
Add a product attribute and choose type boolean and switch between DBAL and ES


### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.