### PR TITLE
ci(sw-27129): add danger php

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+use Danger\Config;
+use Danger\Context;
+use Danger\Platform\Github\Github;
+use Danger\Platform\Gitlab\Gitlab;
+use Danger\Rule\CommitRegex;
+use Danger\Rule\Condition;
+use Danger\Rule\DisallowRepeatedCommits;
+use Danger\Struct\File;
+
+return (new Config())
+    ->useThreadOn(Config::REPORT_LEVEL_WARNING)
+    ->useRule(new DisallowRepeatedCommits())
+    ->useRule(function (Context $context): void {
+        $files = $context->platform->pullRequest->getFiles();
+
+        if ($files->matches('UPGRADE-*.md')->count() === 0) {
+            $context->warning('The Pull Request doesn\'t contain any changes to the Upgrade file');
+        }
+    })
+    ->useRule(new CommitRegex(
+                '/(?m)(?mi)^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)/m',
+                'The commit title `###MESSAGE###` does not match our requirements. Please follow: www.conventionalcommits.org'
+            )
+    )
+    ->useRule(function (Context $context): void {
+        $files = $context->platform->pullRequest->getFiles();
+
+        $invalidFiles = [];
+
+        foreach ($files as $file) {
+            if ($file->status !== File::STATUS_REMOVED && preg_match('/^([-\.\w\/]+)$/', $file->name) === 0) {
+                $invalidFiles[] = $file->name;
+            }
+        }
+
+        if (count($invalidFiles) > 0) {
+            $context->failure(
+                'The following filenames contain invalid special characters, please use only alphanumeric characters, dots, dashes and underscores: <br/>'
+                . print_r($invalidFiles, true)
+            );
+        }
+    })
+    ->after(function (Context $context): void {
+        if ($context->platform instanceof Github && $context->hasFailures()) {
+            $context->platform->addLabels('Incomplete');
+        }
+    })
+;

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,20 @@
+name: Danger
+
+on:
+    pull_request_target:
+    pull_request:
+
+jobs:
+    pr:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Clone
+              uses: actions/checkout@v1
+
+            - name: Danger
+              uses: docker://ghcr.io/shyim/danger-php:latest
+              with:
+                  args: ci
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently, all types of commit messages are possible.
We should be strict about this.

### 2. What does this change do, exactly?
This change introduces a check for the commit messages.
These should follow the https://www.conventionalcommits.org/ specification.