### PR TITLE
SW-26654 Use interface typehints for listing controller

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -39,7 +39,7 @@ use Shopware\Bundle\StoreFrontBundle\Struct\Search\CustomSorting;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
 use Shopware\Components\ProductStream\CriteriaFactoryInterface;
 use Shopware\Components\ProductStream\FacetFilterInterface;
-use Shopware\Components\ProductStream\Repository as ProductStreamRepository;
+use Shopware\Components\ProductStream\RepositoryInterface as ProductStreamRepositoryInterface;
 use Shopware\Models\Category\Repository as CategoryRepository;
 use Shopware\Models\CustomerStream\CustomerStreamRepositoryInterface;
 use Shopware\Models\Emotion\Emotion;
@@ -70,7 +70,7 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
 
     private CategoryRepository $categoryRepository;
 
-    private ProductStreamRepository $productStreamRepository;
+    private ProductStreamRepositoryInterface $productStreamRepository;
 
     public function __construct(
         CustomerStreamRepositoryInterface $customerStreamRepository,
@@ -85,7 +85,7 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
         FacetFilterInterface $facetFilter,
         ManufacturerServiceInterface $manufacturerService,
         CategoryRepository $categoryRepository,
-        ProductStreamRepository $productStreamRepository
+        ProductStreamRepositoryInterface $productStreamRepository
     ) {
         $this->customerStreamRepository = $customerStreamRepository;
         $this->contextService = $contextService;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

- Using the original repository class, instead of the interface, removes the possibility to extend the repository
- There will be an exception, because PHP expects the original repository, instead of the extended one (or just the interface)
  ![image](https://user-images.githubusercontent.com/51320851/163559143-d92414eb-0ad5-4654-ba03-5af9d1ccb461.png)


### 2. What does this change do, exactly?

It changes the typehint for the `ProductStream\Repository` to it's corresponding `ProductStream\RepositoryInterface`

### 3. Describe each step to reproduce the issue or behaviour.

Class from our plugin: https://github.com/findologic/plugin-shopware-5/blob/develop/FinSearchUnified/Components/ProductStream/Repository.php
Reproduction URL: https://shopware5.plugins.findologic.dev/food/

1. Create a custom product stream repository
2. Extend the default repository with your own
3. Open a navigation page

### 4. Please link to the relevant issues (if any).

Change was done here: https://github.com/shopware/shopware/commit/7caa7080a8fd82a039e977af143fe628026cdb11

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.