### PR TITLE
explicitly allow /widgets/index/refreshStatistic in robots.txt to give crawlers the chance to read x-header-tag: noindex and remove already indexed pages

### DIFF
--- a/tests/Functional/Controllers/Frontend/RobotsTxtTest.php
+++ b/tests/Functional/Controllers/Frontend/RobotsTxtTest.php
@@ -60,6 +60,7 @@ SQL,
         static::assertArrayHasKey('Disallow: /de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/note/', $robotsTxt);
+        static::assertArrayHasKey('Disallow: /de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/ticket/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /en/compare/', $robotsTxt);
@@ -68,6 +69,7 @@ SQL,
         static::assertArrayHasKey('Disallow: /en/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /en/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /en/note/', $robotsTxt);
+        static::assertArrayHasKey('Disallow: /en/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /en/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /en/ticket/', $robotsTxt);
 
@@ -97,6 +99,7 @@ SQL,
         static::assertArrayHasKey('Disallow: /de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/note/', $robotsTxt);
+        static::assertArrayHasKey('Disallow: /de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/ticket/', $robotsTxt);
         static::assertArrayNotHasKey('Disallow: /en/compare/', $robotsTxt);
@@ -105,6 +108,7 @@ SQL,
         static::assertArrayNotHasKey('Disallow: /en/account/', $robotsTxt);
         static::assertArrayNotHasKey('Disallow: /en/address/', $robotsTxt);
         static::assertArrayNotHasKey('Disallow: /en/note/', $robotsTxt);
+        static::assertArrayNotHasKey('Disallow: /en/widgets/', $robotsTxt);
         static::assertArrayNotHasKey('Disallow: /en/listing/', $robotsTxt);
         static::assertArrayNotHasKey('Disallow: /en/ticket/', $robotsTxt);
 
@@ -134,6 +138,7 @@ SQL,
         static::assertArrayHasKey('Disallow: /de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/note/', $robotsTxt);
+        static::assertArrayHasKey('Disallow: /de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/ticket/', $robotsTxt);
 
@@ -163,6 +168,7 @@ SQL,
         static::assertArrayHasKey('Disallow: /foo/de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/note/', $robotsTxt);
+        static::assertArrayHasKey('Disallow: /foo/de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/ticket/', $robotsTxt);
 
@@ -194,6 +200,7 @@ SQL,
         static::assertArrayHasKey('Disallow: /foo/de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/note/', $robotsTxt);
+        static::assertArrayHasKey('Disallow: /foo/de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/ticket/', $robotsTxt);
 
@@ -225,6 +232,7 @@ SQL,
         static::assertArrayHasKey('Disallow: /foo/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/note/', $robotsTxt);
+        static::assertArrayHasKey('Disallow: /foo/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/ticket/', $robotsTxt);
 
@@ -254,6 +262,7 @@ SQL,
         static::assertArrayHasKey('Disallow: /foo/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/note/', $robotsTxt);
+        static::assertArrayHasKey('Disallow: /foo/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/ticket/', $robotsTxt);
 
@@ -285,6 +294,7 @@ SQL,
         static::assertArrayHasKey('Disallow: /foo/de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/note/', $robotsTxt);
+        static::assertArrayHasKey('Disallow: /foo/de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/ticket/', $robotsTxt);
 

--- a/tests/Functional/Controllers/Frontend/RobotsTxtTest.php
+++ b/tests/Functional/Controllers/Frontend/RobotsTxtTest.php
@@ -60,7 +60,6 @@ SQL,
         static::assertArrayHasKey('Disallow: /de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/note/', $robotsTxt);
-        static::assertArrayHasKey('Disallow: /de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/ticket/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /en/compare/', $robotsTxt);
@@ -69,7 +68,6 @@ SQL,
         static::assertArrayHasKey('Disallow: /en/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /en/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /en/note/', $robotsTxt);
-        static::assertArrayHasKey('Disallow: /en/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /en/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /en/ticket/', $robotsTxt);
 
@@ -99,7 +97,6 @@ SQL,
         static::assertArrayHasKey('Disallow: /de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/note/', $robotsTxt);
-        static::assertArrayHasKey('Disallow: /de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/ticket/', $robotsTxt);
         static::assertArrayNotHasKey('Disallow: /en/compare/', $robotsTxt);
