### PR TITLE
Update article API behaviour

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -248,7 +248,11 @@ class Article extends Resource implements BatchInterface
         foreach ($prices as &$price) {
             $price['net'] = $price['price'];
             if ($price['customerGroup'] && $price['customerGroup']['taxInput']) {
-                $price['price'] *= (($taxRate + 100) / 100);
+                $taxMultiplier = ($taxRate + 100) / 100;
+
+                $price['price'] *= $taxMultiplier;
+                $price['pseudoPrice'] *= $taxMultiplier;
+                $price['regulationPrice'] *= $taxMultiplier;
             }
         }
 

--- a/tests/Functional/Components/Api/ArticleTest.php
+++ b/tests/Functional/Components/Api/ArticleTest.php
@@ -2599,6 +2599,8 @@ class ArticleTest extends TestCase
 
         static::assertEquals(400, $price['price']);
         static::assertEquals($net, $price['net']);
+        static::assertEquals(450, $price['pseudoPrice']);
+        static::assertEquals(400, $price['regulationPrice']);
     }
 
     public function testAssignCategoriesByPathShouldBeSuccessful(): void
@@ -3383,6 +3385,8 @@ class ArticleTest extends TestCase
                         'from' => 1,
                         'to' => '-',
                         'price' => 400,
+                        'pseudoPrice' => 450,
+                        'regulationPrice' => 400,
                     ],
                 ],
             ],


### PR DESCRIPTION
### 1. Why is this change necessary?
If you fetch an article via API pseudoPrice and regulationPrice is always without tax, even if the flag 'considerTaxInput' is set to true.

### 2. What does this change do, exactly?
Return 'pseudoPrice' and 'regulationPrice' of article with tax if flag 'considerTaxInput' is set to true

### 3. Describe each step to reproduce the issue or behaviour.
Fetch an article from the API

### 4. Please link to the relevant issues (if any).
[SW-17645](https://issues.shopware.com/issues/SW-17645)

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.