### PR TITLE
 Add event to advanced menu plugin

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/AdvancedMenu/Bootstrap.php
@@ -351,8 +351,9 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
     private function convertCategories(array $categories): array
     {
         $converter = Shopware()->Container()->get(LegacyStructConverter::class);
+        $eventManager = Shopware()->Container()->get('events');
 
-        return array_map(function (Category $category) use ($converter) {
+        return array_map(function (Category $category) use ($converter, $eventManager) {
             $data = $converter->convertCategoryStruct($category);
 
             $data['flag'] = false;
@@ -363,7 +364,9 @@ class Shopware_Plugins_Frontend_AdvancedMenu_Bootstrap extends Shopware_Componen
                 $data['link'] = $category->getExternalLink();
             }
 
-            return $data;
+            return $eventManager->filter('Shopware_Plugins_AdvancedMenu_ConvertCategory', $data, [
+                'category' => $category,
+            ]);
         }, $categories);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Because there is no good entry point to extend the advanced menu data.

### 2. What does this change do, exactly?

Adds a new event `Shopware_Plugins_AdvancedMenu_ConvertCategory`. 

### 3. Describe each step to reproduce the issue or behaviour.

Try to add thumbnails to media entries and realize there is no simple ways to append the thumbnail details.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.