### PR TITLE
SW-26453 - Fix translation update api

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Translation.php
+++ b/engine/Shopware/Components/Api/Resource/Translation.php
@@ -432,7 +432,6 @@ class Translation extends Resource implements BatchInterface
             $existing = [];
         } else {
             $existing['data'] = unserialize($existing['data'], ['allowed_classes' => false]);
-            $this->delete($data['key'], $data);
         }
 
         $data = array_replace_recursive(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Because translation update api is not working as expected if a translation already exists. Updating an article translation via PUT for example: if a translation already exists, the existing translation is deleted but the new translation is not written to the database, so the article has no translation anymore.

### 2. What does this change do, exactly?
Removing the unnecessary delete of the previous translation because the insert statement uses "ON DUPLICATE KEY UPDATE 'objectdata'=VALUES('objectdata')" anyways.

### 3. Describe each step to reproduce the issue or behaviour.

1. PUT bulk request of multiple article translations => translations are fine.
2. Do another PUT bulk request of the same article translations => translations are gone.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-26453

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.