### PR TITLE
Update JSMin.php

### DIFF
--- a/engine/Library/minify/JSMin.php
+++ b/engine/Library/minify/JSMin.php
@@ -323,7 +323,7 @@ class JSMin {
                 $c = null;
             }
         }
-        if (ord($c) >= self::ORD_SPACE || $c === "\n" || $c === null) {
+        if ($c === null || ord($c) >= self::ORD_SPACE || $c === "\n") {
             return $c;
         }
         if ($c === "\r") {


### PR DESCRIPTION
prevent deprecation message in php8.1

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
To remove the following deprecation message:

``` ./bin/console sw:theme:cache:generate
Generating new theme cache for shop "Gandalf" ...
PHP Deprecated:  ord(): Passing null to parameter #1 ($character) of type string is deprecated in /var/www/gandalf.tiefenbach-it.com/vendor/shopware/shopware/engine/Library/minify/JSMin.php on line 326

Deprecated: ord(): Passing null to parameter #1 ($character) of type string is deprecated in /var/www/gandalf.tiefenbach-it.com/vendor/shopware/shopware/engine/Library/minify/JSMin.php on line 326
PHP Deprecated:  ord(): Passing null to parameter #1 ($character) of type string is deprecated in /var/www/gandalf.tiefenbach-it.com/vendor/shopware/shopware/engine/Library/minify/JSMin.php on line 326

Deprecated: ord(): Passing null to parameter #1 ($character) of type string is deprecated in /var/www/gandalf.tiefenbach-it.com/vendor/shopware/shopware/engine/Library/minify/JSMin.php on line 326
Clearing HTTP cache ...
```

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.