### PR TITLE
Change default Value for `Shopware.form.field.PagingComboBox` element

### DIFF
--- a/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.PagingComboBox.js
+++ b/themes/Backend/ExtJs/backend/base/component/Shopware.form.field.PagingComboBox.js
@@ -159,7 +159,7 @@ Ext.define('Shopware.form.field.PagingComboBox', {
         }
 
         if (!this.displayTplData.length) {
-            return this.emptyText;
+            return '';
         }
 
         if (!this.isValidRecordData(this.displayTplData[0])) {


### PR DESCRIPTION
### 1. Why is this change necessary?
It's very annoying that the searchable combobox field, has a default value, that you have to clear before you can use the search. Specially for long list, like the profile select in the ImportExport plugin.

### 2. What does this change do, exactly?
If no item is selected, the placeholder text will only be displayed as placeholder and not as value.

### 3. Describe each step to reproduce the issue or behaviour.
Open a Backend module that use a `Shopware.form.field.PagingComboBox` field e.g. ImportExport Plugin > Export > Select profile.

You have to clear the text "Please choose" before you can search for a profile.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.