### PR TITLE
SW-26882: Use version 2 of composer

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -90,7 +90,7 @@
         <exec executable="${script.php}">
             <arg value="composer.phar"/>
             <arg value="self-update"/>
-            <arg value="--1"/>
+            <arg value="--2"/>
             <arg value="--no-interaction"/>
         </exec>
     </target>


### PR DESCRIPTION
### 1. Why is this change necessary?
Because installation via ant and build.xml will fail since version 5.7.14 (up to 5.7.13 it works)

### 2. What does this change do, exactly?
It changes the build.xml to use composer2 over composer1

### 3. Describe each step to reproduce the issue or behaviour.
Just install a 5.7.14 shop by using build.xml

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-26882

### 5. Which documentation changes (if any) need to be made because of this PR?
Should be none

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.