### PR TITLE
Update sOrder.php

### DIFF
--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -1784,10 +1784,8 @@ EOT;
         return $this->db->fetchAll(
             'SELECT s_articles_esd_serials.id AS id, s_articles_esd_serials.serialnumber AS serialnumber
             FROM s_articles_esd_serials
-            LEFT JOIN s_order_esd
-              ON (s_articles_esd_serials.id = s_order_esd.serialID)
-            WHERE s_order_esd.serialID IS NULL
-            AND s_articles_esd_serials.esdID= :esdId',
+            WHERE NOT s_articles_esd_serials.id IN (SELECT serialID FROM s_order_esd)
+            AND s_articles_esd_serials.esdID= :esdId', 
             ['esdId' => $esdId]
         );
     }


### PR DESCRIPTION
 private function getAvailableSerialsOfEsd($esdId) starts working slowly when the number of the license keys in DB increases and that causes the clients to wait about 1 to 2 minutes in order to receive the order. (the number of purchased product keys in DB is about 20,000). These all is caused by LEFT JOIN query in SQL.

The query was changed from a left join to an IN statement.
A new line is added in the WHERE clause, which checks if serialID exists in s_order_esd table or not.