### PR TITLE
Fixes SW-26405 / SW-26463: Set no-cache tag if shipping country is changed

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -275,6 +275,7 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
             "widgets/lastArticles detail\n" .
             "widgets/checkout checkout\n" .
             "widgets/compare compare\n" .
+            "widgets/listing price\n" .
             "widgets/emotion price\n",
         ]);
 

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/CacheControl.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/CacheControl.php
@@ -221,6 +221,10 @@ class CacheControl
             $tags[] = 'checkout';
         }
 
+        if (!empty($this->session->offsetGet('sCountry'))) {
+            $tags[] = 'price';
+        }
+
         if ($request->getCookie('slt')) {
             $tags[] = 'slt';
         }
@@ -250,6 +254,10 @@ class CacheControl
         $tags = [];
         if (empty($this->session->offsetGet('sBasketQuantity')) && empty($this->session->offsetGet('sNotesQuantity'))) {
             $tags[] = 'checkout';
+        }
+
+        if (empty($this->session->offsetGet('sCountry'))) {
+            $tags[] = 'price';
         }
 
         if ($action === 'frontend/compare/delete_all') {


### PR DESCRIPTION
### 1. Why is this change necessary?
It is very important that prices are already correct. This must be the case due to legal provisions. Shopware does not seem to consider this issue important enough, so I have fixed it myself and ask to take this into the standard.
When the customer changes the delivery country in the shopping cart and the selected country has a different tax rate configured, the cached prices are displayed. I tested this with a fresh installation of Shopware 5.6 and Shopware 5.7 and are able to reproduce this issue with both versions. See more details about this issue in the linked issues.

### 2. What does this change do, exactly?
I added a check if the session contains the key `sCountry`. This indicates, that the delivery country has been changed.
In this case the `price` tag is added to the cache tags.
So it is possible to fix this issue by adding the `price` tag to the no cache controller settings.
In `HttpCache/Boostrap.php` I added the price tag for controller `widgets/listing` to ensure that the topseller also display the correct prices.

### 3. Describe each step to reproduce the issue or behaviour.
See linked issues.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-26463
https://issues.shopware.com/issues/SW-26405

### 5. Which documentation changes (if any) need to be made because of this PR?
Maybe it is a good idea to mention that it is important to add the following to the `noCacheControllers` setting via performance module to ensure that the prices are displayed correctly after changing the delivery country.
```
frontend/index price
frontend/detail price
widgets/listing price
widgets/emotion price
```

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.