### PR TITLE
Update ProductHydrator.php

### DIFF
--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/ProductHydrator.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/ProductHydrator.php
@@ -196,7 +196,7 @@ class ProductHydrator extends Hydrator
         $product->setWeight((float) $data['__variant_weight']);
         $product->setWidth((float) $data['__variant_width']);
 
-        $customerGroups = explode('|', $data['__product_blocked_customer_groups']);
+        $customerGroups = explode('|', $data['__product_blocked_customer_groups'] ?? '');
         $customerGroups = array_filter($customerGroups);
         $product->setBlockedCustomerGroupIds($customerGroups);
         $product->setHasAvailableVariant($data['__product_has_available_variants'] > 0);


### PR DESCRIPTION
improve php8.1 support

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If you are running shopware 5 with php8.1 and run the command ./bin/console sw:es:index:populate you will get very much of this messages:

PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/tiefenbach-it.com/vendor/shopware/shopware/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/Hydrator/ProductHydrator.php on line 199

### 2. What does this change do, exactly?
fix the deprecated usage

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.