### PR TITLE
Add regex to naming of content types

### DIFF
--- a/engine/Shopware/Bundle/ContentTypeBundle/Resources/contenttypes.xsd
+++ b/engine/Shopware/Bundle/ContentTypeBundle/Resources/contenttypes.xsd
@@ -18,7 +18,13 @@
 
     <xsd:complexType name="singleType">
         <xsd:sequence>
-            <xsd:element name="typeName" type="xsd:string"/>
+            <xsd:element name="typeName">
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:string">
+                        <xsd:pattern value="[A-z]+"/>
+                    </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:element>
             <xsd:element name="name" type="xsd:string"/>
             <xsd:element name="showInFrontend" type="xsd:boolean" minOccurs="0" default="false"/>
             <xsd:element name="menuIcon" type="xsd:string" minOccurs="0" default="sprite-application-block"/>


### PR DESCRIPTION
### 1. Why is this change necessary?
Chars like `-` causing errors in SQL table or `_` in ExtJS backend

### 2. What does this change do, exactly?
Add a regex for XML

### 3. Describe each step to reproduce the issue or behaviour.
Create a content type with - or _ in the name

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have read the contribution requirements and fulfil them.