### PR TITLE
Change mPDF default fontDir to array

### DIFF
--- a/engine/Shopware/Configs/Default.php
+++ b/engine/Shopware/Configs/Default.php
@@ -375,7 +375,7 @@ return array_replace_recursive([
         // Passed to \Mpdf\Mpdf::__construct:
         'defaultConfig' => [
             'tempDir' => $this->getCacheDir() . '/mpdf/',
-            'fontDir' => $this->DocPath('engine_Library_Mpdf_ttfonts_'),
+            'fontDir' => [$this->DocPath('engine_Library_Mpdf_ttfonts_')],
             'fonttrans' => [
                 'helvetica' => 'arial',
                 'verdana' => 'arial',


### PR DESCRIPTION
### 1. Why is this change necessary?
Because the fontDir variable is set to a string you cannot add additional font directories using Mpdf::AddFontDirectory().
This will cause an `[] operator not supported for strings` error.

### 2. What does this change do, exactly?
Replace the fontDir string with an array containing the font dir.

### 3. Describe each step to reproduce the issue or behaviour.
Call `AddFontDirectory()` on the Shopware mPDF instance.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.