### PR TITLE
Fix TypeError while using proportional taxes and tax rates with decimals (PHP8)

### DIFF
--- a/engine/Shopware/Components/Cart/ProportionalTaxCalculator.php
+++ b/engine/Shopware/Components/Cart/ProportionalTaxCalculator.php
@@ -41,7 +41,7 @@ class ProportionalTaxCalculator implements ProportionalTaxCalculatorInterface
 
         foreach ($sumByTaxes as $taxRate => $price) {
             if ((float) $price === 0.0) {
-                $taxes[] = new Price(0.0, 0.0, $taxRate, 0.0);
+                $taxes[] = new Price(0.0, 0.0, (float) $taxRate, 0.0);
                 continue;
             }
 
@@ -53,7 +53,7 @@ class ProportionalTaxCalculator implements ProportionalTaxCalculatorInterface
 
             $tax = $net * ($taxRate / 100);
 
-            $taxes[] = new Price($isNetPrice ? $net : $priceForTax, $net, $taxRate, $tax);
+            $taxes[] = new Price($isNetPrice ? $net : $priceForTax, $net, (float) $taxRate, $tax);
         }
 
         return $taxes;

--- a/engine/Shopware/Components/Cart/TaxAggregator.php
+++ b/engine/Shopware/Components/Cart/TaxAggregator.php
@@ -119,7 +119,7 @@ class TaxAggregator implements TaxAggregatorInterface
             /** @var callable(array<numeric-string, float> $carry, Price $shippingTax): array<numeric-string, float> $callback */
             $callback = static function (array $carry, Price $shippingTax) {
                 /** @var numeric-string $taxRate */
-                $taxRate = number_format($shippingTax->getTaxRate(), 2);
+                $taxRate = number_format((float) $shippingTax->getTaxRate(), 2);
 
                 if (!\array_key_exists($taxRate, $carry)) {
                     $carry[$taxRate] = 0.0;

--- a/engine/Shopware/Components/Cart/TaxAggregator.php
+++ b/engine/Shopware/Components/Cart/TaxAggregator.php
@@ -119,7 +119,7 @@ class TaxAggregator implements TaxAggregatorInterface
             /** @var callable(array<numeric-string, float> $carry, Price $shippingTax): array<numeric-string, float> $callback */
             $callback = static function (array $carry, Price $shippingTax) {
                 /** @var numeric-string $taxRate */
-                $taxRate = number_format((float) $shippingTax->getTaxRate(), 2);
+                $taxRate = number_format($shippingTax->getTaxRate(), 2);
 
                 if (!\array_key_exists($taxRate, $carry)) {
                     $carry[$taxRate] = 0.0;


### PR DESCRIPTION
### 1. Why is this change necessary?

It throws TypeError error while using proportional taxes and tax rates with decimals

### 2. What does this change do, exactly?

Cast tax rate to float

### 3. Describe each step to reproduce the issue or behaviour.

- Enable Proportional taxes
- Set up a tax rate with decimal for a country (eg 5.5) 
- Assign this tax rate to a product
- Add this product to cart and go to cart

```
Uncaught TypeError: number_format(): Argument #1 ($num) must be of type float, string given
```

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.