### PR TITLE
feat(SW-27133): Add concurrent action cancelling to github actions

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
     build:
         concurrency:
-            group: ${{ github.workflow }}
+            group: ${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -14,6 +14,10 @@ permissions:
 
 jobs:
     build:
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            cancel-in-progress: true
+            
         strategy:
             matrix:
                 os: [ ubuntu-latest, macos-latest ]

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
     build:
         concurrency:
-            group: ${{ github.head_ref }}
+            group: ${{ github.ref }}-${{ github.workflow }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
     build:
         concurrency:
-            group: ${{ github.head_ref || github.run_id }}
+            group: ${{ github.head_ref }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
     build:
         concurrency:
-            group: ${{ github.workflow_ref }}
+            group: ${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -15,8 +15,9 @@ permissions:
 
 jobs:
     build:
-        group: ${{ github.workflow }}-${{ github.ref }}
-        cancel-in-progress: true
+        concurrency:
+            group: ${{ github.head_ref || github.run_id }}
+            cancel-in-progress: true
 
         strategy:
             matrix:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -15,8 +15,6 @@ permissions:
 
 jobs:
     build:
-        concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}
 
         strategy:
             matrix:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - "5.7"
+            - "*"
         paths:
             - devenv.nix
             - devenv.yaml

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
     build:
+        group: ${{ github.workflow }}-${{ github.ref }}
+        cancel-in-progress: true
 
         strategy:
             matrix:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
     build:
         concurrency:
-            group: ${{ github.ref }}
+            group: ${{ github.action }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
     build:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}
+            group: ${{ github.ref }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -15,9 +15,9 @@ permissions:
 jobs:
     build:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            group: ${{ github.workflow }}
             cancel-in-progress: true
-            
+
         strategy:
             matrix:
                 os: [ ubuntu-latest, macos-latest ]

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
     build:
         concurrency:
-            group: ${{ github.job_workflow_sha }}
+            group: ${{ github.workflow_ref }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -17,7 +17,6 @@ jobs:
     build:
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref }}
-            cancel-in-progress: true
 
         strategy:
             matrix:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
     build:
         concurrency:
-            group: ${{ github.action }}
+            group: ${{ github.job_workflow_sha }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -8,6 +8,10 @@ permissions:
 
 jobs:
     php:
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            cancel-in-progress: true
+
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     php:
         concurrency:
-            group: ${{ github.head_ref || github.run_id }}
+            group: ${{ github.head_ref }}
             cancel-in-progress: true
 
         runs-on: ubuntu-latest

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     php:
         concurrency:
-            group: ${{ github.head_ref }}
+            group: ${{ github.ref }}-${{ github.workflow }}
             cancel-in-progress: true
 
         runs-on: ubuntu-latest

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     php:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}
+            group: ${{ github.head_ref || github.run_id }}
             cancel-in-progress: true
 
         runs-on: ubuntu-latest

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     php:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            group: ${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
 
         runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
     analyze:
         concurrency:
-            group: ${{ github.head_ref || github.run_id }}
+            group: ${{ github.head_ref }}
             cancel-in-progress: true
 
         permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,9 +10,8 @@ permissions:
 jobs:
     analyze:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}
+            group: ${{ github.head_ref || github.run_id }}
             cancel-in-progress: true
-
 
         permissions:
             actions: read  # for github/codeql-action/init to get workflow details

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,8 +10,9 @@ permissions:
 jobs:
     analyze:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            group: ${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
+
 
         permissions:
             actions: read  # for github/codeql-action/init to get workflow details

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
     analyze:
         concurrency:
-            group: ${{ github.head_ref }}
+            group: ${{ github.ref }}-${{ github.workflow }}
             cancel-in-progress: true
 
         permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ permissions:
 
 jobs:
     analyze:
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            cancel-in-progress: true
+
         permissions:
             actions: read  # for github/codeql-action/init to get workflow details
             contents: read  # for actions/checkout to fetch code

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     create-install-package:
         concurrency:
-            group: ${{ github.head_ref }}
+            group: ${{ github.ref }}-${{ github.workflow }}
             cancel-in-progress: true
 
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     create-install-package:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}
+            group: ${{ github.head_ref || github.run_id }}
             cancel-in-progress: true
 
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
     create-install-package:
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            cancel-in-progress: true
+
         env:
             PACKAGE_DIR: ./package/
             PACKAGE_PREFIX: install

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,8 +10,9 @@ on:
 jobs:
     create-install-package:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            group: ${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
+
 
         env:
             PACKAGE_DIR: ./package/

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     create-install-package:
         concurrency:
-            group: ${{ github.head_ref || github.run_id }}
+            group: ${{ github.head_ref }}
             cancel-in-progress: true
 
 

--- a/.github/workflows/create-update.yml
+++ b/.github/workflows/create-update.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
     create-update-package:
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            cancel-in-progress: true
+
         env:
             PACKAGE_PREFIX: 'update'
             PACKAGE_DELIMITER: _

--- a/.github/workflows/create-update.yml
+++ b/.github/workflows/create-update.yml
@@ -11,7 +11,7 @@ on:
 jobs:
     create-update-package:
         concurrency:
-            group: ${{ github.head_ref }}
+            group: ${{ github.ref }}-${{ github.workflow }}
             cancel-in-progress: true
 
 

--- a/.github/workflows/create-update.yml
+++ b/.github/workflows/create-update.yml
@@ -11,7 +11,7 @@ on:
 jobs:
     create-update-package:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}
+            group: ${{ github.head_ref || github.run_id }}
             cancel-in-progress: true
 
 

--- a/.github/workflows/create-update.yml
+++ b/.github/workflows/create-update.yml
@@ -11,8 +11,9 @@ on:
 jobs:
     create-update-package:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            group: ${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
+
 
         env:
             PACKAGE_PREFIX: 'update'

--- a/.github/workflows/create-update.yml
+++ b/.github/workflows/create-update.yml
@@ -11,7 +11,7 @@ on:
 jobs:
     create-update-package:
         concurrency:
-            group: ${{ github.head_ref || github.run_id }}
+            group: ${{ github.head_ref }}
             cancel-in-progress: true
 
 

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     check:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            group: ${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
 
         runs-on: ubuntu-latest

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     check:
         concurrency:
-            group: ${{ github.head_ref || github.run_id }}
+            group: ${{ github.head_ref }}
             cancel-in-progress: true
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -5,6 +5,10 @@ on:
 
 jobs:
     check:
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            cancel-in-progress: true
+
         runs-on: ubuntu-latest
         steps:
             -   name: Clone

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -6,8 +6,9 @@ on:
 jobs:
     check:
         concurrency:
-            group: ${{ github.head_ref }}
+            group: ${{ github.ref }}-${{ github.workflow }}
             cancel-in-progress: true
+
         runs-on: ubuntu-latest
         steps:
             -   name: Clone

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -6,9 +6,8 @@ on:
 jobs:
     check:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}
+            group: ${{ github.head_ref || github.run_id }}
             cancel-in-progress: true
-
         runs-on: ubuntu-latest
         steps:
             -   name: Clone

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     Mink:
         concurrency:
-            group: ${{ github.head_ref || github.run_id }}
+            group: ${{ github.head_ref }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -8,6 +8,10 @@ permissions:
 
 jobs:
     Mink:
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            cancel-in-progress: true
+            
         strategy:
             matrix:
                 MINK_TAG: [ 'account', 'checkout1', 'checkout2', 'detail', 'listing', 'note', 'sitemap', 'misc', 'backend' ]

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     Mink:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}
+            group: ${{ github.workflow }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -9,9 +9,9 @@ permissions:
 jobs:
     Mink:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            group: ${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
-            
+
         strategy:
             matrix:
                 MINK_TAG: [ 'account', 'checkout1', 'checkout2', 'detail', 'listing', 'note', 'sitemap', 'misc', 'backend' ]

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -8,7 +8,9 @@ permissions:
 
 jobs:
     Mink:
-
+        concurrency:
+            group: ${{ github.head_ref || github.run_id }}
+            cancel-in-progress: true
 
         strategy:
             matrix:

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     Mink:
         concurrency:
-            group: ${{ github.head_ref }}
+            group: ${{ github.ref }}-${{ github.workflow }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -8,9 +8,7 @@ permissions:
 
 jobs:
     Mink:
-        concurrency:
-            group: ${{ github.workflow }}
-            cancel-in-progress: true
+
 
         strategy:
             matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     php:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            group: ${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     php:
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}
+            group: ${{ github.head_ref || github.run_id }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     php:
         concurrency:
-            group: ${{ github.head_ref }}
+            group: ${{ github.ref }}-${{ github.workflow }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,6 +8,10 @@ permissions:
 
 jobs:
     php:
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+            cancel-in-progress: true
+
         strategy:
             matrix:
                 php: [ '7.4', '8.0', '8.1', '8.2' ]

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
     php:
         concurrency:
-            group: ${{ github.head_ref || github.run_id }}
+            group: ${{ github.head_ref }}
             cancel-in-progress: true
 
         strategy:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,9 +8,7 @@ permissions:
 
 jobs:
     php:
-        concurrency:
-            group: ${{ github.ref }}-${{ github.workflow }}
-            cancel-in-progress: true
+
 
         strategy:
             matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,6 +18,10 @@ jobs:
                 mysql: [ 'pkgs.mysql80' ]
         runs-on: ubuntu-latest
         steps:
+            -   name: test
+                run: |
+                    echo ${{ github.ref }}-${{ github.workflow }}
+
             -   uses: actions/checkout@v3
             -   uses: cachix/install-nix-action@v20
                 with:
@@ -61,6 +65,9 @@ jobs:
                 mysql: [ 'pkgs.mysql80', 'pkgs.mariadb', 'pkgs.mariadb_104', 'config.nur.repos.pascalthesing.mysql57' ]
         runs-on: ubuntu-latest
         steps:
+            -   name: test
+                run: |
+                    echo ${{ github.ref }}-${{ github.workflow }}
             -   uses: actions/checkout@v3
 
             -   uses: cachix/install-nix-action@v20
@@ -77,7 +84,9 @@ jobs:
                     authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
             -   name: Install devenv.sh
-                run: nix-env -if https://github.com/cachix/devenv/tarball/main
+                run: |
+                    nix-env -if https://github.com/cachix/devenv/tarball/main
+                    echo ${{ github.ref }}-${{ github.workflow }}
 
             -   name: Get Composer Cache Directory
                 id: composer-cache

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,6 +3,11 @@ name: Php Unit
 on:
     push:
 
+
+concurrency:
+    group: ${{ github.ref }}-${{ github.workflow }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
New commits do not cancel the GitHub action run for the last one and therefore hog limited runners for themselves

### 2. What does this change do, exactly?
Add concurrency cancelling to GitHub actions

### 3. Describe each step to reproduce the issue or behavior.
Well described in [this](https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre) Thread

### 4. Please link to the relevant issues (if any).
[SW-27133](https://shopware.atlassian.net/browse/SW-27133)

### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.