### PR TITLE
fix: Use empty string as default value to prevent passing null to strtolower

### DIFF
--- a/engine/Shopware/Commands/PluginListCommand.php
+++ b/engine/Shopware/Commands/PluginListCommand.php
@@ -82,7 +82,8 @@ class PluginListCommand extends ShopwareCommand implements CompletionAwareInterf
                 'filter',
                 'f',
                 InputOption::VALUE_REQUIRED,
-                'Filter Plugins (inactive, active, installed, uninstalled)'
+                'Filter Plugins (inactive, active, installed, uninstalled)',
+                ''
             )
             ->addOption(
                 'namespace',


### PR DESCRIPTION
### 1. Why is this change necessary?
```
Deprecated:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /srv/http/sw5git/shopware/engine/Shopware/Commands/PluginListCommand.php on line 116
```

### 2. What does this change do, exactly?
Use an empty string as default value.

### 3. Describe each step to reproduce the issue or behaviour.
Use the `sw:plugin:list` command with php 8.2.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.