### PR TITLE
Fix 'slt' tag not added to nocache cookie

### DIFF
--- a/engine/Shopware/Components/HttpCache/AppCache.php
+++ b/engine/Shopware/Components/HttpCache/AppCache.php
@@ -347,10 +347,7 @@ class AppCache extends HttpCache
             return;
         }
 
-        $noCache = $request->cookies->get('nocache');
-        if (!\is_string($noCache)) {
-            return;
-        }
+        $noCache = $request->cookies->get('nocache', '');
 
         $noCache = array_filter(explode(', ', $noCache));
         if (\in_array('slt', $noCache, true)) {


### PR DESCRIPTION
### 1. Why is this change necessary?
This change is necessary to fix an issue when new customers register or login the response deleting the "no-cache" cookie and the next request does not have the "no-cache" cookie then "AppCache::checkSltCookie" will not add the "no-cache" cookie with the tag "slt". and the response of the checkout widget will return from the cache and show the wrong user info. 

### 2. What does this change do, exactly?
I change the  "AppCache::checkSltCookie" when getting the value of the "no-cache" cookie will be an empty string if not exist.

### 3. Describe each step to reproduce the issue or behaviour.
First login with a user to cache the checkout request and then Send a request for a logged-in another user session with "slt" cookie and without the "no-cache" cookie and check the response the user info in the checkout is wrong

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.