### PR TITLE
Add mainnumber to product export

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -953,6 +953,7 @@ class sExport implements Enlight_Hook
 
                 d.id as `articledetailsID`,
                 IF(v.ordernumber IS NOT NULL,v.ordernumber,d.ordernumber) as ordernumber,
+                main.ordernumber as mainnumber,
 
                 d.suppliernumber,
                 d.ean,
@@ -960,7 +961,7 @@ class sExport implements Enlight_Hook
                 d.height,
                 d.length,
                 d.kind,
-                IF(v.standard=1||kind=1,1,0) as standard,
+                IF(v.standard=1||d.kind=1,1,0) as standard,
                 d.additionaltext,
                 COALESCE(sai.impressions, 0) as impressions,
                 d.sales,
@@ -1006,6 +1007,10 @@ class sExport implements Enlight_Hook
             INNER JOIN s_articles_details d
             ON d.articleID = a.id
             $sql_add_product_variant_join_condition
+
+            LEFT JOIN s_articles_details main
+            ON main.id = a.main_detail_id
+
             LEFT JOIN s_articles_attributes AS `at`
             ON d.id = `at`.articledetailsID
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
I needed or wanted the main number in multiple instances

Google Shopping (yeas main variant ID works as workaround, but is and inaccessible ID for backend user and unfamiliar)
https://support.google.com/merchants/answer/6324507?hl=en

Shopware in/export works with that ID and export is for 3rd-Party service that enriches Product Data the easiest solution - on Demand an up-to-date export. For import the main number is needed.

### 2. What does this change do, exactly?

Add a join on main detail. Tested with ten thousands and noticed no performance impact. The table is already used in that query.


### 3. Describe each step to reproduce the issue or behavior.

Want an export with a mainnumber

### 5. Which documentation changes (if any) need to be made because of this PR?
Add field to field list

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.