### PR TITLE
SW-26672 - Fix contact reference loading in mail log entry builder

### DIFF
--- a/engine/Shopware/Bundle/MailBundle/Service/LogEntryBuilder.php
+++ b/engine/Shopware/Bundle/MailBundle/Service/LogEntryBuilder.php
@@ -227,7 +227,7 @@ class LogEntryBuilder implements LogEntryBuilderInterface
         foreach ($knownRecipients as $recipient) {
             unset($unknownRecipients[$recipient['mail_address']]);
 
-            $associatedContacts[] = $this->entityManager->getPartialReference(
+            $associatedContacts[] = $this->entityManager->getReference(
                 Contact::class,
                 $recipient['id']
             );
@@ -239,7 +239,7 @@ class LogEntryBuilder implements LogEntryBuilderInterface
 
             $this->persistContact($contact);
 
-            $associatedContacts[] = $this->entityManager->getPartialReference(
+            $associatedContacts[] = $this->entityManager->getReference(
                 Contact::class,
                 $contact->getId()
             );


### PR DESCRIPTION
### 1. Why is this change necessary?
PHP throws an error if a mail is sent to an address which has an existing contact record because the mail address is null in the entity object.

![Screenshot 2022-04-25 113221](https://user-images.githubusercontent.com/26323889/165062776-7301feda-b098-4a86-9288-403c50a8f086.png)

### 2. What does this change do, exactly?
Changing the way of getting the referenced contact from partial to full because the mail address property is needed later on.
Out of the Doctrine ORM comment on EntityManagerInterface getPartialReference method:
\* The returned reference may be a partial object if the entity is not yet loaded/managed.
\* If it is a partial object it will not initialize the rest of the entity state on access.
\* Thus you can only ever safely access the identifier of an entity obtained through
\* this method.

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Settings > E-mail management > Email templates and select a mail template (e.g. sORDER).
2. Use the "Send test mail to shop owner" to send the mail.
3. Redo step 2 because this happens only if the mail contact already exists in the database.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.