### PR TITLE
Ignore inactive surcharge dispatches in exports

### DIFF
--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -1709,7 +1709,7 @@ class sExport implements Enlight_Hook
             return false;
         }
 
-        $sql = 'SELECT id, bind_sql FROM s_premium_dispatch WHERE type=2 AND bind_sql IS NOT NULL';
+        $sql = 'SELECT id, bind_sql FROM s_premium_dispatch WHERE type=2 AND active=1 AND bind_sql IS NOT NULL';
         $statements = $this->db->fetchPairs($sql);
 
         $sql_where = '';


### PR DESCRIPTION
### 1. Why is this change necessary?
The product export module does not consider the status of surcharge dispatches and therefore product exports may be wrong or may fail completely because of wrong configured inactive dispatches.

### 2. What does this change do, exactly?
Append an active column check to the surcharge dispatch sql query.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a new dispatch wih type "Aufschlag-Versandregel (in Versandkosten eingerechnet)" and add an invalid custom condition like `foo=bar` to it. Let the dispatch inactive and save it.
- Start a new product export and the export will fail with an error caused by the invalid condition inside the inactive dispatch.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.