### PR TITLE
Fix issue with NULL values within implode

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -29192,11 +29192,6 @@ parameters:
 			path: engine/Shopware/Controllers/Backend/Newsletter.php
 
 		-
-			message: "#^Parameter \\#2 \\$pieces of function implode expects array, array\\<int, string\\>\\|null given\\.$#"
-			count: 2
-			path: engine/Shopware/Controllers/Backend/Newsletter.php
-
-		-
 			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
 			count: 1
 			path: engine/Shopware/Controllers/Backend/Newsletter.php

--- a/engine/Shopware/Controllers/Backend/Newsletter.php
+++ b/engine/Shopware/Controllers/Backend/Newsletter.php
@@ -583,8 +583,8 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
             return false;
         }
 
-        $customerGroups = null;
-        $recipientGroups = null;
+        $customerGroups = [];
+        $recipientGroups = [];
         $mailing['groups'] = unserialize($mailing['groups'], ['allowed_classes' => false]);
 
         // The first element holds the selected customer groups for the current newsletter


### PR DESCRIPTION
In the Newsletter Backend Controller, when sending emails, it's possible to run into an PHP Fatal error when implode is given NULL instead of an array.
Interestingly, later on in the code it's being checked for emptiness, so it's possible for that array to be empty, but it's not starting with an empty array. why I don't know.

Without this fix a Newsletter cannot be sent out.

Current Versions in use: Shopware 5.7.6 and Intelligent Newsletter 3.4.0

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.