### PR TITLE
Fixed listing redirects

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -331,9 +331,9 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
     /**
      * @param array<string, mixed> $categoryContent
      *
-     * @return array{controller?: string, sArticle?: int}
+     * @return string|array{controller?: string, sArticle?: int}
      */
-    private function getRedirectLocation(array $categoryContent, bool $hasEmotion, ShopContextInterface $context): array
+    private function getRedirectLocation(array $categoryContent, bool $hasEmotion, ShopContextInterface $context)
     {
         $location = [];
 

--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -118,7 +118,7 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
         );
 
         $location = $this->getRedirectLocation($categoryContent, $emotionConfiguration['hasEmotion'], $shopContext);
-        if (!empty($location)) {
+        if (null !== $location) {
             $this->redirect($location, ['code' => 301]);
 
             return;
@@ -331,19 +331,21 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
     /**
      * @param array<string, mixed> $categoryContent
      *
-     * @return string|array{controller?: string, sArticle?: int}
+     * @return string|null
      */
-    private function getRedirectLocation(array $categoryContent, bool $hasEmotion, ShopContextInterface $context)
+    private function getRedirectLocation(array $categoryContent, bool $hasEmotion, ShopContextInterface $context): ?string
     {
-        $location = [];
+        if (!empty($categoryContent['external'])) {
+            return $categoryContent['external'];
+        }
+
+        if ($this->isShopsBaseCategoryPage($categoryContent['id'])) {
+            return $this->Front()->Router()->assemble(['controller' => 'index']);
+        }
 
         $checkRedirect = ($hasEmotion && $this->Request()->getParam('sPage')) || (!$hasEmotion);
 
-        if (!empty($categoryContent['external'])) {
-            $location = $categoryContent['external'];
-        } elseif ($this->isShopsBaseCategoryPage($categoryContent['id'])) {
-            $location = ['controller' => 'index'];
-        } elseif ($checkRedirect && $this->config->get('categoryDetailLink')) {
+        if ($checkRedirect && $this->config->get('categoryDetailLink')) {
             $criteria = $this->storeFrontCriteriaFactory->createListingCriteria($this->Request(), $context);
 
             $criteria->resetFacets()
@@ -358,11 +360,15 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
             if (\count($result->getProducts()) === 1) {
                 $products = $result->getProducts();
                 $first = array_shift($products);
-                $location = ['controller' => 'detail', 'sArticle' => $first->getId()];
+
+                return $this->Front()->Router()->assemble([
+                    'controller' => 'detail',
+                    'sArticle' => $first->getId()
+                ]);
             }
         }
 
-        return $location;
+        return null;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
In case of a category has an external link, the method "getRedirectLocation" will return a string. So the return type declaration of this method is wrong and the shop will crash.

### 2. What does this change do, exactly?
I rewrote the method to return only strings for redirects or null if there is no reditect.

### 3. Describe each step to reproduce the issue or behaviour.
Add an external link to a category and call it in the frontend. The shop will crash.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.