### PR TITLE
Negative crc32 result breaks Shopware 5.7.x on 32-bit systems

### DIFF
--- a/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultLayer.php
@@ -43,7 +43,7 @@ class DefaultLayer implements ConfigurationLayerInterface
 
     public function readValues(string $pluginName, ?int $shopId): array
     {
-        $pluginNameKey = 'pluginName' . crc32($pluginName);
+        $pluginNameKey = 'pluginName' . abs(crc32($pluginName));
         $builder = $this->connection->createQueryBuilder();
 
         $values = $builder->from('s_core_config_elements', 'coreConfigElements')

--- a/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultShopLayer.php
+++ b/engine/Shopware/Components/Plugin/Configuration/Layers/DefaultShopLayer.php
@@ -35,8 +35,8 @@ class DefaultShopLayer extends AbstractShopConfigurationLayer
 
     protected function configureQuery(QueryBuilder $builder, ?int $shopId, string $pluginName): QueryBuilder
     {
-        $shopIdKey = 'shopId' . crc32((string) $shopId);
-        $pluginNameKey = 'pluginName' . crc32($pluginName);
+        $shopIdKey = 'shopId' . abs(crc32((string) $shopId));
+        $pluginNameKey = 'pluginName' . abs(crc32($pluginName));
 
         return $builder
             ->andWhere($builder->expr()->eq('corePlugins.name', ':' . $pluginNameKey))


### PR DESCRIPTION
### 1. Why is this change necessary?
Shopware 5.7.x crashes on 32-bit systems with server error (500) and stacktrace:

`Fatal error: Uncaught Doctrine\DBAL\SQLParserUtilsException: Value for :shopId not found in params array. Params array key should be "shopId" in /home/public_html/vendor/doctrine/dbal/lib/Doctrine/DBAL/SQLParserUtilsException.php:21 Stack trace: 
#0 /home/public_html/vendor/doctrine/dbal/lib/Doctrine/DBAL/SQLParserUtils.php(306): Doctrine\DBAL\SQLParserUtilsException::missingParam('shopId') 
#1 /home/public_html/vendor/doctrine/dbal/lib/Doctrine/DBAL/SQLParserUtils.php(227): Doctrine\DBAL\SQLParserUtils::extractParam('shopId', Array, true) 
#2 /home/public_html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(1250): Doctrine\DBAL\SQLParserUtils::expandListParameters('SELECT coreConf...', Array, Array) 
#3 /home/public_html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php(210): Doctrine\DBAL\Connection->executeQuery('SELECT coreConf...', Array, Array) 
#4 /home/public_html/engine/Shopware/Components/Plugin/Configuration/Layers/AbstractShop in /home/public_html/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php on line 185`

### 2. What does this change do, exactly?
The issue is caused by the crc32 function returning negative values on 32-bit systems.
E.g. for shopId=1 it will return crc32(1)=-2082672713.
This will set the $shopIdKey to shopId-2082672713 and this will break the SQL query.

This change will use the absolute value of the crc32. 
This will not make a difference on 64-bit systems, because the crc32 is always positive.
But it will make SW 5.7.x work on 32-bit systems.

### 3. Describe each step to reproduce the issue or behaviour.
Update SW 5.6.x to 5.7.x on a 32-bit system.