### PR TITLE
update contact

### DIFF
--- a/engine/Shopware/Models/Mail/Contact.php
+++ b/engine/Shopware/Models/Mail/Contact.php
@@ -47,7 +47,7 @@ class Contact extends ModelEntity
      *
      * @ORM\Column(name="mail_address", type="string", nullable=false)
      */
-    protected $mailAddress;
+    protected $mailAddress = '';
 
     public function getId(): ?int
     {


### PR DESCRIPTION
Der Rückgabe Typ ist im neuen nur als string erlaubt. 
Ohne Standardwert ist es aber 'null' aber es ist nur 'string' erlaubt, er versucht halt null zurück zugeben.
=====
The return type is only allowed as a string in the new one.
With no default it's 'null' but only 'string' is allowed, it just tries to return null.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.