### PR TITLE
fix calling of namespace

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -696,7 +696,7 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
     {
         if ($this->Request()->isPost()) {
             if (!$this->Request()->getParam('sAddPremium')) {
-                $this->View()->assign('sBasketInfo', Shopware()->Snippets()->getNamespace()->get(
+                $this->View()->assign('sBasketInfo', Shopware()->Snippets()->getNamespace('frontend')->get(
                     'CheckoutSelectPremiumVariant',
                     'Please select an option to place the required premium to the cart',
                     true


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the `addPremiumAction` Method results in an error each time it get's called. The error is as follows:

```
FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Shopware_Components_Snippet_Manager::createDbNamespace() must be of the type string, null given, called in engine/Shopware/Components/Snippet/Manager.php on line 121 and defined in engine/Shopware/Components/Snippet/Manager.php:372
Stack trace:
#0 engine/Shopware/Components/Snippet/Manager.php(121): Shopware_Components_Snippet_Manager->createDbNamespace(NULL, 1, 1)
#1 engine/Shopware/Controllers/Frontend/Checkout.php(657): Shopware_Components_Snippet_Manager->getNamespace()
#2 engine/Library/Enlight/Controller/Action.php(192): Shopware_Controllers_Frontend_Checkout->addPremiumAction()
#3 /202201" while reading response header from upstream, client: 194.12.205.135, server: domain.com, request: "POST /checkout/addPremium/sTargetAction/confirm HTTP/2.0", upstream: "fastcgi://unix:/var/run/php/php7.3-fpm.sock:", host: "domain.com", referrer: "https://domain.com/checkout"
```

### 2. What does this change do, exactly?
The change calls the `getNamespace` method with the parameter `frontend` instead of the parameter `null` which results in the error.

### 3. Describe each step to reproduce the issue or behaviour.
Add a premium product to the cart within your checkout routine and the error occurs in the logs.

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
n/a

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.