### PR TITLE
Move deprecation notice to correct service

### DIFF
--- a/engine/Shopware/Bundle/ESIndexingBundle/DependencyInjection/services.xml
+++ b/engine/Shopware/Bundle/ESIndexingBundle/DependencyInjection/services.xml
@@ -15,7 +15,7 @@
         </service>
 
         <service id="shopware_elastic_search.client.logger" alias="shopware_elastic_search.client">
-            <deprecated>The "%alias_id%" service is deprecated. Use "%service_id%" instead</deprecated>
+            <deprecated>The "%service_id%" service is deprecated. Use "%alias_id%" instead</deprecated>
         </service>
 
         <service id="shopware_elastic_search.shop_indexer_factory"

--- a/engine/Shopware/Bundle/ESIndexingBundle/DependencyInjection/services.xml
+++ b/engine/Shopware/Bundle/ESIndexingBundle/DependencyInjection/services.xml
@@ -12,10 +12,11 @@
             <argument>%shopware.es.client%</argument>
             <argument type="service" id="eslogger"/>
             <argument type="service" id="Shopware\Bundle\ESIndexingBundle\Console\EvaluationHelperInterface"/>
-            <deprecated>The "shopware_elastic_search.client.logger" service is deprecated. Use "%service_id%" instead</deprecated>
         </service>
 
-        <service id="shopware_elastic_search.client.logger" alias="shopware_elastic_search.client"/>
+        <service id="shopware_elastic_search.client.logger" alias="shopware_elastic_search.client">
+            <deprecated>The "%alias_id%" service is deprecated. Use "%service_id%" instead</deprecated>
+        </service>
 
         <service id="shopware_elastic_search.shop_indexer_factory"
                  class="Shopware\Bundle\ESIndexingBundle\DependencyInjection\Factory\ShopIndexerFactory">

--- a/engine/Shopware/Components/DependencyInjection/api.xml
+++ b/engine/Shopware/Components/DependencyInjection/api.xml
@@ -102,16 +102,16 @@
 
         <!-- Necessary because of implementation in \Shopware\Components\Api\Manager::getResource() -->
         <service id="shopware.api.customerstream" alias="shopware.api.customer_stream">
-            <deprecated>%alias_id% is deprecated, use shopware.api.customer_stream instead</deprecated>
+            <deprecated>%service_id% is deprecated, use %alias_id% instead</deprecated>
         </service>
         <service id="shopware.api.customergroup" alias="shopware.api.customer_group">
-            <deprecated>%alias_id% is deprecated, use shopware.api.customer_group instead</deprecated>
+            <deprecated>%service_id% is deprecated, use %alias_id% instead</deprecated>
         </service>
         <service id="shopware.api.propertygroup" alias="shopware.api.property_group">
-            <deprecated>%alias_id% is deprecated, use shopware.api.property_group instead</deprecated>
+            <deprecated>%service_id% is deprecated, use %alias_id% instead</deprecated>
         </service>
         <service id="shopware.api.emotionpreset" alias="shopware.api.emotion_preset">
-            <deprecated>%alias_id% is deprecated, use shopware.api.emotion_preset instead</deprecated>
+            <deprecated>%service_id% is deprecated, use %alias_id% instead</deprecated>
         </service>
     </services>
 </container>

--- a/engine/Shopware/Components/DependencyInjection/logger.xml
+++ b/engine/Shopware/Components/DependencyInjection/logger.xml
@@ -76,7 +76,7 @@
         </service>
 
         <service id="debuglogger" alias="corelogger">
-            <deprecated>The "%alias_id%" service id is deprecated since 5.7.0, use "corelogger" instead. Will be removed with 5.8.0</deprecated>
+            <deprecated>The "%service_id%" service id is deprecated since 5.7.0, use "%alias_id%" instead.</deprecated>
         </service>
 
         <service id="shopware.log.fileparser" class="Shopware\Components\Log\Parser\LogfileParser"/>

--- a/engine/Shopware/Components/DependencyInjection/services.xml
+++ b/engine/Shopware/Components/DependencyInjection/services.xml
@@ -79,7 +79,7 @@
 
         <service id="template_factory" class="Shopware\Components\DependencyInjection\Bridge\Template"/>
         <service id="Template" alias="template">
-            <deprecated>The "%alias_id%" service is deprecated. Use "template" instead</deprecated>
+            <deprecated>The "%service_id%" service is deprecated. Use "%alias_id%" instead</deprecated>
         </service>
         <service id="template" class="Enlight_Template_Manager">
             <factory service="template_factory" method="factory"/>
@@ -178,7 +178,7 @@
         </service>
 
         <service id="Loader" alias="loader">
-            <deprecated>The "%alias_id%" service is deprecated. Use "loader" instead</deprecated>
+            <deprecated>The "%service_id%" service is deprecated. Use "%alias_id%" instead</deprecated>
         </service>
         <service id="loader" class="Enlight_Loader"/>
         <service id="shopware.loader" alias="loader"/>
@@ -644,7 +644,7 @@
         <service id="shopware.plugin_xml_plugin_reader" class="Shopware\Components\Plugin\XmlReader\XmlPluginReader"/>
 
         <service id="shopware.plugin_xml_plugin_info_reader" alias="shopware.plugin_xml_plugin_reader">
-            <deprecated>The "%alias_id%" service id is deprecated since 5.6.0, use "shopware.plugin_xml_plugin_reader" instead.</deprecated>
+            <deprecated>The "%service_id%" service id is deprecated since 5.6.0, use "%alias_id%" instead.</deprecated>
         </service>
 
         <service id="shopware.plugin_requirement_validator" class="Shopware\Components\Plugin\RequirementValidator">


### PR DESCRIPTION
### 1. Why is this change necessary?
Because the deprecation tag is inside the new service instead of the deprecated one every usage of the right service causes a (wrong) deprecation log entry.

### 2. What does this change do, exactly?
Move the deprecation tag from the new service `shopware_elastic_search.client` to the deprecated service `shopware_elastic_search.client.logger`.

### 3. Describe each step to reproduce the issue or behaviour.
Use Shopware 5 with elastic search and debug log level, open up the article list in the backend and look into the logfile. You will find entries with `The "shopware_elastic_search.client.logger" service is deprecated. Use "shopware_elastic_search.client" instead`.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.