### PR TITLE
Fix cart instock info message output

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -589,8 +589,13 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
         $ordernumber = trim($this->Request()->getParam('sAdd'));
         $quantity = (int) $this->Request()->getParam('sQuantity');
         $productId = Shopware()->Modules()->Articles()->sGetArticleIdByOrderNumber($ordernumber);
+        $instockInfo = $this->getInstockInfo($ordernumber, $quantity);
 
-        $this->View()->assign('sBasketInfo', $this->getInstockInfo($ordernumber, $quantity));
+        $this->View()->assign('sBasketInfo', $instockInfo);
+
+        if ($instockInfo !== null) {
+            $this->session->offsetSet('sErrorMessages', $instockInfo);
+        }
 
         if (!empty($productId)) {
             $insertId = $this->basket->sAddArticle($ordernumber, $quantity);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
There is no message when adding an article by articlenumber fails because of unfulfilled instock conditions.
Problem: Assigned view variables are lost on forward/redirect.

### 2. What does this change do, exactly?
Add instock info as session error message which is then assigned to the view as basket info in cart action.

### 3. Describe each step to reproduce the issue or behaviour.
Go to the cart page and add an out of stock article by articlenumber > no message is shown.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.