### PR TITLE
SW-27115 - Fix false update popup if dev branch is used

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -34387,11 +34387,6 @@ parameters:
 			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Checks/LicenseCheck.php
 
 		-
-			message: "#^Parameter \\#2 \\$objectDecodeType of static method Zend_Json\\:\\:decode\\(\\) expects int, true given\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Checks/LicenseCheck.php
-
-		-
 			message: "#^Method ShopwarePlugins\\\\SwagUpdate\\\\Components\\\\Checks\\\\MySQLVersionCheck\\:\\:canHandle\\(\\) has parameter \\$requirement with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Checks/MySQLVersionCheck.php
@@ -34475,11 +34470,6 @@ parameters:
 			message: "#^Method ShopwarePlugins\\\\SwagUpdate\\\\Components\\\\Download\\:\\:setProgressCallback\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Download.php
-
-		-
-			message: "#^Method ShopwarePlugins\\\\SwagUpdate\\\\Components\\\\ExtJsResultMapper\\:\\:toExtJs\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/ExtJsResultMapper.php
 
 		-
 			message: "#^Method ShopwarePlugins\\\\SwagUpdate\\\\Components\\\\FileSystem\\:\\:checkDirectoryPermissions\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -34602,16 +34592,6 @@ parameters:
 			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Struct/Version.php
 
 		-
-			message: "#^Method ShopwarePlugins\\\\SwagUpdate\\\\Components\\\\UpdateCheck\\:\\:checkUpdate\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/UpdateCheck.php
-
-		-
-			message: "#^Parameter \\#2 \\$objectDecodeType of static method Zend_Json\\:\\:decode\\(\\) expects int, true given\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/UpdateCheck.php
-
-		-
 			message: "#^Method ShopwarePlugins\\\\SwagUpdate\\\\Components\\\\Validation\\:\\:checkRequirements\\(\\) has parameter \\$requirements with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Validation.php
@@ -34620,66 +34600,6 @@ parameters:
 			message: "#^Method ShopwarePlugins\\\\SwagUpdate\\\\Components\\\\Validation\\:\\:handleRequirement\\(\\) has parameter \\$requirement with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Validation.php
-
-		-
-			message: "#^Cannot access property \\$version on ShopwarePlugins\\\\SwagUpdate\\\\Components\\\\Struct\\\\Version\\|null\\.$#"
-			count: 2
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:changelogAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:createRecursiveFileIterator\\(\\) return type with generic class RecursiveIteratorIterator does not specify its types\\: T$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:downloadAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:isUpdateAllowedAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:mapResult\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:pluginsAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:popupAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:replaceRecoveryFiles\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:requirementsAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:startUpdateAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_SwagUpdate\\:\\:unpackAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Controllers/Backend/SwagUpdate.php
 
 		-
 			message: "#^Call to an undefined method Enlight_Event_EventArgs\\:\\:getSubject\\(\\)\\.$#"

--- a/engine/Library/Zend/Json.php
+++ b/engine/Library/Zend/Json.php
@@ -34,8 +34,8 @@ class Zend_Json
      * so that it is a boolean true value, allowing it to be used with
      * ext/json's functions.
      */
-    const TYPE_ARRAY  = 1;
-    const TYPE_OBJECT = 0;
+    const TYPE_ARRAY  = true;
+    const TYPE_OBJECT = false;
 
     /**
      * Decodes the given $encodedValue string which is
@@ -44,16 +44,16 @@ class Zend_Json
      * Uses ext/json's json_decode if available.
      *
      * @param string $encodedValue Encoded in JSON format
-     * @param int $objectDecodeType Optional; flag indicating how to decode
-     * objects.
+     * @param bool $objectDecodeType Optional; flag indicating how to decode objects.
      * @return mixed
      * @throws Zend_Json_Exception
      */
-    public static function decode($encodedValue, $objectDecodeType = Zend_Json::TYPE_ARRAY)
+    public static function decode($encodedValue, $objectDecodeType = self::TYPE_ARRAY)
     {
         $encodedValue = (string) $encodedValue;
         $decode = json_decode($encodedValue, $objectDecodeType);
-        if (($jsonLastErr = json_last_error()) !== JSON_ERROR_NONE) {
+        $jsonLastErr = json_last_error();
+        if (($jsonLastErr) !== JSON_ERROR_NONE) {
             switch ($jsonLastErr) {
                 case JSON_ERROR_DEPTH:
                     throw new Zend_Json_Exception('Decoding failed: Maximum stack depth exceeded');
@@ -89,7 +89,9 @@ class Zend_Json
         if (is_object($valueToEncode)) {
             if (method_exists($valueToEncode, 'toJson')) {
                 return $valueToEncode->toJson();
-            } elseif (method_exists($valueToEncode, 'toArray')) {
+            }
+
+            if (method_exists($valueToEncode, 'toArray')) {
                 return self::encode($valueToEncode->toArray(), $cycleCheck);
             }
         }

--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/ExtJsResultMapper.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/ExtJsResultMapper.php
@@ -36,7 +36,7 @@ class ExtJsResultMapper
      *
      * @throws Exception
      *
-     * @return array
+     * @return array<string, bool|int|string>
      */
     public function toExtJs($result)
     {

--- a/tests/Unit/Plugin/Backend/SwagUpdate/Components/SwagUpdateTest.php
+++ b/tests/Unit/Plugin/Backend/SwagUpdate/Components/SwagUpdateTest.php
@@ -35,6 +35,17 @@ use Zend_Http_Response;
 
 class SwagUpdateTest extends TestCase
 {
+    public function testCheckUpdateReturnsNullIfShopwareVersionIsDevelopment(): void
+    {
+        $updateChecker = new UpdateCheck(
+            $this->createMock(Zend_Http_Client::class),
+            false,
+            false
+        );
+
+        static::assertNull($updateChecker->checkUpdate('___VERSION___'));
+    }
+
     public function testCheckUpdateThrowsExceptionOnApiLimit(): void
     {
         $response = new Zend_Http_Response(403, []);


### PR DESCRIPTION
### 1. Why is this change necessary?

in the backend a popup is shown, that there is an update available. But the dev branch "version" is not considered for this case


### 2. What does this change do, exactly?

consider the placeholder of the Shopware version

### 3. Describe each step to reproduce the issue or behaviour.

- checkout this repository and install Shopware
- open the backend


### 4. Please link to the relevant issues (if any).

https://shopware.atlassian.net/browse/SW-27115

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.