### PR TITLE
fix: Type error in Exception code due to PDOException

### DIFF
--- a/engine/Library/Zend/Db/Adapter/Exception.php
+++ b/engine/Library/Zend/Db/Adapter/Exception.php
@@ -40,6 +40,15 @@ class Zend_Db_Adapter_Exception extends Zend_Db_Exception
         if ($e && (0 === $code)) {
             $code = $e->getCode();
         }
+
+        /**
+         * As $e might be an instance of \PDOException $e::getCode() could be
+         * a string or it could be passed as string
+         */
+        if (!is_int($code)) {
+            $code = 0;
+        }
+
         parent::__construct($message, $code, $e);
     }
 
@@ -52,5 +61,4 @@ class Zend_Db_Adapter_Exception extends Zend_Db_Exception
     {
         return $this->getPrevious();
     }
-
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently one might run into an error 
```
Fatal error: Uncaught TypeError: Exception::__construct(): Argument #2 ($code) must be of type int, string given in /srv/http/.../engine/Library/Zend/Db/Adapter/Exception.php on line 43
```
Which is due to an type incompatibility of the exceptions, as described here:
https://www.php.net/manual/en/class.pdoexception.php#95812
As the methods of `\Exception` are `final` one cannot change the return type. PHP apparently handles this problem internally as the \PDOException::getCode() method should return a wrong type as well.

### 2. What does this change do, exactly?
Set the error code to `0` in case of a string error code, as this code is already encoded in the Message and a wrong code (e.g. converted to `int`) probably creates more confusion as it helps.

### 3. Describe each step to reproduce the issue or behaviour.
Install a plugin where the attribute columns are already created in the database but not in the attribute table.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.