### PR TITLE
SW-27128 - add issue templates to github

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug report 🐛
+description: Existing feature does not behave as expected.
+labels: [Bug]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to fill out this bug report!
+    - type: textarea
+      id: description
+      attributes:
+        label: "Description"
+        description: Please enter an explicit description of your issue
+        placeholder: Short and explicit description of your incident...
+      validations:
+        required: true
+    - type: input
+      id: php-version
+      attributes:
+          label: PHP Version
+      validations:
+          required: true
+    - type: input
+      id: shopware-version
+      attributes:
+          label: Shopware Version
+      validations:
+          required: true
+    - type: textarea
+      id: steps-to-reproduce
+      attributes:
+          label: How to reproduce
+          description: Tell us how the bug can be reproduced
+      validations:
+          required: true
+    - type: textarea
+      id: expected-behaviour
+      attributes:
+          label: Expected behaviour
+          description: What did you expect to happen?
+      validations:
+          required: true
+    - type: textarea
+      id: actual-behaviour
+      attributes:
+          label: Actual behaviour
+          description: Please describe the issue
+      validations:
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request 🚀
+description: Suggest an idea for this project
+labels: [Feature]
+body:
+    - type: input
+      id: reference_issues
+      attributes:
+          label: "Reference Issues"
+          description: Common issues
+          placeholder: "#Issues IDs"
+      validations:
+          required: false
+    - type: textarea
+      id: summary
+      attributes:
+          label: "Summary"
+          description: Provide a brief explanation of the feature
+          placeholder: Describe in a few lines your feature request
+      validations:
+          required: true
+    - type: textarea
+      id: basic_example
+      attributes:
+          label: "Basic Example"
+          description: Indicate here some basic examples of your feature.
+          placeholder: A few specific words about your feature request.
+      validations:
+          required: false
+    - type: textarea
+      id: additional_context
+      attributes:
+          label: "Additional context"
+          description: Add any other context or screenshots about the feature request here.
+      validations:
+          required: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+## Reporting a vulnerability
+
+Visit our [security reporting](https://www.shopware.com/en/contact/security-reporting) form to report security vulnerabilities and to take part in our bug bounty program.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
to make it easier for maintainer and issue creator to work on and create issues, there should be templates which ask several things

### 2. What does this change do, exactly?
add new issue-templates to github


### 3. Describe each step to reproduce the issue or behaviour.
you can take a look here how it looks: https://github.com/ennasus4sun/test-02/issues/new/choose

### 4. Please link to the relevant issues (if any).
https://shopware.atlassian.net/browse/SW-27128

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.