### PR TITLE
Feature/allow numbers in contenttype names

### DIFF
--- a/engine/Shopware/Bundle/ContentTypeBundle/Resources/contenttypes.xsd
+++ b/engine/Shopware/Bundle/ContentTypeBundle/Resources/contenttypes.xsd
@@ -21,7 +21,7 @@
             <xsd:element name="typeName">
                 <xsd:simpleType>
                     <xsd:restriction base="xsd:string">
-                        <xsd:pattern value="[A-z]+"/>
+                        <xsd:pattern value="[A-z0-9]+"/>
                     </xsd:restriction>
                 </xsd:simpleType>
             </xsd:element>

--- a/engine/Shopware/Bundle/ContentTypeBundle/Resources/contenttypes.xsd
+++ b/engine/Shopware/Bundle/ContentTypeBundle/Resources/contenttypes.xsd
@@ -21,7 +21,7 @@
             <xsd:element name="typeName">
                 <xsd:simpleType>
                     <xsd:restriction base="xsd:string">
-                        <xsd:pattern value="[A-z0-9]+"/>
+                        <xsd:pattern value="[A-z][A-z0-9]*"/>
                     </xsd:restriction>
                 </xsd:simpleType>
             </xsd:element>

--- a/tests/Unit/Bundle/ContentTypeBundle/XmlReaderTest.php
+++ b/tests/Unit/Bundle/ContentTypeBundle/XmlReaderTest.php
@@ -101,9 +101,9 @@ class XmlReaderTest extends TestCase
         $this->reader->read(__DIR__ . '/fixtures/valid_with_invalid_typeName.xml');
     }
 
-    public function testReadInvalidTypeNameWithNumberFile(): void
+    public function testReadValidTypeNameWithNumber(): void
     {
-        $this->assertIsArray($this->reader->read(__DIR__ . '/fixtures/valid_with_number_in_typeName.xml'));
+        static::assertIsArray($this->reader->read(__DIR__ . '/fixtures/valid_with_number_in_typeName.xml'));
     }
 
     public function testReadingInvalidFrontendConfiguration(): void

--- a/tests/Unit/Bundle/ContentTypeBundle/XmlReaderTest.php
+++ b/tests/Unit/Bundle/ContentTypeBundle/XmlReaderTest.php
@@ -101,6 +101,12 @@ class XmlReaderTest extends TestCase
         $this->reader->read(__DIR__ . '/fixtures/valid_with_invalid_typeName.xml');
     }
 
+    public function testReadInvalidTypeNameWithNumberFile(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->reader->read(__DIR__ . '/fixtures/valid_with_invalid_space_in_typeName.xml');
+    }
+
     public function testReadingInvalidFrontendConfiguration(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Bundle/ContentTypeBundle/XmlReaderTest.php
+++ b/tests/Unit/Bundle/ContentTypeBundle/XmlReaderTest.php
@@ -103,8 +103,7 @@ class XmlReaderTest extends TestCase
 
     public function testReadInvalidTypeNameWithNumberFile(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->reader->read(__DIR__ . '/fixtures/valid_with_invalid_space_in_typeName.xml');
+        $this->assertIsArray($this->reader->read(__DIR__ . '/fixtures/valid_with_number_in_typeName.xml'));
     }
 
     public function testReadingInvalidFrontendConfiguration(): void

--- a/tests/Unit/Bundle/ContentTypeBundle/XmlReaderTest.php
+++ b/tests/Unit/Bundle/ContentTypeBundle/XmlReaderTest.php
@@ -106,6 +106,12 @@ class XmlReaderTest extends TestCase
         static::assertIsArray($this->reader->read(__DIR__ . '/fixtures/valid_with_number_in_typeName.xml'));
     }
 
+    public function testReadInvalidTypeNameStartingWithNumberFile(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->reader->read(__DIR__ . '/fixtures/valid_with_invalid_starting_number_in_typeName.xml');
+    }
+
     public function testReadingInvalidFrontendConfiguration(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Bundle/ContentTypeBundle/fixtures/valid_with_invalid_space_in_typeName.xml
+++ b/tests/Unit/Bundle/ContentTypeBundle/fixtures/valid_with_invalid_space_in_typeName.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<contentTypes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../engine/Shopware/Bundle/ContentTypeBundle/Resources/contenttypes.xsd">
+    <types>
+        <type>
+            <typeName>b2b Companies</typeName>
+            <name>B2B Purchase Groups</name>
+            <fieldSets>
+                <fieldSet>
+                    <field name="name" type="text" required="true">
+                        <label>Name</label>
+                        <showListing>true</showListing>
+                    </field>
+                    <field name="email" type="text">
+                        <label>Email</label>
+                        <showListing>true</showListing>
+                    </field>
+                </fieldSet>
+            </fieldSets>
+        </type>
+    </types>
+</contentTypes>

--- a/tests/Unit/Bundle/ContentTypeBundle/fixtures/valid_with_invalid_starting_number_in_typeName.xml
+++ b/tests/Unit/Bundle/ContentTypeBundle/fixtures/valid_with_invalid_starting_number_in_typeName.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<contentTypes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="../../../engine/Shopware/Bundle/ContentTypeBundle/Resources/contenttypes.xsd">
+    <types>
+        <type>
+            <typeName>123Test</typeName>
+            <name>TEST 123</name>
+            <fieldSets>
+                <fieldSet>
+                    <field name="name" type="text" required="true">
+                        <label>Name</label>
+                        <showListing>true</showListing>
+                    </field>
+                    <field name="email" type="text">
+                        <label>Email</label>
+                        <showListing>true</showListing>
+                    </field>
+                </fieldSet>
+            </fieldSets>
+        </type>
+    </types>
+</contentTypes>

--- a/tests/Unit/Bundle/ContentTypeBundle/fixtures/valid_with_number_in_typeName.xml
+++ b/tests/Unit/Bundle/ContentTypeBundle/fixtures/valid_with_number_in_typeName.xml
@@ -3,7 +3,7 @@
               xsi:noNamespaceSchemaLocation="../../../engine/Shopware/Bundle/ContentTypeBundle/Resources/contenttypes.xsd">
     <types>
         <type>
-            <typeName>b2b Companies</typeName>
+            <typeName>b2bCompanies</typeName>
             <name>B2B Purchase Groups</name>
             <fieldSets>
                 <fieldSet>

--- a/tests/Unit/Bundle/ContentTypeBundle/fixtures/valid_with_number_in_typeName.xml
+++ b/tests/Unit/Bundle/ContentTypeBundle/fixtures/valid_with_number_in_typeName.xml
@@ -3,8 +3,8 @@
               xsi:noNamespaceSchemaLocation="../../../engine/Shopware/Bundle/ContentTypeBundle/Resources/contenttypes.xsd">
     <types>
         <type>
-            <typeName>b2bCompanies</typeName>
-            <name>B2B Purchase Groups</name>
+            <typeName>a123Test</typeName>
+            <name>TEST 123</name>
             <fieldSets>
                 <fieldSet>
                     <field name="name" type="text" required="true">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
After SW-26513 numbers are no longer allowed in naming of content types

### 2. What does this change do, exactly?
Changes regex to allow numbers.

### 3. Describe each step to reproduce the issue or behaviour.
Create a content type with a number in the name. For example "b2b".

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.