### PR TITLE
Skip Element from Media Normalisation if path key not exists

### DIFF
--- a/engine/Shopware/Controllers/Backend/Emotion.php
+++ b/engine/Shopware/Controllers/Backend/Emotion.php
@@ -1325,6 +1325,9 @@ class Shopware_Controllers_Backend_Emotion extends Shopware_Controllers_Backend_
         if ($valueType === 'json') {
             if (\is_array($value)) {
                 foreach ($value as &$val) {
+                    if (!isset($val['path'])) {
+                        continue;
+                    }
                     $val['path'] = $mediaService->normalize($val['path']);
                 }
                 unset($val);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
At the Moment if an Emotion Element has a json Field, it is assumed that there always exists a key with the value path.

### 2. What does this change do, exactly?
It checks before Media normalization if Array Key `path` exists, otherwise skip Media normalization. 

### 3. Describe each step to reproduce the issue or behaviour.
- Create Custom Emotion Element with a hidden json Field
- Try to Save Emotion World with this custom Element 
- Then the following StackTrace appears
```
2022/04/05 10:51:14 [error] 15898#15898: *70241 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in /var/webroot/vendor/shopware/shopware/engine/Shopware/Controllers/Backend/Emotion.php:1333
Stack trace:
#0 /var/webroot/vendor/shopware/shopware/engine/Shopware/Controllers/Backend/Emotion.php(1309): Shopware_Controllers_Backend_Emotion->processDataFieldValue()
#1 /var/webroot/vendor/shopware/shopware/engine/Shopware/Controllers/Backend/Emotion.php(1269): Shopware_Controllers_Backend_Emotion->createElementData()
#2 /var/webroot/vendor/shopware/shopware/engine/Shopware/Controllers/Backend/Emotion.php(1210): Shopware_Controllers_Backend_Emotion->createElements()
#3 /var/webroot/vendor/shopware/shopware/engine/Shopware/Controllers/Backend/Emotion.php(492): Shopware_Controllers_Backend_Emotio" while reading response header from upstream
```

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.