@@ -108,7 +105,6 @@ SQL,
         static::assertArrayNotHasKey('Disallow: /en/account/', $robotsTxt);
         static::assertArrayNotHasKey('Disallow: /en/address/', $robotsTxt);
         static::assertArrayNotHasKey('Disallow: /en/note/', $robotsTxt);
-        static::assertArrayNotHasKey('Disallow: /en/widgets/', $robotsTxt);
         static::assertArrayNotHasKey('Disallow: /en/listing/', $robotsTxt);
         static::assertArrayNotHasKey('Disallow: /en/ticket/', $robotsTxt);
 
@@ -138,7 +134,6 @@ SQL,
         static::assertArrayHasKey('Disallow: /de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/note/', $robotsTxt);
-        static::assertArrayHasKey('Disallow: /de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /de/ticket/', $robotsTxt);
 
@@ -168,7 +163,6 @@ SQL,
         static::assertArrayHasKey('Disallow: /foo/de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/note/', $robotsTxt);
-        static::assertArrayHasKey('Disallow: /foo/de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/ticket/', $robotsTxt);
 
@@ -200,7 +194,6 @@ SQL,
         static::assertArrayHasKey('Disallow: /foo/de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/note/', $robotsTxt);
-        static::assertArrayHasKey('Disallow: /foo/de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/ticket/', $robotsTxt);
 
@@ -232,7 +225,6 @@ SQL,
         static::assertArrayHasKey('Disallow: /foo/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/note/', $robotsTxt);
-        static::assertArrayHasKey('Disallow: /foo/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/ticket/', $robotsTxt);
 
@@ -262,7 +254,6 @@ SQL,
         static::assertArrayHasKey('Disallow: /foo/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/note/', $robotsTxt);
-        static::assertArrayHasKey('Disallow: /foo/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/ticket/', $robotsTxt);
 
@@ -294,7 +285,6 @@ SQL,
         static::assertArrayHasKey('Disallow: /foo/de/account/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/address/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/note/', $robotsTxt);
-        static::assertArrayHasKey('Disallow: /foo/de/widgets/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/listing/', $robotsTxt);
         static::assertArrayHasKey('Disallow: /foo/de/ticket/', $robotsTxt);
 

--- a/themes/Frontend/Bare/frontend/robots_txt/index.tpl
+++ b/themes/Frontend/Bare/frontend/robots_txt/index.tpl
@@ -24,6 +24,7 @@
 
 {block name="frontend_robots_txt_allows"}
     {$robotsTxt->setAllow('/widgets/emotion')}
+    {$robotsTxt->setAllow('/widgets/index/refreshStatistic')}
     {block name="frontend_robots_txt_allows_output"}
         {foreach $robotsTxt->getAllows() as $allow}
             {$allow}

--- a/themes/Frontend/Bare/frontend/robots_txt/index.tpl
+++ b/themes/Frontend/Bare/frontend/robots_txt/index.tpl
@@ -10,7 +10,6 @@
     {$robotsTxt->setDisallow('/account')}
     {$robotsTxt->setDisallow('/address')}
     {$robotsTxt->setDisallow('/note')}
-    {$robotsTxt->setDisallow('/widgets')}
     {$robotsTxt->setDisallow('/listing')}
     {$robotsTxt->setDisallow('/ticket')}
     {$robotsTxt->setDisallow('/tracking')}

--- a/themes/Frontend/Bare/frontend/robots_txt/index.tpl
+++ b/themes/Frontend/Bare/frontend/robots_txt/index.tpl
@@ -10,6 +10,7 @@
     {$robotsTxt->setDisallow('/account')}
     {$robotsTxt->setDisallow('/address')}
     {$robotsTxt->setDisallow('/note')}
+    {$robotsTxt->setDisallow('/widgets')}
     {$robotsTxt->setDisallow('/listing')}
     {$robotsTxt->setDisallow('/ticket')}
     {$robotsTxt->setDisallow('/tracking')}


### PR DESCRIPTION
Google Search Console is complaining that pages under `/widgets` are blocked through `robots.txt`. 
In relation to Googles documentation how to prevent pages from beeing index (https://developers.google.com/search/docs/advanced/crawling/block-indexing) `/widgets` should be removed from `robots.txt` – indeed it already has an `x-header: noindex` entry.