### PR TITLE
Update createMessageId

### DIFF
--- a/engine/Library/Zend/Mail.php
+++ b/engine/Library/Zend/Mail.php
@@ -1092,7 +1092,7 @@ class Zend_Mail extends Zend_Mime_Message
             $recipient = 'unknown';
         }
 
-        $hostName = $this->messageIdHostName;
+        $hostName = $this->messageIdHostName ?? '';
         if (!$hostName) {
             $hostName = (string) ($_SERVER['SERVER_NAME'] ?? '');
         }


### PR DESCRIPTION
This change will make $hostName an empty string if $messageIdHostName is not initialized. If $hostName is still empty after this line, it will try to use the server name or fall back to the value of php_uname('n').

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Fatal error: Uncaught Error: Typed property Zend_Mail::$messageIdHostName must not be accessed before initialization

### 2. What does this change do, exactly?
This change will make $hostName an empty string if $messageIdHostName is not initialized. If $hostName is still empty after this line, it will try to use the server name or fall back to the value of php_uname('n').

### 3. Describe each step to reproduce the issue or behaviour.
If no sender email address is required by a third-party plugin.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.