### PR TITLE
SW-26162 fix possible side effects in swTabMenu

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/js/jquery.tab-menu.js
+++ b/themes/Frontend/Responsive/frontend/_public/src/js/jquery.tab-menu.js
@@ -206,15 +206,11 @@
             $tab = $(me.$tabs.get(index));
             $container = $(me.$container.get(index));
 
-            me.$tabContainer
-                .find('.' + activeTabClass)
-                .removeClass(activeTabClass);
+            me.$tabs.removeClass(activeTabClass);
 
             $tab.addClass(activeTabClass);
 
-            me.$containerList
-                .find('.' + activeContainerClass)
-                .removeClass(activeContainerClass);
+            me.$container.removeClass(activeContainerClass);
 
             $container.addClass(activeContainerClass);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When switching tabs the is--active class is removed from element that has it, because jQuery's `find` function gets all descendants (and not just direct children) which match a selector. So if there are any elements with the `is--active` class in a tabs content, it will also be removed, which is probably not the intention.

### 2. What does this change do, exactly?
Instead of using `find`, it calls `removeClass` on just the tab and container elements, which is fine because `removeClass` does not require the class to be set on the element.

### 3. Describe each step to reproduce the issue or behaviour.
With the following HTML the `is--active` class on the innermost div will be removed once the swTabMenu is initialized:
```
<div class="js--tab-menu tab-menu--cross-selling">
  <div class="tab--navigation">
    <a class="tab--link has--content is--active">
      Test
    </a>
  </div>
  <div class="tab--container-list">
    <div class="tab--container has--content is--active">
      <div class="tab--content">
        <div class="is--active">Test</div>
      </div>
    </div>
  </div>
</div>
```

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-26162

### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.