### PR TITLE
SW-24530 - multi-edit backup can now be imported again

### DIFF
--- a/engine/Shopware/Controllers/Backend/ArticleList.php
+++ b/engine/Shopware/Controllers/Backend/ArticleList.php
@@ -155,8 +155,8 @@ class Shopware_Controllers_Backend_ArticleList extends Shopware_Controllers_Back
     public function restoreAction()
     {
         $resource = $this->Request()->getParam('resource');
-        $id = $this->Request()->getParam('id');
-        $offset = $this->Request()->getParam('offset');
+        $id = (int)$this->Request()->getParam('id');
+        $offset = (int)$this->Request()->getParam('offset');
 
         /** @var ResourceInterface $resource */
         $resource = $this->container->get('multi_edit.' . $resource);

--- a/engine/Shopware/Controllers/Backend/ArticleList.php
+++ b/engine/Shopware/Controllers/Backend/ArticleList.php
@@ -428,7 +428,7 @@ class Shopware_Controllers_Backend_ArticleList extends Shopware_Controllers_Back
 
         $filter = null;
         if ($id) {
-            $filter = $this->getMultiEditRepository()->find((int) $id);
+            $filter = $this->getMultiEditRepository()->find((int)$id);
         }
         if (!$filter instanceof Filter) {
             $filter = new Filter();
@@ -512,7 +512,7 @@ class Shopware_Controllers_Backend_ArticleList extends Shopware_Controllers_Back
      */
     public function deleteProductAction()
     {
-        $id = (int) $this->Request()->getParam('Detail_id');
+        $id = (int)$this->Request()->getParam('Detail_id');
 
         /** @var Detail $variant */
         $variant = $this->getDetailRepository()->find($id);
@@ -547,7 +547,7 @@ class Shopware_Controllers_Backend_ArticleList extends Shopware_Controllers_Back
      */
     private function normalizeFilter($filter)
     {
-        return strtolower((string) preg_replace('/[^\da-z]/i', '_', strip_tags($filter)));
+        return strtolower((string)preg_replace('/[^\da-z]/i', '_', strip_tags($filter)));
     }
 
     /**
@@ -723,7 +723,7 @@ class Shopware_Controllers_Backend_ArticleList extends Shopware_Controllers_Back
         $criteria->sortings = $request->getParam('sort', []);
         $criteria->conditions = $request->getParam('filters', []);
 
-        $categoryId = (int) $request->getParam('categoryId');
+        $categoryId = (int)$request->getParam('categoryId');
         if ($categoryId > 0) {
             $criteria->conditions[] = ['property' => 'categoryIds', 'value' => $categoryId, 'expression' => 'IN'];
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
The problem here is, that a type check for int takes place, but the value is coming as a string and the zip cant be open.

### 2. What does this change do, exactly?
open the backup zip again and imports all data that have been changed before.

### 3. Describe each step to reproduce the issue or behaviour.
change the suppliertime for many articles
restore your changes, backend says all good but the zip are not be open and all changes are not correct re imported.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-24530

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.