### PR TITLE
added check if salutation is required

### DIFF
--- a/engine/Shopware/Bundle/AccountBundle/Service/Validator/CustomerValidator.php
+++ b/engine/Shopware/Bundle/AccountBundle/Service/Validator/CustomerValidator.php
@@ -64,7 +64,12 @@ class CustomerValidator implements CustomerValidatorInterface
 
         $this->validateField('firstname', $customer->getFirstname(), [new NotBlank()]);
         $this->validateField('lastname', $customer->getLastname(), [new NotBlank()]);
-        $this->validateField('salutation', $customer->getSalutation(), $this->getSalutationConstraints());
+
+        $salutationRequired = $this->config->get('shopsalutationrequired');
+        if($salutationRequired){
+          $this->validateField('salutation', $customer->getSalutation(), $this->getSalutationConstraints());
+        }
+
         $this->validateField('email', $customer->getEmail(), [
             new CustomerEmail([
                 'shop' => $this->context->getShopContext()->getShop(),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
If you set the query "Salutation required" in the basic settings to no and delete e.g. not_defined from the fields of the salutation, an error occurs which makes registration no longer possible

### 2. What does this change do, exactly?
In this change it is queried whether the Salutation field is needed at all during registration, if this is the case the Salutation field is validated, otherwise it is ignored.

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to the basic settings
2. Delete the text "not_defined" in the available salutations
3. Set "Salutation required" to no
4. Clear cache & try to register
5. the error occurs


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.