### PR TITLE
Update Application.php

### DIFF
--- a/engine/Shopware/Components/Console/Application.php
+++ b/engine/Shopware/Components/Console/Application.php
@@ -200,17 +200,9 @@ class Application extends BaseApplication
      */
     protected function registerTaggedServiceIds()
     {
-        $ids = (array) $this->kernel->getContainer()->getParameter('console.command.ids');
-        $lazyServices = array_keys($ids);
-
         if ($this->kernel->getContainer()->hasParameter('console.command.ids')) {
-            /** @var array<string, string> $commandIds */
-            $commandIds = $this->kernel->getContainer()->getParameter('console.command.ids');
-
-            foreach ($commandIds as $id) {
-                if (!\in_array($id, $lazyServices)) {
-                    $this->add($this->kernel->getContainer()->get($id));
-                }
+            foreach ($this->kernel->getContainer()->getParameter('console.command.ids') as $id) {
+                $this->add($this->kernel->getContainer()->get($id));
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
We (@migo315 and I) run into a strange issue with the shopware update process from 5.6 to 5.7 with php 7.4.23. Not all Commands showed up after the update to 5.7. After the php update process everything worked fine. So we digged deeper cause shopware and php update at once is to risky for us. 

So we found a hot fix to add to all missing Commands the "protected static $defaultName" parameter and then they showed up again. But with this fix we are not happy so we digged deeper. So we created this pull request. This change make it work again for us. It seems, that we run in a rare situation from in_array. See this: https://www.php.net/manual/en/function.in-array.php and our running example with example data:
https://3v4l.org/T9bA8
Without the strict no service is registered. With strict mode: 
https://3v4l.org/9N4HM

We think, through the symfony update  in sw 5.7 we run with our heavily extended shopware installation in a rare php issue with in_array.

"Prior to PHP 8.0.0, a string needle will match an array value of 0 in non-strict mode, and vice versa. That may lead to undesireable results. Similar edge cases exist for other types, as well. If not absolutely certain of the types of values involved, always use the strict flag to avoid unexpected behavior."

What do you think about that?

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.