### PR TITLE
SW-27005 - Fix PHP notices and warnings

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -14161,21 +14161,6 @@ parameters:
 			path: engine/Shopware/Components/Auth/Adapter/Default.php
 
 		-
-			message: "#^Method Shopware_Components_Auth_Adapter_Default\\:\\:rehash\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Components/Auth/Adapter/Default.php
-
-		-
-			message: "#^Method Shopware_Components_Auth_Adapter_Default\\:\\:updateExpiry\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Components/Auth/Adapter/Default.php
-
-		-
-			message: "#^Method Shopware_Components_Auth_Adapter_Default\\:\\:updateHash\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Components/Auth/Adapter/Default.php
-
-		-
 			message: "#^Property Shopware_Components_Auth_Adapter_Default\\:\\:\\$conditions type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Components/Auth/Adapter/Default.php
@@ -14656,11 +14641,6 @@ parameters:
 			path: engine/Shopware/Components/Cart/Struct/DiscountContext.php
 
 		-
-			message: "#^Property Shopware\\\\Components\\\\Cart\\\\Struct\\\\Price\\:\\:\\$tax \\(float\\) does not accept float\\|null\\.$#"
-			count: 1
-			path: engine/Shopware/Components/Cart/Struct/Price.php
-
-		-
 			message: "#^Method Shopware\\\\Components\\\\Cart\\\\TaxAggregator\\:\\:positionsTaxSum\\(\\) has parameter \\$cart with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Components/Cart/TaxAggregator.php
@@ -15046,11 +15026,6 @@ parameters:
 			path: engine/Shopware/Components/ConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Components\\\\ConfigWriter\\:\\:get\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Components/ConfigWriter.php
-
-		-
 			message: "#^Method Shopware\\\\Components\\\\ConfigWriter\\:\\:insert\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Components/ConfigWriter.php
@@ -15241,11 +15216,6 @@ parameters:
 			path: engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
 
 		-
-			message: "#^Method Shopware\\\\Components\\\\DependencyInjection\\\\Bridge\\\\MailTransport\\:\\:factory\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
-
-		-
 			message: "#^Unable to resolve the template type TClass in call to method static method Enlight_Class\\:\\:Instance\\(\\)$#"
 			count: 2
 			path: engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
@@ -15314,11 +15284,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$resource of method Shopware\\\\Components\\\\DependencyInjection\\\\Container\\:\\:set\\(\\) expects object\\|null, string given\\.$#"
 			count: 1
 			path: engine/Shopware/Components/DependencyInjection/Bridge/Session.php
-
-		-
-			message: "#^Call to an undefined method Enlight_Template_Manager\\:\\:setDefaultResourceType\\(\\)\\.$#"
-			count: 1
-			path: engine/Shopware/Components/DependencyInjection/Bridge/Template.php
 
 		-
 			message: "#^Method Shopware\\\\Components\\\\DependencyInjection\\\\Bridge\\\\Template\\:\\:factory\\(\\) has parameter \\$backendOptions with no value type specified in iterable type array\\.$#"
@@ -19074,11 +19039,6 @@ parameters:
 			message: "#^Method Shopware\\\\Components\\\\SitePageMenu\\:\\:overrideExisting\\(\\) has parameter \\$site with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Components/SitePageMenu.php
-
-		-
-			message: "#^Method Shopware\\\\Components\\\\SitemapXMLRepository\\:\\:filterLink\\(\\) has parameter \\$userParams with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Components/SitemapXMLRepository.php
 
 		-
 			message: "#^Method Shopware\\\\Components\\\\SitemapXMLRepository\\:\\:getSitemapContent\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -18381,17 +18381,7 @@ parameters:
 			path: engine/Shopware/Components/Plugin/FormSynchronizer.php
 
 		-
-			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Models\\\\Shop\\\\Locale\\|null\\.$#"
-			count: 1
-			path: engine/Shopware/Components/Plugin/MenuSynchronizer.php
-
-		-
 			message: "#^Method Shopware\\\\Components\\\\Plugin\\\\MenuSynchronizer\\:\\:createMenuItem\\(\\) has parameter \\$menuItem with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Components/Plugin/MenuSynchronizer.php
-
-		-
-			message: "#^Method Shopware\\\\Components\\\\Plugin\\\\MenuSynchronizer\\:\\:removeNotExistingEntries\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Components/Plugin/MenuSynchronizer.php
 
@@ -18401,17 +18391,7 @@ parameters:
 			path: engine/Shopware/Components/Plugin/MenuSynchronizer.php
 
 		-
-			message: "#^Method Shopware\\\\Components\\\\Plugin\\\\MenuSynchronizer\\:\\:saveMenuTranslation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Components/Plugin/MenuSynchronizer.php
-
-		-
 			message: "#^Method Shopware\\\\Components\\\\Plugin\\\\MenuSynchronizer\\:\\:saveMenuTranslation\\(\\) has parameter \\$labels with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Components/Plugin/MenuSynchronizer.php
-
-		-
-			message: "#^Method Shopware\\\\Components\\\\Plugin\\\\MenuSynchronizer\\:\\:synchronize\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Components/Plugin/MenuSynchronizer.php
 
@@ -37164,36 +37144,6 @@ parameters:
 			message: "#^Query error\\: Column \"s_core_plugins\\.added\" expects value type string, got type DateTime$#"
 			count: 1
 			path: tests/Functional/Components/Plugin/LegacyConfigWriterTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Components\\\\Plugin\\\\MenuSynchronizerTest\\:\\:executeTestAndCheckResult\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Components/Plugin/MenuSynchronizerTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Components\\\\Plugin\\\\MenuSynchronizerTest\\:\\:executeTestAndCheckResult\\(\\) has parameter \\$expectedQueryParameters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Functional/Components/Plugin/MenuSynchronizerTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Components\\\\Plugin\\\\MenuSynchronizerTest\\:\\:executeTestAndCheckResult\\(\\) has parameter \\$menu with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Functional/Components/Plugin/MenuSynchronizerTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Components\\\\Plugin\\\\MenuSynchronizerTest\\:\\:testIndexLowerCaseIsPartOfSnippet\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Components/Plugin/MenuSynchronizerTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Components\\\\Plugin\\\\MenuSynchronizerTest\\:\\:testIndexNotPartOfSnippet\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Components/Plugin/MenuSynchronizerTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Components\\\\Plugin\\\\MenuSynchronizerTest\\:\\:testOtherActionIsPartOfSnippet\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Components/Plugin/MenuSynchronizerTest.php
 
 		-
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Components\\\\Plugin\\\\PluginMigrationTest\\:\\:assertTableColumnExists\\(\\) has no return type specified\\.$#"

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -4006,36 +4006,6 @@ parameters:
 			path: engine/Shopware/Bundle/AccountBundle/Service/RegisterService.php
 
 		-
-			message: "#^Access to an undefined property Enlight_Components_Session_Namespace\\:\\:\\$sOneTimeAccount\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/AccountBundle/Service/StoreFrontCustomerGreetingService.php
-
-		-
-			message: "#^Access to an undefined property Enlight_Components_Session_Namespace\\:\\:\\$userInfo\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/AccountBundle/Service/StoreFrontCustomerGreetingService.php
-
-		-
-			message: "#^Method Shopware\\\\Bundle\\\\AccountBundle\\\\Service\\\\StoreFrontCustomerGreetingService\\:\\:fetch\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/AccountBundle/Service/StoreFrontCustomerGreetingService.php
-
-		-
-			message: "#^Method Shopware\\\\Bundle\\\\AccountBundle\\\\Service\\\\StoreFrontCustomerGreetingService\\:\\:fetchUserInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/AccountBundle/Service/StoreFrontCustomerGreetingService.php
-
-		-
-			message: "#^Method Shopware\\\\Bundle\\\\AccountBundle\\\\Service\\\\StoreFrontCustomerGreetingService\\:\\:fetchUserInfo\\(\\) should return array\\|null but returns array\\<string, mixed\\>\\|false\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/AccountBundle/Service/StoreFrontCustomerGreetingService.php
-
-		-
-			message: "#^Method Shopware\\\\Bundle\\\\AccountBundle\\\\Service\\\\StoreFrontCustomerGreetingServiceInterface\\:\\:fetch\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/AccountBundle/Service/StoreFrontCustomerGreetingServiceInterface.php
-
-		-
 			message: "#^Method Shopware\\\\Bundle\\\\AccountBundle\\\\Type\\\\SalutationType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Bundle/AccountBundle/Type/SalutationType.php
@@ -5474,26 +5444,6 @@ parameters:
 			message: "#^Method Shopware\\\\Bundle\\\\CustomerSearchBundleDBAL\\\\Indexing\\\\CustomerOrderGateway\\:\\:getCustomerOrders\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/CustomerOrderGateway.php
-
-		-
-			message: "#^Method Shopware\\\\Bundle\\\\CustomerSearchBundleDBAL\\\\Indexing\\\\CustomerOrderHydrator\\:\\:explodeAndFilter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/CustomerOrderHydrator.php
-
-		-
-			message: "#^Method Shopware\\\\Bundle\\\\CustomerSearchBundleDBAL\\\\Indexing\\\\CustomerOrderHydrator\\:\\:explodeAndFilter\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/CustomerOrderHydrator.php
-
-		-
-			message: "#^Method Shopware\\\\Bundle\\\\CustomerSearchBundleDBAL\\\\Indexing\\\\CustomerOrderHydrator\\:\\:hydrate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/CustomerOrderHydrator.php
-
-		-
-			message: "#^Method Shopware\\\\Bundle\\\\CustomerSearchBundleDBAL\\\\Indexing\\\\CustomerOrderHydrator\\:\\:hydrate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/CustomerOrderHydrator.php
 
 		-
 			message: "#^Method Shopware\\\\Bundle\\\\CustomerSearchBundleDBAL\\\\Indexing\\\\SearchIndexer\\:\\:buildData\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -34066,11 +34066,6 @@ parameters:
 			path: engine/Shopware/Plugins/Default/Backend/Auth/Bootstrap.php
 
 		-
-			message: "#^Method Shopware_Plugins_Backend_SwagUpdate_Bootstrap\\:\\:onBackendIndexPostDispatch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Bootstrap.php
-
-		-
 			message: "#^Class ShopwarePlugins\\\\SwagUpdate\\\\Components\\\\Archive\\\\Adapter implements generic interface SeekableIterator but does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/Archive/Adapter.php
@@ -34536,26 +34531,6 @@ parameters:
 			path: engine/Shopware/Plugins/Default/Core/ErrorHandler/Bootstrap.php
 
 		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:addContextCookie\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:addSurrogateControl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:disableControllerCache\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:enableControllerCache\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
 			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:enableControllerCache\\(\\) has parameter \\$cacheIds with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -34566,62 +34541,7 @@ parameters:
 			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
 
 		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:getResponseCookie\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:installForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:onClearCache\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:onClearHttpCache\\(\\) should return string but return statement is missing\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:onInvalidateCacheId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:onPostDispatch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:onPostPersist\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:onPreDispatch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:postFlush\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
 			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:renderEsiTag\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:setCacheHeaders\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:setCacheIdHeader\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
 
@@ -34631,23 +34551,8 @@ parameters:
 			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
 
 		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:setNoCacheCookie\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:setNoCacheTag\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
 			message: "#^Negated boolean expression is always true\\.$#"
 			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Parameter \\#2 \\$cacheId of method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:invalidateWithBANRequest\\(\\) expects string, string\\|null given\\.$#"
-			count: 2
 			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
 
 		-
@@ -34931,27 +34836,7 @@ parameters:
 			path: engine/Shopware/Plugins/Default/Core/PaymentMethods/Bootstrap.php
 
 		-
-			message: "#^Method Shopware_Plugins_Core_PaymentMethods_Bootstrap\\:\\:addPaths\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/PaymentMethods/Bootstrap.php
-
-		-
 			message: "#^Method Shopware_Plugins_Core_PaymentMethods_Bootstrap\\:\\:addPaymentClass\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/PaymentMethods/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_PaymentMethods_Bootstrap\\:\\:onBackendCustomerPostDispatch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/PaymentMethods/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_PaymentMethods_Bootstrap\\:\\:onBackendOrderPostDispatch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/PaymentMethods/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_PaymentMethods_Bootstrap\\:\\:subscribeEvents\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Core/PaymentMethods/Bootstrap.php
 
@@ -35317,21 +35202,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method getModuleName\\(\\) on Enlight_Controller_Request_Request\\|null\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_RestApi_Bootstrap\\:\\:onDispatchLoopStartup\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_RestApi_Bootstrap\\:\\:onFrontPreDispatch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_RestApi_Bootstrap\\:\\:onInitResourceAuth\\(\\) should return Zend_Auth\\|null but empty return statement found\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
 

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -4031,11 +4031,6 @@ parameters:
 			path: engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/AttributeData.php
 
 		-
-			message: "#^Method Shopware_Controllers_Backend_Attributes\\:\\:addAclPermission\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/Attributes.php
-
-		-
 			message: "#^Method Shopware_Controllers_Backend_Attributes\\:\\:columnNameExistsAction\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Bundle/AttributeBundle/Controllers/Backend/Attributes.php
@@ -21036,11 +21031,6 @@ parameters:
 			path: engine/Shopware/Controllers/Backend/Article.php
 
 		-
-			message: "#^Method Shopware_Controllers_Backend_Article\\:\\:loadAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Article.php
-
-		-
 			message: "#^Method Shopware_Controllers_Backend_Article\\:\\:loadStoresAction\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Controllers/Backend/Article.php
@@ -22596,36 +22586,6 @@ parameters:
 			path: engine/Shopware/Controllers/Backend/Export.php
 
 		-
-			message: "#^Access to an undefined property Enlight_Controller_Request_RequestHttp\\:\\:\\$targetField\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/ExtJs.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_ExtJs\\:\\:addAclPermission\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/ExtJs.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_ExtJs\\:\\:getAclRules\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/ExtJs.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_ExtJs\\:\\:indexAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/ExtJs.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_ExtJs\\:\\:loadAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/ExtJs.php
-
-		-
-			message: "#^Property Shopware_Controllers_Backend_ExtJs\\:\\:\\$aclPermissions type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/ExtJs.php
-
-		-
 			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Bundle\\\\PluginInstallerBundle\\\\Struct\\\\LocaleStruct\\|null\\.$#"
 			count: 1
 			path: engine/Shopware/Controllers/Backend/FirstRunWizard.php
@@ -22761,42 +22721,12 @@ parameters:
 			path: engine/Shopware/Controllers/Backend/Form.php
 
 		-
-			message: "#^Method Shopware_Controllers_Backend_Index\\:\\:authAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Index.php
-
-		-
 			message: "#^Method Shopware_Controllers_Backend_Index\\:\\:buildTree\\(\\) has parameter \\$nodes with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Controllers/Backend/Index.php
 
 		-
 			message: "#^Method Shopware_Controllers_Backend_Index\\:\\:buildTree\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Index.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_Index\\:\\:changeLocaleAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Index.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_Index\\:\\:indexAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Index.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_Index\\:\\:init\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Index.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_Index\\:\\:loadAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Index.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_Index\\:\\:menuAction\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Controllers/Backend/Index.php
 
@@ -23786,11 +23716,6 @@ parameters:
 			path: engine/Shopware/Controllers/Backend/Search.php
 
 		-
-			message: "#^Method Shopware_Controllers_Backend_Search\\:\\:indexAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Search.php
-
-		-
 			message: "#^Method Shopware_Controllers_Backend_Search\\:\\:resolveCategoryPath\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Controllers/Backend/Search.php
@@ -24007,11 +23932,6 @@ parameters:
 
 		-
 			message: "#^Method Shopware_Controllers_Backend_UpdateWizard\\:\\:handleException\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/UpdateWizard.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_UpdateWizard\\:\\:indexAction\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Controllers/Backend/UpdateWizard.php
 
@@ -24784,11 +24704,6 @@ parameters:
 			message: "#^Method Shopware_Controllers_Frontend_Sitemap\\:\\:translateCategoryTree\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Controllers/Frontend/Sitemap.php
-
-		-
-			message: "#^Method Shopware_Controllers_Frontend_SitemapXml\\:\\:indexAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Frontend/SitemapXml.php
 
 		-
 			message: "#^Access to an undefined property Enlight_Controller_Request_RequestHttp\\:\\:\\$sArticle\\.$#"

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -1281,13 +1281,8 @@ parameters:
 			path: engine/Library/Enlight/Application.php
 
 		-
-			message: "#^Method Enlight_Class\\:\\:Instance\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Class.php
-
-		-
-			message: "#^Method Enlight_Class\\:\\:Instance\\(\\) should return Enlight_Class but returns object\\.$#"
-			count: 1
+			message: "#^Method Enlight_Class\\:\\:Instance\\(\\) should return TClass of object but returns object\\.$#"
+			count: 2
 			path: engine/Library/Enlight/Class.php
 
 		-
@@ -1332,11 +1327,6 @@ parameters:
 
 		-
 			message: "#^Method Enlight_Class\\:\\:resetInstance\\(\\) has parameter \\$class with no type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Class.php
-
-		-
-			message: "#^Property Enlight_Class\\:\\:\\$instances type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Class.php
 
@@ -3794,16 +3784,6 @@ parameters:
 			message: "#^Function smarty_modifier_count\\(\\) has parameter \\$value with no type specified\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Template/Plugins/modifier.count.php
-
-		-
-			message: "#^Function smarty_modifier_currency\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Template/Plugins/modifier.currency.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, float given\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Template/Plugins/modifier.currency.php
 
 		-
 			message: "#^Parameter \\#1 \\$date of class Zend_Date constructor expects array\\|int\\|string\\|Zend_Date\\|null, DateTime\\|int\\|false given\\.$#"
@@ -15428,6 +15408,11 @@ parameters:
 		-
 			message: "#^Method Shopware\\\\Components\\\\DependencyInjection\\\\Bridge\\\\MailTransport\\:\\:factory\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
+			path: engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
+
+		-
+			message: "#^Unable to resolve the template type TClass in call to method static method Enlight_Class\\:\\:Instance\\(\\)$#"
+			count: 2
 			path: engine/Shopware/Components/DependencyInjection/Bridge/MailTransport.php
 
 		-
@@ -34961,21 +34946,6 @@ parameters:
 			path: engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
 
 		-
-			message: "#^Method Shopware_Plugins_Core_MarketingAggregate_Bootstrap\\:\\:initAlsoBoughtResource\\(\\) should return Shopware_Components_AlsoBought but returns Enlight_Class\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_MarketingAggregate_Bootstrap\\:\\:initSimilarShownResource\\(\\) should return Shopware_Components_SimilarShown but returns Enlight_Class\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_MarketingAggregate_Bootstrap\\:\\:initTopSellerResource\\(\\) should return Shopware_Components_TopSeller but returns Enlight_Class\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
-
-		-
 			message: "#^Method Shopware_Plugins_Core_MarketingAggregate_Bootstrap\\:\\:isSimilarShownActivated\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
@@ -35387,11 +35357,6 @@ parameters:
 
 		-
 			message: "#^Method Shopware_Plugins_Core_RebuildIndex_Bootstrap\\:\\:getInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_RebuildIndex_Bootstrap\\:\\:initSeoIndexResource\\(\\) should return Shopware_Components_SeoIndex but returns Enlight_Class\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Core/RebuildIndex/Bootstrap.php
 
@@ -35919,11 +35884,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$foreignKey of method Shopware\\\\Bundle\\\\AttributeBundle\\\\Service\\\\DataLoaderInterface\\:\\:load\\(\\) expects int, string given\\.$#"
 			count: 1
 			path: tests/Functional/Bundle/AttributeBundle/DataLoaderTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Bundle\\\\AttributeBundle\\\\SchemaOperatorTest\\:\\:iterateTypeArray\\(\\) has parameter \\$types with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
 
 		-
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Bundle\\\\ContentTypeBundle\\\\Services\\\\ExtjsBuilderTest\\:\\:dataProviderColumnFields\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -37361,16 +37321,6 @@ parameters:
 			path: tests/Functional/Components/Cart/ProportionalCartCalculationCustomerGroupTest.php
 
 		-
-			message: "#^Query error\\: Column \"s_emarketing_vouchers\\.percental\" expects value type int, got type bool$#"
-			count: 1
-			path: tests/Functional/Components/CheckoutTest.php
-
-		-
-			message: "#^Query error\\: Column \"s_emarketing_vouchers\\.taxconfig\" expects value type string, got type int$#"
-			count: 1
-			path: tests/Functional/Components/CheckoutTest.php
-
-		-
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Components\\\\DependencyInjection\\\\Compiler\\\\ConfigureContainerAwareCommandsTest\\:\\:getShopwareCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Functional/Components/DependencyInjection/Compiler/ConfigureContainerAwareCommandsTest.php
@@ -38062,86 +38012,6 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$data\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$success\\.$#"
-			count: 5
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getAdditionalAddressLine1\\(\\) on Shopware\\\\Models\\\\Customer\\\\Address\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getAdditionalAddressLine2\\(\\) on Shopware\\\\Models\\\\Customer\\\\Address\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getCity\\(\\) on Shopware\\\\Models\\\\Customer\\\\Address\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getDepartment\\(\\) on Shopware\\\\Models\\\\Customer\\\\Address\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getFirstname\\(\\) on Shopware\\\\Models\\\\Customer\\\\Address\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Models\\\\Customer\\\\Group\\|null\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Models\\\\Payment\\\\Payment\\|null\\.$#"
-			count: 12
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getLastname\\(\\) on Shopware\\\\Models\\\\Customer\\\\Address\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getStreet\\(\\) on Shopware\\\\Models\\\\Customer\\\\Address\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getTitle\\(\\) on Shopware\\\\Models\\\\Customer\\\\Address\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getVatId\\(\\) on Shopware\\\\Models\\\\Customer\\\\Address\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Cannot call method getZipcode\\(\\) on Shopware\\\\Models\\\\Customer\\\\Address\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\CustomerTest\\:\\:testUpdateCustomerPaymentDataWithSepa\\(\\) has parameter \\$dummyDataId with no type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$group of method Shopware\\\\Models\\\\Customer\\\\Customer\\:\\:setGroup\\(\\) expects array\\|Shopware\\\\Models\\\\Customer\\\\Group, Shopware\\\\Models\\\\Customer\\\\Group\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/CustomerTest.php
-
-		-
-			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$data\\.$#"
 			count: 5
 			path: tests/Functional/Controllers/Backend/FormTest.php
 
@@ -38179,36 +38049,6 @@ parameters:
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\FormTest\\:\\:testGetFormsWithInvalidIdShouldReturnFailure\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Functional/Controllers/Backend/FormTest.php
-
-		-
-			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$success\\.$#"
-			count: 3
-			path: tests/Functional/Controllers/Backend/LogTest.php
-
-		-
-			message: "#^Method Enlight_Controller_Request_RequestTestCase\\:\\:setClientIp\\(\\) invoked with 2 parameters, 1 required\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Backend/LogTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\LogTest\\:\\:testCreateDeprecatedLog\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/LogTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\LogTest\\:\\:testCreateLog\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/LogTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\LogTest\\:\\:testDeleteLogs\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/LogTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\LogTest\\:\\:testGetLogs\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/LogTest.php
 
 		-
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\MailTest\\:\\:testCreateMail\\(\\) has no return type specified\\.$#"
@@ -38284,51 +38124,6 @@ parameters:
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\NotificationTest\\:\\:testGetCustomerList\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Functional/Controllers/Backend/NotificationTest.php
-
-		-
-			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$success\\.$#"
-			count: 5
-			path: tests/Functional/Controllers/Backend/PaymentTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\PaymentTest\\:\\:testCreatePayments\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/PaymentTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\PaymentTest\\:\\:testDeletePayment\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/PaymentTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\PaymentTest\\:\\:testDeletePayment\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/PaymentTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\PaymentTest\\:\\:testGetCountries\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/PaymentTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\PaymentTest\\:\\:testGetPayments\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/PaymentTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\PaymentTest\\:\\:testUpdatePayments\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/PaymentTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\PaymentTest\\:\\:testUpdatePayments\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/PaymentTest.php
-
-		-
-			message: "#^Property Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\PaymentTest\\:\\:\\$testDataCreate has no type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/PaymentTest.php
 
 		-
 			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$success\\.$#"
@@ -38421,71 +38216,6 @@ parameters:
 			path: tests/Functional/Controllers/Backend/SupplierTest.php
 
 		-
-			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$data\\.$#"
-			count: 7
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$success\\.$#"
-			count: 8
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$totalCount\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\VoucherTest\\:\\:testDeleteVoucher\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\VoucherTest\\:\\:testExportVoucherCode\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\VoucherTest\\:\\:testGenerateVoucherCodes\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\VoucherTest\\:\\:testGetTaxConfiguration\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\VoucherTest\\:\\:testGetVoucher\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\VoucherTest\\:\\:testGetVoucherCodes\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\VoucherTest\\:\\:testUpdateVoucher\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\VoucherTest\\:\\:testValidateOrderCode\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\VoucherTest\\:\\:testValidateVoucherCode\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
-			message: "#^Property Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\VoucherTest\\:\\:\\$voucherData type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/VoucherTest.php
-
-		-
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\WidgetsTest\\:\\:backendAuthProvider\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Functional/Controllers/Backend/WidgetsTest.php
@@ -38526,74 +38256,9 @@ parameters:
 			path: tests/Functional/Controllers/Backend/WidgetsTest.php
 
 		-
-			message: "#^Access to an undefined property Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\BlogTest\\:\\:\\$connection\\.$#"
-			count: 3
-			path: tests/Functional/Controllers/Frontend/BlogTest.php
-
-		-
-			message: "#^Cannot call method getCode\\(\\) on Exception\\|null\\.$#"
-			count: 2
-			path: tests/Functional/Controllers/Frontend/BlogTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\BlogTest\\:\\:invalidCategoryUrlDataProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/BlogTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\BlogTest\\:\\:testDispatchInactiveCategory\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/BlogTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\BlogTest\\:\\:testDispatchNoActiveBlogItem\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/BlogTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\BlogTest\\:\\:testDispatchNonBlogCategory\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/BlogTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\BlogTest\\:\\:testDispatchNotExistingBlogCategory\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/BlogTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\BlogTest\\:\\:testDispatchNotExistingBlogItem\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/BlogTest.php
-
-		-
 			message: "#^Query error\\: Column \"s_core_rulesets\\.value1\" expects value type string, got type 100$#"
 			count: 1
 			path: tests/Functional/Controllers/Frontend/CheckoutTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\SearchTest\\:\\:searchTermProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/SearchTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\SearchTest\\:\\:testAjaxSearch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/SearchTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\SearchTest\\:\\:testSearchEscapes\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/SearchTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$needle of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/SearchTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/SearchTest.php
 
 		-
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\SitemapTest\\:\\:sitemapDataprovider\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -38601,29 +38266,9 @@ parameters:
 			path: tests/Functional/Controllers/Frontend/SitemapTest.php
 
 		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\SitemapTest\\:\\:testIndex\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/SitemapTest.php
-
-		-
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\SitemapTest\\:\\:testIndex\\(\\) has parameter \\$sitemapData with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Functional/Controllers/Frontend/SitemapTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$shop of method Shopware\\\\Components\\\\ShopRegistrationService\\:\\:registerShop\\(\\) expects Shopware\\\\Models\\\\Shop\\\\Shop, Shopware\\\\Models\\\\Shop\\\\Shop\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/SitemapTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Frontend\\\\SitemapXmlTest\\:\\:testIndex\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Frontend/SitemapXmlTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Widgets\\\\IndexTest\\:\\:testShopMenu\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Widgets/IndexTest.php
 
 		-
 			message: "#^Query error\\: Argument \\#1 is not a constant array, got array\\<string, mixed\\>$#"
@@ -39111,16 +38756,6 @@ parameters:
 			path: tests/Functional/Core/sCoreTest.php
 
 		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Library\\\\ZendLocaleTest\\:\\:getLocales\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Functional/Library/ZendLocaleTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Library\\\\ZendLocaleTest\\:\\:testLocalCreation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Library/ZendLocaleTest.php
-
-		-
 			message: "#^Property Shopware\\\\Tests\\\\Functional\\\\Models\\\\Category\\\\BlogCategoryTreeListQueryTest\\:\\:\\$expected type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Functional/Models/Category/BlogCategoryTreeListQueryTest.php
@@ -39178,11 +38813,6 @@ parameters:
 		-
 			message: "#^Cannot call method setActive\\(\\) on Shopware\\\\Models\\\\Shop\\\\Shop\\|null\\.$#"
 			count: 2
-			path: tests/Functional/Models/Order/OrderDocumentDocumentTest.php
-
-		-
-			message: "#^Variable \\$document might not be defined\\.$#"
-			count: 1
 			path: tests/Functional/Models/Order/OrderDocumentDocumentTest.php
 
 		-
@@ -39384,141 +39014,6 @@ parameters:
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\BootstrapTest\\:\\:resetHttpCache\\(\\) has parameter \\$overrideConfig with no type specified\\.$#"
 			count: 1
 			path: tests/Functional/Plugins/Core/HttpCache/BootstrapTest.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Models\\\\Category\\\\Category\\|null\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Cannot call method getNumber\\(\\) on Shopware\\\\Models\\\\Article\\\\Detail\\|null\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Cannot call method setCategories\\(\\) on Shopware\\\\Models\\\\Emotion\\\\Emotion\\|null\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Cannot call method setCategoryId\\(\\) on Shopware\\\\Models\\\\Blog\\\\Blog\\|null\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Cannot call method setReleaseDate\\(\\) on Shopware\\\\Models\\\\Article\\\\Detail\\|null\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:createTestBlog\\(\\) never returns null so it can be removed from the return type\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:createTestCategory\\(\\) never returns null so it can be removed from the return type\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:createTestEmotion\\(\\) never returns null so it can be removed from the return type\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:createTestProduct\\(\\) never returns null so it can be removed from the return type\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:getBlogTestData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:getEmotionTestData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:getProductTestData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:testBlogListingTimeCalculation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:testBlogTimeCalculation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:testCategoryTimeCalculation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:testProductDetailTimeCalculation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:testServiceIsAvailable\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$active of method Shopware\\\\Models\\\\Category\\\\Category\\:\\:setActive\\(\\) expects bool, int given\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$blog of method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:getBlogListingRequest\\(\\) expects Shopware\\\\Models\\\\Blog\\\\Blog, Shopware\\\\Models\\\\Blog\\\\Blog\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$blog of method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:getBlogRequest\\(\\) expects Shopware\\\\Models\\\\Blog\\\\Blog, Shopware\\\\Models\\\\Blog\\\\Blog\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$category of method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:getcategoryRequest\\(\\) expects Shopware\\\\Models\\\\Category\\\\Category, Shopware\\\\Models\\\\Category\\\\Category\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$emotions of method Shopware\\\\Models\\\\Category\\\\Category\\:\\:setEmotions\\(\\) expects Doctrine\\\\Common\\\\Collections\\\\ArrayCollection&iterable\\<Shopware\\\\Models\\\\Emotion\\\\Emotion\\>, Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Shopware\\\\Models\\\\Emotion\\\\Emotion\\|null\\> given\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$entity of method Doctrine\\\\ORM\\\\EntityManager\\:\\:persist\\(\\) expects object, Shopware\\\\Models\\\\Blog\\\\Blog\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$entity of method Doctrine\\\\ORM\\\\EntityManager\\:\\:remove\\(\\) expects object, Shopware\\\\Models\\\\Article\\\\Article\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$entity of method Doctrine\\\\ORM\\\\EntityManager\\:\\:remove\\(\\) expects object, Shopware\\\\Models\\\\Blog\\\\Blog\\|null given\\.$#"
-			count: 2
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$entity of method Doctrine\\\\ORM\\\\EntityManager\\:\\:remove\\(\\) expects object, Shopware\\\\Models\\\\Category\\\\Category\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$product of method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\HttpCache\\\\DynamicCacheTimeServiceTest\\:\\:getProductRequest\\(\\) expects Shopware\\\\Models\\\\Article\\\\Article, Shopware\\\\Models\\\\Article\\\\Article\\|null given\\.$#"
-			count: 1
-			path: tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
 
 		-
 			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Plugins\\\\Core\\\\MarketingAggregate\\\\AbstractMarketing\\:\\:assertArrayEquals\\(\\) has no return type specified\\.$#"

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -26341,11 +26341,6 @@ parameters:
 			path: engine/Shopware/Core/sCore.php
 
 		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: engine/Shopware/Core/sCore.php
-
-		-
 			message: "#^Method sExport\\:\\:_decode_line\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Shopware/Core/sExport.php

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -2046,16 +2046,6 @@ parameters:
 			path: engine/Library/Enlight/Controller/Front.php
 
 		-
-			message: "#^Method Enlight_Controller_Plugins_Json_Bootstrap\\:\\:convertDateTime\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
-
-		-
-			message: "#^Method Enlight_Controller_Plugins_Json_Bootstrap\\:\\:convertDateTime\\(\\) has parameter \\$key with no type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
-
-		-
 			message: "#^Method Enlight_Controller_Plugins_Json_Bootstrap\\:\\:convertToJson\\(\\) has parameter \\$data with no type specified\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
@@ -2076,82 +2066,12 @@ parameters:
 			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
 
 		-
-			message: "#^Method Enlight_Controller_Plugins_Json_Bootstrap\\:\\:init\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
-
-		-
-			message: "#^Method Enlight_Controller_Plugins_Json_Bootstrap\\:\\:onPostDispatch\\(\\) should return bool but empty return statement found\\.$#"
-			count: 2
-			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
-
-		-
-			message: "#^Method Enlight_Controller_Plugins_Json_Bootstrap\\:\\:onPostDispatch\\(\\) should return bool but return statement is missing\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
-
-		-
 			message: "#^Possibly invalid array key type array\\|string\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
 
 		-
-			message: "#^Property Enlight_Controller_Plugins_Json_Bootstrap\\:\\:\\$padding \\(string\\) does not accept bool\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
-
-		-
-			message: "#^Property Enlight_Controller_Plugins_Json_Bootstrap\\:\\:\\$padding \\(string\\) does not accept null\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
-
-		-
-			message: "#^Property Enlight_Controller_Plugins_Json_Bootstrap\\:\\:\\$padding \\(string\\) does not accept string\\|null\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
-
-		-
-			message: "#^Property Enlight_Controller_Plugins_Json_Bootstrap\\:\\:\\$renderer \\(bool\\) does not accept null\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/Json/Bootstrap.php
-
-		-
-			message: "#^Method Enlight_Controller_Plugins_JsonRequest_Bootstrap\\:\\:getPadding\\(\\) should return string but returns bool\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
-
-		-
-			message: "#^Method Enlight_Controller_Plugins_JsonRequest_Bootstrap\\:\\:init\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
-
-		-
-			message: "#^Method Enlight_Controller_Plugins_JsonRequest_Bootstrap\\:\\:onPreDispatch\\(\\) should return bool but return statement is missing\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
-
-		-
-			message: "#^Method Enlight_Controller_Plugins_JsonRequest_Bootstrap\\:\\:setPadding\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
-
-		-
-			message: "#^Method Enlight_Controller_Plugins_JsonRequest_Bootstrap\\:\\:setPadding\\(\\) has parameter \\$padding with no type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
-
-		-
 			message: "#^Method Enlight_Controller_Plugins_JsonRequest_Bootstrap\\:\\:setParseParams\\(\\) has parameter \\$parseParams with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
-
-		-
-			message: "#^Parameter \\#1 \\$spec of method Enlight_Controller_Request_RequestHttp\\:\\:setPost\\(\\) expects array\\|string, bool given\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
-
-		-
-			message: "#^Property Enlight_Controller_Plugins_JsonRequest_Bootstrap\\:\\:\\$padding \\(bool\\) does not accept null\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
 
@@ -3186,21 +3106,6 @@ parameters:
 			path: engine/Library/Enlight/Loader.php
 
 		-
-			message: "#^Method Enlight_Plugin_Bootstrap\\:\\:afterInit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Plugin/Bootstrap.php
-
-		-
-			message: "#^Method Enlight_Plugin_Bootstrap\\:\\:get\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Plugin/Bootstrap.php
-
-		-
-			message: "#^Property Enlight_Plugin_Bootstrap\\:\\:\\$collection \\(Enlight_Plugin_PluginCollection\\) does not accept Enlight_Plugin_PluginCollection\\|null\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Plugin/Bootstrap.php
-
-		-
 			message: "#^Method Enlight_Plugin_Bootstrap_Config\\:\\:install\\(\\) should return bool but return statement is missing\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Plugin/Bootstrap/Config.php
@@ -3774,16 +3679,6 @@ parameters:
 			message: "#^Function smarty_modifier_array_unset\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Template/Plugins/modifier.array_unset.php
-
-		-
-			message: "#^Function smarty_modifier_count\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Template/Plugins/modifier.count.php
-
-		-
-			message: "#^Function smarty_modifier_count\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Template/Plugins/modifier.count.php
 
 		-
 			message: "#^Parameter \\#1 \\$date of class Zend_Date constructor expects array\\|int\\|string\\|Zend_Date\\|null, DateTime\\|int\\|false given\\.$#"
@@ -14314,11 +14209,6 @@ parameters:
 			message: "#^Property Shopware_Components_Auth\\:\\:\\$_baseAdapter \\(Zend_Auth_Adapter_Interface\\) does not accept Zend_Auth_Adapter_Interface\\|null\\.$#"
 			count: 1
 			path: engine/Shopware/Components/Auth.php
-
-		-
-			message: "#^Cannot access property \\$username on bool\\|stdClass\\.$#"
-			count: 1
-			path: engine/Shopware/Components/Auth/Adapter/Default.php
 
 		-
 			message: "#^Method Shopware_Components_Auth_Adapter_Default\\:\\:_authenticateValidateResult\\(\\) has parameter \\$resultIdentity with no value type specified in iterable type array\\.$#"
@@ -34226,11 +34116,6 @@ parameters:
 			path: engine/Shopware/Plugins/Default/Backend/Auth/Bootstrap.php
 
 		-
-			message: "#^Method Shopware_Plugins_Backend_SwagUpdate_Bootstrap\\:\\:afterInit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Bootstrap.php
-
-		-
 			message: "#^Method Shopware_Plugins_Backend_SwagUpdate_Bootstrap\\:\\:onBackendIndexPostDispatch\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Backend/SwagUpdate/Bootstrap.php
@@ -34707,11 +34592,6 @@ parameters:
 
 		-
 			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:addSurrogateControl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_HttpCache_Bootstrap\\:\\:afterInit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
 
@@ -35491,11 +35371,6 @@ parameters:
 			path: engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
 
 		-
-			message: "#^Method Shopware_Plugins_Core_RestApi_Bootstrap\\:\\:afterInit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
-
-		-
 			message: "#^Method Shopware_Plugins_Core_RestApi_Bootstrap\\:\\:onDispatchLoopStartup\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
@@ -35529,16 +35404,6 @@ parameters:
 			message: "#^Method ShopwarePlugins\\\\RestApi\\\\Components\\\\Router\\:\\:assembleRoute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Plugins/Default/Core/RestApi/Components/Router.php
-
-		-
-			message: "#^Method Shopware_Plugins_Core_System_Bootstrap\\:\\:onDispatchLoopShutdown\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Plugins/Default/Core/System/Bootstrap.php
-
-		-
-			message: "#^Parameter \\#1 \\$userAgent of method Shopware_Plugins_Frontend_Statistics_Bootstrap\\:\\:checkIsBot\\(\\) expects string, string\\|false given\\.$#"
-			count: 2
-			path: engine/Shopware/Plugins/Default/Core/System/Bootstrap.php
 
 		-
 			message: "#^Call to an undefined method Enlight_Event_EventArgs\\:\\:getRequest\\(\\)\\.$#"

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -163,7 +163,7 @@ parameters:
                 - engine/Shopware/Commands/ThemeCreateCommand.php
 
         - # For testing purposes the constructor of the price struct gets strings
-            message: '#Parameter .* of class Shopware\\Components\\Cart\\Struct\\Price constructor expects float.*string given#'
+            message: '#Parameter .* of class Shopware\\Components\\Cart\\Struct\\Price constructor expects float|numeric-string, .* given#'
             path: tests/Functional/Components/Cart/ProportionalTaxCalculatorTest.php
 
         # This is a bleeding edge feature and not working well since now. See https://github.com/phpstan/phpstan-doctrine/issues/332

--- a/UPGRADE-5.7.md
+++ b/UPGRADE-5.7.md
@@ -9,6 +9,7 @@ This changelog references changes done in Shopware 5.7 patch versions.
 ### Changes
 
 * Changed behaviour of the translation transfer while setting a product variant as the main variant
+* Changed the test kernel, so PHPUnit tests do no longer ignore PHP warnings and notices and are failing instead
 
 ## 5.7.18
 

--- a/_sql/migrations/1727-update-date-formatting.php
+++ b/_sql/migrations/1727-update-date-formatting.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shopware 5
+ * Copyright (c) shopware AG
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Shopware" is a registered trademark of shopware AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+use Shopware\Components\Migrations\AbstractMigration;
+
+class Migrations_Migration1727 extends AbstractMigration
+{
+    public function up($modus)
+    {
+        $sql = <<<'EOD'
+UPDATE `s_core_config_mails`
+SET content = REPLACE(content, '|date_format:"%d.%m.%Y"', '|date_format:"d.m.Y"'),
+    contentHTML = REPLACE(contentHTML, '|date_format:"%d.%m.%Y"', '|date_format:"d.m.Y"')
+WHERE dirty = 0;
+EOD;
+        $this->addSql($sql);
+    }
+}

--- a/engine/Library/Enlight/Class.php
+++ b/engine/Library/Enlight/Class.php
@@ -33,7 +33,7 @@ abstract class Enlight_Class
     /**
      * Contains all initialized Enlight instances.
      *
-     * @var array
+     * @var array<class-string<Enlight_Class|object>, Enlight_Class|object>
      */
     protected static $instances = [];
 
@@ -59,7 +59,8 @@ abstract class Enlight_Class
         }
         if ($this instanceof Enlight_Hook
           && !$this instanceof Enlight_Hook_Proxy
-          && Shopware()->Hooks()->hasProxy($class)) {
+          && Shopware()->Hooks()->hasProxy($class)
+        ) {
             throw new Enlight_Exception(
                 'Class "' . \get_class($this) . '" has hooks, please use the instance method'
             );
@@ -161,12 +162,14 @@ abstract class Enlight_Class
      * Returns a class instance. If the class is already initialed the existing instance will returned.
      * Otherwise the class will be initialed with the given arguments.
      *
-     * @param class-string $class
-     * @param array        $args
+     * @template TClass of (Enlight_Class|object)
+     *
+     * @param class-string<TClass>|null $class
+     * @param array<mixed>|null         $args
      *
      * @throws \ReflectionException
      *
-     * @return Enlight_Class
+     * @return TClass
      */
     public static function Instance($class = null, $args = null)
     {

--- a/engine/Library/Enlight/Components/Auth.php
+++ b/engine/Library/Enlight/Components/Auth.php
@@ -72,7 +72,9 @@ class Enlight_Components_Auth extends Zend_Auth
 
         if ($result->isValid() && method_exists($adapter, 'getResultRowObject')) {
             $user = $adapter->getResultRowObject();
-            $this->getStorage()->write($user);
+            if (\is_object($user)) {
+                $this->getStorage()->write($user);
+            }
         } else {
             $this->getStorage()->clear();
         }

--- a/engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
+++ b/engine/Library/Enlight/Controller/Plugins/JsonRequest/Bootstrap.php
@@ -35,7 +35,7 @@
 class Enlight_Controller_Plugins_JsonRequest_Bootstrap extends Enlight_Plugin_Bootstrap_Default
 {
     /**
-     * @var bool
+     * @var string|null
      */
     protected $padding;
 
@@ -51,6 +51,8 @@ class Enlight_Controller_Plugins_JsonRequest_Bootstrap extends Enlight_Plugin_Bo
 
     /**
      * Init this plugin. This Plugin should run before the dispatching process.
+     *
+     * @return void
      */
     public function init()
     {
@@ -67,7 +69,7 @@ class Enlight_Controller_Plugins_JsonRequest_Bootstrap extends Enlight_Plugin_Bo
      * Called from the event manager before the dispatch process.
      * Parse the json input data, when it was activated.
      *
-     * @return bool
+     * @return void
      */
     public function onPreDispatch(Enlight_Event_EventArgs $args)
     {
@@ -76,13 +78,15 @@ class Enlight_Controller_Plugins_JsonRequest_Bootstrap extends Enlight_Plugin_Bo
         $request = $subject->Request();
 
         // Parses the json input data, if the content type is correct
+        $contentType = $request->getHeader('Content-Type');
+        $input = $request->getRawBody();
         if (
             $this->parseInput === true
-            && ($contentType = $request->getHeader('Content-Type')) !== false
-            && strpos($contentType, 'application/json') === 0
-            && ($input = $request->getRawBody()) !== false
+            && \is_string($contentType)
+            && str_starts_with($contentType, 'application/json')
+            && \is_string($input)
         ) {
-            if ($input != '') {
+            if ($input !== '') {
                 $input = Zend_Json::decode($input);
             } else {
                 $input = null;
@@ -102,7 +106,8 @@ class Enlight_Controller_Plugins_JsonRequest_Bootstrap extends Enlight_Plugin_Bo
         // Parse the json Params
         if (\count($this->parseParams)) {
             foreach ($this->parseParams as $Param) {
-                if (($value = $request->getParam($Param)) !== null) {
+                $value = $request->getParam($Param);
+                if ($value !== null) {
                     $value = Zend_Json::decode($value);
                     $request->setParam($Param, $value);
                 }
@@ -121,7 +126,7 @@ class Enlight_Controller_Plugins_JsonRequest_Bootstrap extends Enlight_Plugin_Bo
      *
      * @param bool $parseInput
      *
-     * @return Enlight_Controller_Plugins_JsonRequest_Bootstrap
+     * @return $this
      */
     public function setParseInput($parseInput = true)
     {
@@ -136,7 +141,7 @@ class Enlight_Controller_Plugins_JsonRequest_Bootstrap extends Enlight_Plugin_Bo
      *
      * @param array $parseParams
      *
-     * @return Enlight_Controller_Plugins_JsonRequest_Bootstrap
+     * @return $this
      */
     public function setParseParams($parseParams = [])
     {
@@ -145,11 +150,12 @@ class Enlight_Controller_Plugins_JsonRequest_Bootstrap extends Enlight_Plugin_Bo
         return $this;
     }
 
-    /*
-    * @param bool $padding
-    * @return Enlight_Controller_Plugins_Json_Bootstrap
-    */
-    public function setPadding($padding = true)
+    /**
+     * @param string $padding
+     *
+     * @return $this
+     */
+    public function setPadding($padding = '1')
     {
         $this->padding = $padding;
 
@@ -159,7 +165,7 @@ class Enlight_Controller_Plugins_JsonRequest_Bootstrap extends Enlight_Plugin_Bo
     /**
      * Returns the Value set by setPadding()
      *
-     * @return string
+     * @return string|null
      */
     public function getPadding()
     {

--- a/engine/Library/Enlight/Controller/Plugins/ScriptRenderer/Bootstrap.php
+++ b/engine/Library/Enlight/Controller/Plugins/ScriptRenderer/Bootstrap.php
@@ -144,7 +144,7 @@ class Enlight_Controller_Plugins_ScriptRenderer_Bootstrap extends Enlight_Plugin
         $fileNames = (array) $request->getParam('file', $this->defaultFile);
         if (empty($fileNames)) {
             $fileNames = $request->getParam('f');
-            $fileNames = explode('|', $fileNames);
+            $fileNames = explode('|', (string) $fileNames);
         }
 
         $templateNames = [];
@@ -198,7 +198,10 @@ class Enlight_Controller_Plugins_ScriptRenderer_Bootstrap extends Enlight_Plugin
     public function setViewRenderer(?Enlight_Controller_Plugins_ViewRenderer_Bootstrap $viewRenderer = null)
     {
         if ($viewRenderer === null) {
-            $viewRenderer = $this->Collection()->get('ViewRenderer');
+            $collection = $this->Collection();
+            if ($collection !== null) {
+                $viewRenderer = $collection->get('ViewRenderer');
+            }
         }
 
         $this->viewRenderer = $viewRenderer;

--- a/engine/Library/Enlight/Controller/Request/Request.php
+++ b/engine/Library/Enlight/Controller/Request/Request.php
@@ -628,7 +628,7 @@ interface Enlight_Controller_Request_Request
      *
      * @throws \Exception
      *
-     * @return string|false HTTP header value, or false if not found
+     * @return string|false|null HTTP header value, or false if not found
      */
     public function getHeader($header);
 

--- a/engine/Library/Enlight/Controller/Request/RequestHttp.php
+++ b/engine/Library/Enlight/Controller/Request/RequestHttp.php
@@ -843,7 +843,7 @@ class Enlight_Controller_Request_RequestHttp extends Request implements Enlight_
         trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be removed with 5.8', __CLASS__, __METHOD__), E_USER_DEPRECATED);
 
         $userAgent = $this->getHeader('USER_AGENT');
-        if ($userAgent === false) {
+        if (empty($userAgent)) {
             return false;
         }
         $header = strtolower($userAgent);
@@ -869,7 +869,7 @@ class Enlight_Controller_Request_RequestHttp extends Request implements Enlight_
             return $this->server->get('HTTP_' . $temp);
         }
 
-        if (strpos($temp, 'CONTENT_') === 0 && $this->server->has($temp)) {
+        if (str_starts_with($temp, 'CONTENT_') && $this->server->has($temp)) {
             return $this->server->get($temp);
         }
 

--- a/engine/Library/Enlight/Plugin/Bootstrap.php
+++ b/engine/Library/Enlight/Plugin/Bootstrap.php
@@ -36,7 +36,7 @@ abstract class Enlight_Plugin_Bootstrap extends Enlight_Class
     protected $name;
 
     /**
-     * @var Enlight_Plugin_PluginCollection Contains an instance of the Enlight_Plugin_PluginCollection
+     * @var Enlight_Plugin_PluginCollection|null Contains an instance of the Enlight_Plugin_PluginCollection
      */
     protected $collection;
 
@@ -54,6 +54,8 @@ abstract class Enlight_Plugin_Bootstrap extends Enlight_Class
 
     /**
      * Is executed after the collection has been added.
+     *
+     * @return void
      */
     public function afterInit()
     {
@@ -85,7 +87,7 @@ abstract class Enlight_Plugin_Bootstrap extends Enlight_Class
     /**
      * Getter method for the collection property.
      *
-     * @return Enlight_Plugin_PluginCollection
+     * @return Enlight_Plugin_PluginCollection|null
      */
     public function Collection()
     {
@@ -99,6 +101,10 @@ abstract class Enlight_Plugin_Bootstrap extends Enlight_Class
      */
     public function Application()
     {
+        if (!$this->collection instanceof Enlight_Plugin_PluginCollection) {
+            throw new RuntimeException('Could not get "Application". Plugin collection is not set.');
+        }
+
         return $this->collection->Application();
     }
 
@@ -106,9 +112,15 @@ abstract class Enlight_Plugin_Bootstrap extends Enlight_Class
      * Get service from resource loader
      *
      * @param string $name
+     *
+     * @return mixed|object|null
      */
     public function get($name)
     {
+        if (!$this->collection instanceof Enlight_Plugin_PluginCollection) {
+            throw new RuntimeException(sprintf('Could not get "%s". Plugin collection is not set.', $name));
+        }
+
         return $this->collection->Application()->Container()->get($name);
     }
 }

--- a/engine/Library/Enlight/Template/Plugins/modifier.count.php
+++ b/engine/Library/Enlight/Template/Plugins/modifier.count.php
@@ -19,14 +19,13 @@
 
 /**
  * Overwrites the default smarty count modifier for PHP8 compatibility reasons
+ *
+ * @param mixed|null $value
+ *
+ * @return int
  */
 function smarty_modifier_count($value)
 {
-    // PHP version is below 8.0.0, use default behavior
-    if (\PHP_VERSION_ID < 80000) {
-        return \count($value);
-    }
-
     // Neither a countable object nor an array
     if (!\is_array($value) && !($value instanceof Countable)) {
         return 0;

--- a/engine/Library/Enlight/Template/Plugins/modifier.currency.php
+++ b/engine/Library/Enlight/Template/Plugins/modifier.currency.php
@@ -22,9 +22,9 @@
  *
  * @see http://framework.zend.com/manual/de/zend.currency.options.html
  *
- * @param float        $value    Value can have a coma as a decimal separator
- * @param array|string $config
- * @param string       $position where the currency symbol should be displayed
+ * @param float|string                $value    Value can have a coma as a decimal separator
+ * @param array<string, mixed>|string $config
+ * @param string|null                 $position where the currency symbol should be displayed
  *
  * @return string
  */
@@ -49,9 +49,8 @@ function smarty_modifier_currency($value, $config = null, $position = null)
     }
 
     $currency = Shopware()->Container()->get('currency');
-    $formattedValue = (float) str_replace(',', '.', $value);
+    $formattedValue = (float) str_replace(',', '.', (string) $value);
     $formattedValue = $currency->toCurrency($formattedValue, $config);
-    $formattedValue = mb_convert_encoding($formattedValue, 'HTML-ENTITIES', 'UTF-8');
 
     return htmlentities($formattedValue, ENT_COMPAT, 'UTF-8', false);
 }

--- a/engine/Library/Smarty/sysplugins/smarty_internal_configfilelexer.php
+++ b/engine/Library/Smarty/sysplugins/smarty_internal_configfilelexer.php
@@ -92,7 +92,7 @@ class Smarty_Internal_Configfilelexer
         $yy_global_pattern = "/\G(#|;)|\G(\\[)|\G(\\])|\G(=)|\G([ \t\r]+)|\G(\n)|\G([0-9]*[a-zA-Z_]\\w*)|\G([\S\s])/iS";
 
         do {
-            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, null, $this->counter)) {
+            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, 0, $this->counter)) {
                 $yysubmatches = $yymatches;
                 $yymatches = array_filter($yymatches, 'strlen'); // remove empty sub-patterns
                 if (!count($yymatches)) {
@@ -204,7 +204,7 @@ class Smarty_Internal_Configfilelexer
         $yy_global_pattern = "/\G([ \t\r]+)|\G(\\d+\\.\\d+(?=[ \t\r]*[\n#;]))|\G(\\d+(?=[ \t\r]*[\n#;]))|\G(\"\"\")|\G('[^'\\\\]*(?:\\\\.[^'\\\\]*)*'(?=[ \t\r]*[\n#;]))|\G(\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"(?=[ \t\r]*[\n#;]))|\G([a-zA-Z]+(?=[ \t\r]*[\n#;]))|\G([^\n]+?(?=[ \t\r]*\n))|\G(\n)/iS";
 
         do {
-            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, null, $this->counter)) {
+            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, 0, $this->counter)) {
                 $yysubmatches = $yymatches;
                 $yymatches = array_filter($yymatches, 'strlen'); // remove empty sub-patterns
                 if (!count($yymatches)) {
@@ -325,7 +325,7 @@ class Smarty_Internal_Configfilelexer
         $yy_global_pattern = "/\G([^\n]+?(?=[ \t\r]*\n))/iS";
 
         do {
-            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, null, $this->counter)) {
+            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, 0, $this->counter)) {
                 $yysubmatches = $yymatches;
                 $yymatches = array_filter($yymatches, 'strlen'); // remove empty sub-patterns
                 if (!count($yymatches)) {
@@ -394,7 +394,7 @@ class Smarty_Internal_Configfilelexer
         $yy_global_pattern = "/\G([ \t\r]+)|\G([^\n]+?(?=[ \t\r]*\n))|\G(\n)/iS";
 
         do {
-            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, null, $this->counter)) {
+            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, 0, $this->counter)) {
                 $yysubmatches = $yymatches;
                 $yymatches = array_filter($yymatches, 'strlen'); // remove empty sub-patterns
                 if (!count($yymatches)) {
@@ -472,7 +472,7 @@ class Smarty_Internal_Configfilelexer
         $yy_global_pattern = "/\G(\\.)|\G(.*?(?=[\.=[\]\r\n]))/iS";
 
         do {
-            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, null, $this->counter)) {
+            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, 0, $this->counter)) {
                 $yysubmatches = $yymatches;
                 $yymatches = array_filter($yymatches, 'strlen'); // remove empty sub-patterns
                 if (!count($yymatches)) {
@@ -544,7 +544,7 @@ class Smarty_Internal_Configfilelexer
         $yy_global_pattern = "/\G(\"\"\"(?=[ \t\r]*[\n#;]))|\G([\S\s])/iS";
 
         do {
-            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, null, $this->counter)) {
+            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, 0, $this->counter)) {
                 $yysubmatches = $yymatches;
                 $yymatches = array_filter($yymatches, 'strlen'); // remove empty sub-patterns
                 if (!count($yymatches)) {

--- a/engine/Library/Smarty/sysplugins/smarty_internal_data.php
+++ b/engine/Library/Smarty/sysplugins/smarty_internal_data.php
@@ -464,6 +464,7 @@ class Smarty_Data extends Smarty_Internal_Data {
  * @package Smarty
  * @subpackage Template
  */
+#[AllowDynamicProperties]
 class Smarty_Variable {
 
     /**

--- a/engine/Library/Smarty/sysplugins/smarty_internal_template.php
+++ b/engine/Library/Smarty/sysplugins/smarty_internal_template.php
@@ -241,7 +241,7 @@ class Smarty_Internal_Template extends Smarty_Internal_TemplateBase {
      * @param integer $cache_lifetime life time of cache data
      * @param array   $vars optional  variables to assign
      * @param int     $parent_scope   scope in which {include} should execute
-     * @returns string template content
+     * @return string template content
      */
     public function getSubTemplate($template, $cache_id, $compile_id, $caching, $cache_lifetime, $data, $parent_scope)
     {
@@ -298,7 +298,7 @@ class Smarty_Internal_Template extends Smarty_Internal_TemplateBase {
      * @param array   $vars optional  variables to assign
      * @param int     $parent_scope   scope in which {include} should execute
      * @param string  $hash           nocache hash code
-     * @returns string template content
+     * @return string template content
      */
     public function setupInlineSubTemplate($template, $cache_id, $compile_id, $caching, $cache_lifetime, $data, $parent_scope, $hash)
     {

--- a/engine/Library/Smarty/sysplugins/smarty_internal_templatebase.php
+++ b/engine/Library/Smarty/sysplugins/smarty_internal_templatebase.php
@@ -402,7 +402,7 @@ abstract class Smarty_Internal_TemplateBase extends Smarty_Internal_Data {
      * creates a data object
      *
      * @param object $parent next higher level of Smarty variables
-     * @returns Smarty_Data data object
+     * @return Smarty_Data data object
      */
     public function createData($parent = null)
     {

--- a/engine/Library/Smarty/sysplugins/smarty_internal_templatelexer.php
+++ b/engine/Library/Smarty/sysplugins/smarty_internal_templatelexer.php
@@ -916,7 +916,7 @@ class Smarty_Internal_Templatelexer
         $yy_global_pattern = "/\G(".$this->ldel."\\s*literal\\s*".$this->rdel.")|\G(".$this->ldel."\\s*\/literal\\s*".$this->rdel.")|\G(<\\?(?:php\\w+|=|[a-zA-Z]+)?)|\G(\\?>)|\G(<%)|\G(%>)|\G([\S\s])/iS";
 
         do {
-            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, null, $this->counter)) {
+            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, 0, $this->counter)) {
                 $yysubmatches = $yymatches;
                 $yymatches = array_filter($yymatches, 'strlen'); // remove empty sub-patterns
                 if (!count($yymatches)) {
@@ -1046,7 +1046,7 @@ class Smarty_Internal_Templatelexer
         $yy_global_pattern = "/\G(".$this->ldel."\\s{1,}\/)|\G(".$this->ldel."\\s*(if|elseif|else if|while)\\s+)|\G(".$this->ldel."\\s*for\\s+)|\G(".$this->ldel."\\s*foreach(?![^\s]))|\G(".$this->ldel."\\s{1,})|\G(".$this->ldel."\/)|\G(".$this->ldel.")|\G(\")|\G(`\\$)|\G(\\$[0-9]*[a-zA-Z_]\\w*)|\G(\\$)|\G(([^\"\\\\]*?)((?:\\\\.[^\"\\\\]*?)*?)(?=(".$this->ldel."|\\$|`\\$|\")))|\G([\S\s])/iS";
 
         do {
-            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, null, $this->counter)) {
+            if ($this->mbstring_overload ? preg_match($yy_global_pattern, mb_substr($this->data, $this->counter,2000000000,'latin1'), $yymatches) : preg_match($yy_global_pattern,$this->data, $yymatches, 0, $this->counter)) {
                 $yysubmatches = $yymatches;
                 $yymatches = array_filter($yymatches, 'strlen'); // remove empty sub-patterns
                 if (!count($yymatches)) {

--- a/engine/Library/Zend/Auth/Adapter/DbTable.php
+++ b/engine/Library/Zend/Auth/Adapter/DbTable.php
@@ -297,7 +297,7 @@ class Zend_Auth_Adapter_DbTable implements Zend_Auth_Adapter_Interface
      * @param string|array $returnColumns
      * @param string|array $omitColumns
      *
-     * @return stdClass|bool
+     * @return stdClass|false
      */
     public function getResultRowObject($returnColumns = null, $omitColumns = null)
     {
@@ -308,15 +308,16 @@ class Zend_Auth_Adapter_DbTable implements Zend_Auth_Adapter_Interface
         $returnObject = new stdClass();
 
         if ($returnColumns !== null) {
-            $availableColumns = array_keys($this->_resultRow);
             foreach ((array) $returnColumns as $returnColumn) {
-                if (in_array($returnColumn, $availableColumns)) {
+                if (array_key_exists($returnColumn, $this->_resultRow)) {
                     $returnObject->{$returnColumn} = $this->_resultRow[$returnColumn];
                 }
             }
 
             return $returnObject;
-        } elseif ($omitColumns !== null) {
+        }
+
+        if ($omitColumns !== null) {
             $omitColumns = (array) $omitColumns;
             foreach ($this->_resultRow as $resultColumn => $resultValue) {
                 if (!in_array($resultColumn, $omitColumns)) {

--- a/engine/Library/Zend/Config.php
+++ b/engine/Library/Zend/Config.php
@@ -243,6 +243,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->_count;
@@ -253,6 +254,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $this->_skipNextIteration = false;
@@ -264,6 +266,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->_data);
@@ -273,6 +276,7 @@ class Zend_Config implements Countable, Iterator
      * Defined by Iterator interface
      *
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ($this->_skipNextIteration) {
@@ -287,6 +291,7 @@ class Zend_Config implements Countable, Iterator
      * Defined by Iterator interface
      *
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->_skipNextIteration = false;
@@ -299,6 +304,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->_index < $this->_count;

--- a/engine/Library/Zend/Db/Table/Row/Abstract.php
+++ b/engine/Library/Zend/Db/Table/Row/Abstract.php
@@ -256,6 +256,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @param string $offset
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->__isset($offset);
@@ -268,6 +269,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @param string $offset
      * @return string
      */
+    #[\ReturnTypeWillChange]
      public function offsetGet($offset)
      {
          return $this->__get($offset);
@@ -280,6 +282,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
       * @param string $offset
       * @param mixed $value
       */
+    #[\ReturnTypeWillChange]
      public function offsetSet($offset, $value)
      {
          $this->__set($offset, $value);
@@ -291,6 +294,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
       *
       * @param string $offset
       */
+    #[\ReturnTypeWillChange]
      public function offsetUnset($offset)
      {
          return $this->__unset($offset);
@@ -629,6 +633,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
         return $result;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator((array) $this->_data);

--- a/engine/Library/Zend/Http/Response.php
+++ b/engine/Library/Zend/Http/Response.php
@@ -252,7 +252,7 @@ class Zend_Http_Response
         $body = '';
 
         // Decode the body if it was transfer-encoded
-        switch (strtolower($this->getHeader('transfer-encoding'))) {
+        switch (strtolower($this->getHeader('transfer-encoding') ?? '')) {
 
             // Handle chunked body
             case 'chunked':
@@ -267,7 +267,7 @@ class Zend_Http_Response
         }
 
         // Decode any content-encoding (gzip or deflate) if needed
-        switch (strtolower($this->getHeader('content-encoding'))) {
+        switch (strtolower($this->getHeader('content-encoding') ?? '')) {
 
             // Handle gzip encoding
             case 'gzip':

--- a/engine/Library/Zend/Mail.php
+++ b/engine/Library/Zend/Mail.php
@@ -1205,6 +1205,9 @@ class Zend_Mail extends Zend_Mime_Message
      */
     protected function _filterName($name)
     {
+        if (empty($name)) {
+            return '';
+        }
         $rule = array("\r" => '',
                       "\n" => '',
                       "\t" => '',

--- a/engine/Shopware/Bundle/AccountBundle/Form/Account/AddressFormType.php
+++ b/engine/Shopware/Bundle/AccountBundle/Form/Account/AddressFormType.php
@@ -87,7 +87,7 @@ class AddressFormType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
             array_walk_recursive($data, function (&$item) {
-                $item = strip_tags($item);
+                $item = strip_tags((string) $item);
             });
             $event->setData($data);
         });

--- a/engine/Shopware/Bundle/AttributeBundle/Repository/Reader/OrderReader.php
+++ b/engine/Shopware/Bundle/AttributeBundle/Repository/Reader/OrderReader.php
@@ -52,8 +52,8 @@ class OrderReader extends GenericReader
         foreach ($orders as &$order) {
             $order['orderStateName'] = $namespace->get($order['orderStateKey']);
             $order['orderDocuments'] = $this->getOrderDocuments($documents, $order);
-            $order['supplierId'] = explode(',', $order['supplierId']);
-            $order['articleNumber'] = explode(',', $order['articleNumber']);
+            $order['supplierId'] = explode(',', $order['supplierId'] ?? '');
+            $order['articleNumber'] = explode(',', $order['articleNumber'] ?? '');
         }
 
         return $orders;

--- a/engine/Shopware/Bundle/CookieBundle/Services/CookieHandler.php
+++ b/engine/Shopware/Bundle/CookieBundle/Services/CookieHandler.php
@@ -69,7 +69,7 @@ class CookieHandler implements CookieHandlerInterface
             return false;
         }
 
-        foreach ($preferences['groups'] as $cookieGroup) {
+        foreach ($preferences['groups'] ?? [] as $cookieGroup) {
             foreach ($cookieGroup['cookies'] as $cookie) {
                 if ($cookie['name'] !== $foundCookie->getName()) {
                     continue;

--- a/engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/CustomerOrderHydrator.php
+++ b/engine/Shopware/Bundle/CustomerSearchBundleDBAL/Indexing/CustomerOrderHydrator.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -28,6 +30,11 @@ use DateTime;
 
 class CustomerOrderHydrator
 {
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return CustomerOrder
+     */
     public function hydrate(array $data)
     {
         $struct = new CustomerOrder();
@@ -36,34 +43,37 @@ class CustomerOrderHydrator
             return $struct;
         }
 
-        $struct->setOrderCount((int) $data['count_orders']);
-        $struct->setTotalAmount((float) $data['invoice_amount_sum']);
-        $struct->setAvgAmount((float) $data['invoice_amount_avg']);
-        $struct->setMinAmount((float) $data['invoice_amount_min']);
-        $struct->setMaxAmount((float) $data['invoice_amount_max']);
-        $struct->setAvgProductPrice((float) $data['product_avg']);
-        $struct->setFirstOrderTime(new DateTime($data['first_order_time']));
-        $struct->setLastOrderTime(new DateTime($data['last_order_time']));
-        $struct->setPayments($this->explodeAndFilter($data['selected_payments']));
-        $struct->setShops($this->explodeAndFilter($data['ordered_in_shops']));
-        $struct->setDevices($this->explodeAndFilter($data['ordered_with_devices']));
-        $struct->setDispatches($this->explodeAndFilter($data['selected_dispachtes']));
-        $struct->setWeekdays($this->explodeAndFilter($data['weekdays']));
+        $struct->setOrderCount((int) ($data['count_orders'] ?? 0));
+        $struct->setTotalAmount((float) ($data['invoice_amount_sum'] ?? 0.0));
+        $struct->setAvgAmount((float) ($data['invoice_amount_avg'] ?? 0.0));
+        $struct->setMinAmount((float) ($data['invoice_amount_min'] ?? 0.0));
+        $struct->setMaxAmount((float) ($data['invoice_amount_max'] ?? 0.0));
+        $struct->setAvgProductPrice((float) ($data['product_avg'] ?? 0.0));
+        $struct->setFirstOrderTime(isset($data['first_order_time']) ? new DateTime($data['first_order_time']) : null);
+        $struct->setLastOrderTime(isset($data['last_order_time']) ? new DateTime($data['last_order_time']) : null);
+        $struct->setPayments(array_map('\intval', $this->explodeAndFilter($data['selected_payments'] ?? '')));
+        $struct->setShops(array_map('\intval', $this->explodeAndFilter($data['ordered_in_shops'] ?? '')));
+        $struct->setDevices($this->explodeAndFilter($data['ordered_with_devices'] ?? ''));
+        $struct->setDispatches(array_map('\intval', $this->explodeAndFilter($data['selected_dispachtes'] ?? '')));
+        $struct->setWeekdays($this->explodeAndFilter($data['weekdays'] ?? ''));
 
         if (\array_key_exists('product_numbers', $data)) {
-            $struct->setProducts($this->explodeAndFilter($data['product_numbers']));
+            $struct->setProducts($this->explodeAndFilter($data['product_numbers'] ?? ''));
         }
         if (\array_key_exists('category_ids', $data)) {
-            $struct->setCategories($this->explodeAndFilter($data['category_ids']));
+            $struct->setCategories(array_map('\intval', $this->explodeAndFilter($data['category_ids'] ?? '')));
         }
         if (\array_key_exists('manufacturer_ids', $data)) {
-            $struct->setManufacturers($this->explodeAndFilter($data['manufacturer_ids']));
+            $struct->setManufacturers(array_map('\intval', $this->explodeAndFilter($data['manufacturer_ids'] ?? '')));
         }
 
         return $struct;
     }
 
-    private function explodeAndFilter($value)
+    /**
+     * @return array<string|numeric-string>
+     */
+    private function explodeAndFilter(string $value): array
     {
         return array_filter(explode(',', $value));
     }

--- a/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductProvider.php
+++ b/engine/Shopware/Bundle/ESIndexingBundle/Product/ProductProvider.php
@@ -368,16 +368,13 @@ class ProductProvider implements ProviderInterface
             ->where('mapping.articleID IN (:ids)')
             ->setParameter(':ids', $ids, Connection::PARAM_INT_ARRAY);
 
-        $data = $query->execute()->fetchAll(PDO::FETCH_ASSOC);
+        $data = $query->execute()->fetchAllAssociative();
 
         $result = [];
         foreach ($data as $row) {
             $productId = (int) $row['productId'];
-            $categories = [];
-            if (isset($result[$productId])) {
-                $categories = $result[$productId];
-            }
-            $temp = explode('|', $row['path']);
+            $categories = $result[$productId] ?? [];
+            $temp = explode('|', $row['path'] ?? '');
             $temp[] = $row['id'];
 
             $result[$productId] = array_merge($categories, $temp);
@@ -470,7 +467,7 @@ class ProductProvider implements ProviderInterface
                 $customerGroup = $context->getCurrentCustomerGroup()->getKey();
                 $key = $customerGroup . '_' . $context->getCurrency()->getId();
 
-                $rule = $rules[$context->getFallbackCustomerGroup()->getKey()];
+                $rule = $rules[$context->getFallbackCustomerGroup()->getKey()] ?? null;
                 if (isset($rules[$customerGroup])) {
                     $rule = $rules[$customerGroup];
                 }

--- a/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php
+++ b/engine/Shopware/Bundle/EmotionBundle/ComponentHandler/ArticleSliderComponentHandler.php
@@ -121,7 +121,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
                 break;
 
             case self::TYPE_STATIC_PRODUCT:
-                $products = $element->getConfig()->get(self::SELECTED_PRODUCTS, '');
+                $products = $element->getConfig()->get(self::SELECTED_PRODUCTS, '') ?? '';
                 $productNumbers = array_filter(explode('|', $products));
                 if (empty($productNumbers)) {
                     $productNumbers = [];
@@ -130,7 +130,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
                 $collection->getBatchRequest()->setProductNumbers($key, $productNumbers);
                 break;
             case self::TYPE_STATIC_VARIANT:
-                $productVariants = $element->getConfig()->get(self::SELECTED_VARIANTS, '');
+                $productVariants = $element->getConfig()->get(self::SELECTED_VARIANTS, '') ?? '';
                 $productNumbers = array_filter(explode('|', $productVariants));
                 if (empty($productNumbers)) {
                     $productNumbers = [];
@@ -161,7 +161,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
                 break;
 
             case self::TYPE_STATIC_PRODUCT:
-                $products = $element->getConfig()->get(self::SELECTED_PRODUCTS, '');
+                $products = $element->getConfig()->get(self::SELECTED_PRODUCTS, '') ?? '';
                 $productNumbers = array_filter(explode('|', $products));
                 $listProducts = $collection->getBatchResult()->get($key);
 
@@ -176,7 +176,7 @@ class ArticleSliderComponentHandler implements ComponentHandlerInterface
                 $element->getData()->set('products', $products);
                 break;
             case self::TYPE_STATIC_VARIANT:
-                $products = $element->getConfig()->get(self::SELECTED_VARIANTS, '');
+                $products = $element->getConfig()->get(self::SELECTED_VARIANTS, '') ?? '';
                 $productNumbers = array_filter(explode('|', $products));
                 $listProducts = $collection->getBatchResult()->get($key);
                 $listProducts = $this->additionalTextService->buildAdditionalTextLists($listProducts, $context);

--- a/engine/Shopware/Bundle/MailBundle/Service/LogService.php
+++ b/engine/Shopware/Bundle/MailBundle/Service/LogService.php
@@ -159,6 +159,9 @@ class LogService implements LogServiceInterface
         }
 
         $recipients = array_unique(array_filter(array_map('trim', $recipients)));
+        if (empty($recipients)) {
+            return [];
+        }
 
         $sql = 'SELECT LOWER(mail_address), id FROM s_mail_log_contact WHERE mail_address IN (:addresses)';
         $foundRecipients = $this->connection->executeQuery($sql, ['addresses' => $recipients])->fetchAll(PDO::FETCH_KEY_PAIR);

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLocalService.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginLocalService.php
@@ -162,7 +162,7 @@ class PluginLocalService
                 $row['iconPath'] = null;
             }
 
-            $translations = json_decode($row['translations'], true);
+            $translations = json_decode($row['translations'] ?? '', true);
 
             if (isset($translations[$locale]['label'])) {
                 $row['label'] = $translations[$locale]['label'];
@@ -265,7 +265,7 @@ class PluginLocalService
         }
 
         $dom = new DOMDocument();
-        $dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        $dom->loadHTML(htmlentities($html));
 
         $nodes = (new DOMXPath($dom))->query("//@*[local-name() != 'href']");
         if ($nodes === false) {

--- a/engine/Shopware/Bundle/PluginInstallerBundle/Struct/StructHydrator.php
+++ b/engine/Shopware/Bundle/PluginInstallerBundle/Struct/StructHydrator.php
@@ -333,17 +333,17 @@ class StructHydrator
      */
     public function assignLocalData(PluginStruct $plugin, $data)
     {
-        $plugin->setId((int) $data['id']);
+        $plugin->setId((int) ($data['id'] ?? 0));
         $plugin->setTechnicalName($data['name']);
-        $plugin->setLabel($data['label']);
-        $plugin->setActive((bool) $data['active']);
-        $plugin->setVersion($data['version']);
-        $plugin->setCapabilityActivate((bool) $data['capability_enable']);
-        $plugin->setCapabilityUpdate((bool) $data['capability_update']);
-        $plugin->setCapabilityInstall((bool) $data['capability_install']);
-        $plugin->setCapabilitySecureUninstall((bool) $data['capability_secure_uninstall']);
-        $plugin->setLocalUpdateAvailable($data['update_version'] !== null);
-        $plugin->setLink($data['link']);
+        $plugin->setLabel($data['label'] ?? '');
+        $plugin->setActive((bool) ($data['active'] ?? false));
+        $plugin->setVersion($data['version'] ?? '0.0.1');
+        $plugin->setCapabilityActivate((bool) ($data['capability_enable'] ?? false));
+        $plugin->setCapabilityUpdate((bool) ($data['capability_update'] ?? false));
+        $plugin->setCapabilityInstall((bool) ($data['capability_install'] ?? false));
+        $plugin->setCapabilitySecureUninstall((bool) ($data['capability_secure_uninstall'] ?? false));
+        $plugin->setLocalUpdateAvailable(isset($data['update_version']));
+        $plugin->setLink($data['link'] ?? '');
 
         if (\array_key_exists('redirectToStore', $data)) {
             $plugin->setRedirectToStore((bool) $data['redirectToStore']);
@@ -353,11 +353,11 @@ class StructHydrator
             $plugin->setLowestPrice((float) $data['lowestPriceValue']);
         }
 
-        $plugin->setSource($data['source']);
-        $plugin->setFormId($data['form_id']);
-        $plugin->setLocalIcon($data['iconPath']);
-        $plugin->setLocalDescription($data['description']);
-        $plugin->setInSafeMode((bool) $data['in_safe_mode']);
+        $plugin->setSource($data['source'] ?? '');
+        $plugin->setFormId($data['form_id'] ?? 0);
+        $plugin->setLocalIcon($data['iconPath'] ?? '');
+        $plugin->setLocalDescription($data['description'] ?? '');
+        $plugin->setInSafeMode((bool) ($data['in_safe_mode'] ?? false));
 
         if (isset($data['installation_date']) && !empty($data['installation_date'])) {
             $date = new DateTime($data['installation_date']);

--- a/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/TermHelper.php
+++ b/engine/Shopware/Bundle/SearchBundleDBAL/SearchTerm/TermHelper.php
@@ -71,6 +71,9 @@ class TermHelper implements TermHelperInterface
      */
     public function splitTerm($string)
     {
+        if (empty($string)) {
+            return [];
+        }
         if ($this->replaceUmlauts) {
             $string = str_replace(
                 ['Ü', 'ü', 'ä', 'Ä', 'ö', 'Ö', 'ß'],

--- a/engine/Shopware/Bundle/SitemapBundle/Provider/StaticUrlProvider.php
+++ b/engine/Shopware/Bundle/SitemapBundle/Provider/StaticUrlProvider.php
@@ -27,6 +27,7 @@ namespace Shopware\Bundle\SitemapBundle\Provider;
 use DateTime;
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use PDO;
+use Shopware\Bundle\SitemapBundle\Service\LinkFilter;
 use Shopware\Bundle\SitemapBundle\Struct\Url;
 use Shopware\Bundle\SitemapBundle\UrlProviderInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
@@ -66,7 +67,7 @@ class StaticUrlProvider implements UrlProviderInterface
                 'sCustom' => $site['id'],
             ];
 
-            if (!$this->filterLink($site['link'], $site['urlParams'])) {
+            if (!LinkFilter::filterLink($site['link'], $site['urlParams'])) {
                 unset($sites[$key]);
                 continue;
             }
@@ -150,26 +151,5 @@ class StaticUrlProvider implements UrlProviderInterface
         }
 
         return array_values($sites);
-    }
-
-    /**
-     * Helper function to filter predefined links, which should not be in the sitemap (external links, sitemap links itself)
-     * Returns false, if the link is not allowed
-     *
-     * @param array<string, mixed> $userParams
-     */
-    private function filterLink(?string $link, array &$userParams): bool
-    {
-        if (empty($link)) {
-            return true;
-        }
-        $parsedUserParams = (string) parse_url($link, PHP_URL_QUERY);
-        parse_str($parsedUserParams, $userParams);
-        $blacklist = ['', 'sitemap', 'sitemapXml'];
-        if (\in_array($userParams['sViewport'], $blacklist, true)) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/engine/Shopware/Bundle/SitemapBundle/Service/LinkFilter.php
+++ b/engine/Shopware/Bundle/SitemapBundle/Service/LinkFilter.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -22,15 +24,28 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Bundle\AccountBundle\Service;
+namespace Shopware\Bundle\SitemapBundle\Service;
 
-interface StoreFrontCustomerGreetingServiceInterface
+class LinkFilter
 {
     /**
-     * Returns the customer information for the header greeting "hi, max"
-     * In case that the slt configuration is disabled, or no customer can be detected, the function returns null.
+     * Helper function to filter predefined links, which should not be in the sitemap (external links, sitemap links itself)
+     * Returns false, if the link is not allowed
      *
-     * @return array<string, mixed>|null
+     * @param array<string, mixed> $userParams
      */
-    public function fetch();
+    public static function filterLink(?string $link, array &$userParams = []): bool
+    {
+        if (empty($link)) {
+            return true;
+        }
+        $parsedUserParams = (string) parse_url($link, PHP_URL_QUERY);
+        parse_str($parsedUserParams, $userParams);
+        $blacklist = ['', 'sitemap', 'sitemapXml'];
+        if (\in_array($userParams['sViewport'] ?? [], $blacklist, true)) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ConfiguratorGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/ConfiguratorGateway.php
@@ -195,6 +195,9 @@ class ConfiguratorGateway implements ConfiguratorGatewayInterface
 
         $result = [];
         foreach ($data as $row) {
+            if (empty($row)) {
+                continue;
+            }
             $rowIds = array_map('\intval', explode('|', $row));
 
             foreach ($rowIds as $optionId) {

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CustomFacetGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CustomFacetGateway.php
@@ -200,7 +200,7 @@ class CustomFacetGateway implements CustomFacetGatewayInterface
 
         return array_map(
             function ($ids) use ($allFacetIds) {
-                $ids = array_filter(explode('|', $ids));
+                $ids = array_filter(explode('|', $ids ?? ''));
 
                 if (!empty($ids)) {
                     return array_map('\intval', $ids);

--- a/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CustomSortingGateway.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Gateway/DBAL/CustomSortingGateway.php
@@ -194,7 +194,7 @@ class CustomSortingGateway implements CustomSortingGatewayInterface
 
         return array_map(
             function ($ids) use ($allSortingIds) {
-                $ids = array_filter(explode('|', $ids));
+                $ids = array_filter(explode('|', $ids ?? ''));
 
                 if (!empty($ids)) {
                     return array_map('\intval', $ids);

--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/CheapestPriceService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/CheapestPriceService.php
@@ -114,7 +114,7 @@ class CheapestPriceService implements CheapestPriceServiceInterface
                 continue;
             }
 
-            $price = $prices[$product->getNumber()];
+            $price = $prices[$product->getNumber()] ?? null;
 
             if (!$price instanceof PriceRule) {
                 continue;

--- a/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/HrefLangService.php
+++ b/engine/Shopware/Bundle/StoreFrontBundle/Service/Core/HrefLangService.php
@@ -218,6 +218,10 @@ class HrefLangService implements HrefLangServiceInterface
             return true;
         }
 
+        if (!isset($parameters['controller'], $parameters['action'])) {
+            return false;
+        }
+
         if ($parameters['controller'] === 'index' && $parameters['action'] === 'index') {
             return true;
         }

--- a/engine/Shopware/Components/Api/Resource/Article.php
+++ b/engine/Shopware/Components/Api/Resource/Article.php
@@ -496,7 +496,7 @@ class Article extends Resource implements BatchInterface
             $article->setMainDetail($detail);
         }
 
-        if (!$data['mainDetail']) {
+        if (empty($data['mainDetail'])) {
             $data['mainDetail'] = [];
         }
 
@@ -838,7 +838,7 @@ class Article extends Resource implements BatchInterface
 
         $product = $this->getSingleResult($builder);
 
-        return $product['similar'];
+        return $product['similar'] ?? null;
     }
 
     /**
@@ -859,7 +859,7 @@ class Article extends Resource implements BatchInterface
 
         $product = $this->getSingleResult($builder);
 
-        return $product['related'];
+        return $product['related'] ?? null;
     }
 
     /**
@@ -1056,7 +1056,7 @@ class Article extends Resource implements BatchInterface
                 }
             }
 
-            if ($variantData['isMain'] || $variantData['standard']) {
+            if (!empty($variantData['isMain']) || !empty($variantData['standard'])) {
                 $newMain = $variant;
                 $newMain->setKind(1);
                 $oldMainId = $article->getMainDetail()->getId();
@@ -1510,7 +1510,7 @@ class Article extends Resource implements BatchInterface
             }
 
             $relatedProduct = null;
-            if ($relatedData['number']) {
+            if (!empty($relatedData['number'])) {
                 $productId = $this->getManager()->getConnection()->fetchOne(
                     'SELECT articleID FROM s_articles_details WHERE ordernumber = :number',
                     [':number' => $relatedData['number']]
@@ -1539,7 +1539,7 @@ class Article extends Resource implements BatchInterface
                 throw new CustomValidationException(sprintf('Related product by number/id "%s" not found', $property));
             }
 
-            if ($relatedData['cross']) {
+            if (!empty($relatedData['cross'])) {
                 $relatedProduct->getRelated()->add($article);
             }
         }
@@ -1570,7 +1570,7 @@ class Article extends Resource implements BatchInterface
             }
 
             $similarProduct = null;
-            if ($similarData['number']) {
+            if (!empty($similarData['number'])) {
                 $productId = $this->getManager()->getConnection()->fetchOne(
                     'SELECT articleID FROM s_articles_details WHERE ordernumber = :number',
                     [':number' => $similarData['number']]
@@ -1599,7 +1599,7 @@ class Article extends Resource implements BatchInterface
                 throw new CustomValidationException(sprintf('Similar product by number/id "%s" not found', $property));
             }
 
-            if ($similarData['cross']) {
+            if (!empty($similarData['cross'])) {
                 $similarProduct->getSimilar()->add($article);
             }
         }

--- a/engine/Shopware/Components/Api/Resource/Customer.php
+++ b/engine/Shopware/Components/Api/Resource/Customer.php
@@ -215,7 +215,7 @@ class Customer extends Resource
     public function create(array $params)
     {
         $this->checkPrivilege('create');
-        $this->setupContext($params['shopId']);
+        $this->setupContext($params['shopId'] ?? null);
 
         // Create models
         $customer = new CustomerModel();
@@ -237,13 +237,13 @@ class Customer extends Resource
         $customer->fromArray($params);
 
         $billing = $this->createAddress($params['billing']) ?? new AddressModel();
-        $shipping = $this->createAddress($params['shipping']);
+        $shipping = $this->createAddress($params['shipping'] ?? null);
 
         $registerService = $this->getContainer()->get(RegisterServiceInterface::class);
         $context = $this->getContainer()->get(ContextServiceInterface::class)->getShopContext()->getShop();
 
         $context->addAttribute('sendOptinMail', new Attribute([
-            'sendOptinMail' => $params['sendOptinMail'] === true,
+            'sendOptinMail' => ($params['sendOptinMail'] ?? false) === true,
         ]));
 
         $registerService->register($context, $customer, $billing, $shipping);
@@ -489,7 +489,7 @@ class Customer extends Resource
         }
 
         // If a different payment method is selected, it must also be placed in the "paymentPreset" so that the risk management that does not reset.
-        if ($customer->getId() && $customer->getPaymentId() !== $params['paymentId']) {
+        if (isset($params['paymentId']) && $customer->getId() && $customer->getPaymentId() !== $params['paymentId']) {
             $params['paymentPreset'] = $params['paymentId'];
         }
 
@@ -528,7 +528,7 @@ class Customer extends Resource
             return null;
         }
 
-        if (!$data['country']) {
+        if (empty($data['country'])) {
             throw new CustomValidationException('A country is required.');
         }
 

--- a/engine/Shopware/Components/Api/Resource/EmotionPreset.php
+++ b/engine/Shopware/Components/Api/Resource/EmotionPreset.php
@@ -164,7 +164,7 @@ class EmotionPreset extends Resource
             unset($translation);
         }
 
-        if (!\is_array($data['requiredPlugins'])) {
+        if (!isset($data['requiredPlugins']) || !\is_array($data['requiredPlugins'])) {
             $data['requiredPlugins'] = [];
         }
 
@@ -241,7 +241,7 @@ class EmotionPreset extends Resource
     {
         $pluginNames = [];
         foreach ($presets as $id => $preset) {
-            $plugins = json_decode($preset['requiredPlugins'], true) ?? [];
+            $plugins = json_decode($preset['requiredPlugins'] ?? '', true) ?? [];
             $combinedPlugins = array_combine(array_column($plugins, 'name'), $plugins);
             if (!\is_array($combinedPlugins)) {
                 $preset['requiredPlugins'] = [];
@@ -263,8 +263,8 @@ class EmotionPreset extends Resource
                 'premium' => $preset['premium'],
                 'custom' => $preset['custom'],
                 'thumbnail' => $preset['thumbnail'],
-                'preview' => $preset['preview'],
-                'presetData' => $preset['presetData'],
+                'preview' => $preset['preview'] ?? null,
+                'presetData' => $preset['presetData'] ?? null,
                 'requiredPlugins' => $this->getPluginsForPreset($preset, $localPlugins),
                 'assetsImported' => $preset['assetsImported'],
             ];
@@ -336,7 +336,7 @@ class EmotionPreset extends Resource
                     'installed' => false,
                     'plugin_label' => $plugin['label'],
                     'plugin_name' => $plugin['name'],
-                    'current_version' => null,
+                    'current_version' => '',
                     'valid' => false,
                 ], $plugin);
 

--- a/engine/Shopware/Components/Api/Resource/Translation.php
+++ b/engine/Shopware/Components/Api/Resource/Translation.php
@@ -90,7 +90,7 @@ class Translation extends Resource implements BatchInterface
 
     public function getIdByData($data)
     {
-        if ($data['useNumberAsId']) {
+        if (!empty($data['useNumberAsId'])) {
             return $this->getIdByNumber(
                 $data['key'],
                 $data['type']

--- a/engine/Shopware/Components/Api/Resource/User.php
+++ b/engine/Shopware/Components/Api/Resource/User.php
@@ -359,7 +359,7 @@ class User extends Resource
         $defaultEncoderName = $passwordEncoderRegistry->getDefaultPasswordEncoderName();
         $encoder = $passwordEncoderRegistry->getEncoderByName($defaultEncoderName);
 
-        $data['password'] = $encoder->encodePassword($data['password']);
+        $data['password'] = $encoder->encodePassword($data['password'] ?? '');
         $data['encoder'] = $encoder->getName();
 
         return $data;

--- a/engine/Shopware/Components/Api/Resource/Variant.php
+++ b/engine/Shopware/Components/Api/Resource/Variant.php
@@ -699,8 +699,8 @@ class Variant extends Resource implements BatchInterface
 
         foreach ($data['configuratorOptions'] as $optionData) {
             $availableGroup = $this->getAvailableGroup($availableGroups, [
-                'id' => $optionData['groupId'],
-                'name' => $optionData['group'],
+                'id' => $optionData['groupId'] ?? null,
+                'name' => $optionData['group'] ?? null,
             ]);
 
             // Group is in the product configurator set configured?
@@ -710,8 +710,8 @@ class Variant extends Resource implements BatchInterface
 
             // Check if the option is available in the configured product configurator set.
             $option = $this->getAvailableOption($availableGroup->getOptions(), [
-                'id' => $optionData['optionId'],
-                'name' => $optionData['option'],
+                'id' => $optionData['optionId'] ?? null,
+                'name' => $optionData['option'] ?? null,
             ]);
 
             if (!$option) {
@@ -919,11 +919,12 @@ class Variant extends Resource implements BatchInterface
     {
         // Convert string to lower case to avoid problems with case insensitivity in database
         // vs case sensitivity in PHP
-        $groupName = mb_strtolower($groupData['name']);
+        $groupName = mb_strtolower($groupData['name'] ?? '');
 
         foreach ($availableGroups as $availableGroup) {
             if (($groupData['id'] !== null && (int) $availableGroup->getId() === (int) $groupData['id'])
-                || (mb_strtolower($availableGroup->getName()) === $groupName && $groupData['name'] !== null)) {
+                || (mb_strtolower($availableGroup->getName()) === $groupName && $groupData['name'] !== null)
+            ) {
                 return $availableGroup;
             }
         }
@@ -942,11 +943,12 @@ class Variant extends Resource implements BatchInterface
     {
         // Convert string to lower case to avoid problems with case insensitivity in database
         // vs case sensitivity in PHP
-        $optionName = mb_strtolower($optionData['name']);
+        $optionName = mb_strtolower($optionData['name'] ?? '');
 
         foreach ($availableOptions as $availableOption) {
             if ((mb_strtolower($availableOption->getName()) === $optionName && $optionData['name'] !== null)
-                || ((int) $availableOption->getId() === (int) $optionData['id'] && $optionData['id'] !== null)) {
+                || ((int) $availableOption->getId() === (int) $optionData['id'] && $optionData['id'] !== null)
+            ) {
                 return $availableOption;
             }
         }

--- a/engine/Shopware/Components/Auth/Adapter/Default.php
+++ b/engine/Shopware/Components/Auth/Adapter/Default.php
@@ -150,8 +150,8 @@ class Shopware_Components_Auth_Adapter_Default extends Enlight_Components_Auth_A
 
             // Reset failed login count
             $this->setFailedLogins(0);
-        } else {
-            // If more then 4 previous failed logins lock account for n * failedlogins seconds
+        } elseif ($user) {
+            // If more than 4 previous failed logins lock account for n * failedlogins seconds
             if ($user->failedlogins >= 4) {
                 $lockedUntil = new Zend_Date();
                 $lockedUntil->addSecond($this->lockSeconds * $user->failedlogins);
@@ -172,16 +172,16 @@ class Shopware_Components_Auth_Adapter_Default extends Enlight_Components_Auth_A
     }
 
     /**
-     * @deprecated in 5.6, will be private in 5.7
+     * @deprecated in 5.6, will be private in 5.8
      *
      * @param string $plaintext
      * @param string $hash
      * @param string $encoderName
+     *
+     * @return void
      */
     public function rehash($plaintext, $hash, $encoderName)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.7.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $newHash = Shopware()->PasswordEncoder()->reencodePassword($plaintext, $hash, $encoderName);
 
         if ($newHash === $hash) {
@@ -203,6 +203,8 @@ class Shopware_Components_Auth_Adapter_Default extends Enlight_Components_Auth_A
      *
      * @param string $plaintext
      * @param string $defaultEncoderName
+     *
+     * @return void
      */
     public function updateHash($plaintext, $defaultEncoderName)
     {
@@ -218,6 +220,9 @@ class Shopware_Components_Auth_Adapter_Default extends Enlight_Components_Auth_A
         );
     }
 
+    /**
+     * @return void
+     */
     protected function updateExpiry()
     {
         if ($this->expiryColumn === null) {

--- a/engine/Shopware/Components/Auth/Adapter/Default.php
+++ b/engine/Shopware/Components/Auth/Adapter/Default.php
@@ -225,6 +225,9 @@ class Shopware_Components_Auth_Adapter_Default extends Enlight_Components_Auth_A
         }
 
         $user = $this->getResultRowObject();
+        if (!\is_object($user)) {
+            return;
+        }
 
         $this->_zendDb->update(
             $this->_tableName,

--- a/engine/Shopware/Components/CacheManager.php
+++ b/engine/Shopware/Components/CacheManager.php
@@ -148,9 +148,9 @@ class CacheManager
     }
 
     /**
-     * @return Zend_Cache_Core
-     *
      * @deprecated in 5.6, will be removed in 5.8. Use `cache` service directly via DI
+     *
+     * @return Zend_Cache_Core
      */
     public function getCoreCache()
     {
@@ -438,11 +438,11 @@ class CacheManager
     /**
      * Returns cache information
      *
+     * @deprecated in 5.6, will be private in 5.8 without replacement
+     *
      * @param string $dir
      *
      * @return array
-     *
-     * @deprecated in 5.6, will be private in 5.8 without replacement
      */
     public function getDirectoryInfo($dir)
     {
@@ -554,11 +554,11 @@ class CacheManager
     /**
      * Format size method
      *
+     * @deprecated in 5.6, will be private in 5.8 without replacement
+     *
      * @param float $bytes
      *
      * @return string
-     *
-     * @deprecated in 5.6, will be private in 5.8 without replacement
      */
     public function encodeSize($bytes)
     {

--- a/engine/Shopware/Components/Captcha/AbstractCaptcha.php
+++ b/engine/Shopware/Components/Captcha/AbstractCaptcha.php
@@ -98,7 +98,7 @@ abstract class AbstractCaptcha implements CaptchaInterface
         $string = implode(' ', str_split($string));
 
         if (!empty($font)) {
-            for ($i = 0, $iMax = \strlen($string); $i <= $iMax; ++$i) {
+            for ($i = 0, $iMax = \strlen($string); $i < $iMax; ++$i) {
                 $rand1 = Random::getInteger(35, 40);
                 $rand2 = Random::getInteger(15, 20);
                 $rand3 = Random::getInteger(60, 70);

--- a/engine/Shopware/Components/Cart/ProportionalCartMerger.php
+++ b/engine/Shopware/Components/Cart/ProportionalCartMerger.php
@@ -95,8 +95,8 @@ class ProportionalCartMerger implements ProportionalCartMergerInterface
      */
     private function mergeAmount(array $item1, array $item2, string $property)
     {
-        $hasComma = str_contains($item1[$property], ',');
-        $amount = (float) str_replace(',', '.', $item1[$property]) + (float) str_replace(',', '.', $item2[$property]);
+        $hasComma = str_contains($item1[$property] ?? '', ',');
+        $amount = (float) str_replace(',', '.', $item1[$property] ?? '') + (float) str_replace(',', '.', $item2[$property] ?? '');
 
         if ($hasComma) {
             $amount = $this->modules->Articles()->sFormatPrice($amount);

--- a/engine/Shopware/Components/Cart/Struct/Price.php
+++ b/engine/Shopware/Components/Cart/Struct/Price.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -26,38 +28,26 @@ namespace Shopware\Components\Cart\Struct;
 
 class Price
 {
-    /**
-     * @var float
-     */
-    private $price;
+    private float $price;
+
+    private float $netPrice;
+
+    private float $taxRate;
+
+    private float $tax;
 
     /**
-     * @var float
-     */
-    private $netPrice;
-
-    /**
-     * @var float
-     */
-    private $taxRate;
-
-    /**
-     * @var float
-     */
-    private $tax;
-
-    /**
-     * @param float      $price
-     * @param float      $netPrice
-     * @param float      $taxRate
-     * @param float|null $tax
+     * @param float|numeric-string      $price
+     * @param float|numeric-string      $netPrice
+     * @param float|numeric-string      $taxRate
+     * @param float|numeric-string|null $tax
      */
     public function __construct($price, $netPrice, $taxRate, $tax)
     {
-        $this->price = $price;
-        $this->netPrice = $netPrice;
-        $this->taxRate = $taxRate;
-        $this->tax = $tax;
+        $this->price = (float) $price;
+        $this->netPrice = (float) $netPrice;
+        $this->taxRate = (float) $taxRate;
+        $this->tax = (float) $tax;
     }
 
     /**

--- a/engine/Shopware/Components/Check/Path.php
+++ b/engine/Shopware/Components/Check/Path.php
@@ -75,8 +75,11 @@ class Shopware_Components_Check_Path implements IteratorAggregate, Countable
     /**
      * Returns the check list
      *
+     * @deprecated - Native return type will be added with Shopware 5.8
+     *
      * @return Iterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->getList();

--- a/engine/Shopware/Components/ConfigWriter.php
+++ b/engine/Shopware/Components/ConfigWriter.php
@@ -45,6 +45,8 @@ class ConfigWriter
      * @param string      $name
      * @param string|null $namespace
      * @param int         $shopId
+     *
+     * @return mixed|null
      */
     public function get($name, $namespace = null, $shopId = 1)
     {
@@ -54,6 +56,10 @@ class ConfigWriter
 
         if ($result['configured']) {
             return unserialize($result['configured'], ['allowed_classes' => false]);
+        }
+
+        if ($result['value'] === null) {
+            return null;
         }
 
         return unserialize($result['value'], ['allowed_classes' => false]);

--- a/engine/Shopware/Components/CsvIterator.php
+++ b/engine/Shopware/Components/CsvIterator.php
@@ -77,7 +77,7 @@ class Shopware_Components_CsvIterator extends Enlight_Class implements Iterator
     private $_header;
 
     /**
-     * This is the constructor. It try to open the CSV file.
+     * This is the constructor. It tries to open the CSV file.
      *
      * @param string           $filename  the full path of the CSV file
      * @param non-empty-string $delimiter the delimiter
@@ -111,7 +111,7 @@ class Shopware_Components_CsvIterator extends Enlight_Class implements Iterator
     }
 
     /**
-     * This is the destructor. It close the CSV file.
+     * This is the destructor. It closes the CSV file.
      */
     public function __destruct()
     {
@@ -141,9 +141,9 @@ class Shopware_Components_CsvIterator extends Enlight_Class implements Iterator
     /**
      * This method move the file pointer to the next row.
      *
-     * @return void
+     * @deprecated - Native return type will be added with Shopware 5.8
      *
-     * @deprecated - Native return and parameter type will be added with Shopware 5.8
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function next()
@@ -155,9 +155,9 @@ class Shopware_Components_CsvIterator extends Enlight_Class implements Iterator
     /**
      * This method reset the file handler.
      *
-     * @return void
+     * @deprecated - Native return type will be added with Shopware 5.8
      *
-     * @deprecated - Native return and parameter type will be added with Shopware 5.8
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function rewind()
@@ -171,9 +171,9 @@ class Shopware_Components_CsvIterator extends Enlight_Class implements Iterator
     /**
      * This method returns the current row number.
      *
-     * @return int|null
+     * @deprecated - Native return type will be added with Shopware 5.8
      *
-     * @deprecated - Native return and parameter type will be added with Shopware 5.8
+     * @return int|null
      */
     #[\ReturnTypeWillChange]
     public function key()
@@ -182,11 +182,11 @@ class Shopware_Components_CsvIterator extends Enlight_Class implements Iterator
     }
 
     /**
-     * This methods return the current CSV row data.
+     * This method return the current CSV row data.
+     *
+     * @deprecated - Native return type will be added with Shopware 5.8
      *
      * @return array The row as a one-dimensional array
-     *
-     * @deprecated - Native return and parameter type will be added with Shopware 5.8
      */
     #[\ReturnTypeWillChange]
     public function current()
@@ -202,9 +202,9 @@ class Shopware_Components_CsvIterator extends Enlight_Class implements Iterator
     /**
      * This method checks if the current row is readable.
      *
-     * @return bool if the current row is readable
+     * @deprecated - Native return type will be added with Shopware 5.8
      *
-     * @deprecated - Native return and parameter type will be added with Shopware 5.8
+     * @return bool if the current row is readable
      */
     #[\ReturnTypeWillChange]
     public function valid()

--- a/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Session.php
@@ -114,7 +114,9 @@ class Session
         $sessionOptions['cookie_path'] = empty($basePath) ? '/' : $basePath;
 
         if ($saveHandler) {
-            session_set_save_handler($saveHandler);
+            if (empty($sessionOptions['unitTestEnabled'])) {
+                session_set_save_handler($saveHandler);
+            }
             unset($sessionOptions['save_handler']);
         }
 

--- a/engine/Shopware/Components/DependencyInjection/Bridge/Template.php
+++ b/engine/Shopware/Components/DependencyInjection/Bridge/Template.php
@@ -45,17 +45,16 @@ class Template
         array $securityConfig,
         array $backendOptions
     ) {
-        /** @var Enlight_Template_Manager $template */
-        $template = Enlight_Class::Instance('Enlight_Template_Manager', [null, $backendOptions]);
+        $template = Enlight_Class::Instance(Enlight_Template_Manager::class, [null, $backendOptions]);
+        \assert($template instanceof Enlight_Template_Manager);
 
-        $template->enableSecurity(
-            new Security($template, $securityConfig)
-        );
+        $template->enableSecurity(new Security($template, $securityConfig));
 
         $template->setOptions($templateConfig);
         $template->setEventManager($eventManager);
 
         $template->registerResource('snippet', $snippetResource);
+        /* @phpstan-ignore-next-line is handled by magic method `\Smarty_Internal_TemplateBase::__call` and will set the property `\Smarty::$default_resource_type` */
         $template->setDefaultResourceType('snippet');
 
         $template->registerPlugin(Smarty::PLUGIN_MODIFIER, 'escapeHtml', [$escaper, 'escapeHtml']);

--- a/engine/Shopware/Components/DispatchFormatHelper.php
+++ b/engine/Shopware/Components/DispatchFormatHelper.php
@@ -27,8 +27,8 @@ namespace Shopware\Components;
 class DispatchFormatHelper
 {
     /**
-     * @param string $unFormatted
-     * @param bool   $isController
+     * @param string|null $unFormatted
+     * @param bool        $isController
      *
      * @return string
      */
@@ -40,17 +40,17 @@ class DispatchFormatHelper
             $allowedCharacters .= '\.';
         }
 
-        return preg_replace('#[^' . $allowedCharacters . ']+#', '', $unFormatted);
+        return preg_replace('#[^' . $allowedCharacters . ']+#', '', $unFormatted ?? '');
     }
 
     /**
-     * @param string $unFormatted
+     * @param string|null $unFormatted
      *
      * @return string
      */
     public function formatNameForDispatch($unFormatted)
     {
-        $segments = explode('_', $unFormatted);
+        $segments = explode('_', $unFormatted ?? '');
 
         foreach ($segments as $key => $segment) {
             $segment = (string) preg_replace('#[A-Z]#', ' $0', $segment);

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -464,19 +464,19 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         $Document = array_merge(
             $Document,
             [
-                'comment' => $this->_config['docComment'],
+                'comment' => $this->_config['docComment'] ?? null,
                 'id' => $id,
                 'bid' => $this->_documentBid,
                 'date' => $this->_config['date'],
-                'deliveryDate' => $this->_config['delivery_date'],
+                'deliveryDate' => $this->_config['delivery_date'] ?? null,
                 // The "netto" config flag, if set to true, allows creating
                 // netto documents for brutto orders. Setting it to false,
                 // does not however create brutto documents for netto orders.
-                'netto' => $this->_order->order->taxfree ? true : $this->_config['netto'],
+                'netto' => $this->_order->order->taxfree ? true : ($this->_config['netto'] ?? null),
                 'nettoPositions' => $this->_order->order->net,
             ]
         );
-        $Document['voucher'] = $this->getVoucher($this->_config['voucher']);
+        $Document['voucher'] = $this->getVoucher($this->_config['voucher'] ?? null);
         $this->_view->assign('Document', $Document);
 
         // Translate payment and dispatch depending on the order's language
@@ -529,7 +529,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         }
         unset($product);
 
-        if ($this->_config['_previewForcePagebreak']) {
+        if (!empty($this->_config['_previewForcePagebreak'])) {
             $positions = array_merge($positions, $positions);
         }
 
@@ -692,7 +692,7 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
             return;
         }
 
-        $bid = $this->_config['bid'];
+        $bid = $this->_config['bid'] ?? null;
         if (!empty($bid)) {
             $this->_documentBid = $bid;
         }
@@ -713,7 +713,8 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
             UPDATE `s_order_documents` SET `date` = now(),`amount` = ?
             WHERE `type` = ? AND userID = ? AND orderID = ? LIMIT 1
             ';
-            $amount = ($this->_order->order->taxfree ? true : $this->_config['netto']) ? round($this->_order->amountNetto, 2) : round($this->_order->amount, 2);
+            $useNet = $this->_order->order->taxfree ? true : ($this->_config['netto'] ?? null);
+            $amount = $useNet ? round($this->_order->amountNetto, 2) : round($this->_order->amount, 2);
             if ($typID == 4) {
                 $amount *= -1;
             }
@@ -756,7 +757,8 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
 
             $hash = md5(uniqid((string) rand()));
 
-            $amount = ($this->_order->order->taxfree ? true : $this->_config['netto']) ? round($this->_order->amountNetto, 2) : round($this->_order->amount, 2);
+            $useNet = $this->_order->order->taxfree ? true : ($this->_config['netto'] ?? null);
+            $amount = $useNet ? round($this->_order->amountNetto, 2) : round($this->_order->amount, 2);
             if ($typID == 4) {
                 $amount *= -1;
             }

--- a/engine/Shopware/Components/Emotion/Preset/EmotionToPresetDataTransformer.php
+++ b/engine/Shopware/Components/Emotion/Preset/EmotionToPresetDataTransformer.php
@@ -163,7 +163,7 @@ class EmotionToPresetDataTransformer implements EmotionToPresetDataTransformerIn
                 $data['emotionId'],
                 $data['elementId']
             );
-            $field = $fieldMapping[$data['fieldId']];
+            $field = $fieldMapping[$data['fieldId']] ?? null;
 
             if ($field) {
                 $data['fieldId'] = $field['name'];

--- a/engine/Shopware/Components/Emotion/Preset/PresetDataSynchronizer.php
+++ b/engine/Shopware/Components/Emotion/Preset/PresetDataSynchronizer.php
@@ -182,7 +182,7 @@ class PresetDataSynchronizer implements PresetDataSynchronizerInterface
     private function findElementBySyncKey(array $presetData, $elementSyncKey)
     {
         foreach ($presetData['elements'] as $element) {
-            if ($element['syncKey'] === $elementSyncKey) {
+            if (isset($element['syncKey']) && $element['syncKey'] === $elementSyncKey) {
                 return $element;
             }
         }

--- a/engine/Shopware/Components/Escaper/Escaper.php
+++ b/engine/Shopware/Components/Escaper/Escaper.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -27,7 +29,7 @@ namespace Shopware\Components\Escaper;
 use Laminas\Escaper\Escaper as LaminasEscaper;
 
 /**
- * @see https://github.com/laminas/laminas-escaper/blob/2.9.x/src/Escaper.php
+ * @see https://github.com/laminas/laminas-escaper/blob/2.12.x/src/Escaper.php
  */
 class Escaper implements EscaperInterface
 {

--- a/engine/Shopware/Components/HttpCache/DefaultRouteService.php
+++ b/engine/Shopware/Components/HttpCache/DefaultRouteService.php
@@ -52,7 +52,7 @@ class DefaultRouteService
      */
     public function getDefaultNoCacheTags()
     {
-        $controllers = $this->config['noCacheControllers'];
+        $controllers = $this->config['noCacheControllers'] ?? null;
         $result = [];
 
         if (empty($controllers)) {

--- a/engine/Shopware/Components/HttpCache/InvalidationDate/InvalidationDateTrait.php
+++ b/engine/Shopware/Components/HttpCache/InvalidationDate/InvalidationDateTrait.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -32,7 +34,7 @@ trait InvalidationDateTrait
     /**
      * getMostRecentDate sorts an array of DateTime objects and returns the most recent one.
      *
-     * @param array<DateTimeInterface|string> $dates
+     * @param array<DateTimeInterface|string|null> $dates
      *
      * @return DateTimeInterface|null
      */
@@ -43,7 +45,7 @@ trait InvalidationDateTrait
         // Convert all date-strings into DateTime-objects
         $dates = array_map(function ($el) use ($now) {
             if (!$el instanceof DateTimeInterface) {
-                $el = new DateTime($el);
+                $el = new DateTime($el ?? '');
             }
 
             return $now < $el ? $el : null;
@@ -56,17 +58,10 @@ trait InvalidationDateTrait
             return null;
         }
 
-        // Pop a date as reference
-        $nearest = array_pop($dates);
+        usort($dates, function (DateTimeInterface $a, DateTimeInterface $b): int {
+            return $a <=> $b;
+        });
 
-        // Find the nearest date
-        foreach ($dates as $date) {
-            if ($now->diff($nearest) < $now->diff($date)) {
-                continue;
-            }
-            $nearest = $date;
-        }
-
-        return $nearest;
+        return array_pop($dates);
     }
 }

--- a/engine/Shopware/Components/OrderNumberValidator/RegexOrderNumberValidator.php
+++ b/engine/Shopware/Components/OrderNumberValidator/RegexOrderNumberValidator.php
@@ -28,10 +28,7 @@ use Shopware\Components\OrderNumberValidator\Exception\InvalidOrderNumberExcepti
 
 class RegexOrderNumberValidator implements OrderNumberValidatorInterface
 {
-    /**
-     * @var string
-     */
-    private $pattern;
+    private string $pattern;
 
     public function __construct(string $pattern)
     {

--- a/engine/Shopware/Components/Plugin/MenuSynchronizer.php
+++ b/engine/Shopware/Components/Plugin/MenuSynchronizer.php
@@ -25,26 +25,20 @@
 namespace Shopware\Components\Plugin;
 
 use Doctrine\DBAL\Connection;
-use Exception;
 use InvalidArgumentException;
 use RuntimeException;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Components\Snippet\Writer\DatabaseWriter;
 use Shopware\Models\Menu\Menu;
+use Shopware\Models\Menu\Repository;
 use Shopware\Models\Plugin\Plugin;
 use Shopware\Models\Shop\Locale;
 
 class MenuSynchronizer
 {
-    /**
-     * @var ModelManager
-     */
-    private $em;
+    private ModelManager $em;
 
-    /**
-     * @var \Shopware\Models\Menu\Repository
-     */
-    private $menuRepository;
+    private Repository $menuRepository;
 
     public function __construct(ModelManager $em)
     {
@@ -53,7 +47,7 @@ class MenuSynchronizer
     }
 
     /**
-     * @throws InvalidArgumentException
+     * @return void
      */
     public function synchronize(Plugin $plugin, array $menu)
     {
@@ -74,7 +68,6 @@ class MenuSynchronizer
                 if (!isset($menuItem['parent'])) {
                     throw new InvalidArgumentException('Root Menu Item must provide parent element');
                 }
-                /** @var Menu|null $parent */
                 $parent = $this->menuRepository->findOneBy($menuItem['parent']);
                 if (!$parent) {
                     throw new InvalidArgumentException(sprintf('Unable to find parent for query %s', print_r($menuItem['parent'], true)));
@@ -88,12 +81,7 @@ class MenuSynchronizer
         $this->removeNotExistingEntries($plugin->getId(), $menuNames);
     }
 
-    /**
-     * @param string $name
-     *
-     * @throws Exception
-     */
-    private function saveMenuTranslation(array $labels, $name)
+    private function saveMenuTranslation(array $labels, string $name): void
     {
         $databaseWriter = new DatabaseWriter($this->em->getConnection());
         foreach ($labels as $locale => $text) {
@@ -106,22 +94,19 @@ class MenuSynchronizer
             }
 
             $locale = Shopware()->Models()->getRepository(Locale::class)->findOneBy(['locale' => $locale]);
+            if (!$locale instanceof Locale) {
+                continue;
+            }
 
             $databaseWriter->write([$name => $text], 'backend/index/view/main', $locale->getId(), 1);
         }
     }
 
-    /**
-     * @throws RuntimeException
-     *
-     * @return Menu
-     */
-    private function createMenuItem(Plugin $plugin, ?Menu $parent = null, array $menuItem)
+    private function createMenuItem(Plugin $plugin, ?Menu $parent, array $menuItem): Menu
     {
         $item = null;
 
         if ($plugin->getId()) {
-            /** @var Menu $item */
             $item = $this->menuRepository->findOneBy([
                 'pluginId' => $plugin->getId(),
                 'label' => $menuItem['name'],
@@ -135,26 +120,18 @@ class MenuSynchronizer
         $item->setParent($parent);
         $item->setPlugin($plugin);
 
-        if (!isset($menuItem['label']['en']) || empty($menuItem['label']['en'])) {
+        if (empty($menuItem['label']['en'])) {
             throw new RuntimeException('Label with lang en required');
         }
         $item->setLabel($menuItem['name']);
 
-        $item->setController(
-            isset($menuItem['controller']) ? $menuItem['controller'] : null
-        );
+        $item->setController($menuItem['controller'] ?? null);
 
-        $item->setAction(
-            isset($menuItem['action']) ? $menuItem['action'] : null
-        );
+        $item->setAction($menuItem['action'] ?? null);
 
-        $item->setOnclick(
-            isset($menuItem['onclick']) ? $menuItem['onclick'] : null
-        );
+        $item->setOnclick($menuItem['onclick'] ?? null);
 
-        $item->setClass(
-            isset($menuItem['class']) ? $menuItem['class'] : null
-        );
+        $item->setClass($menuItem['class'] ?? null);
 
         if (isset($menuItem['active'])) {
             $item->setActive((bool) $menuItem['active']);
@@ -188,10 +165,7 @@ class MenuSynchronizer
         return $item;
     }
 
-    /**
-     * @param int $pluginId
-     */
-    private function removeNotExistingEntries($pluginId, array $menuNames)
+    private function removeNotExistingEntries(int $pluginId, array $menuNames): void
     {
         $builder = $this->em->getConnection()->createQueryBuilder();
         $builder->delete('s_core_menu');

--- a/engine/Shopware/Components/Plugin/Namespace.php
+++ b/engine/Shopware/Components/Plugin/Namespace.php
@@ -623,7 +623,7 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
      */
     protected function buildPath($namespace, $pluginName, $pluginSource)
     {
-        $baseDir = $this->pluginDirectories[$pluginSource];
+        $baseDir = $this->pluginDirectories[$pluginSource] ?? '';
 
         return $baseDir . $namespace . DIRECTORY_SEPARATOR . $pluginName . DIRECTORY_SEPARATOR;
     }

--- a/engine/Shopware/Components/Privacy/CookieRemoveSubscriber.php
+++ b/engine/Shopware/Components/Privacy/CookieRemoveSubscriber.php
@@ -95,13 +95,13 @@ class CookieRemoveSubscriber implements SubscriberInterface
             );
         }
 
-        $allowCookie = (int) $controller->Request()->cookies->getInt('allowCookie');
+        $allowCookie = $controller->Request()->cookies->getInt('allowCookie');
         if ($this->config->get('cookie_note_mode') !== self::COOKIE_MODE_TECHNICAL) {
             if ($allowCookie === 1) {
                 return;
             }
 
-            header_remove('Set-Cookie');
+            $controller->Response()->headers->remove('Set-Cookie');
 
             return;
         }

--- a/engine/Shopware/Components/ProductStream/Repository.php
+++ b/engine/Shopware/Components/ProductStream/Repository.php
@@ -48,6 +48,9 @@ class Repository implements RepositoryInterface
     public function prepareCriteria(Criteria $criteria, $productStreamId)
     {
         $productStream = $this->getStreamById($productStreamId);
+        if (!\array_key_exists('type', $productStream)) {
+            return;
+        }
 
         if ((int) $productStream['type'] === ProductStream::TYPE_CONDITION) {
             $this->prepareConditionStream($productStream, $criteria);

--- a/engine/Shopware/Components/Routing/Generators/DefaultGenerator.php
+++ b/engine/Shopware/Components/Routing/Generators/DefaultGenerator.php
@@ -86,14 +86,16 @@ class DefaultGenerator implements GeneratorInterface
 
         foreach ($params as $key => $value) {
             if (\is_object($value)) {
-                trigger_error(sprintf('Using objects as params in %s:%s is deprecated since Shopware 5.6 and will result in an exception with 5.7.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
+                trigger_error(sprintf('Using objects as params in %s:%s is deprecated since Shopware 5.6 and will result in an exception with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
             }
 
             $route[] = $key;
             $route[] = \is_array($value) ? http_build_query($value) : $value;
         }
 
-        $route = array_map('urlencode', $route);
+        $route = array_map(function ($routePart) {
+            return $routePart !== null ? urlencode($routePart) : null;
+        }, $route);
 
         return implode($this->separator, $route);
     }

--- a/engine/Shopware/Components/Routing/Generators/RewriteGenerator.php
+++ b/engine/Shopware/Components/Routing/Generators/RewriteGenerator.php
@@ -159,7 +159,9 @@ class RewriteGenerator implements GeneratorListInterface
         $orgQuery = ['sViewport' => $query['controller']];
         switch ($query['controller']) {
             case 'detail':
-                $orgQuery['sArticle'] = $query['sArticle'];
+                if (isset($query['sArticle'])) {
+                    $orgQuery['sArticle'] = $query['sArticle'];
+                }
                 break;
             case 'blog':
                 if (isset($query['action']) && $query['action'] !== 'index') {

--- a/engine/Shopware/Components/SitePageMenu.php
+++ b/engine/Shopware/Components/SitePageMenu.php
@@ -90,7 +90,7 @@ class SitePageMenu
                 $menu[$key] = [];
             }
 
-            if ($site['__page_translation']) {
+            if (isset($site['__page_translation'])) {
                 $translations = unserialize($site['__page_translation'], ['allowed_classes' => false]);
 
                 if ($translations) {

--- a/engine/Shopware/Components/SitemapXMLRepository.php
+++ b/engine/Shopware/Components/SitemapXMLRepository.php
@@ -33,6 +33,7 @@ use Shopware\Bundle\SearchBundle\Condition\LastProductIdCondition;
 use Shopware\Bundle\SearchBundle\Criteria;
 use Shopware\Bundle\SearchBundle\ProductNumberSearchInterface;
 use Shopware\Bundle\SearchBundle\StoreFrontCriteriaFactoryInterface;
+use Shopware\Bundle\SitemapBundle\Service\LinkFilter;
 use Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Category\Category;
@@ -265,7 +266,7 @@ class SitemapXMLRepository
                 'sCustom' => $site['id'],
             ];
 
-            $site['show'] = $this->filterLink($site['link'], $site['urlParams']);
+            $site['show'] = LinkFilter::filterLink($site['link'], $site['urlParams']);
         }
 
         return $sites;
@@ -307,33 +308,6 @@ class SitemapXMLRepository
         }
 
         return $sites;
-    }
-
-    /**
-     * Helper function to filter predefined links, which should not be in the sitemap (external links, sitemap links itself)
-     * Returns false, if the link is not allowed
-     *
-     * @param string $link
-     * @param array  $userParams
-     *
-     * @return bool
-     */
-    private function filterLink($link, &$userParams)
-    {
-        if (empty($link)) {
-            return true;
-        }
-
-        $parsedUserParams = (string) parse_url($link, PHP_URL_QUERY);
-        parse_str($parsedUserParams, $userParams);
-
-        $blacklist = ['', 'sitemap', 'sitemapXml'];
-
-        if (\in_array($userParams['sViewport'], $blacklist, true)) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/engine/Shopware/Components/Snippet/Writer/DatabaseWriter.php
+++ b/engine/Shopware/Components/Snippet/Writer/DatabaseWriter.php
@@ -74,14 +74,14 @@ class DatabaseWriter
             if (!$this->update) {
                 $this->insertBatch($data, $namespace, $localeId, $shopId);
             } else {
-                $rows = $this->db->fetchAll(
+                $rows = $this->db->fetchAllAssociative(
                     'SELECT * FROM s_core_snippets WHERE shopID = :shopId AND localeID = :localeId AND namespace = :namespace',
                     [
                         'shopId' => $shopId,
                         'localeId' => $localeId,
                         'namespace' => $namespace,
                     ]
-                );
+                ) ?: [];
 
                 foreach ($data as $name => $value) {
                     $row = null;

--- a/engine/Shopware/Components/StateTranslatorService.php
+++ b/engine/Shopware/Components/StateTranslatorService.php
@@ -62,7 +62,7 @@ class StateTranslatorService implements StateTranslatorServiceInterface
     {
         $type = strtolower($type);
 
-        if (!$this->availableTypes[$type]) {
+        if (empty($this->availableTypes[$type])) {
             throw new RuntimeException(sprintf('Invalid type \'%s\' given.', $type));
         }
 

--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -23,6 +23,7 @@
  */
 
 use Shopware\Bundle\MailBundle\Service\LogEntryBuilder;
+use Shopware\Bundle\MediaBundle\MediaServiceInterface;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Mail\Mail;
 use Shopware\Models\Shop\Shop;
@@ -43,12 +44,12 @@ class Shopware_Components_TemplateMail
     protected $modelManager;
 
     /**
-     * @var \Shopware_Components_Translation
+     * @var Shopware_Components_Translation
      */
     protected $translationReader;
 
     /**
-     * @var \Shopware_Components_StringCompiler
+     * @var Shopware_Components_StringCompiler
      */
     protected $stringCompiler;
 
@@ -78,7 +79,7 @@ class Shopware_Components_TemplateMail
     ];
 
     /**
-     * @return \Shopware_Components_TemplateMail
+     * @return Shopware_Components_TemplateMail
      */
     public function setModelManager(ModelManager $modelManager)
     {
@@ -98,7 +99,7 @@ class Shopware_Components_TemplateMail
     /**
      * @param Shop $shop
      *
-     * @return \Shopware_Components_TemplateMail
+     * @return Shopware_Components_TemplateMail
      */
     public function setShop($shop)
     {
@@ -118,21 +119,21 @@ class Shopware_Components_TemplateMail
     /**
      * @throws \Exception
      *
-     * @return \Shopware_Components_Translation
+     * @return Shopware_Components_Translation
      */
     public function getTranslationReader()
     {
         if ($this->translationReader === null) {
-            $this->translationReader = Shopware()->Container()->get(\Shopware_Components_Translation::class);
+            $this->translationReader = Shopware()->Container()->get(Shopware_Components_Translation::class);
         }
 
         return $this->translationReader;
     }
 
     /**
-     * @param \Shopware_Components_Translation $translationReader
+     * @param Shopware_Components_Translation $translationReader
      *
-     * @return \Shopware_Components_TemplateMail
+     * @return Shopware_Components_TemplateMail
      */
     public function setTranslationReader($translationReader)
     {
@@ -142,7 +143,7 @@ class Shopware_Components_TemplateMail
     }
 
     /**
-     * @return \Shopware_Components_TemplateMail
+     * @return Shopware_Components_TemplateMail
      */
     public function setStringCompiler(Shopware_Components_StringCompiler $stringCompiler)
     {
@@ -152,7 +153,7 @@ class Shopware_Components_TemplateMail
     }
 
     /**
-     * @return \Shopware_Components_StringCompiler
+     * @return Shopware_Components_StringCompiler
      */
     public function getStringCompiler()
     {
@@ -165,9 +166,9 @@ class Shopware_Components_TemplateMail
      * @param Shop        $shop
      * @param array       $overrideConfig
      *
-     * @throws \Enlight_Exception
+     * @throws Enlight_Exception
      *
-     * @return \Enlight_Components_Mail
+     * @return Enlight_Components_Mail
      */
     public function createMail($mailModel, $context = [], $shop = null, $overrideConfig = [])
     {
@@ -177,12 +178,11 @@ class Shopware_Components_TemplateMail
 
         if (!($mailModel instanceof Mail)) {
             $modelName = $mailModel;
-            /** @var Mail|null $mailModel */
             $mailModel = $this->getModelManager()->getRepository(Mail::class)->findOneBy(
                 ['name' => $modelName]
             );
-            if (!$mailModel) {
-                throw new \Enlight_Exception(sprintf('Mail-Template with name "%s" could not be found.', $modelName));
+            if (!$mailModel instanceof Mail) {
+                throw new Enlight_Exception(sprintf('Mail-Template with name "%s" could not be found.', $modelName));
             }
         }
 
@@ -258,9 +258,9 @@ class Shopware_Components_TemplateMail
      *
      * @param array $overrideConfig
      *
-     * @throws \Enlight_Exception
+     * @throws Enlight_Exception
      *
-     * @return \Enlight_Components_Mail
+     * @return Enlight_Components_Mail
      */
     public function loadValues(Enlight_Components_Mail $mail, Mail $mailModel, $overrideConfig = [])
     {
@@ -296,14 +296,13 @@ class Shopware_Components_TemplateMail
             $mail->setBodyHtml($stringCompiler->compileString($mailModel->getContentHtml()));
         }
 
-        /** @var \Shopware\Models\Mail\Attachment $attachment */
         foreach ($mailModel->getAttachments() as $attachment) {
             if ($attachment->getShopId() !== null
                 && ($this->getShop() === null || $attachment->getShopId() !== $this->getShop()->getId())) {
                 continue;
             }
 
-            $mediaService = Shopware()->Container()->get(\Shopware\Bundle\MediaBundle\MediaServiceInterface::class);
+            $mediaService = Shopware()->Container()->get(MediaServiceInterface::class);
             if (!$mediaService->has($attachment->getPath())) {
                 Shopware()->Container()->get('corelogger')->error('Could not load file: ' . $attachment->getPath());
             } else {

--- a/engine/Shopware/Components/Translation/ObjectTranslator.php
+++ b/engine/Shopware/Components/Translation/ObjectTranslator.php
@@ -81,7 +81,7 @@ class ObjectTranslator
 
         $objectIndex = $objectIndex ?: $translationIndex;
 
-        $translation = $this->translations[$object['id']];
+        $translation = $this->translations[$object['id']] ?? null;
         if ($translation && !empty($translation[$translationIndex])) {
             $object[$objectIndex] = $translation[$translationIndex];
         } elseif ($fallback) {

--- a/engine/Shopware/Controllers/Backend/Address.php
+++ b/engine/Shopware/Controllers/Backend/Address.php
@@ -90,7 +90,7 @@ class Shopware_Controllers_Backend_Address extends Shopware_Controllers_Backend_
         }
 
         $data['country'] = $data['countryId'];
-        $data['state'] = $data['stateId'];
+        $data['state'] = $data['stateId'] ?? null;
 
         $form = $this->get('shopware.form.factory')->create(AddressFormType::class, $model);
         $form->submit($data);

--- a/engine/Shopware/Controllers/Backend/Analytics.php
+++ b/engine/Shopware/Controllers/Backend/Analytics.php
@@ -212,9 +212,15 @@ class Shopware_Controllers_Backend_Analytics extends Shopware_Controllers_Backen
             $this->getToDate()
         );
 
-        $turnover = array_map('reset', $turnover->getData());
-        $visitors = array_map('reset', $visitors->getData());
-        $registrations = array_map('reset', $registrations->getData());
+        $turnover = array_map(function ($turnoverItem) {
+            return reset($turnoverItem);
+        }, $turnover->getData());
+        $visitors = array_map(function ($visitorsItem) {
+            return reset($visitorsItem);
+        }, $visitors->getData());
+        $registrations = array_map(function ($registrationsItem) {
+            return reset($registrationsItem);
+        }, $registrations->getData());
 
         $data = array_merge_recursive($turnover, $visitors);
         $data = array_merge_recursive($data, $registrations);

--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -843,8 +843,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getArticleCategories($articleId)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $builder = $this->get('models')->createQueryBuilder();
         $builder->select(['categories.id'])
             ->from(Category::class, 'categories', 'categories.id')
@@ -881,8 +879,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getArticleSimilars($articleId)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $result = $this->getRepository()
             ->getArticleSimilarsQuery($articleId)
             ->getArrayResult();
@@ -905,8 +901,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getArticleRelatedProductStreams($articleId)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $result = $this->get(ModelManager::class)->getRepository(Product::class)
             ->getArticleRelatedProductStreamsQuery($articleId)
             ->getArrayResult();
@@ -928,8 +922,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getArticleRelated($articleId)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $result = $this->getRepository()
             ->getArticleRelatedQuery($articleId)
             ->getArrayResult();
@@ -1016,8 +1008,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getArticleLinks($articleId)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $result = $this->getRepository()
             ->getArticleLinksQuery($articleId)
             ->getArrayResult();
@@ -1048,8 +1038,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getArticleDownloads($articleId)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $result = $this->getRepository()
             ->getArticleDownloadsQuery($articleId)
             ->getArrayResult();
@@ -1075,8 +1063,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getArticleCustomerGroups($articleId)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $result = $this->getRepository()
             ->getArticleCustomerGroupsQuery($articleId)
             ->getArrayResult();
@@ -1098,12 +1084,10 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      *
      * @param int $articleId
      *
-     * @return array
+     * @return array|null
      */
     public function getArticleConfiguratorSet($articleId)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $builder = $this->get('models')->createQueryBuilder();
         $builder->select(['configuratorSet', 'groups', 'options'])
             ->from(Set::class, 'configuratorSet')
@@ -1118,7 +1102,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
 
         $result = $builder->getQuery()->getArrayResult();
 
-        return $result[0];
+        return $result[0] ?? null;
     }
 
     /**
@@ -1135,8 +1119,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getArticleDependencies($configuratorSetId)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         return $this->getRepository()
             ->getConfiguratorDependenciesQuery($configuratorSetId)
             ->getArrayResult();
@@ -1157,13 +1139,11 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getArticleConfiguratorTemplate($articleId, $tax)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $query = $this->getRepository()->getConfiguratorTemplateByArticleIdQuery($articleId);
 
         $configuratorTemplate = $query->getArrayResult();
 
-        $prices = $configuratorTemplate[0]['prices'];
+        $prices = $configuratorTemplate[0]['prices'] ?? null;
 
         if (!empty($prices)) {
             $configuratorTemplate[0]['prices'] = $this->formatPricesFromNetToGross($prices, $tax);
@@ -1856,8 +1836,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getFreeSerialCount($esdId)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $query = $this->getRepository()->getFreeSerialsCountByEsdQuery($esdId);
 
         return $query->getSingleScalarResult();
@@ -2100,8 +2078,6 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     public function getChartData()
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $productId = $this->Request()->getParam('articleId');
         $dateFormat = '%Y%m';
         $limit = 12;
@@ -2417,7 +2393,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     }
 
     /**
-     * @deprecated in 5.6, will be removed in 5.7 without a replacement
+     * @deprecated in 5.6, will be removed in 5.8 without a replacement
      *
      * Helper function to get access to the configuratorGroup repository.
      *
@@ -2425,7 +2401,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     protected function getConfiguratorGroupRepository()
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be removed with 5.7. Will be removed without replacement.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
+        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be removed with 5.8. Will be removed without replacement.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
 
         if ($this->configuratorGroupRepository === null) {
             $this->configuratorGroupRepository = $this->get('models')->getRepository(Group::class);
@@ -3263,9 +3239,10 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
         foreach ($prices as $key => $price) {
             $customerGroup = $price['customerGroup'];
             if ($customerGroup['taxInput']) {
-                $price['price'] = $price['price'] / 100 * (100 + $tax['tax']);
-                $price['pseudoPrice'] = $price['pseudoPrice'] / 100 * (100 + $tax['tax']);
-                $price['regulationPrice'] = $price['regulationPrice'] / 100 * (100 + $tax['tax']);
+                $taxValue = $tax['tax'] ?? 0;
+                $price['price'] = $price['price'] / 100 * (100 + $taxValue);
+                $price['pseudoPrice'] = $price['pseudoPrice'] / 100 * (100 + $taxValue);
+                $price['regulationPrice'] = $price['regulationPrice'] / 100 * (100 + $taxValue);
             }
             $prices[$key] = $price;
         }
@@ -3552,11 +3529,11 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     }
 
     /**
-     * @deprecated in 5.6, will be removed in 5.7 without a replacement
+     * @deprecated in 5.6, will be removed in 5.8 without a replacement
      */
     protected function getDependencyByOptionId($optionId, $dependencies)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be removed with 5.7. Will be removed without replacement.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
+        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be removed with 5.8. Will be removed without replacement.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
 
         $returnValue = [];
         foreach ($dependencies as $dependency) {
@@ -3799,7 +3776,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
         $modelManger = $this->get('models');
         if (!empty($data['configuratorSetId'])) {
             $data['configuratorSet'] = $modelManger->find(Set::class, $data['configuratorSetId']);
-        } elseif ($data['isConfigurator']) {
+        } elseif (!empty($data['isConfigurator'])) {
             $set = new Set();
             $set->setName('Set-' . $data['mainDetail']['number']);
             $set->setPublic(false);
@@ -3893,9 +3870,9 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     protected function prepareMainDetailAssociatedData($data)
     {
-        $data['mainDetail'] = $data['mainDetail'][0];
-        $data['mainDetail']['active'] = $data['active'];
-        $data['mainDetail']['lastStock'] = (int) ($data['lastStock'] >= 0 ? $data['lastStock'] : 0);
+        $data['mainDetail'] = $data['mainDetail'][0] ?? null;
+        $data['mainDetail']['active'] = $data['active'] ?? null;
+        $data['mainDetail']['lastStock'] = max((int) ($data['lastStock'] ?? 0), 0);
 
         if (!empty($data['mainDetail']['unitId'])) {
             $data['mainDetail']['unit'] = $this->get('models')->find(Unit::class, $data['mainDetail']['unitId']);
@@ -3917,7 +3894,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     protected function prepareCategoryAssociatedData($data)
     {
         $categories = [];
-        foreach ($data['categories'] as $categoryData) {
+        foreach ($data['categories'] ?? [] as $categoryData) {
             if (!empty($categoryData['id'])) {
                 $model = $this->get('models')->find(Category::class, $categoryData['id']);
                 $categories[] = $model;
@@ -3993,7 +3970,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     protected function prepareRelatedAssociatedData($data, $article)
     {
         $related = [];
-        foreach ($data['related'] as $relatedData) {
+        foreach ($data['related'] ?? [] as $relatedData) {
             if (empty($relatedData['id'])) {
                 continue;
             }
@@ -4024,7 +4001,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     protected function prepareRelatedProductStreamsData($data)
     {
         $relatedStreams = [];
-        foreach ($data['streams'] as $relatedProductStreamData) {
+        foreach ($data['streams'] ?? [] as $relatedProductStreamData) {
             if (empty($relatedProductStreamData['id'])) {
                 continue;
             }
@@ -4050,7 +4027,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     protected function prepareSimilarAssociatedData($data, $article)
     {
         $similar = [];
-        foreach ($data['similar'] as $similarData) {
+        foreach ($data['similar'] ?? [] as $similarData) {
             if (empty($similarData['id'])) {
                 continue;
             }
@@ -4081,7 +4058,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     protected function prepareImageAssociatedData($data)
     {
         $position = 1;
-        foreach ($data['images'] as &$imageData) {
+        foreach ($data['images'] ?? [] as &$imageData) {
             $imageData['position'] = $position;
             if (!empty($imageData['mediaId'])) {
                 $media = $this->get('models')->find(Media::class, $imageData['mediaId']);
@@ -4110,7 +4087,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     protected function prepareMainPricesAssociatedData($data, $article)
     {
-        $data['mainDetail']['prices'] = $this->preparePricesAssociatedData($data['mainPrices'], $article, $data['tax']);
+        $data['mainDetail']['prices'] = $this->preparePricesAssociatedData($data['mainPrices'] ?? [], $article, $data['tax']);
 
         return $data;
     }
@@ -4136,7 +4113,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
 
             $priceData['to'] = (int) $priceData['to'];
 
-            // If the "to" value isn't numeric, set the place holder "beliebig"
+            // If the "to" value isn't numeric, set the placeholder "beliebig"
             if ($priceData['to'] <= 0) {
                 $priceData['to'] = 'beliebig';
             }
@@ -4165,7 +4142,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     protected function prepareLinkAssociatedData($data)
     {
-        foreach ($data['links'] as &$linkData) {
+        foreach ($data['links'] ?? [] as &$linkData) {
             $linkData['link'] = trim($linkData['link']);
             // Map the boolean ExtJS link target to the string format which used in the database
             $linkData['target'] = ($linkData['target'] === true) ? '_blank' : '_parent';
@@ -4184,7 +4161,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     protected function prepareDownloadAssociatedData($data)
     {
         $mediaService = Shopware()->Container()->get(MediaServiceInterface::class);
-        foreach ($data['downloads'] as &$downloadData) {
+        foreach ($data['downloads'] ?? [] as &$downloadData) {
             $downloadData['file'] = $mediaService->normalize($downloadData['file']);
         }
 
@@ -4494,7 +4471,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
     }
 
     /**
-     * @deprecated in 5.6, will be removed in 5.7 without a replacement
+     * @deprecated in 5.6, will be removed in 5.8 without a replacement
      *
      * Internal helper function to get the field names of the passed violation array.
      *
@@ -4504,7 +4481,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
      */
     protected function getViolationFields($violations)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be removed with 5.7. Will be removed without replacement.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
+        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be removed with 5.8. Will be removed without replacement.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
 
         $fields = [];
         foreach ($violations as $violation) {

--- a/engine/Shopware/Controllers/Backend/Category.php
+++ b/engine/Shopware/Controllers/Backend/Category.php
@@ -80,8 +80,6 @@ class Shopware_Controllers_Backend_Category extends Shopware_Controllers_Backend
      */
     public function getRepository()
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         if ($this->repository === null) {
             $this->repository = $this->em->getRepository(Category::class);
         }
@@ -96,8 +94,6 @@ class Shopware_Controllers_Backend_Category extends Shopware_Controllers_Backend
      */
     public function getCategoryComponent()
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         return Shopware()->Container()->get('categorydenormalization');
     }
 
@@ -190,7 +186,7 @@ class Shopware_Controllers_Backend_Category extends Shopware_Controllers_Backend
         $data = iterator_to_array($paginator);
         $data = $data[0];
 
-        $data['imagePath'] = $data['media']['id'];
+        $data['imagePath'] = $data['media']['id'] ?? null;
 
         $this->View()->assign(['success' => true, 'data' => $data]);
     }
@@ -536,10 +532,8 @@ class Shopware_Controllers_Backend_Category extends Shopware_Controllers_Backend
      */
     public function saveDetail()
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $params = $this->Request()->getParams();
-        $categoryId = (int) $params['id'];
+        $categoryId = (int) ($params['id'] ?? 0);
 
         $repo = $this->em->getRepository(Category::class);
 
@@ -548,7 +542,7 @@ class Shopware_Controllers_Backend_Category extends Shopware_Controllers_Backend
             $this->em->persist($categoryModel);
 
             // Find parent for newly created category
-            $params['parentId'] = is_numeric($params['parentId']) ? (int) $params['parentId'] : 1;
+            $params['parentId'] = isset($params['parentId']) && is_numeric($params['parentId']) ? (int) $params['parentId'] : 1;
             /** @var Category $parentCategory */
             $parentCategory = $repo->find($params['parentId']);
             $categoryModel->setParent($parentCategory);
@@ -579,7 +573,7 @@ class Shopware_Controllers_Backend_Category extends Shopware_Controllers_Backend
         }
 
         $categoryModel->setStream(null);
-        if ($params['streamId']) {
+        if (isset($params['streamId'])) {
             $params['stream'] = $this->em->find(ProductStream::class, (int) $params['streamId']);
         }
 
@@ -605,7 +599,7 @@ class Shopware_Controllers_Backend_Category extends Shopware_Controllers_Backend
         $paginator = $this->em->createPaginator($query);
         $data = iterator_to_array($paginator);
         $data = $data[0];
-        $data['imagePath'] = $data['media']['path'];
+        $data['imagePath'] = $data['media']['path'] ?? null;
 
         $this->View()->assign(['success' => true, 'data' => $data, 'total' => \count($data)]);
     }
@@ -932,15 +926,11 @@ class Shopware_Controllers_Backend_Category extends Shopware_Controllers_Backend
 
     /**
      * This method loads the customer group models for the passed ids in the "customerGroups" parameter.
-     *
-     * @param array $data
-     *
-     * @return array
      */
-    private function prepareCustomerGroupsAssociatedData($data)
+    private function prepareCustomerGroupsAssociatedData(array $data): array
     {
         $customerGroups = [];
-        foreach ($data['customerGroups'] as $customerGroupData) {
+        foreach ($data['customerGroups'] ?? [] as $customerGroupData) {
             if (!empty($customerGroupData['id'])) {
                 $model = $this->em->find(Group::class, $customerGroupData['id']);
                 $customerGroups[] = $model;

--- a/engine/Shopware/Controllers/Backend/Config.php
+++ b/engine/Shopware/Controllers/Backend/Config.php
@@ -218,7 +218,7 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
             $store = $values['options']['store'];
 
             // Replace the store, which may contain multiple translations, with a store with translated messages:
-            if ($values['options']['translateUsingSnippets']) {
+            if (!empty($values['options']['translateUsingSnippets'])) {
                 $values['options']['store'] = $this->translateStoreUsingSnippets($store, $values['options']['namespace']);
             } else {
                 $values['options']['store'] = $this->translateStore($language, $store, $storeFallbackLocales);
@@ -721,7 +721,7 @@ class Shopware_Controllers_Backend_Config extends Shopware_Controllers_Backend_E
                     throw new RuntimeException(sprintf('Model object is not an instance of expected class "%s"', Document::class));
                 }
 
-                if ($data['id']) {
+                if (!empty($data['id'])) {
                     $elements = new ArrayCollection();
                     foreach ($data['elements'] as $element) {
                         $elementModel = $this->getRepository('documentElement')->find($element['id']);

--- a/engine/Shopware/Controllers/Backend/Customer.php
+++ b/engine/Shopware/Controllers/Backend/Customer.php
@@ -781,8 +781,8 @@ class Shopware_Controllers_Backend_Customer extends Shopware_Controllers_Backend
         }
 
         $namespace = Shopware()->Container()->get('snippets')->getNamespace('frontend/salutation');
-        $data['defaultBillingAddress']['salutationSnippet'] = $namespace->get($data['defaultBillingAddress']['salutation']);
-        $data['defaultShippingAddress']['salutationSnippet'] = $namespace->get($data['defaultShippingAddress']['salutation']);
+        $data['defaultBillingAddress']['salutationSnippet'] = $namespace->get($data['defaultBillingAddress']['salutation'] ?? null);
+        $data['defaultShippingAddress']['salutationSnippet'] = $namespace->get($data['defaultShippingAddress']['salutation'] ?? null);
         $data['customerStreamIds'] = $this->fetchCustomerStreams($id);
 
         if ($data['firstLogin'] instanceof DateTimeInterface && $data['firstLogin']->getTimestamp() < 0) {
@@ -825,13 +825,13 @@ class Shopware_Controllers_Backend_Customer extends Shopware_Controllers_Backend
         }
 
         // If a different payment method is selected, it must also be placed in the "paymentPreset" so that the risk management that does not reset.
-        if ($customer->getPaymentId() !== $params['paymentId']) {
+        if (isset($params['paymentId']) && $customer->getPaymentId() !== $params['paymentId']) {
             $params['paymentPreset'] = $params['paymentId'];
         }
 
         if (empty($params['shipping'][0]['firstName']) && empty($params['shipping'][0]['lastName'])) {
             // Shipping params are empty use the billing ones
-            $params['shipping'][0] = $params['billing'][0];
+            $params['shipping'][0] = $params['billing'][0] ?? null;
         }
 
         if ($paymentData && !empty($params['paymentData'])) {

--- a/engine/Shopware/Controllers/Backend/EmotionPreset.php
+++ b/engine/Shopware/Controllers/Backend/EmotionPreset.php
@@ -141,7 +141,7 @@ class Shopware_Controllers_Backend_EmotionPreset extends Shopware_Controllers_Ba
         $transformer = $this->container->get(EmotionToPresetDataTransformerInterface::class);
         $data = $this->Request()->getParams();
 
-        if (!$data['emotionId']) {
+        if (empty($data['emotionId'])) {
             $this->View()->assign(['success' => false]);
 
             return;
@@ -149,7 +149,7 @@ class Shopware_Controllers_Backend_EmotionPreset extends Shopware_Controllers_Ba
 
         $data = array_merge($data, $transformer->transform($data['emotionId']));
 
-        if ($data['id']) {
+        if (!empty($data['id'])) {
             $resource->update($data['id'], $data, $this->getLocale());
         } else {
             $resource->create($data, $this->getLocale());

--- a/engine/Shopware/Controllers/Backend/ExtJs.php
+++ b/engine/Shopware/Controllers/Backend/ExtJs.php
@@ -27,7 +27,7 @@ abstract class Shopware_Controllers_Backend_ExtJs extends Enlight_Controller_Act
     /**
      * Array with all permissions to check in this controller
      *
-     * @var array
+     * @var array<string, array{privilege: string, errorMessage: string}>
      */
     protected $aclPermissions = [];
 
@@ -43,7 +43,7 @@ abstract class Shopware_Controllers_Backend_ExtJs extends Enlight_Controller_Act
         $this->Front()->Plugins()->JsonRequest()
             ->setParseInput()
             ->setParseParams(['group', 'sort', 'filter'])
-            ->setPadding($this->Request()->targetField);
+            ->setPadding($this->Request()->get('targetField'));
 
         // Call controller acl rules (user - defined)
         $this->initAcl();
@@ -63,7 +63,7 @@ abstract class Shopware_Controllers_Backend_ExtJs extends Enlight_Controller_Act
     /**
      * Returns all acl permissions
      *
-     * @return array
+     * @return array<string, array{privilege: string, errorMessage: string}>
      */
     public function getAclRules()
     {
@@ -72,6 +72,8 @@ abstract class Shopware_Controllers_Backend_ExtJs extends Enlight_Controller_Act
 
     /**
      * Needs to be present for the script renderer
+     *
+     * @return void
      */
     public function indexAction()
     {
@@ -87,6 +89,8 @@ abstract class Shopware_Controllers_Backend_ExtJs extends Enlight_Controller_Act
 
     /**
      * Needs to be present for the script renderer
+     *
+     * @return void
      */
     public function loadAction()
     {
@@ -116,6 +120,8 @@ abstract class Shopware_Controllers_Backend_ExtJs extends Enlight_Controller_Act
      * @param string $action       Name of action with or without 'Action'-suffix
      * @param string $privilege    Name of privilege as you have set in s_core_acl_privileges
      * @param string $errorMessage Optionally error message to show if permission denied
+     *
+     * @return void
      */
     protected function addAclPermission($action, $privilege, $errorMessage = '')
     {
@@ -150,7 +156,7 @@ abstract class Shopware_Controllers_Backend_ExtJs extends Enlight_Controller_Act
     /**
      * @param mixed|null $identity
      *
-     * @return bool|string
+     * @return string
      */
     protected function getTinyMceLang($identity)
     {

--- a/engine/Shopware/Controllers/Backend/Index.php
+++ b/engine/Shopware/Controllers/Backend/Index.php
@@ -36,6 +36,8 @@ class Shopware_Controllers_Backend_Index extends Enlight_Controller_Action imple
 
     /**
      * Loads auth and script renderer resource
+     *
+     * @return void
      */
     public function init()
     {
@@ -86,6 +88,8 @@ class Shopware_Controllers_Backend_Index extends Enlight_Controller_Action imple
      * Backend Menu
      * Licence Information
      * Rss-Data for example
+     *
+     * @return void
      */
     public function indexAction()
     {
@@ -145,12 +149,17 @@ class Shopware_Controllers_Backend_Index extends Enlight_Controller_Action imple
         $this->View()->assign('extJsDeveloperModeActive', $this->container->getParameter('shopware.extjs.developer_mode'));
     }
 
+    /**
+     * @return void
+     */
     public function authAction()
     {
     }
 
     /**
      * Allows changing the locale by sending a Shopware localeId or an ISO-3166 locale (e.g. de_DE)
+     *
+     * @return void
      */
     public function changeLocaleAction()
     {
@@ -207,6 +216,8 @@ class Shopware_Controllers_Backend_Index extends Enlight_Controller_Action imple
      * Load action for the script renderer.
      *
      * @throws Enlight_Controller_Exception
+     *
+     * @return void
      */
     public function loadAction()
     {
@@ -226,6 +237,8 @@ class Shopware_Controllers_Backend_Index extends Enlight_Controller_Action imple
      * Load action for the script renderer.
      *
      * @throws Enlight_Controller_Exception
+     *
+     * @return void
      */
     public function menuAction()
     {
@@ -253,10 +266,8 @@ class Shopware_Controllers_Backend_Index extends Enlight_Controller_Action imple
      * Returns if the first run wizard should be loaded in the current backend instance
      *
      * @param stdClass $identity
-     *
-     * @return bool
      */
-    private function isFirstRunWizardEnabled($identity)
+    private function isFirstRunWizardEnabled($identity): bool
     {
         // Only admins can see the wizard
         if ($identity->role->getAdmin()) {
@@ -266,12 +277,7 @@ class Shopware_Controllers_Backend_Index extends Enlight_Controller_Action imple
         return false;
     }
 
-    /**
-     * @param int|null $parentId
-     *
-     * @return array
-     */
-    private function buildTree(array $nodes, $parentId = null)
+    private function buildTree(array $nodes, ?int $parentId = null): array
     {
         $menuTree = [];
         foreach ($nodes as $key => $node) {

--- a/engine/Shopware/Controllers/Backend/Log.php
+++ b/engine/Shopware/Controllers/Backend/Log.php
@@ -127,7 +127,7 @@ class Shopware_Controllers_Backend_Log extends Shopware_Controllers_Backend_ExtJ
             $params = $this->Request()->getParams();
             unset($params['module'], $params['controller'], $params['action'], $params['_dc']);
 
-            if ($params[0]) {
+            if (!empty($params[0])) {
                 foreach ($params as $values) {
                     $logModel = $this->get('models')->find(Log::class, $values['id']);
 

--- a/engine/Shopware/Controllers/Backend/MediaManager.php
+++ b/engine/Shopware/Controllers/Backend/MediaManager.php
@@ -717,8 +717,8 @@ class Shopware_Controllers_Backend_MediaManager extends Shopware_Controllers_Bac
         }
 
         $thumbnailHighDpi = isset($data['thumbnailHighDpi']) && $data['thumbnailHighDpi'];
-        $thumbnailQuality = $data['thumbnailQuality'] ?: 90;
-        $thumbnailHighDpiQuality = $data['thumbnailHighDpiQuality'] ?: 70;
+        $thumbnailQuality = $data['thumbnailQuality'] ?? 90;
+        $thumbnailHighDpiQuality = $data['thumbnailHighDpiQuality'] ?? 70;
 
         $albumId = $album->getId();
         if (empty($albumId) && $data['parent'] !== null) {
@@ -785,7 +785,7 @@ class Shopware_Controllers_Backend_MediaManager extends Shopware_Controllers_Bac
             if (stripos($album['text'], $search) === 0) {
                 $found[] = $album;
             }
-            $children = $album['data'];
+            $children = $album['data'] ?? null;
 
             if (\is_array($children) && \count($children) > 0) {
                 $foundChildren[] = $this->filterAlbums($children, $search);

--- a/engine/Shopware/Controllers/Backend/Newsletter.php
+++ b/engine/Shopware/Controllers/Backend/Newsletter.php
@@ -447,7 +447,7 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
         $template->assign('sUser', $user, true);
         $hash = $this->createHash((int) $user['mailaddressID'], (int) $mailing['id']);
         $template->assign('sCampaignHash', $hash, true);
-        $template->assign('sRecommendations', $this->getMailingSuggest($mailing['id'], $user['id']), true);
+        $template->assign('sRecommendations', $this->getMailingSuggest($mailing['id'], $user['userID']), true);
         $template->assign('sVoucher', $this->getMailingVoucher($mailing['id']), true);
         $template->assign('sCampaign', $this->getMailingDetails($mailing['id']), true);
         $template->assign('sConfig', Shopware()->Config());
@@ -508,8 +508,6 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
      */
     public function getMailingDetails($id)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $details = Shopware()->Modules()->Marketing()->sMailCampaignsGetDetail((int) $id);
         if (!\is_array($details)) {
             return [];
@@ -554,8 +552,6 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
      */
     public function getMailingVoucher($id)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $sql = 'SELECT value FROM s_campaigns_containers WHERE type=? AND promotionID=?';
         $voucherID = Shopware()->Db()->fetchOne($sql, [Container::TYPE_VOUCHER, $id]);
         if (empty($voucherID)) {
@@ -583,8 +579,6 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
      */
     public function getMailingEmails($id)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $sql = 'SELECT `groups`, languageID FROM s_campaigns_mailings WHERE id=?';
         $mailing = Shopware()->Db()->fetchRow($sql, [$id]);
 
@@ -594,16 +588,16 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
 
         $customerGroups = [];
         $recipientGroups = [];
-        $mailing['groups'] = unserialize($mailing['groups'], ['allowed_classes' => false]);
+        $mailing['groups'] = unserialize($mailing['groups'], ['allowed_classes' => false]) ?: [];
 
         // The first element holds the selected customer groups for the current newsletter
-        foreach ($mailing['groups'][0] as $customerGroupKey => $customerGroupValue) {
+        foreach ($mailing['groups'][0] ?? [] as $customerGroupKey => $customerGroupValue) {
             $customerGroups[] = Shopware()->Db()->quoteInto('su.customergroup=?', $customerGroupKey);
         }
         $customerGroups = implode(' OR ', $customerGroups);
 
         // The second element holds the selected *newsletter* groups for the current newsletter
-        foreach ($mailing['groups'][1] as $customerGroupKey => $customerGroupValue) {
+        foreach ($mailing['groups'][1] ?? [] as $customerGroupKey => $customerGroupValue) {
             $recipientGroups[] = Shopware()->Db()->quoteInto('sc.groupID=?', $customerGroupKey);
         }
         $recipientGroups = implode(' OR ', $recipientGroups);
@@ -667,8 +661,6 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
      */
     public function getVoucherCode($voucherID)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $sql = '
             SELECT id, code
             FROM s_emarketing_voucher_codes evc
@@ -697,8 +689,6 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
      */
     public function getMailingUserByEmail($email)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $select = '
             cm.email, cm.email as newsletter, cg.name as `group`,
             IFNULL(u.salutation, nd.salutation) as salutation,
@@ -766,8 +756,6 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
      */
     public function preFilter($source)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $source = str_replace('<suggestions></suggestions>', '{include file="suggest`$sMailing.template`"}', $source);
         $source = str_replace('<weblog></weblog>', '<img src="{url module=backend controller=newsletter action=log mailing=$sMailing.id mailaddress=$sUser.mailaddressID fullPath}" style="width:1px;height:1px">', $source);
         $source = str_replace('@suggestions', '{include file="alt/suggest`$sMailing.template`"}', $source);
@@ -788,8 +776,6 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
      */
     public function outputFilter($source)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $source = preg_replace('#(src|background)="([^:"./][^:"]+)"#Umsi', '$1="../../campaigns/$2"', $source);
         $callback = [Shopware()->Plugins()->Core()->PostFilter(), 'rewriteSrc'];
 
@@ -807,8 +793,6 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
      */
     public function altFilter($source)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $source = preg_replace('#<a.+href="(.*)".*>#Umsi', '$1', $source);
         $source = str_replace(['<br />', '</p>', '&nbsp;'], ["\n", "\n", ' '], $source);
         $source = trim(strip_tags((string) preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/s', '', $source)));
@@ -828,8 +812,6 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
      */
     public function trackFilter($source, $mailingID)
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
         $track = 'sPartner=sCampaign' . (int) $mailingID;
         $host = preg_quote(Shopware()->Config()->get('BasePath'), '#');
         $pattern = '#href="(https?://' . $host . '[^<]*[?][^<]+)"#Umsi';
@@ -848,9 +830,6 @@ class Shopware_Controllers_Backend_Newsletter extends Enlight_Controller_Action 
      */
     public function createHash()
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be private with 5.8.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
-
-        // todo@all Create new method to get same secret hashes for values
         $license = '';
         $parts = \func_get_args();
         $parts[] = $license;

--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1508,10 +1508,10 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
             $order['locale'] = $order['languageSubShop']['locale'];
 
             // Deprecated: use payment instance
-            $order['debit'] = $order['customer']['debit'];
+            $order['debit'] = $order['customer']['debit'] ?? null;
             $order['customerEmail'] = $order['customer']['email'];
-            $order['billing']['salutationSnippet'] = $namespace->get($order['billing']['salutation']);
-            $order['shipping']['salutationSnippet'] = $namespace->get($order['shipping']['salutation']);
+            $order['billing']['salutationSnippet'] = $namespace->get($order['billing']['salutation'] ?? '');
+            $order['shipping']['salutationSnippet'] = $namespace->get($order['shipping']['salutation'] ?? '');
 
             foreach ($order['details'] as &$orderDetail) {
                 $number = $orderDetail['articleNumber'];
@@ -2422,7 +2422,7 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
 
     private function getCurrentLocale(): ?ShopLocale
     {
-        return $this->get('auth')->getIdentity()->locale;
+        return $this->get('auth')->getIdentity()->locale ?? null;
     }
 
     private function checkIfOrderHasBeenModifiedSince(DateTime $lastOrderChange, Order $order, Enlight_Components_Snippet_Namespace $namespace): bool

--- a/engine/Shopware/Controllers/Backend/ProductFeed.php
+++ b/engine/Shopware/Controllers/Backend/ProductFeed.php
@@ -143,7 +143,7 @@ class Shopware_Controllers_Backend_ProductFeed extends Shopware_Controllers_Back
     {
         $params = $this->Request()->getParams();
 
-        $feedId = $params['id'];
+        $feedId = $params['id'] ?? null;
         if (!empty($feedId)) {
             // Edit Product Feed
             /** @var ProductFeed $productFeed */

--- a/engine/Shopware/Controllers/Backend/RiskManagement.php
+++ b/engine/Shopware/Controllers/Backend/RiskManagement.php
@@ -111,7 +111,7 @@ class Shopware_Controllers_Backend_RiskManagement extends Shopware_Controllers_B
             unset($params['_dc']);
 
             // 2-dimensional array
-            if ($params[0]) {
+            if (!empty($params[0])) {
                 $data = [];
                 foreach ($params as $values) {
                     $ruleModel = $this->get('models')->find(RuleSet::class, $values['id']);

--- a/engine/Shopware/Controllers/Backend/Shipping.php
+++ b/engine/Shopware/Controllers/Backend/Shipping.php
@@ -469,10 +469,10 @@ class Shopware_Controllers_Backend_Shipping extends Shopware_Controllers_Backend
         }
 
         // Clean up params and init some fields
-        $payments = $params['payments'];
-        $holidays = $params['holidays'];
-        $countries = $params['countries'];
-        $categories = $params['categories'];
+        $payments = $params['payments'] ?? [];
+        $holidays = $params['holidays'] ?? [];
+        $countries = $params['countries'] ?? [];
+        $categories = $params['categories'] ?? [];
 
         if (!isset($params['shippingFree']) || $params['shippingFree'] === '' || $params['shippingFree'] === '0') {
             $params['shippingFree'] = null;
@@ -489,13 +489,13 @@ class Shopware_Controllers_Backend_Shipping extends Shopware_Controllers_Backend
         $params['customerGroupId'] = $this->cleanData($params['customerGroupId']);
         $params['bindTimeFrom'] = $this->cleanData($params['bindTimeFrom']);
         $params['bindTimeTo'] = $this->cleanData($params['bindTimeTo']);
-        $params['bindInStock'] = $this->cleanData($params['bindInStock']);
+        $params['bindInStock'] = $this->cleanData($params['bindInStock'] ?? null);
         $params['bindWeekdayFrom'] = $this->cleanData($params['bindWeekdayFrom']);
         $params['bindWeekdayTo'] = $this->cleanData($params['bindWeekdayTo']);
         $params['bindWeightFrom'] = $this->cleanData($params['bindWeightFrom']);
         $params['bindWeightTo'] = $this->cleanData($params['bindWeightTo']);
         $params['bindPriceFrom'] = $this->cleanData($params['bindPriceFrom']);
-        $params['bindPriceTo'] = $this->cleanData($params['bindPriceTo']);
+        $params['bindPriceTo'] = $this->cleanData($params['bindPriceTo'] ?? null);
         $params['bindSql'] = $this->cleanData($params['bindSql']);
         $params['calculationSql'] = $this->cleanData($params['calculationSql']);
 

--- a/engine/Shopware/Controllers/Backend/Supplier.php
+++ b/engine/Shopware/Controllers/Backend/Supplier.php
@@ -100,7 +100,7 @@ class Shopware_Controllers_Backend_Supplier extends Shopware_Controllers_Backend
         $mediaService = Shopware()->Container()->get(MediaServiceInterface::class);
 
         foreach ($suppliers as &$supplier) {
-            $supplier['description'] = strip_tags($supplier['description']);
+            $supplier['description'] = strip_tags((string) $supplier['description']);
             $supplier['image'] = $mediaService->getUrl($supplier['image']);
         }
         unset($supplier);

--- a/engine/Shopware/Controllers/Backend/UserManager.php
+++ b/engine/Shopware/Controllers/Backend/UserManager.php
@@ -226,7 +226,7 @@ class Shopware_Controllers_Backend_UserManager extends Shopware_Controllers_Back
             $params['enabled'] = false;
         }
 
-        if ($params['admin'] === 'on' || $params['admin'] === true || $params['admin'] === 1) {
+        if (isset($params['admin']) && ($params['admin'] === 'on' || $params['admin'] === true || $params['admin'] === 1)) {
             $params['admin'] = true;
         } else {
             $params['admin'] = false;
@@ -288,7 +288,7 @@ class Shopware_Controllers_Backend_UserManager extends Shopware_Controllers_Back
 
         // Strip roles with parent id set
         foreach ($roles as &$role) {
-            if ($role['parentID'] != null) {
+            if (!empty($role['parentID'])) {
                 unset($role);
             }
         }

--- a/engine/Shopware/Controllers/Backend/Vote.php
+++ b/engine/Shopware/Controllers/Backend/Vote.php
@@ -36,7 +36,7 @@ class Shopware_Controllers_Backend_Vote extends Shopware_Controllers_Backend_App
 
     public function save($data)
     {
-        if (!empty($data['answer']) && $data['answer_date'] == null) {
+        if (!empty($data['answer']) && empty($data['answer_date'])) {
             $data['answerDate'] = new DateTime();
         }
         if (empty($data['shopId'])) {

--- a/engine/Shopware/Controllers/Backend/Voucher.php
+++ b/engine/Shopware/Controllers/Backend/Voucher.php
@@ -92,7 +92,7 @@ class Shopware_Controllers_Backend_Voucher extends Shopware_Controllers_Backend_
         $offset = (int) $this->Request()->getParam('start');
         $limit = (int) $this->Request()->getParam('limit');
         $filter = $this->Request()->getParam('filter');
-        $filter = $filter[0]['value'];
+        $filter = $filter[0]['value'] ?? null;
         $sqlBindings = [];
         $searchSQL = '';
 
@@ -106,8 +106,8 @@ class Shopware_Controllers_Backend_Voucher extends Shopware_Controllers_Backend_
         }
         // Sorting data
         $sortData = $this->Request()->getParam('sort');
-        $sortField = $sortData[0]['property'];
-        $dir = $sortData[0]['direction'];
+        $sortField = $sortData[0]['property'] ?? null;
+        $dir = $sortData[0]['direction'] ?? null;
         $sort = '';
         if ((!empty($sortField) && $dir === 'ASC') || $dir === 'DESC') {
             // To prevent sql-injections
@@ -154,7 +154,7 @@ class Shopware_Controllers_Backend_Voucher extends Shopware_Controllers_Backend_
 
         $orderBy = $this->Request()->getParam('sort');
         $filter = $this->Request()->getParam('filter');
-        $filter = $filter[0]['value'];
+        $filter = $filter[0]['value'] ?? null;
         $offset = $this->Request()->getParam('start');
         $limit = $this->Request()->getParam('limit');
 
@@ -321,7 +321,7 @@ class Shopware_Controllers_Backend_Voucher extends Shopware_Controllers_Backend_
     public function saveVoucherAction()
     {
         $params = $this->Request()->getParams();
-        $voucherId = empty($params['voucherID']) ? $params['id'] : $params['voucherID'];
+        $voucherId = empty($params['voucherID']) ? $params['id'] ?? null : $params['voucherID'];
         if (!empty($voucherId)) {
             if (!$this->_isAllowed('update', 'voucher')) {
                 return;

--- a/engine/Shopware/Controllers/Backend/Widgets.php
+++ b/engine/Shopware/Controllers/Backend/Widgets.php
@@ -309,7 +309,7 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
             ]
         );
 
-        if ($fetchConversion['visitors'] != 0) {
+        if (\is_array($fetchConversion) && $fetchConversion['visitors'] != 0) {
             $fetchConversion = number_format($fetchConversion['countOrders'] / $fetchConversion['visitors'] * 100, 2);
         } else {
             $fetchConversion = number_format(0, 2);
@@ -483,7 +483,7 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
      */
     public function getNoticeAction()
     {
-        $userID = $_SESSION['ShopwareBackend']['Auth']->id;
+        $userID = $_SESSION['ShopwareBackend']['Auth']->id ?? null;
 
         if (empty($userID)) {
             $this->View()->assign(['success' => false, 'message' => 'No user id']);
@@ -508,7 +508,7 @@ class Shopware_Controllers_Backend_Widgets extends Shopware_Controllers_Backend_
     {
         $noticeMsg = (string) $this->Request()->getParam('notice');
 
-        $userID = $_SESSION['ShopwareBackend']['Auth']->id;
+        $userID = $_SESSION['ShopwareBackend']['Auth']->id ?? null;
 
         if (empty($userID)) {
             $this->View()->assign(['success' => false, 'message' => 'No user id']);

--- a/engine/Shopware/Controllers/Frontend/Account.php
+++ b/engine/Shopware/Controllers/Frontend/Account.php
@@ -104,8 +104,8 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
         $this->response->headers->addCacheControlDirective('no-store');
         $this->response->headers->addCacheControlDirective('no-cache');
 
-        $activeBillingAddressId = $customerData['additional']['user']['default_billing_address_id'];
-        $activeShippingAddressId = $customerData['additional']['user']['default_shipping_address_id'];
+        $activeBillingAddressId = $customerData['additional']['user']['default_billing_address_id'] ?? null;
+        $activeShippingAddressId = $customerData['additional']['user']['default_shipping_address_id'] ?? null;
 
         if (!empty($customerData['shippingaddress']['country']['id'])) {
             $country = $this->get(CountryGatewayInterface::class)->getCountry($customerData['shippingaddress']['country']['id'], $this->get(ContextServiceInterface::class)->getContext());
@@ -899,7 +899,12 @@ class Shopware_Controllers_Frontend_Account extends Enlight_Controller_Action
 
     private function isOneTimeAccount(): bool
     {
-        return $this->container->get('session')->offsetGet('sOneTimeAccount')
-            || (int) $this->View()->getAssign('sUserData')['additional']['user']['accountmode'] === Customer::ACCOUNT_MODE_FAST_LOGIN;
+        $customerData = $this->View()->getAssign('sUserData');
+        if (!isset($customerData['additional']['user'])) {
+            return false;
+        }
+
+        return $this->container->get('session')->get('sOneTimeAccount')
+            || (int) $customerData['additional']['user']['accountmode'] === Customer::ACCOUNT_MODE_FAST_LOGIN;
     }
 }

--- a/engine/Shopware/Controllers/Frontend/Blog.php
+++ b/engine/Shopware/Controllers/Frontend/Blog.php
@@ -153,9 +153,9 @@ class Shopware_Controllers_Frontend_Blog extends Enlight_Controller_Action
         $categoryId = (int) $this->Request()->getQuery('sCategory');
         $page = (int) $this->request->getParam('sPage', 1);
         $page = $page >= 1 ? $page : 1;
-        $filterDate = urldecode($this->Request()->getParam('sFilterDate'));
-        $filterAuthor = urldecode($this->Request()->getParam('sFilterAuthor'));
-        $filterTags = urldecode($this->Request()->getParam('sFilterTags'));
+        $filterDate = urldecode($this->Request()->getParam('sFilterDate', ''));
+        $filterAuthor = urldecode($this->Request()->getParam('sFilterAuthor', ''));
+        $filterTags = urldecode($this->Request()->getParam('sFilterTags', ''));
 
         // Redirect if blog's category is not a child of the current shop's category
         $shopCategory = $this->get('shop')->getCategory();

--- a/engine/Shopware/Controllers/Frontend/Checkout.php
+++ b/engine/Shopware/Controllers/Frontend/Checkout.php
@@ -41,12 +41,13 @@ use Shopware\Components\CSRFGetProtectionAware;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Country\Country;
 use Shopware\Models\Customer\Address;
+use Shopware\Models\Customer\Customer;
 use Shopware\Models\Shop\Currency;
 use ShopwarePlugin\PaymentMethods\Components\BasePaymentMethod;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 /**
- * @phpstan-type CheckoutBasketArray array{content?: array<string, mixed>, Amount?: string, AmountNet?: string, Quantity?: int, AmountNumeric: float, AmountNetNumeric: float, AmountWithTax?: string, AmountWithTaxNumeric?: float, sCurrencyId: int, sCurrencyName: string, sCurrencyFactor: float, sShippingcosts: float, sShippingcostsTax: float|null, sShippingcostsTaxProportional?: array<\Shopware\Components\Cart\Struct\Price>, sShippingcostsNet: float, sShippingcostsWithTax: float, sShippingcostsDifference: float|null, sTaxRates: array<string, float>, sAmount: float, sAmountTax: float, sAmountWithTax?: float}
+ * @phpstan-type CheckoutBasketArray array{content?: array<string, mixed>, Amount?: string, AmountNet?: string, Quantity?: int, AmountNumeric: float, AmountNetNumeric: float, AmountWithTax?: string, AmountWithTaxNumeric?: float, sCurrencyId: int, sCurrencyName: string, sCurrencyFactor: float, sShippingcosts: float, sShippingcostsTax: float|null, sShippingcostsTaxProportional?: array<\Shopware\Components\Cart\Struct\Price>, sShippingcostsNet: float, sShippingcostsWithTax: float, sShippingcostsDifference?: float|null, sTaxRates: array<string, float>, sAmount: float, sAmountTax: float, sAmountWithTax?: float}
  *
  * @phpstan-import-type ShippingCostArray from \sAdmin
  */
@@ -170,6 +171,7 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
      */
     public function cartAction()
     {
+        $accountMode = (int) ($this->View()->getAssign('sUserData')['additional']['user']['accountmode'] ?? Customer::ACCOUNT_MODE_CUSTOMER);
         $country = $this->getSelectedCountry();
         $this->View()->assign('sCountry', $country);
         $this->View()->assign('sPayment', $this->getSelectedPayment());
@@ -177,7 +179,7 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
         $this->View()->assign('sCountryList', $this->getCountryList());
         $this->View()->assign('sPayments', $this->getPayments());
         $this->View()->assign('sDispatches', $this->getDispatches());
-        $this->View()->assign('sDispatchNoOrder', (int) $this->View()->getAssign('sUserData')['additional']['user']['accountmode'] === 0 && $this->getDispatchNoOrder());
+        $this->View()->assign('sDispatchNoOrder', $accountMode === Customer::ACCOUNT_MODE_CUSTOMER && $this->getDispatchNoOrder());
         $this->View()->assign('sState', $this->getSelectedState());
 
         $this->View()->assign('sUserData', $this->getUserData());
@@ -185,9 +187,9 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
         $this->View()->assign('sInvalidCartItems', $this->getInvalidProducts($this->View()->getAssign('sBasket')));
 
         $this->View()->assign(CheckoutKey::SHIPPING_COSTS, $this->View()->getAssign('sBasket')[CheckoutKey::SHIPPING_COSTS]);
-        $this->View()->assign(CheckoutKey::SHIPPING_COSTS_DIFFERENCE, $this->View()->getAssign('sBasket')[CheckoutKey::SHIPPING_COSTS_DIFFERENCE]);
+        $this->View()->assign(CheckoutKey::SHIPPING_COSTS_DIFFERENCE, $this->View()->getAssign('sBasket')[CheckoutKey::SHIPPING_COSTS_DIFFERENCE] ?? null);
         $this->View()->assign(CheckoutKey::AMOUNT, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT]);
-        $this->View()->assign(CheckoutKey::AMOUNT_WITH_TAX, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT_WITH_TAX]);
+        $this->View()->assign(CheckoutKey::AMOUNT_WITH_TAX, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT_WITH_TAX] ?? 0.0);
         $this->View()->assign(CheckoutKey::AMOUNT_TAX, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT_TAX]);
         $this->View()->assign('sAmountNet', $this->View()->getAssign('sBasket')[CartKey::AMOUNT_NET_NUMERIC]);
 
@@ -259,9 +261,9 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
 
         $this->View()->assign('sLaststock', $this->basket->sCheckBasketQuantities());
         $this->View()->assign(CheckoutKey::SHIPPING_COSTS, $this->View()->getAssign('sBasket')[CheckoutKey::SHIPPING_COSTS]);
-        $this->View()->assign(CheckoutKey::SHIPPING_COSTS_DIFFERENCE, $this->View()->getAssign('sBasket')[CheckoutKey::SHIPPING_COSTS_DIFFERENCE]);
+        $this->View()->assign(CheckoutKey::SHIPPING_COSTS_DIFFERENCE, $this->View()->getAssign('sBasket')[CheckoutKey::SHIPPING_COSTS_DIFFERENCE] ?? null);
         $this->View()->assign(CheckoutKey::AMOUNT, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT]);
-        $this->View()->assign(CheckoutKey::AMOUNT_WITH_TAX, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT_WITH_TAX]);
+        $this->View()->assign(CheckoutKey::AMOUNT_WITH_TAX, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT_WITH_TAX] ?? 0.0);
         $this->View()->assign(CheckoutKey::AMOUNT_TAX, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT_TAX]);
         $this->View()->assign('sAmountNet', $this->View()->getAssign('sBasket')[CartKey::AMOUNT_NET_NUMERIC]);
 
@@ -860,9 +862,9 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
 
         $this->View()->assign('sLaststock', $this->basket->sCheckBasketQuantities());
         $this->View()->assign(CheckoutKey::SHIPPING_COSTS, $this->View()->getAssign('sBasket')[CheckoutKey::SHIPPING_COSTS]);
-        $this->View()->assign(CheckoutKey::SHIPPING_COSTS_DIFFERENCE, $this->View()->getAssign('sBasket')[CheckoutKey::SHIPPING_COSTS_DIFFERENCE]);
+        $this->View()->assign(CheckoutKey::SHIPPING_COSTS_DIFFERENCE, $this->View()->getAssign('sBasket')[CheckoutKey::SHIPPING_COSTS_DIFFERENCE] ?? null);
         $this->View()->assign(CheckoutKey::AMOUNT, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT]);
-        $this->View()->assign(CheckoutKey::AMOUNT_WITH_TAX, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT_WITH_TAX]);
+        $this->View()->assign(CheckoutKey::AMOUNT_WITH_TAX, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT_WITH_TAX] ?? 0.0);
         $this->View()->assign(CheckoutKey::AMOUNT_TAX, $this->View()->getAssign('sBasket')[CheckoutKey::AMOUNT_TAX]);
         $this->View()->assign('sAmountNet', $this->View()->getAssign('sBasket')[CartKey::AMOUNT_NET_NUMERIC]);
         $this->View()->assign('sRegisterFinished', !empty($this->session['sRegisterFinished']));
@@ -1782,11 +1784,11 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
         $view->assign(CheckoutKey::SHIPPING_COSTS, $basket[CheckoutKey::SHIPPING_COSTS]);
         $view->assign(CheckoutKey::SHIPPING_COSTS_DIFFERENCE, $basket[CheckoutKey::SHIPPING_COSTS_DIFFERENCE] ?? null);
         $view->assign(CheckoutKey::AMOUNT, $basket[CheckoutKey::AMOUNT]);
-        $view->assign(CheckoutKey::AMOUNT_WITH_TAX, $basket[CheckoutKey::AMOUNT_WITH_TAX] ?? null);
+        $view->assign(CheckoutKey::AMOUNT_WITH_TAX, $basket[CheckoutKey::AMOUNT_WITH_TAX] ?? 0.0);
         $view->assign(CheckoutKey::AMOUNT_TAX, $basket[CheckoutKey::AMOUNT_TAX]);
         $view->assign('sAmountNet', $basket[CartKey::AMOUNT_NET_NUMERIC]);
         $view->assign('sDispatches', $this->getDispatches());
-        $accountMode = (int) $this->View()->getAssign('sUserData')['additional']['user']['accountmode'];
+        $accountMode = (int) ($this->View()->getAssign('sUserData')['additional']['user']['accountmode'] ?? null);
         $view->assign('sDispatchNoOrder', $accountMode === 0 && $this->getDispatchNoOrder());
         $view->assign('showShippingCalculation', (bool) $this->Request()->getParam('openShippingCalculations'));
         $view->assign('sMinimumSurcharge', $this->getMinimumCharge());
@@ -2005,8 +2007,11 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
                 continue;
             }
 
+            if (empty($attrName)) {
+                continue;
+            }
             $serviceAttr = $cartItem['additional_details'][$attrName];
-            if (empty($attrName) || ($serviceAttr && $serviceAttr != 'false')) {
+            if ($serviceAttr && $serviceAttr !== 'false') {
                 continue;
             }
 
@@ -2157,7 +2162,8 @@ class Shopware_Controllers_Frontend_Checkout extends Enlight_Controller_Action i
      */
     private function areAddressesEqual(array $addressA, array $addressB): bool
     {
-        foreach (['id', 'customernumber', 'phone', 'ustid'] as $key) {
+        // 'country' and 'state' are arrays, but not relevant as the IDs are also present which will then be compared
+        foreach (['id', 'userID', 'orderID', 'customernumber', 'phone', 'ustid', 'country', 'state', 'attribute'] as $key) {
             unset($addressA[$key], $addressB[$key]);
         }
 

--- a/engine/Shopware/Controllers/Frontend/Forms.php
+++ b/engine/Shopware/Controllers/Frontend/Forms.php
@@ -256,7 +256,7 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
                     }
                 }
 
-                $fields[$id] = $this->_createInputElement($element, $this->_postData[$id]);
+                $fields[$id] = $this->_createInputElement($element, $this->_postData[$id] ?? null);
                 $labels[$id] = $this->_createLabelElement($element);
             }
         }
@@ -455,7 +455,7 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
                     $element['class'][0],
                     $requiredField,
                     $requiredFieldAria,
-                    $post[0],
+                    $post[0] ?? null,
                     $placeholder0,
                     $element['name'][0],
                     $element['name'][0]
@@ -465,7 +465,7 @@ class Shopware_Controllers_Frontend_Forms extends Enlight_Controller_Action
                     $element['class'][1],
                     $requiredField,
                     $requiredFieldAria,
-                    $post[1],
+                    $post[1] ?? null,
                     $placeholder1,
                     $element['name'][1],
                     $element['name'][1]

--- a/engine/Shopware/Controllers/Frontend/Register.php
+++ b/engine/Shopware/Controllers/Frontend/Register.php
@@ -181,7 +181,7 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
         ]));
 
         $customer->setReferer((string) $session->offsetGet('sReferer'));
-        $customer->setValidation((string) $data['register']['personal']['sValidation']);
+        $customer->setValidation((string) ($data['register']['personal']['sValidation'] ?? ''));
         $customer->setAffiliate((int) $session->offsetGet('sPartner'));
         $customer->setPaymentId((int) $session->offsetGet('sPaymentID'));
         $customer->setDoubleOptinRegister($doubleOptinRegister);
@@ -268,7 +268,12 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
             return;
         }
 
-        if (($data = unserialize($result, ['allowed_classes' => false])) === false || !isset($data['customerId'])) {
+        try {
+            $data = unserialize($result, ['allowed_classes' => false]);
+        } catch (Throwable $e) {
+            $data = false;
+        }
+        if ($data === false || !isset($data['customerId'])) {
             throw new InvalidArgumentException(sprintf('The data for hash \'%s\' is corrupted.', $hash));
         }
         $customerId = (int) $data['customerId'];
@@ -439,12 +444,12 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
         $data = $this->request->getPost();
 
         $countryStateName = 'country_state_' . $data['register']['billing']['country'];
-        $data['register']['billing']['state'] = $data['register']['billing'][$countryStateName];
+        $data['register']['billing']['state'] = $data['register']['billing'][$countryStateName] ?? null;
 
-        $countryStateName = 'country_shipping_state_' . $data['register']['shipping']['country'];
-        $data['register']['shipping']['state'] = $data['register']['shipping'][$countryStateName];
+        $countryStateName = 'country_shipping_state_' . ($data['register']['shipping']['country'] ?? null);
+        $data['register']['shipping']['state'] = $data['register']['shipping'][$countryStateName] ?? null;
         $data['register']['billing'] += $data['register']['personal'];
-        $data['register']['shipping']['phone'] = $data['register']['personal']['phone'];
+        $data['register']['shipping']['phone'] = $data['register']['personal']['phone'] ?? null;
 
         if (!$data['register']['personal']['accountmode']) {
             $data['register']['personal']['accountmode'] = Customer::ACCOUNT_MODE_CUSTOMER;

--- a/engine/Shopware/Controllers/Frontend/Search.php
+++ b/engine/Shopware/Controllers/Frontend/Search.php
@@ -144,7 +144,7 @@ class Shopware_Controllers_Frontend_Search extends Enlight_Controller_Action
                 LIMIT 2
             ';
             $products = $this->get('db')->fetchAll($sql, [$search]);
-            if ($products[0]['configurator_set_id']) {
+            if (!empty($products[0]['configurator_set_id'])) {
                 $number = $products[0]['ordernumber'];
             }
 

--- a/engine/Shopware/Controllers/Frontend/Sitemap.php
+++ b/engine/Shopware/Controllers/Frontend/Sitemap.php
@@ -23,6 +23,7 @@
  */
 
 use Doctrine\DBAL\Connection;
+use Shopware\Bundle\SitemapBundle\Service\LinkFilter;
 use Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Emotion\Emotion;
@@ -191,7 +192,7 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
     private function convertSite($site, array $translations)
     {
         $site = array_merge($site, $this->fetchTranslation($site['id'], $translations));
-        $site['hideOnSitemap'] = !$this->filterLink($site['link']);
+        $site['hideOnSitemap'] = !LinkFilter::filterLink($site['link']);
 
         $site = array_merge(
             $site,
@@ -245,28 +246,6 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
     }
 
     /**
-     * Helper function to filter predefined links, which should not be in the sitemap (external links, sitemap links itself)
-     * Returns false, if the link is not allowed
-     */
-    private function filterLink(string $link): bool
-    {
-        if (empty($link)) {
-            return true;
-        }
-
-        $userParams = (string) parse_url($link, PHP_URL_QUERY);
-        parse_str($userParams, $userParamsArray);
-
-        $blacklist = ['', 'sitemap', 'sitemapXml'];
-
-        if (\in_array($userParamsArray['sViewport'], $blacklist, true)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
      * Helper function to get all supplier pages
      */
     private function getSupplierPages(): array
@@ -311,9 +290,9 @@ class Shopware_Controllers_Frontend_Sitemap extends Enlight_Controller_Action
         foreach ($campaigns as &$campaign) {
             $translation = $this->fetchTranslation($campaign['id'], $translations);
 
-            $translation['seo_title'] = $translation['seoTitle'];
-            $translation['seo_keywords'] = $translation['seoKeywords'];
-            $translation['seo_description'] = $translation['seoDescription'];
+            $translation['seo_title'] = $translation['seoTitle'] ?? null;
+            $translation['seo_keywords'] = $translation['seoKeywords'] ?? null;
+            $translation['seo_description'] = $translation['seoDescription'] ?? null;
 
             $campaign = array_merge($campaign, $translation);
 

--- a/engine/Shopware/Controllers/Frontend/SitemapXml.php
+++ b/engine/Shopware/Controllers/Frontend/SitemapXml.php
@@ -23,19 +23,19 @@
  */
 
 /**
- * @deprecated Will be removed in Shopware 5.7
+ * @deprecated Will be removed in Shopware 5.8
  */
 class Shopware_Controllers_Frontend_SitemapXml extends Enlight_Controller_Action
 {
     /**
      * Index action method
+     *
+     * @return void
      */
     public function indexAction()
     {
-        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be removed with 5.7. Will be removed without replacement.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
+        trigger_error(sprintf('%s:%s is deprecated since Shopware 5.6 and will be removed with 5.8. Will be removed without replacement.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
 
-        $this->redirect([
-            'controller' => 'sitemap_index.xml',
-        ]);
+        $this->redirect(['controller' => 'sitemap_index.xml']);
     }
 }

--- a/engine/Shopware/Controllers/Widgets/Listing.php
+++ b/engine/Shopware/Controllers/Widgets/Listing.php
@@ -326,6 +326,8 @@ class Shopware_Controllers_Widgets_Listing extends Enlight_Controller_Action
 
         if ($this->Request()->getParam('loadFacets')) {
             $body['facets'] = array_values($result->getFacets());
+            $body['listing'] = false;
+            $body['pagination'] = false;
         }
         if ($this->Request()->getParam('loadProducts')) {
             $this->prepareListing($result);

--- a/engine/Shopware/Core/sArticles.php
+++ b/engine/Shopware/Core/sArticles.php
@@ -1831,7 +1831,6 @@ class sArticles implements Enlight_Hook
     public function sGetConfiguratorImage($sArticle, $sCombination = '')
     {
         if (!empty($sArticle['sConfigurator']) || !empty($sCombination)) {
-            $foundImage = false;
             $configuratorImages = false;
             $mainKey = 0;
 
@@ -1839,22 +1838,23 @@ class sArticles implements Enlight_Hook
                 if (!empty($sArticle['image']['res']['description'])) {
                     $sArticle['image']['description'] = $sArticle['image']['res']['description'];
                 }
-                $sArticle['image']['relations'] = $sArticle['image']['res']['relations'];
-                foreach ($sArticle['sConfigurator'] as $key => $group) {
-                    foreach ($group['values'] as $key2 => $option) {
-                        $groupVal = $group['groupnameOrig'] ? $group['groupnameOrig'] : $group['groupname'];
+                $sArticle['image']['relations'] = $sArticle['image']['res']['relations'] ?? null;
+                foreach ($sArticle['sConfigurator'] as $group) {
+                    foreach ($group['values'] as $option) {
+                        $groupVal = $group['groupnameOrig'] ?? $group['groupname'];
                         $groupVal = str_replace(['/', ' '], '', $groupVal);
-                        $optionVal = $option['optionnameOrig'] ? $option['optionnameOrig'] : $option['optionname'];
+                        $optionVal = $option['optionnameOrig'] ?? $option['optionname'];
                         $optionVal = str_replace(['/', ' '], '', $optionVal);
                         if (!empty($option['selected'])) {
                             $replacedOptionVal = str_replace(' ', '', $optionVal);
-                            $referenceImages[strtolower($groupVal . ':' . $optionVal)] = true;
+                            \assert(\is_string($replacedOptionVal));
+                            $referenceImages[strtolower(sprintf('%s:%s', $groupVal, $replacedOptionVal))] = true;
                         }
                     }
                 }
 
                 foreach (array_merge($sArticle['images'] ?? [], [\count($sArticle['images'] ?? []) => $sArticle['image']]) as $value) {
-                    if (preg_match('/(.*){(.*)}/', $value['relations'])) {
+                    if (preg_match('/(.*){(.*)}/', $value['relations'] ?? '')) {
                         $configuratorImages = true;
 
                         break;
@@ -1940,7 +1940,8 @@ class sArticles implements Enlight_Hook
 
         if (!empty($sArticle['images'])) {
             foreach ($sArticle['images'] as $key => $image) {
-                if ($image['relations'] === '&{}' || $image['relations'] === '||{}') {
+                $relations = $image['relations'] ?? '';
+                if ($relations === '&{}' || $relations === '||{}') {
                     $sArticle['images'][$key]['relations'] = '';
                 }
             }
@@ -2269,7 +2270,7 @@ class sArticles implements Enlight_Hook
                 $size = sprintf('%sx%s', $size, $size);
             }
 
-            if ($image['type'] === Media::TYPE_IMAGE || $image['media']['type'] === Media::TYPE_IMAGE) {
+            if (isset($image['type']) && $image['type'] === Media::TYPE_IMAGE || $image['media']['type'] === Media::TYPE_IMAGE) {
                 $imageData['src'][$key] = $mediaService->getUrl('media/image/thumbnail/' . $image['path'] . '_' . $size . '.' . $image['extension']);
 
                 if ($highDpiThumbnails) {

--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -426,7 +426,7 @@ class sBasket implements \Enlight_Hook
             $tax = 19;
         }
 
-        if (!$this->sSYSTEM->sUSERGROUPDATA['tax'] && $this->sSYSTEM->sUSERGROUPDATA['id']) {
+        if (empty($this->sSYSTEM->sUSERGROUPDATA['tax']) && $this->sSYSTEM->sUSERGROUPDATA['id']) {
             $discountNet = $discount;
         } else {
             $discountNet = round($discount / (100 + $tax) * 100, 3);
@@ -754,7 +754,7 @@ class sBasket implements \Enlight_Hook
             return ['sErrorFlag' => true, 'sErrorMessages' => $sErrorMessages];
         }
 
-        if ($voucherDetails['id']) {
+        if (!empty($voucherDetails['id'])) {
             // If we have voucher details, it's a reusable code
             // We need to check how many times it has already been used
             $usedVoucherCount = $this->db->fetchRow(
@@ -784,10 +784,10 @@ class sBasket implements \Enlight_Hook
                 ) ?: [];
                 unset($voucherCodeDetails['voucherID']);
                 $voucherDetails = array_merge($voucherCodeDetails, $voucherDetails);
-                $individualCode = $voucherDetails && $voucherDetails['description'];
+                $individualCode = $voucherDetails && ($voucherDetails['description'] ?? null);
             }
         }
-        $streams = array_filter(explode('|', $voucherDetails['customer_stream_ids']));
+        $streams = array_filter(explode('|', $voucherDetails['customer_stream_ids'] ?? ''));
 
         if (!empty($streams)) {
             $context = $this->contextService->getShopContext();
@@ -809,7 +809,7 @@ class sBasket implements \Enlight_Hook
         // 3 - Voucher is reusable and has already been used to the limit
         if (!$voucherDetails
             || !$voucherCode
-            || ($voucherDetails['numberofunits'] <= $usedVoucherCount['vouchers'] && !$individualCode)
+            || (($voucherDetails['numberofunits'] ?? 0) <= ($usedVoucherCount['vouchers'] ?? 0) && !$individualCode)
         ) {
             $sErrorMessages[] = $this->snippetManager->getNamespace('frontend/basket/internalMessages')->get(
                 'VoucherFailureNotFound',
@@ -875,7 +875,7 @@ class sBasket implements \Enlight_Hook
             $voucherDetails['value'] *= $factor;
         }
 
-        $basketValue = $amount['totalAmount'] / $factor;
+        $basketValue = ($amount['totalAmount'] ?? 0) / $factor;
         // Check if the basket's value is above the voucher's
         if ($basketValue < $voucherDetails['minimumcharge']) {
             $snippet = $this->snippetManager->getNamespace('frontend/basket/internalMessages')->get(
@@ -1092,7 +1092,7 @@ class sBasket implements \Enlight_Hook
 
         if ($minimumOrder && !$this->sSYSTEM->sUSERGROUPDATA['minimumordersurcharge']) {
             $amount = $this->sGetAmount();
-            if ($amount['totalAmount'] < ($minimumOrder * $factor)) {
+            if (($amount['totalAmount'] ?? 0) < ($minimumOrder * $factor)) {
                 return $minimumOrder * $factor;
             }
         }
@@ -1149,7 +1149,7 @@ class sBasket implements \Enlight_Hook
             $tax = 19;
         }
 
-        if (!$this->sSYSTEM->sUSERGROUPDATA['tax'] && $this->sSYSTEM->sUSERGROUPDATA['id']) {
+        if (empty($this->sSYSTEM->sUSERGROUPDATA['tax']) && $this->sSYSTEM->sUSERGROUPDATA['id']) {
             $discountNet = $minimumOrderSurcharge;
         } else {
             $discountNet = round($minimumOrderSurcharge / (100 + $tax) * 100, 3);
@@ -1215,13 +1215,13 @@ class sBasket implements \Enlight_Hook
     }
 
     /**
-     * Add percentual surcharge
+     * Add percentage surcharge
      * Used only internally in sBasket::sGetBasket
      *
      * @throws \Enlight_Exception
      * @throws \Zend_Db_Adapter_Exception
      *
-     * @return false|void|null False on failure, null on success
+     * @return false|null False on failure, null on success
      */
     public function sInsertSurchargePercent()
     {
@@ -1287,7 +1287,7 @@ class sBasket implements \Enlight_Hook
             $tax = 19;
         }
 
-        if (!$this->sSYSTEM->sUSERGROUPDATA['tax'] && $this->sSYSTEM->sUSERGROUPDATA['id']) {
+        if (empty($this->sSYSTEM->sUSERGROUPDATA['tax']) && $this->sSYSTEM->sUSERGROUPDATA['id']) {
             $discountNet = $surcharge;
         } else {
             $discountNet = round($surcharge / (100 + $tax) * 100, 3);
@@ -1796,7 +1796,7 @@ class sBasket implements \Enlight_Hook
                         'price' => $grossPrice,
                         'netprice' => $netPrice,
                         'currencyFactor' => $this->sSYSTEM->sCurrency['factor'],
-                        'articlename' => $additionalInfo['name'],
+                        'articlename' => $additionalInfo['name'] ?? null,
                     ]
                 );
 
@@ -2337,7 +2337,7 @@ class sBasket implements \Enlight_Hook
     private function filterUsedVoucher($userId, $voucherDetails)
     {
         $sErrorMessages = [];
-        if ($userId && $voucherDetails['id']) {
+        if ($userId && !empty($voucherDetails['id'])) {
             $queryVoucher = $this->db->fetchAll(
                 'SELECT s_order_details.id AS id
                     FROM s_order, s_order_details
@@ -2721,7 +2721,7 @@ class sBasket implements \Enlight_Hook
                         ->round($netprice, $tax, $quantity);
 
                     // If basket comprised any discount, calculate brutto-value for the discount
-                    if ($this->sSYSTEM->sUSERGROUPDATA['basketdiscount'] && $this->sCheckForDiscount()) {
+                    if ($this->contextService->getShopContext()->getCurrentCustomerGroup()->getPercentageDiscount() && $this->sCheckForDiscount()) {
                         $discount += ($getProducts[$key]['amountWithTax'] / 100 * $this->sSYSTEM->sUSERGROUPDATA['basketdiscount']);
                     }
                 } elseif ($getProducts[$key]['modus'] == CartPositionsMode::CUSTOMER_GROUP_DISCOUNT) {
@@ -2737,7 +2737,7 @@ class sBasket implements \Enlight_Hook
                                  || $getProducts[$key]['modus'] == CartPositionsMode::SWAG_BUNDLE_DISCOUNT
                 ) {
                     $getProducts[$key]['amountWithTax'] = round(1 * ($price / 100 * (100 + $tax)), 2);
-                    if ($this->sSYSTEM->sUSERGROUPDATA['basketdiscount'] && $this->sCheckForDiscount()) {
+                    if (isset($this->sSYSTEM->sUSERGROUPDATA['basketdiscount']) && $this->sCheckForDiscount()) {
                         $discount += ($getProducts[$key]['amountWithTax'] / 100 * $this->sSYSTEM->sUSERGROUPDATA['basketdiscount']);
                     }
                 }
@@ -2951,22 +2951,22 @@ SQL;
             $additionalInfo = [];
             $quantity = $cartItem->getQuantity();
 
-            if ($additionalInformation[$cartItem->getId()]) {
+            if (isset($additionalInformation[$cartItem->getId()])) {
                 $additionalInfo = $additionalInformation[$cartItem->getId()];
             }
             // Check if quantity matches minimum purchase
-            if (!$additionalInfo['minpurchase']) {
+            if (empty($additionalInfo['minpurchase'])) {
                 $additionalInfo['minpurchase'] = 1;
             }
 
-            $additionalInfo['blocked_customer_groups'] = array_filter(explode('|', $additionalInfo['blocked_customer_groups']));
+            $additionalInfo['blocked_customer_groups'] = array_filter(explode('|', $additionalInfo['blocked_customer_groups'] ?? ''));
 
             if ($quantity < $additionalInfo['minpurchase']) {
                 $quantity = $additionalInfo['minpurchase'];
             }
 
             // Check if quantity matches the step requirements
-            if (!$additionalInfo['purchasesteps']) {
+            if (empty($additionalInfo['purchasesteps'])) {
                 $additionalInfo['purchasesteps'] = 1;
             }
 
@@ -2988,7 +2988,7 @@ SQL;
                 $additionalInfo['purchaseunit'] = 1;
             }
 
-            if (isset($products[$additionalInfo['ordernumber']])) {
+            if (isset($additionalInfo['ordernumber']) && isset($products[$additionalInfo['ordernumber']])) {
                 $additionalInfo['product'] = $products[$additionalInfo['ordernumber']];
 
                 $additionalInfo['name'] = $additionalInfo['product']->getName();
@@ -3048,7 +3048,7 @@ SQL;
         /** @var CartItemStruct $cartItem */
         foreach ($cartItems as $cartItem) {
             $quantity = $cartItem->getQuantity();
-            $prices = $itemPrices[$cartItem->getId()];
+            $prices = $itemPrices[$cartItem->getId()] ?? null;
             $additionalInfo = $cartItem->getAdditionalInfo();
             $priceResult = [];
 
@@ -3314,7 +3314,7 @@ SQL;
 
     private function getBasketQuantity(int $quantity, array $basketProduct, array $product): int
     {
-        $newQuantity = ($quantity + $basketProduct['quantity']) ?: 0;
+        $newQuantity = $quantity + ($basketProduct['quantity'] ?? 0);
 
         if ($product['laststock'] && $newQuantity > $product['instock']) {
             return (int) $product['instock'];

--- a/engine/Shopware/Core/sCategories.php
+++ b/engine/Shopware/Core/sCategories.php
@@ -438,7 +438,7 @@ class sCategories implements Enlight_Hook
             $category['description'] = $category['name'];
             $category['link'] = $category['external'] ?: $url . $category['id'];
             $category['hidetop'] = $category['hideTop'];
-            if ($category['sub']) {
+            if (isset($category['sub'])) {
                 $category['sub'] = $this->mapCategoryTree($category['sub']);
             }
         }

--- a/engine/Shopware/Core/sCore.php
+++ b/engine/Shopware/Core/sCore.php
@@ -103,7 +103,7 @@ class sCore implements \Enlight_Hook
      */
     public function sRewriteLink($link = null, $title = null)
     {
-        $url = html_entity_decode(str_replace(',', '=', $link));
+        $url = html_entity_decode(str_replace(',', '=', $link ?? ''));
         $query = (string) parse_url($url, PHP_URL_QUERY);
         parse_str($query, $queryArray);
 

--- a/engine/Shopware/Core/sExport.php
+++ b/engine/Shopware/Core/sExport.php
@@ -414,7 +414,7 @@ class sExport implements Enlight_Hook
     }
 
     /**
-     * @param string      $string
+     * @param string|null $string
      * @param string      $esc_type
      * @param string|null $char_set
      *
@@ -426,14 +426,17 @@ class sExport implements Enlight_Hook
     }
 
     /**
-     * @param string      $string
+     * @param string|null $string
      * @param string      $esc_type
      * @param string|null $char_set
      *
-     * @return mixed|string
+     * @return string
      */
     public function sEscapeString($string, $esc_type = '', $char_set = null)
     {
+        if ($string === null) {
+            $string = '';
+        }
         if (empty($esc_type)) {
             if (!empty($this->sSettings['formatID']) && $this->sSettings['formatID'] == 3) {
                 $esc_type = 'html';
@@ -492,7 +495,7 @@ class sExport implements Enlight_Hook
 
             case 'quotes':
                 // Escape unescaped single quotes
-                return preg_replace("%(?<!\\\\)'%", "\\'", $string);
+                return (string) preg_replace("%(?<!\\\\)'%", "\\'", $string);
 
             case 'hex':
                 // Escape every character into hex
@@ -542,6 +545,8 @@ class sExport implements Enlight_Hook
 
                 return $_res;
         }
+
+        return $string;
     }
 
     /**

--- a/engine/Shopware/Core/sOrder.php
+++ b/engine/Shopware/Core/sOrder.php
@@ -63,12 +63,12 @@ class sOrder implements Enlight_Hook
      *
      * @var array
      */
-    public $sShippingData;
+    public $sShippingData = [];
 
     /**
      * User comment to save within this order
      *
-     * @var string
+     * @var string|null
      */
     public $sComment;
 
@@ -132,7 +132,7 @@ class sOrder implements Enlight_Hook
     /**
      * TransactionID (epayment)
      *
-     * @var string
+     * @var string|null
      */
     public $bookingId;
 
@@ -318,7 +318,7 @@ class sOrder implements Enlight_Hook
             // Not enough serial numbers anymore, inform merchant
             $context = [
                 'sArticleName' => $basketRow['articlename'],
-                'sMail' => $this->sUserData['additional']['user']['email'],
+                'sMail' => $this->sUserData['additional']['user']['email'] ?? null,
             ];
 
             $mail = Shopware()->TemplateMail()->createMail('sNOSERIALS', $context);
@@ -395,7 +395,7 @@ class sOrder implements Enlight_Hook
      */
     public function sCreateTemporaryOrder()
     {
-        $this->sShippingData[CartKey::AMOUNT_NUMERIC] = $this->sShippingData[CartKey::AMOUNT_NUMERIC] ? $this->sShippingData[CartKey::AMOUNT_NUMERIC] : '0';
+        $this->sShippingData[CartKey::AMOUNT_NUMERIC] = $this->sShippingData[CartKey::AMOUNT_NUMERIC] ?? '0';
         if (!$this->sShippingcostsNumeric) {
             $this->sShippingcostsNumeric = 0.;
         }
@@ -500,7 +500,7 @@ class sOrder implements Enlight_Hook
             if (!$basketRow['taxID']) {
                 $basketRow['taxID'] = '0';
             }
-            if (!$basketRow['releasedate']) {
+            if (empty($basketRow['releasedate'])) {
                 $basketRow['releasedate'] = null;
             }
 
@@ -508,7 +508,7 @@ class sOrder implements Enlight_Hook
                 'orderID' => $orderID,
                 'ordernumber' => 0,
                 'articleID' => $basketRow['articleID'],
-                'articleDetailID' => $basketRow['additional_details']['articleDetailsID'],
+                'articleDetailID' => $basketRow['additional_details']['articleDetailsID'] ?? null,
                 'articleordernumber' => $basketRow['ordernumber'],
                 'price' => $basketRow['priceNumeric'],
                 'quantity' => $basketRow['quantity'],
@@ -541,10 +541,10 @@ class sOrder implements Enlight_Hook
      */
     public function sSaveOrder()
     {
-        $this->sComment = stripslashes($this->sComment);
+        $this->sComment = stripslashes($this->sComment ?? '');
         $this->sComment = stripcslashes($this->sComment);
 
-        $this->sShippingData[CartKey::AMOUNT_NUMERIC] = $this->sShippingData[CartKey::AMOUNT_NUMERIC] ?: '0';
+        $this->sShippingData[CartKey::AMOUNT_NUMERIC] = $this->sShippingData[CartKey::AMOUNT_NUMERIC] ?? '0';
 
         if ($this->isTransactionExist($this->bookingId)) {
             return false;
@@ -610,7 +610,7 @@ class sOrder implements Enlight_Hook
             'invoice_amount_net' => $this->sBasketData[CartKey::AMOUNT_NET_NUMERIC],
             'invoice_shipping' => (float) $this->sShippingcostsNumeric,
             'invoice_shipping_net' => (float) $this->sShippingcostsNumericNet,
-            'invoice_shipping_tax_rate' => isset($this->sBasketData[CheckoutKey::SHIPPING_COSTS_TAX_PROPORTIONAL]) ? 0 : $this->sBasketData[CheckoutKey::SHIPPING_COSTS_TAX],
+            'invoice_shipping_tax_rate' => isset($this->sBasketData[CheckoutKey::SHIPPING_COSTS_TAX_PROPORTIONAL]) ? 0 : ($this->sBasketData[CheckoutKey::SHIPPING_COSTS_TAX] ?? 0),
             'ordertime' => new Zend_Db_Expr('NOW()'),
             'changed' => new Zend_Db_Expr('NOW()'),
             'status' => 0,
@@ -725,8 +725,8 @@ class sOrder implements Enlight_Hook
                 $basketRow['taxID'],
                 $basketRow['tax_rate'],
                 $this->db->quote((string) $basketRow['ean']),
-                $this->db->quote((string) $basketRow['itemUnit']),
-                $this->db->quote((string) $basketRow['packunit']),
+                $this->db->quote((string) ($basketRow['itemUnit'] ?? '')),
+                $this->db->quote((string) ($basketRow['packunit'] ?? '')),
                 $basketRow['additional_details']['articleDetailsID'] ?? 'null'
             );
 
@@ -824,7 +824,7 @@ class sOrder implements Enlight_Hook
             'sAmountNumeric' => $this->sAmountWithTax ? $this->sAmountWithTax : $this->sAmount,
             'sAmountNet' => $this->sSYSTEM->sMODULES['sArticles']->sFormatPrice($this->sBasketData[CartKey::AMOUNT_NET_NUMERIC]) . ' ' . $this->sBasketData[CheckoutKey::CURRENCY_NAME],
             'sAmountNetNumeric' => $this->sBasketData[CartKey::AMOUNT_NET_NUMERIC],
-            'sTaxRates' => $this->sBasketData[CheckoutKey::TAX_RATES],
+            'sTaxRates' => $this->sBasketData[CheckoutKey::TAX_RATES] ?? null,
             'ordernumber' => $orderNumber,
             'sOrderDay' => date('d.m.Y'),
             'sOrderTime' => date('H:i'),
@@ -893,37 +893,37 @@ class sOrder implements Enlight_Hook
         $shopContext = $this->contextService->getShopContext();
 
         $context = [
-            'sOrderDetails' => $variables['sOrderDetails'],
+            'sOrderDetails' => $variables['sOrderDetails'] ?? null,
 
-            'billingaddress' => $variables['billingaddress'],
-            'shippingaddress' => $variables['shippingaddress'],
+            'billingaddress' => $variables['billingaddress'] ?? null,
+            'shippingaddress' => $variables['shippingaddress'] ?? null,
             'additional' => $variables['additional'],
 
-            'sTaxRates' => $variables[CheckoutKey::TAX_RATES],
-            'sShippingCosts' => $variables['sShippingCosts'],
-            'sAmount' => $variables[CheckoutKey::AMOUNT],
-            'sAmountNumeric' => $variables['sAmountNumeric'],
-            'sAmountNet' => $variables['sAmountNet'],
-            'sAmountNetNumeric' => $variables['sAmountNetNumeric'],
+            'sTaxRates' => $variables[CheckoutKey::TAX_RATES] ?? null,
+            'sShippingCosts' => $variables['sShippingCosts'] ?? null,
+            'sAmount' => $variables[CheckoutKey::AMOUNT] ?? null,
+            'sAmountNumeric' => $variables['sAmountNumeric'] ?? null,
+            'sAmountNet' => $variables['sAmountNet'] ?? null,
+            'sAmountNetNumeric' => $variables['sAmountNetNumeric'] ?? null,
 
-            'sOrderNumber' => $variables['ordernumber'],
-            'sOrderDay' => $variables['sOrderDay'],
-            'sOrderTime' => $variables['sOrderTime'],
-            'sComment' => $variables['sComment'],
+            'sOrderNumber' => $variables['ordernumber'] ?? null,
+            'sOrderDay' => $variables['sOrderDay'] ?? null,
+            'sOrderTime' => $variables['sOrderTime'] ?? null,
+            'sComment' => $variables['sComment'] ?? null,
 
-            'attributes' => $variables['attributes'],
-            'sCurrency' => $this->sBasketData[CheckoutKey::CURRENCY_NAME],
+            'attributes' => $variables['attributes'] ?? null,
+            'sCurrency' => $this->sBasketData[CheckoutKey::CURRENCY_NAME] ?? null,
 
             'sLanguage' => $shopContext->getShop()->getId(),
 
             'sSubShop' => $shopContext->getShop()->getId(),
 
-            'sEsd' => $variables['sEsd'],
+            'sEsd' => $variables['sEsd'] ?? null,
             'sNet' => $this->sNet,
         ];
 
         // Support for individual payment means with custom-tables
-        if ($variables['additional']['payment']['table']) {
+        if (!empty($variables['additional']['payment']['table'])) {
             $paymentTable = $this->db->fetchRow(
                 "SELECT * FROM {$variables['additional']['payment']['table']}
                  WHERE userID=?",
@@ -934,11 +934,11 @@ class sOrder implements Enlight_Hook
             $context['sPaymentTable'] = [];
         }
 
-        if ($variables['sDispatch']) {
+        if (isset($variables['sDispatch'])) {
             $context['sDispatch'] = $variables['sDispatch'];
         }
 
-        if ($variables['sBookingID']) {
+        if (isset($variables['sBookingID'])) {
             $context['sBookingID'] = $variables['sBookingID'];
         }
 
@@ -973,7 +973,7 @@ class sOrder implements Enlight_Hook
             $mail = Shopware()->TemplateMail()->createMail('sORDER', $context, null, $overrideConfig);
         }
 
-        $mail->addTo($this->sUserData['additional']['user']['email']);
+        $mail->addTo($this->sUserData['additional']['user']['email'] ?? '');
 
         if (!$this->config->get('sNO_ORDER_MAIL')) {
             $mail->addBcc($this->config->get('sMAIL'));
@@ -1093,9 +1093,9 @@ class sOrder implements Enlight_Hook
             ':countryID' => $address['countryID'],
             ':stateID' => $address['stateID'],
             ':ustid' => $address['ustid'],
-            ':additional_address_line1' => $address['additional_address_line1'],
-            ':additional_address_line2' => $address['additional_address_line2'],
-            ':title' => $address['title'],
+            ':additional_address_line1' => $address['additional_address_line1'] ?? null,
+            ':additional_address_line2' => $address['additional_address_line2'] ?? null,
+            ':title' => $address['title'] ?? null,
         ];
         $array = $this->eventManager->filter(
             'Shopware_Modules_Order_SaveBilling_FilterArray',
@@ -1198,12 +1198,12 @@ class sOrder implements Enlight_Hook
             ':street' => (string) $address['street'],
             ':zipcode' => (string) $address['zipcode'],
             ':city' => (string) $address['city'],
-            ':phone' => (string) $address['phone'],
+            ':phone' => (string) ($address['phone'] ?? ''),
             ':countryID' => $address['countryID'],
             ':stateID' => $address['stateID'],
-            ':additional_address_line1' => (string) $address['additional_address_line1'],
-            ':additional_address_line2' => (string) $address['additional_address_line2'],
-            ':title' => (string) $address['title'],
+            ':additional_address_line1' => (string) ($address['additional_address_line1'] ?? ''),
+            ':additional_address_line2' => (string) ($address['additional_address_line2'] ?? ''),
+            ':title' => (string) ($address['title'] ?? ''),
         ];
         $array = $this->eventManager->filter(
             'Shopware_Modules_Order_SaveShipping_FilterArray',
@@ -1811,13 +1811,13 @@ EOT;
      * Checks if the passed transaction id is already set as transaction id of an
      * existing order.
      *
-     * @param string $transactionId
+     * @param string|null $transactionId
      *
      * @return bool
      */
     private function isTransactionExist($transactionId)
     {
-        if (\strlen($transactionId) <= 3) {
+        if (!\is_string($transactionId) || \strlen($transactionId) <= 3) {
             return false;
         }
 
@@ -1936,7 +1936,7 @@ EOT;
                 $content['articlename'] = str_replace("\n\n", "\n", $content['articlename']);
             }
 
-            $content['ordernumber'] = trim(html_entity_decode($content['ordernumber']));
+            $content['ordernumber'] = trim(html_entity_decode($content['ordernumber'] ?? ''));
 
             $details[] = $content;
         }
@@ -1997,7 +1997,7 @@ EOT;
     {
         $userData['billingaddress'] = $this->htmlEntityDecodeRecursive($userData['billingaddress']);
         $userData['shippingaddress'] = $this->htmlEntityDecodeRecursive($userData['shippingaddress']);
-        $userData['country'] = $this->htmlEntityDecodeRecursive($userData['country']);
+        $userData['country'] = $this->htmlEntityDecodeRecursive($userData['country'] ?? null);
 
         $userData['additional']['payment']['description'] = html_entity_decode(
             $userData['additional']['payment']['description']
@@ -2016,7 +2016,7 @@ EOT;
         }
 
         $func = static function ($item) use (&$func) {
-            return \is_array($item) ? array_map($func, $item) : html_entity_decode($item);
+            return \is_array($item) ? array_map($func, $item) : html_entity_decode((string) $item);
         };
 
         return array_map($func, $data);
@@ -2041,25 +2041,25 @@ EOT;
             $basketRow['articlename']
         );
 
-        if (!$basketRow['price']) {
+        if (empty($basketRow['price'])) {
             $basketRow['price'] = '0,00';
         }
-        if (!$basketRow['esdarticle']) {
+        if (empty($basketRow['esdarticle'])) {
             $basketRow['esdarticle'] = '0';
         }
-        if (!$basketRow['modus']) {
+        if (empty($basketRow['modus'])) {
             $basketRow['modus'] = '0';
         }
-        if (!$basketRow['taxID']) {
+        if (empty($basketRow['taxID'])) {
             $basketRow['taxID'] = '0';
         }
-        if ($this->sNet == true) {
+        if ($this->sNet) {
             $basketRow['taxID'] = '0';
         }
-        if (!$basketRow['ean']) {
+        if (empty($basketRow['ean'])) {
             $basketRow['ean'] = '';
         }
-        if (!$basketRow['releasedate']) {
+        if (empty($basketRow['releasedate'])) {
             $basketRow['releasedate'] = '0000-00-00';
         }
 

--- a/engine/Shopware/Models/Article/Repository.php
+++ b/engine/Shopware/Models/Article/Repository.php
@@ -1994,7 +1994,7 @@ class Repository extends ModelRepository
         $builder->leftJoin('supplier.articles', 'articles');
         $builder->groupBy('supplier.id');
 
-        if (\is_array($filter) && ($filter[0]['property'] === 'name')) {
+        if (\is_array($filter) && \array_key_exists(0, $filter) && ($filter[0]['property'] === 'name')) {
             // filter the displayed columns with the passed filter
             $builder
                 ->where('supplier.name LIKE ?1') // Search only the beginning of the customer number.

--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -201,7 +201,7 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
     public function __construct($id, $config = [])
     {
         // Test-data for preview mode
-        if ((bool) $config['_preview'] === true && (bool) $config['_previewSample'] === true) {
+        if ($config['_preview'] && ($config['_previewSample'] ?? null)) {
             $array = $this->getDemoData();
 
             $array['_order']->language = 1;
@@ -216,7 +216,7 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
         $this->_id = $id;
         $this->_config = $config;
         $this->_summaryNet = (bool) ($config['summaryNet'] ?? false);
-        $this->_shippingCostsAsPosition = (bool) $config['shippingCostsAsPosition'];
+        $this->_shippingCostsAsPosition = (bool) ($config['shippingCostsAsPosition'] ?? false);
 
         $this->getOrder();
 

--- a/engine/Shopware/Models/Mail/LogRepository.php
+++ b/engine/Shopware/Models/Mail/LogRepository.php
@@ -28,8 +28,8 @@ use DateTime;
 use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\QueryBuilder;
 use Shopware\Components\Model\ModelRepository;
+use Shopware\Components\Model\QueryBuilder;
 
 /**
  * @extends ModelRepository<Log>
@@ -100,9 +100,7 @@ class LogRepository extends ModelRepository implements LogRepositoryInterface
     protected function addDateConstraint(QueryBuilder $qb, ?DateTimeInterface $since, ?DateTimeInterface $until): void
     {
         $qb->andWhere('log.sentAt BETWEEN :since AND :until')
-            ->setParameters([
-                'since' => $since ?: $this->minDate,
-                'until' => $until ?: $this->maxDate,
-            ]);
+            ->setParameter('since', $since ?: $this->minDate)
+            ->setParameter('until', $until ?: $this->maxDate);
     }
 }

--- a/engine/Shopware/Models/Shop/DetachedShop.php
+++ b/engine/Shopware/Models/Shop/DetachedShop.php
@@ -41,6 +41,10 @@ class DetachedShop extends Shop
         $self = new self();
 
         foreach ($shop as $field => $value) {
+            if (\in_array($field, ['__initializer__', '__cloner__', '__isInitialized__'], true)) {
+                /* skip properties from Doctrine proxies @see \Doctrine\Common\Proxy\ProxyGenerator */
+                continue;
+            }
             $self->{$field} = $value;
         }
 

--- a/engine/Shopware/Plugins/Default/Backend/Auth/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Backend/Auth/Bootstrap.php
@@ -256,7 +256,7 @@ class Shopware_Plugins_Backend_Auth_Bootstrap extends Shopware_Components_Plugin
             }
 
             if (!$this->isAllowed($test)) {
-                throw new Enlight_Controller_Exception($test['errorMessage'] ?: 'Permission denied', 401);
+                throw new Enlight_Controller_Exception($test['errorMessage'] ?? 'Permission denied', 401);
             }
 
             return $auth;

--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Bootstrap.php
@@ -74,6 +74,8 @@ class Shopware_Plugins_Backend_SwagUpdate_Bootstrap extends Shopware_Components_
     /**
      * When index backend module was loaded, add our snippet- and template-directory
      * Also extend the template
+     *
+     * @return void
      */
     public function onBackendIndexPostDispatch(Enlight_Controller_ActionEventArgs $args)
     {

--- a/engine/Shopware/Plugins/Default/Core/ErrorHandler/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/ErrorHandler/Bootstrap.php
@@ -181,8 +181,8 @@ class Shopware_Plugins_Core_ErrorHandler_Bootstrap extends Shopware_Components_P
             return;
         }
 
-        // Ignore access to not initialized variables in smarty templates
-        if ($errno === E_NOTICE && stripos($errfile, '/var/cache/') !== false && stripos($errfile, '/templates/') !== false) {
+        // Ignore access to not initialized variables in smarty templates. Since PHP 8.0 those are warnings
+        if (\in_array($errno, [E_NOTICE, E_WARNING], true) && str_contains($errfile, '/var/cache/') && str_contains($errfile, '/templates/')) {
             return;
         }
 

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -865,11 +865,11 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
     private function hasSurrogateEsiCapability(Request $request): bool
     {
         $value = $request->getHeader('Surrogate-Capability');
-        if ($value === false) {
+        if (empty($value)) {
             return false;
         }
 
-        return strpos($value, 'ESI/1.0') !== false;
+        return str_contains($value, 'ESI/1.0');
     }
 
     /**

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/Bootstrap.php
@@ -215,8 +215,6 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      * Enable plugin method
      * Although plugin is flagged as capability: enable => false,
      * it can still be enabled/disabled programmatically
-     *
-     * @return bool
      */
     public function enable()
     {
@@ -227,8 +225,6 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      * Disable plugin method
      * Although plugin is flagged as capability: enable => false,
      * it can still be enabled/disabled programmatically
-     *
-     * @return bool
      */
     public function disable()
     {
@@ -237,6 +233,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
     /**
      * Install config-form
+     *
+     * @return void
      */
     public function installForm()
     {
@@ -308,8 +306,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      */
     public function getProxyUrl(?Request $request = null)
     {
-        $proxyUrl = trim($this->Config()->get('proxy'));
-        if (!empty($proxyUrl)) {
+        $proxyUrl = trim((string) $this->Config()->get('proxy', ''));
+        if ($proxyUrl !== '') {
             return $proxyUrl;
         }
 
@@ -320,11 +318,7 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
                    . $request->getBaseUrl() . '/';
         }
 
-        $em = $this->get(ModelManager::class);
-        $repository = $em->getRepository(Shop::class);
-
-        $shop = $repository->findOneBy(['default' => true]);
-
+        $shop = $this->get(ModelManager::class)->getRepository(Shop::class)->findOneBy(['default' => true]);
         if (!$shop->getHost()) {
             return null;
         }
@@ -339,6 +333,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
     /**
      * Do http caching jobs
+     *
+     * @return void
      */
     public function onPreDispatch(Enlight_Controller_ActionEventArgs $args)
     {
@@ -394,6 +390,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
     /**
      * On post dispatch we try to find affected articleIds displayed during this request
+     *
+     * @return void
      */
     public function onPostDispatch(Enlight_Controller_ActionEventArgs $args)
     {
@@ -439,6 +437,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
         if ($this->clearCache()) {
             return "Cleared HTTP-Cache\n";
         }
+
+        return '';
     }
 
     /**
@@ -450,6 +450,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      * <code>
      * Shopware()->Events()->notify('Shopware_Plugins_HttpCache_ClearCache');
      * </code>
+     *
+     * @return void
      */
     public function onClearCache(Enlight_Event_EventArgs $args)
     {
@@ -470,6 +472,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      *     array('cacheId' => 'a123')
      * );
      * </code>
+     *
+     * @return void
      */
     public function onInvalidateCacheId(Enlight_Event_EventArgs $args)
     {
@@ -486,6 +490,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
     /**
      * Sets the Shopware cache headers
+     *
+     * @return bool
      */
     public function setCacheHeaders()
     {
@@ -525,7 +531,9 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
     }
 
     /**
-     * This methods sets the nocache-cookie if actions in the shop are triggered
+     * This method sets the nocache-cookie if actions in the shop are triggered
+     *
+     * @return void
      */
     public function setNoCacheCookie()
     {
@@ -550,6 +558,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      *
      * @param string $newTag
      * @param bool   $remove
+     *
+     * @return void
      */
     public function setNoCacheTag($newTag, $remove = false)
     {
@@ -590,6 +600,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      * Helper function to flag the request with cacheIds to invalidate the caching.
      *
      * @param array $cacheIds
+     *
+     * @return void
      */
     public function setCacheIdHeader($cacheIds = [])
     {
@@ -609,6 +621,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
     /**
      * Execute cache invalidation after Doctrine flush
+     *
+     * @return void
      */
     public function postFlush(EventArgs $eventArgs)
     {
@@ -621,6 +635,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
     /**
      * Cache invalidation based on model events
+     *
+     * @return void
      */
     public function onPostPersist(Enlight_Event_EventArgs $eventArgs)
     {
@@ -697,6 +713,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      *
      * @param int   $cacheTime
      * @param array $cacheIds
+     *
+     * @return void
      */
     public function enableControllerCache($cacheTime = 3600, $cacheIds = [])
     {
@@ -706,13 +724,15 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
     /**
      * Helper function to disable the http cache for a single shopware controller
+     *
+     * @return void
      */
     public function disableControllerCache()
     {
         $this->response->headers->set('cache-control', 'private', true);
     }
 
-    private function getResponseCookie(Response $response)
+    private function getResponseCookie(Response $response): ?string
     {
         $cookies = $response->getCookies();
         foreach ($cookies as $cookie) {
@@ -726,10 +746,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
 
     /**
      * Clears the cache
-     *
-     * @return bool
      */
-    private function clearCache()
+    private function clearCache(): bool
     {
         return $this->invalidate();
     }
@@ -739,12 +757,8 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      *
      * This sends a http-ban-request to the proxyUrl containing
      * the $cacheId in the x-shopware-invalidates http-header
-     *
-     * @param string $cacheId
-     *
-     * @return bool
      */
-    private function invalidateCacheId($cacheId)
+    private function invalidateCacheId(string $cacheId): bool
     {
         if (!$this->Config()->get('proxyPrune')) {
             return false;
@@ -757,14 +771,14 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      * Will send BAN requests to all configured reverse proxies. If cacheId is provided,
      * the corresponding headers will be set.
      *
-     * @param string $cacheId If set, only pages including these cacheIds will be invalidated
+     * @param string|null $cacheId If set, only pages including these cacheIds will be invalidated
      *
      * @return bool True will be returned, if *all* operations succeeded
      */
-    private function invalidate($cacheId = null)
+    private function invalidate(?string $cacheId = null): bool
     {
-        $proxyUrl = trim($this->Config()->get('proxy'));
-        if (!empty($proxyUrl)) {
+        $proxyUrl = trim((string) $this->Config()->get('proxy', ''));
+        if ($proxyUrl !== '') {
             return $this->invalidateWithBANRequest($proxyUrl, $cacheId);
         }
 
@@ -782,12 +796,9 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
     }
 
     /**
-     * @param string $urls    Comma separated URLs
-     * @param string $cacheId
-     *
-     * @return bool
+     * @param string $urls Comma separated URLs
      */
-    private function invalidateWithBANRequest($urls, $cacheId)
+    private function invalidateWithBANRequest(string $urls, ?string $cacheId): bool
     {
         // Expand + trim proxies (comma separated)
         $urls = array_map(
@@ -823,12 +834,7 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
         return $success;
     }
 
-    /**
-     * @param string $cacheId
-     *
-     * @return bool
-     */
-    private function invalidateWithStore($cacheId = null)
+    private function invalidateWithStore(?string $cacheId = null): bool
     {
         /** @var HttpCache $httpCache */
         $httpCache = $this->get('httpcache');
@@ -850,7 +856,7 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
      *
      * @param Response $response A Response instance
      */
-    private function addSurrogateControl(Response $response)
+    private function addSurrogateControl(Response $response): void
     {
         $response->headers->set('Surrogate-Control', 'content="ESI/1.0"', true);
     }
@@ -875,7 +881,7 @@ class Shopware_Plugins_Core_HttpCache_Bootstrap extends Shopware_Components_Plug
     /**
      * Add context cookie
      */
-    private function addContextCookie(Request $request, Response $response)
+    private function addContextCookie(Request $request, Response $response): void
     {
         /** @var CacheControl $cacheControl */
         $cacheControl = $this->get('http_cache.cache_control');

--- a/engine/Shopware/Plugins/Default/Core/HttpCache/CacheControl.php
+++ b/engine/Shopware/Plugins/Default/Core/HttpCache/CacheControl.php
@@ -178,7 +178,7 @@ class CacheControl
     public function getNoCacheTagsForRequest(Request $request, $shopId)
     {
         $tags = [];
-        $autoAdmin = $this->config['admin'];
+        $autoAdmin = $this->config['admin'] ?? null;
 
         if (!empty($autoAdmin)) {
             $tags[] = 'admin-' . $shopId;

--- a/engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/MarketingAggregate/Bootstrap.php
@@ -372,7 +372,7 @@ class Shopware_Plugins_Core_MarketingAggregate_Bootstrap extends Shopware_Compon
 
         $details = $arguments->getDetails();
         foreach ($details as $article) {
-            if ($article['modus'] != 0 || empty($article['articleID'])) {
+            if (($article['modus'] ?? null) != 0 || empty($article['articleID'])) {
                 continue;
             }
 

--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Bootstrap.php
@@ -22,6 +22,10 @@
  * our trademarks remain entirely with us.
  */
 
+use ShopwarePlugin\PaymentMethods\Components\DebitPaymentMethod;
+use ShopwarePlugin\PaymentMethods\Components\GenericPaymentMethod;
+use ShopwarePlugin\PaymentMethods\Components\SepaPaymentMethod;
+
 class Shopware_Plugins_Core_PaymentMethods_Bootstrap extends Shopware_Components_Plugin_Bootstrap
 {
     /**
@@ -96,15 +100,17 @@ class Shopware_Plugins_Core_PaymentMethods_Bootstrap extends Shopware_Components
 
         $this->Application()->Loader()->registerNamespace('ShopwarePlugin\PaymentMethods\Components', __DIR__ . '/Components/');
 
-        $dirs['debit'] = 'ShopwarePlugin\PaymentMethods\Components\DebitPaymentMethod';
-        $dirs['sepa'] = 'ShopwarePlugin\PaymentMethods\Components\SepaPaymentMethod';
-        $dirs['default'] = 'ShopwarePlugin\PaymentMethods\Components\GenericPaymentMethod';
+        $dirs['debit'] = DebitPaymentMethod::class;
+        $dirs['sepa'] = SepaPaymentMethod::class;
+        $dirs['default'] = GenericPaymentMethod::class;
 
         return $dirs;
     }
 
     /**
      * Add View path to Smarty
+     *
+     * @return void
      */
     public function addPaths(Enlight_Event_EventArgs $arguments)
     {
@@ -117,6 +123,8 @@ class Shopware_Plugins_Core_PaymentMethods_Bootstrap extends Shopware_Components
 
     /**
      * Called when the BackendOrderPostDispatch Event is triggered
+     *
+     * @return void
      */
     public function onBackendOrderPostDispatch(Enlight_Event_EventArgs $args)
     {
@@ -137,6 +145,8 @@ class Shopware_Plugins_Core_PaymentMethods_Bootstrap extends Shopware_Components
 
     /**
      * Called when the BackendCustomerPostDispatch Event is triggered
+     *
+     * @return void
      */
     public function onBackendCustomerPostDispatch(Enlight_Event_EventArgs $args)
     {
@@ -159,7 +169,7 @@ class Shopware_Plugins_Core_PaymentMethods_Bootstrap extends Shopware_Components
     /**
      * Registers all necessary events and hooks.
      */
-    private function subscribeEvents()
+    private function subscribeEvents(): void
     {
         $this->subscribeEvent(
             'Shopware_Modules_Admin_InitiatePaymentClass_AddClass',

--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Components/DebitPaymentMethod.php
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Components/DebitPaymentMethod.php
@@ -53,7 +53,7 @@ class DebitPaymentMethod extends GenericPaymentMethod
         ];
 
         foreach ($fields as $field) {
-            $value = $paymentData[$field] ?: '';
+            $value = $paymentData[$field] ?? '';
             $value = trim($value);
 
             if (empty($value)) {

--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Components/GenericPaymentMethod.php
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Components/GenericPaymentMethod.php
@@ -27,6 +27,7 @@ namespace ShopwarePlugin\PaymentMethods\Components;
 use DateTime;
 use Enlight_Controller_Request_Request;
 use Shopware\Models\Customer\Customer;
+use Shopware\Models\Order\Order;
 
 /**
  * Used for all payment methods that require no specific logic
@@ -65,7 +66,7 @@ class GenericPaymentMethod extends BasePaymentMethod
     {
         $orderAmount = Shopware()->Models()->createQueryBuilder()
             ->select('orders.invoiceAmount')
-            ->from('Shopware\Models\Order\Order', 'orders')
+            ->from(Order::class, 'orders')
             ->where('orders.id = ?1')
             ->setParameter(1, $orderId)
             ->getQuery()

--- a/engine/Shopware/Plugins/Default/Core/PaymentMethods/Components/SepaPaymentMethod.php
+++ b/engine/Shopware/Plugins/Default/Core/PaymentMethods/Components/SepaPaymentMethod.php
@@ -52,13 +52,13 @@ class SepaPaymentMethod extends GenericPaymentMethod
         $sErrorFlag = [];
         $sErrorMessages = [];
 
-        if (!$paymentData['sSepaIban'] || trim($paymentData['sSepaIban']) === '') {
+        if (empty($paymentData['sSepaIban']) || trim($paymentData['sSepaIban']) === '') {
             $sErrorFlag['sSepaIban'] = true;
         }
-        if (Shopware()->Config()->get('sepaShowBic') && Shopware()->Config()->get('sepaRequireBic') && (!$paymentData['sSepaBic'] || trim($paymentData['sSepaBic']) === '')) {
+        if (Shopware()->Config()->get('sepaShowBic') && Shopware()->Config()->get('sepaRequireBic') && (empty($paymentData['sSepaBic']) || trim($paymentData['sSepaBic']) === '')) {
             $sErrorFlag['sSepaBic'] = true;
         }
-        if (Shopware()->Config()->get('sepaShowBankName') && Shopware()->Config()->get('sepaRequireBankName') && (!$paymentData['sSepaBankName'] || trim($paymentData['sSepaBankName']) === '')) {
+        if (Shopware()->Config()->get('sepaShowBankName') && Shopware()->Config()->get('sepaRequireBankName') && (empty($paymentData['sSepaBankName']) || trim($paymentData['sSepaBankName']) === '')) {
             $sErrorFlag['sSepaBankName'] = true;
         }
 
@@ -71,7 +71,7 @@ class SepaPaymentMethod extends GenericPaymentMethod
             $sErrorMessages[] = Shopware()->Snippets()->getNamespace('frontend/account/internalMessages')->get('ErrorFillIn', 'Please fill in all red fields');
         }
 
-        if ($paymentData['sSepaIban'] && !$this->validateIBAN((string) $paymentData['sSepaIban'])) {
+        if (isset($paymentData['sSepaIban']) && !$this->validateIBAN((string) $paymentData['sSepaIban'])) {
             $sErrorMessages[] = Shopware()->Snippets()->getNamespace('frontend/plugins/payment/sepa')->get('ErrorIBAN', 'Invalid IBAN');
             $sErrorFlag['sSepaIban'] = true;
         }
@@ -171,7 +171,12 @@ class SepaPaymentMethod extends GenericPaymentMethod
             ->find($userId)->getDefaultBillingAddress();
         $paymentData = $this->getCurrentPaymentDataAsArray($userId);
         if (!\is_array($paymentData)) {
-            $paymentData = [];
+            $paymentData = [
+                'sSepaUseBillingData' => null,
+                'sSepaBankName' => null,
+                'sSepaBic' => null,
+                'sSepaIban' => null,
+            ];
         }
 
         $date = new DateTime();

--- a/engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/RestApi/Bootstrap.php
@@ -77,6 +77,8 @@ class Shopware_Plugins_Core_RestApi_Bootstrap extends Shopware_Components_Plugin
 
     /**
      * Listener method for the Enlight_Controller_Front_DispatchLoopStartup event.
+     *
+     * @return void
      */
     public function onDispatchLoopStartup(Enlight_Controller_EventArgs $args)
     {
@@ -95,6 +97,8 @@ class Shopware_Plugins_Core_RestApi_Bootstrap extends Shopware_Components_Plugin
 
     /**
      * This pre-dispatch event-hook checks permissions
+     *
+     * @return void
      */
     public function onFrontPreDispatch(Enlight_Controller_EventArgs $args)
     {
@@ -160,7 +164,7 @@ class Shopware_Plugins_Core_RestApi_Bootstrap extends Shopware_Components_Plugin
     public function onInitResourceAuth(Enlight_Event_EventArgs $args)
     {
         if (!$this->isApiCall) {
-            return;
+            return null;
         }
 
         $adapter = new Zend_Auth_Adapter_Http([

--- a/engine/Shopware/Plugins/Default/Core/System/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/System/Bootstrap.php
@@ -53,6 +53,8 @@ class Shopware_Plugins_Core_System_Bootstrap extends Shopware_Components_Plugin_
     /**
      * Listener method of the Enlight_Controller_Front_DispatchLoopShutdown event.
      * If the request is from a Bot, discard the session
+     *
+     * @return void
      */
     public function onDispatchLoopShutdown(Enlight_Controller_EventArgs $args)
     {
@@ -67,7 +69,7 @@ class Shopware_Plugins_Core_System_Bootstrap extends Shopware_Components_Plugin_
 
         /** @var Shopware_Plugins_Frontend_Statistics_Bootstrap $plugin */
         $plugin = Shopware()->Plugins()->Frontend()->Statistics();
-        if ($plugin->checkIsBot($args->getRequest()->getHeader('USER_AGENT'))) {
+        if ($plugin->checkIsBot($args->getRequest()->getHeader('USER_AGENT') ?: '')) {
             $this->get('session')->invalidate();
         }
     }
@@ -97,7 +99,7 @@ class Shopware_Plugins_Core_System_Bootstrap extends Shopware_Components_Plugin_
             if ($request !== null && Shopware()->Session()->get('Bot') === null) {
                 /** @var Shopware_Plugins_Frontend_Statistics_Bootstrap $plugin */
                 $plugin = Shopware()->Plugins()->Frontend()->Statistics();
-                Shopware()->Session()->set('Bot', $plugin->checkIsBot($request->getHeader('USER_AGENT')));
+                Shopware()->Session()->set('Bot', $plugin->checkIsBot($request->getHeader('USER_AGENT') ?: ''));
             }
             $system->sBotSession = Shopware()->Session()->get('Bot');
         }

--- a/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
@@ -129,7 +129,7 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
         $view->assign('ShowNotification', true);
 
         $sNotificationArticleWaitingForOptInApprovement = $session->get('sNotifcationArticleWaitingForOptInApprovement', []);
-        $view->assign('WaitingForOptInApprovement', $sNotificationArticleWaitingForOptInApprovement[$sArticle['ordernumber']]);
+        $view->assign('WaitingForOptInApprovement', $sNotificationArticleWaitingForOptInApprovement[$sArticle['ordernumber']] ?? null);
     }
 
     /**

--- a/tests/Functional/Bundle/AccountBundle/Controller/AccountTest.php
+++ b/tests/Functional/Bundle/AccountBundle/Controller/AccountTest.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
 
 namespace Shopware\Tests\Functional\Bundle\AccountBundle\Controller;
 
-use Enlight_Components_Db_Adapter_Pdo_Mysql;
 use Enlight_Components_Session_Namespace;
 use Enlight_Components_Test_Controller_TestCase as ControllerTestCase;
 use Shopware_Components_Config;
@@ -127,12 +126,12 @@ class AccountTest extends ControllerTestCase
     public function testHashPostLogin(): void
     {
         // test with md5 password and without the ignoreAccountMode parameter
-        static::assertEmpty($this->session->offsetGet('sUserId'));
+        static::assertEmpty($this->session->get('sUserId'));
 
         $this->setUserDataToPost();
         $this->dispatch('/account/login');
 
-        static::assertEmpty($this->session->offsetGet('sUserId'));
+        static::assertEmpty($this->session->get('sUserId'));
 
         $this->logoutUser();
     }
@@ -222,9 +221,10 @@ class AccountTest extends ControllerTestCase
     {
         $sql = 'SELECT email, password FROM s_user WHERE id = 1';
         $database = $this->container->get('db');
-        static::assertInstanceOf(Enlight_Components_Db_Adapter_Pdo_Mysql::class, $database);
 
         $userData = $database->fetchRow($sql);
+        static::assertNotEmpty($userData['email']);
+        static::assertNotEmpty($userData['password']);
         $this->Request()->setMethod('POST')
             ->setPost('email', $userData['email'])
             ->setPost('passwordMD5', $userData['password']);

--- a/tests/Functional/Bundle/AccountBundle/Controller/RegisterTest.php
+++ b/tests/Functional/Bundle/AccountBundle/Controller/RegisterTest.php
@@ -72,6 +72,7 @@ class RegisterTest extends ControllerTestCase
             'register' => [
                 'personal' => $this->getPersonalData(),
                 'billing' => $this->getBillingData(),
+                'shipping' => $this->getShippingData(),
             ],
         ]);
 
@@ -104,6 +105,7 @@ class RegisterTest extends ControllerTestCase
             'register' => [
                 'personal' => $this->getPersonalData(),
                 'billing' => $this->getBillingData(),
+                'shipping' => $this->getShippingData(),
             ],
         ]);
 
@@ -173,6 +175,7 @@ class RegisterTest extends ControllerTestCase
                     'company' => 'company',
                     'department' => 'department',
                 ]),
+                'shipping' => $this->getShippingData(),
             ],
         ]);
 
@@ -199,6 +202,7 @@ class RegisterTest extends ControllerTestCase
                     'accountmode' => Customer::ACCOUNT_MODE_FAST_LOGIN,
                 ]),
                 'billing' => $this->getBillingData(),
+                'shipping' => $this->getShippingData(),
             ],
         ]);
 
@@ -228,6 +232,7 @@ class RegisterTest extends ControllerTestCase
             'register' => [
                 'personal' => $this->getPersonalData(),
                 'billing' => $this->getBillingData(),
+                'shipping' => $this->getShippingData(),
             ],
         ]);
 

--- a/tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
+++ b/tests/Functional/Bundle/AttributeBundle/SchemaOperatorTest.php
@@ -24,26 +24,30 @@
 
 namespace Shopware\Tests\Functional\Bundle\AttributeBundle;
 
+use Doctrine\DBAL\DBALException;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Shopware\Bundle\AttributeBundle\Service\ConfigurationStruct;
+use Shopware\Bundle\AttributeBundle\Service\CrudService;
+use Shopware\Bundle\AttributeBundle\Service\TableMapping;
+use Shopware\Bundle\AttributeBundle\Service\TypeMappingInterface;
 
 class SchemaOperatorTest extends TestCase
 {
     public function testDefaultValues(): void
     {
         $types = [
-            'string' => 'test123',
-            'integer' => 123,
-            'float' => 123,
-            'boolean' => 1,
-            'date' => '2010-01-01',
-            'datetime' => '2010-01-01 10:00:00',
-            'text' => 'test123',
-            'html' => 'test123',
-            'combobox' => '1',
-            'multi_selection' => '1',
-            'single_selection' => 'SW10003',
+            TypeMappingInterface::TYPE_STRING => 'test123',
+            TypeMappingInterface::TYPE_INTEGER => 123,
+            TypeMappingInterface::TYPE_FLOAT => 123,
+            TypeMappingInterface::TYPE_BOOLEAN => 1,
+            TypeMappingInterface::TYPE_DATE => '2010-01-01',
+            TypeMappingInterface::TYPE_DATETIME => '2010-01-01 10:00:00',
+            TypeMappingInterface::TYPE_TEXT => 'test123',
+            TypeMappingInterface::TYPE_HTML => 'test123',
+            TypeMappingInterface::TYPE_COMBOBOX => '1',
+            TypeMappingInterface::TYPE_MULTI_SELECTION => '1',
+            TypeMappingInterface::TYPE_SINGLE_SELECTION => 'SW10003',
         ];
 
         $this->iterateTypeArray($types);
@@ -52,17 +56,17 @@ class SchemaOperatorTest extends TestCase
     public function testNullDefaultValues(): void
     {
         $types = [
-            'string' => null,
-            'integer' => null,
-            'float' => null,
-            'boolean' => null,
-            'date' => null,
-            'datetime' => null,
-            'text' => null,
-            'html' => null,
-            'combobox' => null,
-            'multi_selection' => null,
-            'single_selection' => null,
+            TypeMappingInterface::TYPE_STRING => null,
+            TypeMappingInterface::TYPE_INTEGER => null,
+            TypeMappingInterface::TYPE_FLOAT => null,
+            TypeMappingInterface::TYPE_BOOLEAN => null,
+            TypeMappingInterface::TYPE_DATE => null,
+            TypeMappingInterface::TYPE_DATETIME => null,
+            TypeMappingInterface::TYPE_TEXT => null,
+            TypeMappingInterface::TYPE_HTML => null,
+            TypeMappingInterface::TYPE_COMBOBOX => null,
+            TypeMappingInterface::TYPE_MULTI_SELECTION => null,
+            TypeMappingInterface::TYPE_SINGLE_SELECTION => null,
         ];
 
         $this->iterateTypeArray($types);
@@ -71,17 +75,17 @@ class SchemaOperatorTest extends TestCase
     public function testNullStringDefaultValues(): void
     {
         $types = [
-            'string' => 'NULL',
-            'integer' => 'NULL',
-            'float' => 'NULL',
-            'boolean' => 'NULL',
-            'date' => 'NULL',
-            'datetime' => 'NULL',
-            'text' => 'NULL',
-            'html' => 'NULL',
-            'combobox' => 'NULL',
-            'multi_selection' => 'NULL',
-            'single_selection' => 'NULL',
+            TypeMappingInterface::TYPE_STRING => 'NULL',
+            TypeMappingInterface::TYPE_INTEGER => 'NULL',
+            TypeMappingInterface::TYPE_FLOAT => 'NULL',
+            TypeMappingInterface::TYPE_BOOLEAN => 'NULL',
+            TypeMappingInterface::TYPE_DATE => 'NULL',
+            TypeMappingInterface::TYPE_DATETIME => 'NULL',
+            TypeMappingInterface::TYPE_TEXT => 'NULL',
+            TypeMappingInterface::TYPE_HTML => 'NULL',
+            TypeMappingInterface::TYPE_COMBOBOX => 'NULL',
+            TypeMappingInterface::TYPE_MULTI_SELECTION => 'NULL',
+            TypeMappingInterface::TYPE_SINGLE_SELECTION => 'NULL',
         ];
 
         $this->iterateTypeArray($types);
@@ -92,16 +96,16 @@ class SchemaOperatorTest extends TestCase
      */
     public function testDefaultValuesBoolean(): void
     {
-        $this->iterateTypeArray(['boolean' => 1]);
-        $this->iterateTypeArray(['boolean' => 0]);
-        $this->iterateTypeArray(['boolean' => true]);
-        $this->iterateTypeArray(['boolean' => false]);
-        $this->iterateTypeArray(['boolean' => null]);
-        $this->iterateTypeArray(['boolean' => '1']);
-        $this->iterateTypeArray(['boolean' => '0']);
-        $this->iterateTypeArray(['boolean' => 'true']);
-        $this->iterateTypeArray(['boolean' => 'false']);
-        $this->iterateTypeArray(['boolean' => 'null']);
+        $this->iterateTypeArray([TypeMappingInterface::TYPE_BOOLEAN => 1]);
+        $this->iterateTypeArray([TypeMappingInterface::TYPE_BOOLEAN => 0]);
+        $this->iterateTypeArray([TypeMappingInterface::TYPE_BOOLEAN => true]);
+        $this->iterateTypeArray([TypeMappingInterface::TYPE_BOOLEAN => false]);
+        $this->iterateTypeArray([TypeMappingInterface::TYPE_BOOLEAN => null]);
+        $this->iterateTypeArray([TypeMappingInterface::TYPE_BOOLEAN => '1']);
+        $this->iterateTypeArray([TypeMappingInterface::TYPE_BOOLEAN => '0']);
+        $this->iterateTypeArray([TypeMappingInterface::TYPE_BOOLEAN => 'true']);
+        $this->iterateTypeArray([TypeMappingInterface::TYPE_BOOLEAN => 'false']);
+        $this->iterateTypeArray([TypeMappingInterface::TYPE_BOOLEAN => 'null']);
     }
 
     public function testUpdateConfiguration(): void
@@ -109,22 +113,21 @@ class SchemaOperatorTest extends TestCase
         $service = Shopware()->Container()->get('shopware_attribute.crud_service');
         $tableMapping = Shopware()->Container()->get('shopware_attribute.table_mapping');
         $table = 's_articles_attributes';
-        $columnName = 'attr_' . uniqid((string) mt_rand(), false);
+        $columnName = 'attr_' . uniqid((string) mt_rand());
 
-        $service->update($table, $columnName, 'bool');
+        $service->update($table, $columnName, TypeMappingInterface::TYPE_BOOLEAN);
         static::assertTrue($tableMapping->isTableColumn($table, $columnName));
-        $service->update($table, $columnName, 'date');
+        $service->update($table, $columnName, TypeMappingInterface::TYPE_DATE);
         static::assertTrue($tableMapping->isTableColumn($table, $columnName));
 
-        /** @var ConfigurationStruct|null $column */
         $column = $service->get($table, $columnName);
         static::assertInstanceOf(ConfigurationStruct::class, $column);
-        static::assertEquals('date', $column->getColumnType());
+        static::assertEquals(TypeMappingInterface::TYPE_DATE, $column->getColumnType());
     }
 
     public function testReinsertColumnConfigurationShouldFail(): void
     {
-        $this->expectException(\Doctrine\DBAL\DBALException::class);
+        $this->expectException(DBALException::class);
         $connection = Shopware()->Container()->get('dbal_connection');
         $attributeData = [
             'table_name' => 's_articles_attributes',
@@ -136,14 +139,14 @@ class SchemaOperatorTest extends TestCase
     }
 
     /**
-     * @param array $types
+     * @param array<string, mixed> $types
      *
      * @throws Exception
      */
-    private function iterateTypeArray($types): void
+    private function iterateTypeArray(array $types): void
     {
-        $service = Shopware()->Container()->get(\Shopware\Bundle\AttributeBundle\Service\CrudService::class);
-        $tableMapping = Shopware()->Container()->get(\Shopware\Bundle\AttributeBundle\Service\TableMapping::class);
+        $service = Shopware()->Container()->get(CrudService::class);
+        $tableMapping = Shopware()->Container()->get(TableMapping::class);
         $table = 's_articles_attributes';
 
         foreach ($types as $type => $default) {

--- a/tests/Functional/Bundle/CustomerSearchBundleDBAL/TestCase.php
+++ b/tests/Functional/Bundle/CustomerSearchBundleDBAL/TestCase.php
@@ -114,7 +114,7 @@ class TestCase extends Enlight_Components_Test_TestCase
             $customer['addresses'] = [['country_id' => 2]];
         }
 
-        $customerId = $this->insert('s_user', array_merge([
+        $customerData = array_merge([
             'firstname' => 'example',
             'lastname' => 'example',
             'customergroup' => 'EK',
@@ -123,7 +123,9 @@ class TestCase extends Enlight_Components_Test_TestCase
             'paymentpreset' => 1,
             'subshopID' => $customer['subshopID'] ?? 1000,
             'failedlogins' => 0,
-        ], $customer));
+        ], $customer);
+        unset($customerData['addresses'], $customerData['orders'], $customerData['newsletter']);
+        $customerId = $this->insert('s_user', $customerData);
 
         if (\array_key_exists('addresses', $customer)) {
             foreach ($customer['addresses'] as $address) {

--- a/tests/Functional/Bundle/SearchBundle/Condition/ImmediateDeliveryConditionTest.php
+++ b/tests/Functional/Bundle/SearchBundle/Condition/ImmediateDeliveryConditionTest.php
@@ -43,10 +43,10 @@ class ImmediateDeliveryConditionTest extends TestCase
 
         $this->search(
             [
-                'first' => ['inStock' => 0, 'minPurchase' => 1],
-                'second' => ['inStock' => 0, 'minPurchase' => 1],
-                'third' => ['inStock' => 2, 'minPurchase' => 1],
-                'fourth' => ['inStock' => 1, 'minPurchase' => 1],
+                'first' => ['inStock' => 0, 'minPurchase' => 1, 'createVariants' => false],
+                'second' => ['inStock' => 0, 'minPurchase' => 1, 'createVariants' => false],
+                'third' => ['inStock' => 2, 'minPurchase' => 1, 'createVariants' => false],
+                'fourth' => ['inStock' => 1, 'minPurchase' => 1, 'createVariants' => false],
             ],
             ['third', 'fourth'],
             null,
@@ -60,10 +60,10 @@ class ImmediateDeliveryConditionTest extends TestCase
 
         $this->search(
             [
-                'first' => ['inStock' => 0, 'minPurchase' => 1],
-                'second' => ['inStock' => 0, 'minPurchase' => 1],
-                'third' => ['inStock' => 3, 'minPurchase' => 3],
-                'fourth' => ['inStock' => 20, 'minPurchase' => 20],
+                'first' => ['inStock' => 0, 'minPurchase' => 1, 'createVariants' => false],
+                'second' => ['inStock' => 0, 'minPurchase' => 1, 'createVariants' => false],
+                'third' => ['inStock' => 3, 'minPurchase' => 3, 'createVariants' => false],
+                'fourth' => ['inStock' => 20, 'minPurchase' => 20, 'createVariants' => false],
             ],
             ['third', 'fourth'],
             null,
@@ -77,11 +77,11 @@ class ImmediateDeliveryConditionTest extends TestCase
 
         $this->search(
             [
-                'first' => ['inStock' => 0, 'minPurchase' => 1],
-                'second' => ['inStock' => 0, 'minPurchase' => 1],
-                'third' => ['inStock' => 1, 'minPurchase' => 1],
+                'first' => ['inStock' => 0, 'minPurchase' => 1, 'createVariants' => false],
+                'second' => ['inStock' => 0, 'minPurchase' => 1, 'createVariants' => false],
+                'third' => ['inStock' => 1, 'minPurchase' => 1, 'createVariants' => false],
                 'fourth' => ['inStock' => 1, 'minPurchase' => 1, 'createVariants' => true],
-                'fifth' => ['inStock' => 2, 'minPurchase' => 1],
+                'fifth' => ['inStock' => 2, 'minPurchase' => 1, 'createVariants' => false],
             ],
             ['third', 'fifth'],
             null,
@@ -118,10 +118,10 @@ class ImmediateDeliveryConditionTest extends TestCase
         $additionally
     ): Article {
         if ($additionally['createVariants'] === true) {
-            $fourth = $this->getProduct('fourth', $context, $category);
+            $fourth = $this->getProduct($number, $context, $category);
             $configurator = $this->helper->getConfigurator(
                 $context->getCurrentCustomerGroup(),
-                'fourth'
+                $number
             );
 
             $fourth = array_merge($fourth, $configurator);

--- a/tests/Functional/Bundle/SearchBundle/Condition/PriceConditionTest.php
+++ b/tests/Functional/Bundle/SearchBundle/Condition/PriceConditionTest.php
@@ -225,7 +225,7 @@ class PriceConditionTest extends TestCase
             ];
         }
 
-        if ($prices['priceGroup']) {
+        if (isset($prices['priceGroup'])) {
             $product['priceGroupActive'] = true;
             $product['priceGroupId'] = $prices['priceGroup']->getId();
         }

--- a/tests/Functional/Bundle/SearchBundle/Condition/VariantConditionWithPriceGroupTest.php
+++ b/tests/Functional/Bundle/SearchBundle/Condition/VariantConditionWithPriceGroupTest.php
@@ -266,7 +266,7 @@ class VariantConditionWithPriceGroupTest extends TestCase
             ++$i;
         }
 
-        if ($data['priceGroup']) {
+        if (isset($data['priceGroup'])) {
             $product['priceGroupActive'] = true;
             $product['priceGroupId'] = $data['priceGroup']->getId();
         }

--- a/tests/Functional/Bundle/StoreFrontBundle/ManufacturerTest.php
+++ b/tests/Functional/Bundle/StoreFrontBundle/ManufacturerTest.php
@@ -37,7 +37,7 @@ class ManufacturerTest extends TestCase
 
         $manufacturer = $this->helper->createManufacturer([
             'name' => 'testManufacturerList-1',
-            'image' => 'Manufacturer-Cover-1',
+            'image' => 'media/image/Manufacturer-Cover-1',
             'link' => 'www.google.de?manufacturer=1',
             'metaTitle' => 'Meta title',
             'description' => 'Lorem ipsum manufacturer',
@@ -47,7 +47,7 @@ class ManufacturerTest extends TestCase
 
         $manufacturer = $this->helper->createManufacturer([
             'name' => 'testManufacturerList-2',
-            'image' => 'Manufacturer-Cover-2.jpg',
+            'image' => 'media/image/Manufacturer-Cover-2.jpg',
             'link' => 'www.google.de?manufacturer=2',
             'metaTitle' => 'Meta title',
             'description' => 'Lorem ipsum manufacturer',
@@ -57,7 +57,7 @@ class ManufacturerTest extends TestCase
 
         $manufacturer = $this->helper->createManufacturer([
             'name' => 'testManufacturerList-2',
-            'image' => 'Manufacturer-Cover-2.jpg',
+            'image' => 'media/image/Manufacturer-Cover-2.jpg',
             'link' => 'www.google.de?manufacturer=2',
             'metaTitle' => 'Meta title',
             'description' => 'Lorem ipsum manufacturer',

--- a/tests/Functional/Bundle/StoreFrontBundle/VoteTest.php
+++ b/tests/Functional/Bundle/StoreFrontBundle/VoteTest.php
@@ -192,7 +192,7 @@ class VoteTest extends TestCase
         $config = Shopware()->Container()->get(Shopware_Components_Config::class);
         $originals = [];
         foreach ($configs as $key => $value) {
-            $originals = $config->get($key);
+            $originals[$key] = $config->get($key);
             $config->offsetSet($key, $value);
         }
 

--- a/tests/Functional/Components/Api/CacheTest.php
+++ b/tests/Functional/Components/Api/CacheTest.php
@@ -89,7 +89,7 @@ class CacheTest extends TestCase
         $this->getResource()->delete('template');
 
         $info = $this->getResource()->getOne('template');
-        static::assertEquals(0, $info['files']);
+        static::assertFalse(isset($info['files']));
     }
 
     /**
@@ -99,10 +99,10 @@ class CacheTest extends TestCase
     {
         $this->getResource()->delete('http');
         $info = $this->getResource()->getOne('http');
-        static::assertEquals(0, $info['files']);
+        static::assertFalse(isset($info['files']));
 
         $this->getResource()->delete('template');
         $info = $this->getResource()->getOne('template');
-        static::assertEquals(0, $info['files']);
+        static::assertFalse(isset($info['files']));
     }
 }

--- a/tests/Functional/Components/Api/EmotionPresetTest.php
+++ b/tests/Functional/Components/Api/EmotionPresetTest.php
@@ -35,30 +35,28 @@ use Shopware\Components\Api\Exception\PrivilegeException;
 use Shopware\Components\Api\Exception\ValidationException;
 use Shopware\Components\Api\Resource\EmotionPreset;
 use Shopware\Models\Emotion\Preset;
+use Shopware\Tests\Functional\Traits\ContainerTrait;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
 /**
  * @group EmotionPreset
  */
 class EmotionPresetTest extends TestCase
 {
+    use ContainerTrait;
+    use DatabaseTransactionBehaviour;
+
     private Connection $connection;
 
     private EmotionPreset $resource;
 
     protected function setUp(): void
     {
-        $this->connection = Shopware()->Container()->get(Connection::class);
-        $this->connection->beginTransaction();
+        $this->connection = $this->getContainer()->get(Connection::class);
         $this->connection->executeQuery('DELETE FROM s_emotion_presets');
         $this->connection->executeQuery('DELETE FROM s_core_plugins');
-        $this->resource = Shopware()->Container()->get(EmotionPreset::class);
+        $this->resource = $this->getContainer()->get(EmotionPreset::class);
         parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->connection->rollBack();
-        parent::tearDown();
     }
 
     public function testCreate(): void

--- a/tests/Functional/Components/Captcha/CaptchaValidatorTest.php
+++ b/tests/Functional/Components/Captcha/CaptchaValidatorTest.php
@@ -31,10 +31,13 @@ use Enlight_Template_Manager;
 use PHPUnit\Framework\TestCase;
 use Shopware\Components\Captcha\CaptchaValidator;
 use Shopware\Components\Captcha\DefaultCaptcha;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 use Shopware_Components_Config;
 
 class CaptchaValidatorTest extends TestCase
 {
+    use DatabaseTransactionBehaviour;
+
     private DefaultCaptcha $captcha;
 
     public function setUp(): void

--- a/tests/Functional/Components/Cart/CalculationOnLogoutTest.php
+++ b/tests/Functional/Components/Cart/CalculationOnLogoutTest.php
@@ -27,20 +27,14 @@ declare(strict_types=1);
 namespace Shopware\Tests\Functional\Components\Cart;
 
 use Enlight_Controller_Request_RequestHttp;
-use Shopware\Tests\Functional\Components\CheckoutTest;
+use Shopware\Tests\Functional\Components\CheckoutTestCase;
 use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
-class CalculationOnLogoutTest extends CheckoutTest
+class CalculationOnLogoutTest extends CheckoutTestCase
 {
     use DatabaseTransactionBehaviour;
 
     public bool $clearBasketOnReset = false;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-        Shopware()->Session()->offsetSet('sessionId', null);
-    }
 
     public function testLogout(): void
     {
@@ -54,7 +48,7 @@ class CalculationOnLogoutTest extends CheckoutTest
 
         $currentAmount = Shopware()->Session()->get('sBasketAmount');
 
-        $this->loginFrontendCustomer('H');
+        $this->loginCustomerOfGroup('H');
 
         Shopware()->Modules()->Admin()->logout();
 

--- a/tests/Functional/Components/Cart/CartDatabaseViewTest.php
+++ b/tests/Functional/Components/Cart/CartDatabaseViewTest.php
@@ -27,11 +27,11 @@ declare(strict_types=1);
 namespace Shopware\Tests\Functional\Components\Cart;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Tests\Functional\Components\CheckoutTest;
+use Shopware\Tests\Functional\Components\CheckoutTestCase;
 use Shopware\Tests\Functional\Traits\ContainerTrait;
 use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
-class CartDatabaseViewTest extends CheckoutTest
+class CartDatabaseViewTest extends CheckoutTestCase
 {
     use ContainerTrait;
     use DatabaseTransactionBehaviour;
@@ -42,7 +42,7 @@ class CartDatabaseViewTest extends CheckoutTest
     {
         $productNumber = $this->createProduct(5, 19.00);
 
-        $this->loginFrontendCustomer();
+        $this->loginCustomerOfGroup();
 
         $this->addProduct($productNumber);
         $this->visitConfirm();

--- a/tests/Functional/Components/Cart/CartMigrationTest.php
+++ b/tests/Functional/Components/Cart/CartMigrationTest.php
@@ -24,16 +24,19 @@
 
 namespace Shopware\Tests\Functional\Components\Cart;
 
-use Enlight_Controller_Request_RequestHttp;
+use Doctrine\DBAL\Connection;
 use Enlight_Controller_Request_RequestTestCase;
 use PHPUnit\Framework\TestCase;
+use Shopware\Components\Model\ModelManager;
 use Shopware\Components\ShopRegistrationServiceInterface;
 use Shopware\Models\Shop\Shop;
+use Shopware\Tests\Functional\Traits\ContainerTrait;
 use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 use Shopware\Tests\Functional\Traits\FixtureBehaviour;
 
 class CartMigrationTest extends TestCase
 {
+    use ContainerTrait;
     use DatabaseTransactionBehaviour;
     use FixtureBehaviour;
 
@@ -41,46 +44,51 @@ class CartMigrationTest extends TestCase
     {
         self::executeFixture(__DIR__ . '/fixture/cart_migration_1.sql');
 
-        Shopware()->Front()->setRequest(new Enlight_Controller_Request_RequestTestCase());
-        Shopware()->Modules()->Basket()->sRefreshBasket();
-        static::assertEquals(0, Shopware()->Session()->get('sBasketAmount'));
+        $this->setFrontRequest();
+        $this->getContainer()->get('modules')->Basket()->sRefreshBasket();
+        static::assertEquals(0, $this->getContainer()->get('session')->get('sBasketAmount'));
 
-        $this->loginFrontendUser();
+        $this->loginCustomer();
 
-        static::assertGreaterThan(0, Shopware()->Session()->get('sBasketAmount'));
+        static::assertGreaterThan(0, $this->getContainer()->get('session')->get('sBasketAmount'));
     }
 
     public function testMigrateOnLoginWithFilledCart(): void
     {
         self::executeFixture(__DIR__ . '/fixture/cart_migration_1.sql');
 
-        Shopware()->Modules()->Basket()->sAddArticle('SW10001');
-        Shopware()->Modules()->Basket()->sRefreshBasket();
+        $this->setFrontRequest();
+        $this->getContainer()->get('modules')->Basket()->sAddArticle('SW10001');
+        $this->getContainer()->get('modules')->Basket()->sRefreshBasket();
 
-        $currentBasketAmount = Shopware()->Session()->get('sBasketAmount');
+        $currentBasketAmount = $this->getContainer()->get('session')->get('sBasketAmount');
 
-        $this->loginFrontendUser();
+        $this->loginCustomer();
 
-        static::assertEquals($currentBasketAmount, Shopware()->Session()->get('sBasketAmount'));
+        static::assertEquals($currentBasketAmount, $this->getContainer()->get('session')->get('sBasketAmount'));
     }
 
-    private function loginFrontendUser(): void
+    private function setFrontRequest(): void
     {
-        $user = Shopware()->Db()->fetchRow(
-            'SELECT `id`, `email`, `password`, `subshopID`, `language` FROM s_user WHERE `id` = 1'
+        $this->getContainer()->get('front')->setRequest(new Enlight_Controller_Request_RequestTestCase());
+    }
+
+    private function loginCustomer(): void
+    {
+        $customer = $this->getContainer()->get(Connection::class)->fetchAssociative(
+            'SELECT `email`, `password`, `language` FROM s_user WHERE `id` = 1'
         );
+        static::assertIsArray($customer);
 
-        $shop = Shopware()->Models()->getRepository(Shop::class)->getActiveById($user['language']);
-        static::assertNotNull($shop);
-        Shopware()->Container()->get(ShopRegistrationServiceInterface::class)->registerResources($shop);
+        $shop = $this->getContainer()->get(ModelManager::class)->getRepository(Shop::class)->getActiveById($customer['language']);
+        static::assertInstanceOf(Shop::class, $shop);
+        $this->getContainer()->get(ShopRegistrationServiceInterface::class)->registerResources($shop);
 
-        $request = new Enlight_Controller_Request_RequestHttp();
-        $request->setPost([
-            'email' => $user['email'],
-            'passwordMD5' => $user['password'],
+        $this->getContainer()->get('front')->ensureRequest()->setPost([
+            'email' => $customer['email'],
+            'passwordMD5' => $customer['password'],
         ]);
-        Shopware()->Front()->setRequest($request);
-        Shopware()->Session()->set('Admin', true);
-        Shopware()->Modules()->Admin()->sLogin(true);
+        $this->getContainer()->get('session')->set('Admin', true);
+        static::assertIsArray($this->getContainer()->get('modules')->Admin()->sLogin(true));
     }
 }

--- a/tests/Functional/Components/Cart/CartRaceConditionTest.php
+++ b/tests/Functional/Components/Cart/CartRaceConditionTest.php
@@ -27,10 +27,10 @@ declare(strict_types=1);
 namespace Shopware\Tests\Functional\Components\Cart;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Tests\Functional\Components\CheckoutTest;
+use Shopware\Tests\Functional\Components\CheckoutTestCase;
 use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
-class CartRaceConditionTest extends CheckoutTest
+class CartRaceConditionTest extends CheckoutTestCase
 {
     use DatabaseTransactionBehaviour;
 
@@ -40,7 +40,7 @@ class CartRaceConditionTest extends CheckoutTest
     {
         $productNumber = $this->createProduct(5, 19.00);
 
-        $this->loginFrontendCustomer();
+        $this->loginCustomerOfGroup();
 
         $this->addProduct($productNumber);
         $this->visitConfirm();
@@ -56,7 +56,7 @@ class CartRaceConditionTest extends CheckoutTest
     {
         $productNumber1 = $this->createProduct(5, 19.00);
 
-        $this->loginFrontendCustomer();
+        $this->loginCustomerOfGroup();
 
         $this->addProduct($productNumber1);
         $this->visitConfirm();

--- a/tests/Functional/Components/Cart/FloatTaxCalculationTest.php
+++ b/tests/Functional/Components/Cart/FloatTaxCalculationTest.php
@@ -27,9 +27,9 @@ declare(strict_types=1);
 namespace Shopware\Tests\Functional\Components\Cart;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Tests\Functional\Components\CheckoutTest;
+use Shopware\Tests\Functional\Components\CheckoutTestCase;
 
-class FloatTaxCalculationTest extends CheckoutTest
+class FloatTaxCalculationTest extends CheckoutTestCase
 {
     private Connection $connection;
 

--- a/tests/Functional/Components/Cart/PaymentTokenServiceTest.php
+++ b/tests/Functional/Components/Cart/PaymentTokenServiceTest.php
@@ -119,7 +119,6 @@ class PaymentTokenServiceTest extends Enlight_Components_Test_Controller_TestCas
      */
     public function testPaymentTokenPath(string $virtualUrl, string $path): void
     {
-        session_destroy();
         Shopware()->Container()->reset('session');
 
         $currentUrl = Shopware()->Shop()->getBaseUrl();

--- a/tests/Functional/Components/Cart/ProportionalCartCalculationCustomerGroupTest.php
+++ b/tests/Functional/Components/Cart/ProportionalCartCalculationCustomerGroupTest.php
@@ -27,12 +27,12 @@ declare(strict_types=1);
 namespace Shopware\Tests\Functional\Components\Cart;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Tests\Functional\Components\CheckoutTest;
+use Shopware\Tests\Functional\Components\CheckoutTestCase;
 
 /**
  * @group Basket
  */
-class ProportionalCartCalculationCustomerGroupTest extends CheckoutTest
+class ProportionalCartCalculationCustomerGroupTest extends CheckoutTestCase
 {
     public function setUp(): void
     {

--- a/tests/Functional/Components/Cart/ProportionalCartCalculationDispatchTest.php
+++ b/tests/Functional/Components/Cart/ProportionalCartCalculationDispatchTest.php
@@ -27,12 +27,12 @@ declare(strict_types=1);
 namespace Shopware\Tests\Functional\Components\Cart;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Tests\Functional\Components\CheckoutTest;
+use Shopware\Tests\Functional\Components\CheckoutTestCase;
 
 /**
  * @group Basket
  */
-class ProportionalCartCalculationDispatchTest extends CheckoutTest
+class ProportionalCartCalculationDispatchTest extends CheckoutTestCase
 {
     public function setUp(): void
     {

--- a/tests/Functional/Components/Cart/ProportionalCartCalculationSurchargeTest.php
+++ b/tests/Functional/Components/Cart/ProportionalCartCalculationSurchargeTest.php
@@ -27,12 +27,12 @@ declare(strict_types=1);
 namespace Shopware\Tests\Functional\Components\Cart;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Tests\Functional\Components\CheckoutTest;
+use Shopware\Tests\Functional\Components\CheckoutTestCase;
 
 /**
  * @group Basket
  */
-class ProportionalCartCalculationSurchargeTest extends CheckoutTest
+class ProportionalCartCalculationSurchargeTest extends CheckoutTestCase
 {
     /**
      * A product with 7% tax

--- a/tests/Functional/Components/Cart/ProportionalCartCalculationVoucherTest.php
+++ b/tests/Functional/Components/Cart/ProportionalCartCalculationVoucherTest.php
@@ -27,12 +27,12 @@ declare(strict_types=1);
 namespace Shopware\Tests\Functional\Components\Cart;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Tests\Functional\Components\CheckoutTest;
+use Shopware\Tests\Functional\Components\CheckoutTestCase;
 
 /**
  * @group Basket
  */
-class ProportionalCartCalculationVoucherTest extends CheckoutTest
+class ProportionalCartCalculationVoucherTest extends CheckoutTestCase
 {
     public function setUp(): void
     {

--- a/tests/Functional/Components/Cart/fixture/cart_migration_1.sql
+++ b/tests/Functional/Components/Cart/fixture/cart_migration_1.sql
@@ -1,3 +1,3 @@
-INSERT INTO `s_order_basket` (`sessionID`, `userID`, `articlename`, `articleID`, `ordernumber`, `shippingfree`, `quantity`, `price`, `netprice`, `tax_rate`, `datum`, `modus`, `esdarticle`, `partnerID`, `lastviewport`, `useragent`, `config`, `currencyFactor`) VALUES
-('52f0cf0e9f3737fd42f8371ec79fbd5a', 1, 'Münsterländer Aperitif 16%', 3, 'SW10003', 0, 1, 14.95, 12.563025210084, 19, '2019-04-05 09:09:54', 0, 0, '', 'account', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36', '', 1),
-('52f0cf0e9f3737fd42f8371ec79fbd5a', 1, 'Warenkorbrabatt', 0, 'SHIPPINGDISCOUNT', 0, 1, -2, -1.68, 19, '2019-04-05 09:10:30', 4, 0, '', '', '', '', 1);
+INSERT INTO `s_order_basket` (`userID`, `articlename`, `articleID`, `ordernumber`, `shippingfree`, `quantity`, `price`, `netprice`, `tax_rate`, `datum`, `modus`, `esdarticle`, `partnerID`, `lastviewport`, `useragent`, `config`, `currencyFactor`) VALUES
+(1, 'Münsterländer Aperitif 16%', 3, 'SW10003', 0, 1, 14.95, 12.563025210084, 19, '2019-04-05 09:09:54', 0, 0, '', 'account', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36', '', 1),
+(1, 'Warenkorbrabatt', 0, 'SHIPPINGDISCOUNT', 0, 1, -2, -1.68, 19, '2019-04-05 09:10:30', 4, 0, '', '', '', '', 1);

--- a/tests/Functional/Components/CheckoutTestCase.php
+++ b/tests/Functional/Components/CheckoutTestCase.php
@@ -27,14 +27,14 @@ declare(strict_types=1);
 namespace Shopware\Tests\Functional\Components;
 
 use Doctrine\DBAL\Connection;
-use Enlight_Components_Test_Controller_TestCase;
+use Enlight_Components_Test_Controller_TestCase as ControllerTestCase;
 use Shopware\Components\Random;
 use Shopware\Tests\Functional\Bundle\StoreFrontBundle\Helper;
 use Shopware\Tests\Functional\Traits\ContainerTrait;
 use Shopware\Tests\Functional\Traits\CustomerLoginTrait;
 use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
-abstract class CheckoutTest extends Enlight_Components_Test_Controller_TestCase
+abstract class CheckoutTestCase extends ControllerTestCase
 {
     use ContainerTrait;
     use CustomerLoginTrait;
@@ -115,7 +115,10 @@ abstract class CheckoutTest extends Enlight_Components_Test_Controller_TestCase
         ]);
     }
 
-    protected function createVoucher(float $value, int $taxId, bool $percental = true): string
+    /**
+     * @param 0|1 $percental
+     */
+    protected function createVoucher(float $value, int $taxId, int $percental = 1): string
     {
         $code = Random::getAlphanumericString(12);
         $this->getContainer()->get(Connection::class)
@@ -130,7 +133,7 @@ abstract class CheckoutTest extends Enlight_Components_Test_Controller_TestCase
                 'modus' => 0,
                 'numorder' => 1000,
                 'percental' => $percental,
-                'taxconfig' => $taxId,
+                'taxconfig' => (string) $taxId,
             ]);
 
         return $code;
@@ -199,7 +202,7 @@ abstract class CheckoutTest extends Enlight_Components_Test_Controller_TestCase
         ]);
     }
 
-    protected function loginFrontendCustomer(string $group = 'EK'): void
+    protected function loginCustomerOfGroup(string $group = 'EK'): void
     {
         $customer = Shopware()->Db()->fetchRow(
             'SELECT id, email, password, subshopID, language FROM s_user WHERE customergroup = ? LIMIT 1',

--- a/tests/Functional/Components/DependencyInjection/Compiler/LegacyApiResourcesPassTest.php
+++ b/tests/Functional/Components/DependencyInjection/Compiler/LegacyApiResourcesPassTest.php
@@ -45,7 +45,7 @@ class LegacyApiResourcesPassTest extends TestCase
         $container
             ->register('shopware.api.mynewresource.hasalreadytag')
             ->setClass(Article::class)
-            ->setTags(['shopware.api.mynewresource.hasalreadytag'])
+            ->setTags(['shopware.api.mynewresource.hasalreadytag' => ['attr' => ['foo']]])
             ->setPublic(true);
 
         $container->compile();

--- a/tests/Functional/Components/Emotion/Preset/EmotionToPresetDataTransformerTest.php
+++ b/tests/Functional/Components/Emotion/Preset/EmotionToPresetDataTransformerTest.php
@@ -32,12 +32,17 @@ use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Shopware\Components\Emotion\Preset\EmotionToPresetDataTransformer;
 use Shopware\Components\Emotion\Preset\EmotionToPresetDataTransformerInterface;
+use Shopware\Tests\Functional\Traits\ContainerTrait;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
 /**
  * @group EmotionPreset
  */
 class EmotionToPresetDataTransformerTest extends TestCase
 {
+    use ContainerTrait;
+    use DatabaseTransactionBehaviour;
+
     /**
      * @var EmotionToPresetDataTransformer
      */
@@ -50,18 +55,12 @@ class EmotionToPresetDataTransformerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->connection = Shopware()->Container()->get(Connection::class);
-        $this->connection->beginTransaction();
+        $this->connection = $this->getContainer()->get(Connection::class);
 
         $this->connection->executeQuery('DELETE FROM s_emotion_presets');
         $this->connection->executeQuery('DELETE FROM s_core_plugins');
 
-        $this->transformer = Shopware()->Container()->get(EmotionToPresetDataTransformerInterface::class);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->connection->rollBack();
+        $this->transformer = $this->getContainer()->get(EmotionToPresetDataTransformerInterface::class);
     }
 
     public function testShouldFailBecauseOfMissingEmotion(): void

--- a/tests/Functional/Components/Emotion/Preset/PresetDataSynchronizerTest.php
+++ b/tests/Functional/Components/Emotion/Preset/PresetDataSynchronizerTest.php
@@ -32,46 +32,36 @@ use Shopware\Components\Api\Resource\EmotionPreset;
 use Shopware\Components\Emotion\Preset\Exception\PresetAssetImportException;
 use Shopware\Components\Emotion\Preset\PresetDataSynchronizer;
 use Shopware\Components\Emotion\Preset\PresetDataSynchronizerInterface;
+use Shopware\Tests\Functional\Traits\ContainerTrait;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
 /**
  * @group EmotionPreset
  */
 class PresetDataSynchronizerTest extends TestCase
 {
-    /**
-     * @var PresetDataSynchronizer
-     */
-    private $synchronizerService;
+    use ContainerTrait;
+    use DatabaseTransactionBehaviour;
 
-    /**
-     * @var EmotionPreset
-     */
-    private $presetResource;
+    private PresetDataSynchronizer $synchronizerService;
 
-    /**
-     * @var Connection
-     */
-    private $connection;
+    private EmotionPreset $presetResource;
+
+    private Connection $connection;
 
     private string $imageData;
 
     protected function setUp(): void
     {
-        $this->connection = Shopware()->Container()->get(Connection::class);
-        $this->connection->beginTransaction();
+        $this->connection = $this->getContainer()->get(Connection::class);
 
         $this->connection->executeQuery('DELETE FROM s_emotion_presets');
         $this->connection->executeQuery('DELETE FROM s_core_plugins');
 
-        $this->synchronizerService = Shopware()->Container()->get(PresetDataSynchronizerInterface::class);
-        $this->presetResource = Shopware()->Container()->get(EmotionPreset::class);
+        $this->synchronizerService = $this->getContainer()->get(PresetDataSynchronizerInterface::class);
+        $this->presetResource = $this->getContainer()->get(EmotionPreset::class);
 
         $this->imageData = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
-    }
-
-    protected function tearDown(): void
-    {
-        $this->connection->rollBack();
     }
 
     public function testAssetImportWithPresetAlreadyImported(): void

--- a/tests/Functional/Components/NumberRangeIncrementerTest.php
+++ b/tests/Functional/Components/NumberRangeIncrementerTest.php
@@ -31,10 +31,12 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Shopware\Components\NumberRangeIncrementer;
 use Shopware\Tests\Functional\Traits\ContainerTrait;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
 class NumberRangeIncrementerTest extends TestCase
 {
     use ContainerTrait;
+    use DatabaseTransactionBehaviour;
 
     private Connection $connection;
 

--- a/tests/Functional/Components/Privacy/CookieRemoveSubscriberTest.php
+++ b/tests/Functional/Components/Privacy/CookieRemoveSubscriberTest.php
@@ -34,11 +34,8 @@ use Enlight_Controller_Response_ResponseTestCase;
 use Enlight_Template_Manager;
 use Enlight_View_Default;
 use PHPUnit\Framework\TestCase;
-use Shopware\Bundle\CookieBundle\CookieCollection;
 use Shopware\Bundle\CookieBundle\Services\CookieHandler;
 use Shopware\Bundle\CookieBundle\Services\CookieRemoveHandler;
-use Shopware\Bundle\CookieBundle\Structs\CookieGroupStruct;
-use Shopware\Bundle\CookieBundle\Structs\CookieStruct;
 use Shopware\Components\Privacy\CookieRemoveSubscriber;
 use Shopware_Controllers_Frontend_Index;
 
@@ -73,9 +70,8 @@ class CookieRemoveSubscriberTest extends TestCase
         Shopware()->Config()->offsetSet('cookie_note_mode', CookieRemoveSubscriber::COOKIE_MODE_ALL);
         Shopware()->Config()->offsetSet('show_cookie_note', 1);
 
-        $_COOKIE['allowCookie'] = 1;
-
         $controller = $this->getController();
+        $controller->Request()->cookies->set('allowCookie', 1);
 
         // May not be removed, since further code may not be executed
         $controller->Response()->setCookie('notRemoved', 'foo');
@@ -177,21 +173,5 @@ class CookieRemoveSubscriberTest extends TestCase
             Shopware()->Container()->get(CookieHandler::class),
             $httpCacheEnabled
         );
-    }
-}
-
-class PreserveCookieFromRemovingSubscriber
-{
-    public function addCookie(): CookieCollection
-    {
-        $cookieCollection = new CookieCollection();
-        $cookieCollection->add(new CookieStruct(
-            'keepMe',
-            '/^keepMe$/',
-            'keepMe',
-            CookieGroupStruct::PERSONALIZATION
-        ));
-
-        return $cookieCollection;
     }
 }

--- a/tests/Functional/Components/ProductStream/RepositoryTest.php
+++ b/tests/Functional/Components/ProductStream/RepositoryTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Tests\Functional\Shopware\Components\ProductStream;
+namespace Shopware\Tests\Functional\Components\ProductStream;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;

--- a/tests/Functional/Components/Router/RouterTest.php
+++ b/tests/Functional/Components/Router/RouterTest.php
@@ -110,7 +110,8 @@ class RouterTest extends Enlight_Components_Test_TestCase
         static::assertIsString($url);
         $match = $router->match($url);
         static::assertIsArray($match);
-        static::assertEquals(array_intersect($match, $params), $params);
+        unset($match['module'], $match['controller'], $match['action'], $match['index']);
+        static::assertEquals($params, $match);
     }
 
     public function getTestParamsProvider(): array

--- a/tests/Functional/Components/Template/TemplateManagerTest.php
+++ b/tests/Functional/Components/Template/TemplateManagerTest.php
@@ -89,14 +89,14 @@ class TemplateManagerTest extends TestCase
     public function testValidPermissionsAreSet(): void
     {
         $testDir = sys_get_temp_dir() . '/tpl-test';
+        if (!is_dir($testDir)) {
+            mkdir($testDir);
+        }
         $backendOptions = [
             'hashed_directory_perm' => 0777 & ~umask(),
             'cache_file_perm' => 0666 & ~umask(),
         ];
-        /** @var Enlight_Template_Manager $template */
-        $template = Enlight_Class::Instance('Enlight_Template_Manager', [null, $backendOptions]);
-
-        mkdir($testDir);
+        $template = Enlight_Class::Instance(Enlight_Template_Manager::class, [null, $backendOptions]);
 
         $cacheDirectory = $testDir . '/compile-test';
         $cacheFile = $cacheDirectory . '/8843d7f92416211de9ebb963ff4ce28125932878.string.php';

--- a/tests/Functional/Components/TemplateMailTest.php
+++ b/tests/Functional/Components/TemplateMailTest.php
@@ -284,26 +284,14 @@ class TemplateMailTest extends Enlight_Components_Test_TestCase
 
     private function getSmartyMailMockObject(): Mail
     {
-        $templateMock = $this->createMock(Mail::class);
+        $mail = new Mail();
+        $mail->setFromMail('{$sConfig.sMAIL}');
+        $mail->setFromName('{$sConfig.sSHOPNAME}');
+        $mail->setSubject('Ihr Bestellung bei {$sConfig.sSHOPNAME}');
+        $mail->setContent('Testbestellung bei {$sConfig.sSHOPNAME}');
+        $mail->setContentHtml('Testbestellung HTML bei {$sConfig.sSHOPNAME}');
+        $mail->setIsHtml();
 
-        $templateMock->method('getFromMail')
-            ->willReturn('{$sConfig.sMAIL}');
-
-        $templateMock->method('getFromName')
-            ->willReturn('{$sConfig.sSHOPNAME}');
-
-        $templateMock->method('getSubject')
-            ->willReturn('Ihr Bestellung bei {$sConfig.sSHOPNAME}');
-
-        $templateMock->method('getContent')
-            ->willReturn('Testbestellung bei {$sConfig.sSHOPNAME}');
-
-        $templateMock->method('getContentHtml')
-            ->willReturn('Testbestellung HTML bei {$sConfig.sSHOPNAME}');
-
-        $templateMock->method('isHtml')
-            ->willReturn(true);
-
-        return $templateMock;
+        return $mail;
     }
 }

--- a/tests/Functional/Controllers/Backend/AnalyticsTest.php
+++ b/tests/Functional/Controllers/Backend/AnalyticsTest.php
@@ -1154,7 +1154,7 @@ class AnalyticsTest extends ControllerTestCase
     {
         preg_match_all(
             '#[?&]([qp]|query|highlight|encquery|url|field-keywords|as_q|sucheall|satitle|KW)=([^&\$]+)#',
-            utf8_encode($url) . '&',
+            mb_convert_encoding($url, 'UTF-8', 'ISO-8859-1') . '&',
             $matches
         );
         if (empty($matches[0])) {

--- a/tests/Functional/Controllers/Backend/ArticleTest.php
+++ b/tests/Functional/Controllers/Backend/ArticleTest.php
@@ -166,7 +166,6 @@ class ArticleTest extends TestCase
             'autoNumber' => '10002',
             'mainPrices' => [
                 [
-                    'id' => 0,
                     'from' => 1,
                     'to' => 'Beliebig',
                     'price' => 10,

--- a/tests/Functional/Controllers/Backend/LogTest.php
+++ b/tests/Functional/Controllers/Backend/LogTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -25,6 +27,7 @@
 namespace Shopware\Tests\Functional\Controllers\Backend;
 
 use DateTime;
+use Doctrine\DBAL\Connection;
 use Enlight_Components_Test_Controller_TestCase;
 
 class LogTest extends Enlight_Components_Test_Controller_TestCase
@@ -44,11 +47,10 @@ class LogTest extends Enlight_Components_Test_Controller_TestCase
      * Tests the getLogsAction()
      * to test if reading the logs is working
      */
-    public function testGetLogs()
+    public function testGetLogs(): void
     {
-        /* @var \Enlight_Controller_Response_ResponseTestCase */
         $this->dispatch('backend/log/getLogs');
-        static::assertTrue($this->View()->success);
+        static::assertTrue($this->View()->getAssign('success'));
 
         $jsonBody = $this->View()->getAssign();
 
@@ -61,11 +63,11 @@ class LogTest extends Enlight_Components_Test_Controller_TestCase
      * This test tests the creating of a new log.
      * This function is called before testDeleteLogs
      */
-    public function testCreateLog()
+    public function testCreateLog(): int
     {
-        Shopware()->Container()->get(\Doctrine\DBAL\Connection::class)->beginTransaction();
+        Shopware()->Container()->get(Connection::class)->beginTransaction();
 
-        $this->Request()->setClientIp('10.0.0.3', false);
+        $this->Request()->setClientIp('10.0.0.3');
         $this->Request()->setMethod('POST')->setPost(
             [
                 'type' => 'backend',
@@ -78,7 +80,7 @@ class LogTest extends Enlight_Components_Test_Controller_TestCase
         );
 
         $this->dispatch('backend/logger/createLog');
-        static::assertTrue($this->View()->success);
+        static::assertTrue($this->View()->getAssign('success'));
 
         $jsonBody = $this->View()->getAssign();
 
@@ -93,10 +95,8 @@ class LogTest extends Enlight_Components_Test_Controller_TestCase
      * This test-method tests the deleting of a log.
      *
      * @depends testCreateLog
-     *
-     * @param string $lastId
      */
-    public function testDeleteLogs($lastId)
+    public function testDeleteLogs(int $lastId): void
     {
         $this->Request()->setMethod('POST')->setPost(['id' => $lastId]);
 
@@ -105,20 +105,21 @@ class LogTest extends Enlight_Components_Test_Controller_TestCase
         $jsonBody = $this->View()->getAssign();
 
         static::assertArrayHasKey('success', $jsonBody);
+        static::assertTrue($jsonBody['success']);
         static::assertArrayHasKey('data', $jsonBody);
 
-        Shopware()->Container()->get(\Doctrine\DBAL\Connection::class)->rollBack();
+        Shopware()->Container()->get(Connection::class)->rollBack();
     }
 
     /**
      * This test tests the creating of a new log.
      * This function is called before testDeleteLogs
      */
-    public function testCreateDeprecatedLog()
+    public function testCreateDeprecatedLog(): void
     {
-        Shopware()->Container()->get(\Doctrine\DBAL\Connection::class)->beginTransaction();
+        Shopware()->Container()->get(Connection::class)->beginTransaction();
 
-        $this->Request()->setClientIp('10.0.0.3', false);
+        $this->Request()->setClientIp('10.0.0.3');
         $this->Request()->setMethod('POST')->setPost(
             [
                 'type' => 'backend',
@@ -130,8 +131,8 @@ class LogTest extends Enlight_Components_Test_Controller_TestCase
             ]
         );
 
-        $this->dispatch('backend/log/createLog');
-        static::assertTrue($this->View()->success);
+        $this->dispatch('backend/logger/createLog');
+        static::assertTrue($this->View()->getAssign('success'));
 
         $jsonBody = $this->View()->getAssign();
 
@@ -139,7 +140,7 @@ class LogTest extends Enlight_Components_Test_Controller_TestCase
         static::assertArrayHasKey('success', $jsonBody);
         static::assertArrayHasKey('id', $jsonBody['data']);
 
-        Shopware()->Container()->get(\Doctrine\DBAL\Connection::class)->rollBack();
+        Shopware()->Container()->get(Connection::class)->rollBack();
     }
 
     public function testSystemLogList(): void
@@ -195,7 +196,6 @@ class LogTest extends Enlight_Components_Test_Controller_TestCase
         $pluginLogger->info('Running test...');
         $coreLogger->info('Running test...');
 
-        /** @var string $environment */
         $environment = $container->getParameter('kernel.environment');
 
         // test filtering

--- a/tests/Functional/Controllers/Backend/MailTest.php
+++ b/tests/Functional/Controllers/Backend/MailTest.php
@@ -28,10 +28,7 @@ use Enlight_Components_Test_Controller_TestCase;
 
 class MailTest extends Enlight_Components_Test_Controller_TestCase
 {
-    /**
-     * @var array
-     */
-    public $testData = [
+    public array $testData = [
         'name' => 'Testmail123',
         'fromMail' => 'Shopware Demoshop',
         'fromName' => 'info@example.com',

--- a/tests/Functional/Controllers/Backend/MediaManagerTest.php
+++ b/tests/Functional/Controllers/Backend/MediaManagerTest.php
@@ -40,7 +40,7 @@ class MediaManagerTest extends TestCase
     /**
      * Creates a new album,
      * checks if the new album has inherited the parents settings
-     * and deletes it afterwards
+     * and deletes it afterward
      */
     public function testAlbumInheritance(): void
     {
@@ -54,7 +54,7 @@ class MediaManagerTest extends TestCase
             'parentId' => '-11',
             'position' => '',
             'text' => 'PHPUNIT_ALBUM',
-            'thumbnailSize' => '',
+            'thumbnailSize' => [],
         ];
 
         $request = new Enlight_Controller_Request_RequestTestCase();

--- a/tests/Functional/Controllers/Backend/OrderProductSearchTest.php
+++ b/tests/Functional/Controllers/Backend/OrderProductSearchTest.php
@@ -680,7 +680,7 @@ class OrderProductSearchTest extends Enlight_Components_Test_Controller_TestCase
             ]],
         ];
 
-        if ($searchParams['orderId']) {
+        if (isset($searchParams['orderId'])) {
             $params['orderId'] = $searchParams['orderId'];
         }
 

--- a/tests/Functional/Controllers/Backend/OrderTest.php
+++ b/tests/Functional/Controllers/Backend/OrderTest.php
@@ -396,7 +396,7 @@ class OrderTest extends ControllerTestCase
         $controller->savePositionAction();
 
         $results = $controller->View()->getAssign();
-        static::assertTrue($results['success'], (string) $results['message']);
+        static::assertTrue($results['success'], $results['message'] ?? '');
 
         static::assertSame(self::NEW_TAX, $results['data']['taxRate']);
     }

--- a/tests/Functional/Controllers/Backend/PaymentTest.php
+++ b/tests/Functional/Controllers/Backend/PaymentTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -25,10 +27,18 @@
 namespace Shopware\Tests\Functional\Controllers\Backend;
 
 use Enlight_Components_Test_Controller_TestCase;
+use Shopware\Tests\Functional\Traits\ContainerTrait;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
 class PaymentTest extends Enlight_Components_Test_Controller_TestCase
 {
-    private $testDataCreate = [
+    use ContainerTrait;
+    use DatabaseTransactionBehaviour;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $testDataCreate = [
         'name' => 'New payment',
         'description' => 'New payment',
         'source' => 1,
@@ -55,19 +65,18 @@ class PaymentTest extends Enlight_Components_Test_Controller_TestCase
         parent::setUp();
 
         // Disable auth and acl
-        Shopware()->Plugins()->Backend()->Auth()->setNoAuth();
-        Shopware()->Plugins()->Backend()->Auth()->setNoAcl();
+        $this->getContainer()->get('plugins')->Backend()->Auth()->setNoAuth();
+        $this->getContainer()->get('plugins')->Backend()->Auth()->setNoAcl();
     }
 
     /**
      * Tests the getPaymentsAction()
      * to test if reading the payments is working
      */
-    public function testGetPayments()
+    public function testGetPayments(): void
     {
-        /* @var \Enlight_Controller_Response_ResponseTestCase */
         $this->dispatch('backend/payment/getPayments');
-        static::assertTrue($this->View()->success);
+        static::assertTrue($this->View()->getAssign('success'));
 
         $jsonBody = $this->View()->getAssign();
 
@@ -79,11 +88,10 @@ class PaymentTest extends Enlight_Components_Test_Controller_TestCase
      * Tests the getCountriesAction()
      * to test if reading the countries is working
      */
-    public function testGetCountries()
+    public function testGetCountries(): void
     {
-        /* @var \Enlight_Controller_Response_ResponseTestCase */
         $this->dispatch('backend/payment/getCountries');
-        static::assertTrue($this->View()->success);
+        static::assertTrue($this->View()->getAssign('success'));
 
         $jsonBody = $this->View()->getAssign();
 
@@ -93,15 +101,15 @@ class PaymentTest extends Enlight_Components_Test_Controller_TestCase
 
     /**
      * Function to test creating a new payment
+     *
+     * @return array<string, mixed>
      */
-    public function testCreatePayments()
+    public function testCreatePayments(): array
     {
-        Shopware()->Db()->exec('DELETE FROM s_core_paymentmeans WHERE name = "New payment"');
-
         $this->Request()->setMethod('POST')->setPost($this->testDataCreate);
         $this->dispatch('backend/payment/createPayments');
 
-        static::assertTrue($this->View()->success);
+        static::assertTrue($this->View()->getAssign('success'));
         $jsonBody = $this->View()->getAssign();
 
         static::assertArrayHasKey('data', $jsonBody);
@@ -112,18 +120,14 @@ class PaymentTest extends Enlight_Components_Test_Controller_TestCase
 
     /**
      * Function to test updating a payment
-     *
-     * @param array $data Contains the data of the created payment
-     *
-     * @depends testCreatePayments
      */
-    public function testUpdatePayments($data)
+    public function testUpdatePayments(): void
     {
+        $data = $this->testCreatePayments();
         $this->Request()->setMethod('POST')->setPost(['id' => $data['id'], 'name' => 'Neue Zahlungsart']);
 
-        /* @var \Enlight_Controller_Response_ResponseTestCase */
         $this->dispatch('backend/payment/updatePayments');
-        static::assertTrue($this->View()->success);
+        static::assertTrue($this->View()->getAssign('success'));
 
         $jsonBody = $this->View()->getAssign();
 
@@ -133,18 +137,15 @@ class PaymentTest extends Enlight_Components_Test_Controller_TestCase
 
     /**
      * Function to test deleting a payment
-     *
-     * @param array $data Contains the data of the created payment
-     *
-     * @depends testCreatePayments
      */
-    public function testDeletePayment($data)
+    public function testDeletePayment(): void
     {
+        $data = $this->testCreatePayments();
+        $this->resetRequest();
         $this->Request()->setMethod('POST')->setPost(['id' => $data['id']]);
 
-        /* @var \Enlight_Controller_Response_ResponseTestCase */
         $this->dispatch('backend/payment/deletePayment');
-        static::assertTrue($this->View()->success);
+        static::assertTrue($this->View()->getAssign('success'));
 
         $jsonBody = $this->View()->getAssign();
 

--- a/tests/Functional/Controllers/Backend/RiskManagementTest.php
+++ b/tests/Functional/Controllers/Backend/RiskManagementTest.php
@@ -123,8 +123,9 @@ class RiskManagementTest extends Enlight_Components_Test_Controller_TestCase
 
         $jsonBody = $this->View()->getAssign();
 
-        static::assertArrayHasKey('data', $jsonBody);
         static::assertArrayHasKey('success', $jsonBody);
+        static::assertTrue($jsonBody['success'], $jsonBody['errorMsg'] ?? '');
+        static::assertArrayHasKey('data', $jsonBody);
     }
 
     /**

--- a/tests/Functional/Controllers/Backend/VoteTest.php
+++ b/tests/Functional/Controllers/Backend/VoteTest.php
@@ -27,9 +27,12 @@ declare(strict_types=1);
 namespace Shopware\Tests\Functional\Controllers\Backend;
 
 use Enlight_Components_Test_Controller_TestCase;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
 class VoteTest extends Enlight_Components_Test_Controller_TestCase
 {
+    use DatabaseTransactionBehaviour;
+
     /**
      * Standard set up for every test - just disable auth
      */
@@ -78,13 +81,12 @@ class VoteTest extends Enlight_Components_Test_Controller_TestCase
 
     /**
      * Test method to test the answerVoteAction-method, which sets an answer to a vote
-     *
-     * @depends testGetVotes
-     *
-     * @param array<string, mixed> $data Contains the product, which is created in testGetVotes
      */
-    public function testAnswerVote(array $data): void
+    public function testAnswerVote(): void
     {
+        $data = $this->testGetVotes();
+        $this->resetRequest()->resetResponse();
+
         $data['answer'] = 'Test';
         $this->Request()->setMethod('POST')->setPost($data);
 
@@ -98,13 +100,12 @@ class VoteTest extends Enlight_Components_Test_Controller_TestCase
     /**
      * Test method to test the acceptVoteAction-method, which sets the active-property to 1, so the vote is enabled
      * in the frontend
-     *
-     * @depends testGetVotes
-     *
-     * @param array<string, mixed> $data Contains the product, which is created in testGetVotes
      */
-    public function testAcceptVote(array $data): void
+    public function testAcceptVote(): void
     {
+        $data = $this->testGetVotes();
+        $this->resetRequest()->resetResponse();
+
         $sql = 'UPDATE s_articles_vote SET active=0 WHERE id=?';
         Shopware()->Db()->query($sql, [$data['id']]);
 
@@ -120,13 +121,12 @@ class VoteTest extends Enlight_Components_Test_Controller_TestCase
 
     /**
      * Test method to test the deleteVoteAction-method, which deletes the product created in the testGetVotes-method
-     *
-     * @depends testGetVotes
-     *
-     * @param array<string, mixed> $data Contains the product, which is created in testGetVotes
      */
-    public function testDeleteVote(array $data): void
+    public function testDeleteVote(): void
     {
+        $data = $this->testGetVotes();
+        $this->resetRequest()->resetResponse();
+
         $this->Request()->setMethod('POST')->setPost($data);
         $this->dispatch('backend/vote/delete');
         static::assertTrue($this->View()->getAssign('success'));

--- a/tests/Functional/Controllers/Backend/VoucherTest.php
+++ b/tests/Functional/Controllers/Backend/VoucherTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -32,12 +34,7 @@ use Shopware\Models\Voucher\Voucher;
 class VoucherTest extends Enlight_Components_Test_Controller_TestCase
 {
     /**
-     * @var Repository
-     */
-    protected $repository;
-
-    /**
-     * Voucher dummy data
+     * @var array<string, mixed>
      */
     private array $voucherData = [
         'description' => 'description',
@@ -60,14 +57,10 @@ class VoucherTest extends Enlight_Components_Test_Controller_TestCase
         'value' => '10',
     ];
 
-    /**
-     * @var ModelManager
-     */
-    private $manager;
+    private Repository $repository;
 
-    /**
-     * Standard set up for every test - just disable auth
-     */
+    private ModelManager $manager;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -80,10 +73,7 @@ class VoucherTest extends Enlight_Components_Test_Controller_TestCase
         Shopware()->Plugins()->Backend()->Auth()->setNoAcl();
     }
 
-    /**
-     * test the voucher list
-     */
-    public function testGetVoucher()
+    public function testGetVoucher(): void
     {
         // Delete old data
         $vouchers = $this->repository->findBy(['orderCode' => '65168phpunit']);
@@ -95,10 +85,10 @@ class VoucherTest extends Enlight_Components_Test_Controller_TestCase
         $voucher = $this->createDummy();
 
         $this->dispatch('backend/voucher/getVoucher?page=1&start=0&limit=2000');
-        static::assertTrue($this->View()->success);
-        $returnData = $this->View()->data;
+        static::assertTrue($this->View()->getAssign('success'));
+        $returnData = $this->View()->getAssign('data');
         static::assertNotEmpty($returnData);
-        static::assertGreaterThan(0, $this->View()->totalCount);
+        static::assertGreaterThan(0, $this->View()->getAssign('totalCount'));
         $lastInsert = $returnData[\count($returnData) - 1];
         static::assertEquals($voucher->getId(), $lastInsert['id']);
 
@@ -106,42 +96,31 @@ class VoucherTest extends Enlight_Components_Test_Controller_TestCase
         $this->manager->flush();
     }
 
-    /**
-     * test adding a voucher
-     *
-     * @return string The id to for the testUpdateVoucher Method
-     */
-    public function testAddVoucher()
+    public function testAddVoucher(): int
     {
-        $this->manager->getConnection()->executeUpdate('DELETE FROM s_emarketing_vouchers WHERE ordercode = :code', [
+        $this->manager->getConnection()->executeStatement('DELETE FROM s_emarketing_vouchers WHERE ordercode = :code', [
             ':code' => $this->voucherData['orderCode'],
         ]);
 
         $params = $this->voucherData;
         $this->Request()->setParams($params);
         $this->dispatch('backend/voucher/saveVoucher');
-        static::assertTrue($this->View()->success);
-        static::assertEquals($params['description'], $this->View()->data['description']);
+        static::assertTrue($this->View()->getAssign('success'));
+        static::assertEquals($params['description'], $this->View()->getAssign('data')['description']);
 
-        return $this->View()->data['id'];
+        return $this->View()->getAssign('data')['id'];
     }
 
     /**
-     * the the getVoucherDetail Method
-     *
      * @depends testAddVoucher
-     *
-     * @param string $id
-     *
-     * @return string the id to for the testUpdateVoucher Method
      */
-    public function testGetVoucherDetail($id)
+    public function testGetVoucherDetail(int $id): int
     {
         $params['voucherID'] = $id;
         $this->Request()->setParams($params);
         $this->dispatch('backend/voucher/getVoucherDetail');
-        static::assertTrue($this->View()->success);
-        $returningData = $this->View()->data;
+        static::assertTrue($this->View()->getAssign('success'));
+        $returningData = $this->View()->getAssign('data');
         $voucherData = $this->voucherData;
         static::assertEquals($voucherData['description'], $returningData['description']);
         static::assertEquals($voucherData['numberOfUnits'], $returningData['numberOfUnits']);
@@ -154,11 +133,9 @@ class VoucherTest extends Enlight_Components_Test_Controller_TestCase
     }
 
     /**
-     * test the voucherCode validation methods with the created voucher
-     *
      * @depends testAddVoucher
      */
-    public function testValidateVoucherCode()
+    public function testValidateVoucherCode(): void
     {
         $params = [];
         $voucherModel = $this->createDummy(false);
@@ -186,13 +163,9 @@ class VoucherTest extends Enlight_Components_Test_Controller_TestCase
     }
 
     /**
-     * Test the orderCode validation methods with the created voucher
-     *
      * @depends testAddVoucher
-     *
-     * @param string $id
      */
-    public function testValidateOrderCode($id)
+    public function testValidateOrderCode(int $id): void
     {
         $params = [];
         $voucherData = $this->voucherData;
@@ -217,13 +190,9 @@ class VoucherTest extends Enlight_Components_Test_Controller_TestCase
     }
 
     /**
-     * Test updating a voucher
-     *
      * @depends testGetVoucherDetail
-     *
-     * @param string $id
      */
-    public function testUpdateVoucher($id)
+    public function testUpdateVoucher(int $id): int
     {
         $params = $this->voucherData;
         $params['id'] = $id;
@@ -231,59 +200,47 @@ class VoucherTest extends Enlight_Components_Test_Controller_TestCase
         $this->Request()->setParams($params);
 
         $this->dispatch('backend/voucher/saveVoucher');
-        static::assertTrue($this->View()->success);
-        static::assertEquals($params['description'], $this->View()->data['description']);
+        static::assertTrue($this->View()->getAssign('success'));
+        static::assertEquals($params['description'], $this->View()->getAssign('data')['description']);
 
         return $id;
     }
 
     /**
-     * Test generating voucher codes
-     *
      * @depends testUpdateVoucher
-     *
-     * @param string $id
      */
-    public function testGenerateVoucherCodes($id)
+    public function testGenerateVoucherCodes(int $id): int
     {
         $voucherData = $this->voucherData;
         $params = [];
         $params['numberOfUnits'] = $voucherData['numberOfUnits'];
-        $params['voucherId'] = (int) $id;
+        $params['voucherId'] = $id;
         $this->Request()->setParams($params);
         $this->dispatch('backend/voucher/createVoucherCodes');
-        static::assertTrue($this->View()->success);
+        static::assertTrue($this->View()->getAssign('success'));
 
         return $id;
     }
 
     /**
-     * Test the listing of the voucher codes
-     *
      * @depends testGenerateVoucherCodes
-     *
-     * @param string $id
      */
-    public function testGetVoucherCodes($id)
+    public function testGetVoucherCodes(int $id): int
     {
         $this->dispatch('backend/voucher/getVoucherCodes?voucherID=' . $id);
-        static::assertTrue($this->View()->success);
-        static::assertCount(50, $this->View()->data);
+        static::assertTrue($this->View()->getAssign('success'));
+        static::assertCount(50, $this->View()->getAssign('data'));
 
         return $id;
     }
 
     /**
-     * Test the exportVoucherCode Method
-     *
      * @depends testGetVoucherCodes
-     *
-     * @param string $id
      */
-    public function testExportVoucherCode($id)
+    public function testExportVoucherCode(int $id): int
     {
         $params = [];
-        $params['voucherId'] = (int) $id;
+        $params['voucherId'] = $id;
         $this->Request()->setParams($params);
         $this->dispatch('backend/voucher/exportVoucherCode');
         $header = $this->Response()->getHeaders();
@@ -299,40 +256,26 @@ class VoucherTest extends Enlight_Components_Test_Controller_TestCase
     }
 
     /**
-     * Test the delete the voucher method
-     *
      * @depends testExportVoucherCode
-     *
-     * @param string $id
      */
-    public function testDeleteVoucher($id)
+    public function testDeleteVoucher(int $id): void
     {
         $params = [];
-        $params['id'] = (int) $id;
+        $params['id'] = $id;
         $this->Request()->setParams($params);
         $this->dispatch('backend/voucher/deleteVoucher');
-        static::assertTrue($this->View()->success);
+        static::assertTrue($this->View()->getAssign('success'));
         static::assertNull($this->repository->find($params['id']));
     }
 
-    /**
-     * Test getTaxConfiguration Method
-     */
-    public function testGetTaxConfiguration()
+    public function testGetTaxConfiguration(): void
     {
         $this->dispatch('backend/voucher/getTaxConfiguration');
-        static::assertTrue($this->View()->success);
-        static::assertNotEmpty($this->View()->data);
+        static::assertTrue($this->View()->getAssign('success'));
+        static::assertNotEmpty($this->View()->getAssign('data'));
     }
 
-    /**
-     * Creates the dummy voucher
-     *
-     * @param bool $individualMode
-     *
-     * @return Voucher
-     */
-    private function getDummyVoucher($individualMode = true)
+    private function getDummyVoucher(bool $individualMode = true): Voucher
     {
         $voucher = new Voucher();
         $voucherData = $this->voucherData;
@@ -345,14 +288,7 @@ class VoucherTest extends Enlight_Components_Test_Controller_TestCase
         return $voucher;
     }
 
-    /**
-     * Helper method to create the dummy object
-     *
-     * @param bool $individualMode
-     *
-     * @return Voucher
-     */
-    private function createDummy($individualMode = true)
+    private function createDummy(bool $individualMode = true): Voucher
     {
         $voucher = $this->getDummyVoucher($individualMode);
         $this->manager->persist($voucher);

--- a/tests/Functional/Controllers/Frontend/RegisterWithCaptchaTest.php
+++ b/tests/Functional/Controllers/Frontend/RegisterWithCaptchaTest.php
@@ -30,10 +30,12 @@ use Doctrine\DBAL\Connection;
 use Enlight_Components_Test_Plugin_TestCase;
 use Shopware\Components\Captcha\DefaultCaptcha;
 use Shopware\Tests\Functional\Traits\ContainerTrait;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
 class RegisterWithCaptchaTest extends Enlight_Components_Test_Plugin_TestCase
 {
     use ContainerTrait;
+    use DatabaseTransactionBehaviour;
 
     private const USER_AGENT = 'Mozilla/5.0 (Android; Tablet; rv:14.0) Gecko/14.0 Firefox/14.0';
 

--- a/tests/Functional/Controllers/Frontend/SearchTest.php
+++ b/tests/Functional/Controllers/Frontend/SearchTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -35,12 +37,12 @@ class SearchTest extends Enlight_Components_Test_Controller_TestCase
         parent::tearDown();
     }
 
-    public function testAjaxSearch()
+    public function testAjaxSearch(): void
     {
         $this->dispatch('ajax_search?sSearch=ipad');
 
         // Check for valid markup
-        // Ignore whitespace, since this testcase checks wether the list is structured correctly (li following ul)
+        // Ignore whitespace, since this testcase checks whether the list is structured correctly (li following ul)
         self::assertStringContainsStringIgnoringWhitespace(
             '<ul class="results--list"> <li class="list--entry',
             $this->getResponseContent()
@@ -78,7 +80,7 @@ class SearchTest extends Enlight_Components_Test_Controller_TestCase
         $body = $this->Response()->getBody();
 
         static::assertIsString($body);
-        static::assertStringNotContainsStringIgnoringCase('an error has occured', $body); // Check for error-handler response as well, which would fake a HTTP 200 OK response
+        static::assertStringNotContainsStringIgnoringCase('an error has occurred', $body); // Check for error-handler response as well, which would fake a HTTP 200 OK response
         static::assertStringNotContainsStringIgnoringCase('ein fehler ist aufgetreten', $body);
 
         // search for an emoji, might not be displayed correctly in IDE
@@ -90,14 +92,14 @@ class SearchTest extends Enlight_Components_Test_Controller_TestCase
         $body = $this->Response()->getBody();
 
         static::assertIsString($body);
-        static::assertStringNotContainsStringIgnoringCase('an error has occured', $body); // Check for error-handler response as well, which would fake a HTTP 200 OK response
+        static::assertStringNotContainsStringIgnoringCase('an error has occurred', $body); // Check for error-handler response as well, which would fake a HTTP 200 OK response
         static::assertStringNotContainsStringIgnoringCase('ein fehler ist aufgetreten', $body);
     }
 
     /**
      * @dataProvider searchTermProvider
      */
-    public function testSearchEscapes(string $term, string $filtered)
+    public function testSearchEscapes(string $term, string $filtered): void
     {
         $this->dispatch(sprintf('search?sSearch=%s', $term));
 
@@ -108,7 +110,10 @@ class SearchTest extends Enlight_Components_Test_Controller_TestCase
         static::assertStringNotContainsString($term, $body, sprintf('Malicious term "%s" found on search page', $term));
     }
 
-    public function searchTermProvider()
+    /**
+     * @return list<list<string>>
+     */
+    public function searchTermProvider(): array
     {
         return [
             ['"Apostrophes"', htmlentities(strip_tags('"Apostrophes"'))],
@@ -127,13 +132,13 @@ alert(2)
         ];
     }
 
-    private static function assertStringContainsStringIgnoringWhitespace(string $needle, string $haystack, string $message = ''): void
+    private static function assertStringContainsStringIgnoringWhitespace(string $needle, string $haystack): void
     {
-        static::assertStringContainsString(
-            preg_replace('/\s/', '', $needle),
-            preg_replace('/\s/', '', $haystack),
-            $message
-        );
+        $needle = preg_replace('/\s/', '', $needle);
+        static::assertIsString($needle);
+        $haystack = preg_replace('/\s/', '', $haystack);
+        static::assertIsString($haystack);
+        static::assertStringContainsString($needle, $haystack);
     }
 
     private function getResponseContent(): string

--- a/tests/Functional/Controllers/Frontend/SitemapTest.php
+++ b/tests/Functional/Controllers/Frontend/SitemapTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -28,25 +30,29 @@ use Enlight_Class;
 use Enlight_Components_Test_Controller_TestCase;
 use Enlight_Template_Manager;
 use Enlight_View_Default;
+use Shopware\Components\Model\ModelManager;
 use Shopware\Components\ShopRegistrationServiceInterface;
 use Shopware\Models\Shop\Shop;
+use Shopware\Tests\Functional\Traits\ContainerTrait;
 use Shopware_Controllers_Frontend_Sitemap;
 
 class SitemapTest extends Enlight_Components_Test_Controller_TestCase
 {
+    use ContainerTrait;
+
     public static function tearDownAfterClass(): void
     {
         Shopware()->Container()->get(ShopRegistrationServiceInterface::class)->registerShop(Shopware()->Models()->getRepository(Shop::class)->getActiveDefault());
     }
 
     /**
-     * @param int $shopId
-     *
      * @dataProvider sitemapDataprovider
      */
-    public function testIndex($shopId, array $sitemapData)
+    public function testIndex(int $shopId, array $sitemapData): void
     {
-        Shopware()->Container()->get(ShopRegistrationServiceInterface::class)->registerShop(Shopware()->Models()->getRepository(Shop::class)->find($shopId));
+        $shop = $this->getContainer()->get(ModelManager::class)->getRepository(Shop::class)->find($shopId);
+        static::assertInstanceOf(Shop::class, $shop);
+        $this->getContainer()->get(ShopRegistrationServiceInterface::class)->registerShop($shop);
 
         $controller = $this->getController();
         $controller->indexAction();
@@ -69,10 +75,7 @@ class SitemapTest extends Enlight_Components_Test_Controller_TestCase
         }
     }
 
-    /**
-     * @return array
-     */
-    public function sitemapDataprovider()
+    public function sitemapDataprovider(): array
     {
         return [
             [
@@ -104,18 +107,15 @@ class SitemapTest extends Enlight_Components_Test_Controller_TestCase
         ];
     }
 
-    /**
-     * @return Shopware_Controllers_Frontend_Sitemap
-     */
-    private function getController()
+    private function getController(): Shopware_Controllers_Frontend_Sitemap
     {
-        /** @var Shopware_Controllers_Frontend_Sitemap $controller */
         $controller = Enlight_Class::Instance(Shopware_Controllers_Frontend_Sitemap::class, [
             $this->Request(),
             $this->Response(),
         ]);
+        static::assertInstanceOf(Shopware_Controllers_Frontend_Sitemap::class, $controller);
 
-        $controller->setContainer(Shopware()->Container());
+        $controller->setContainer($this->getContainer());
         $controller->setView(new Enlight_View_Default(new Enlight_Template_Manager()));
 
         return $controller;

--- a/tests/Functional/Controllers/Widgets/IndexTest.php
+++ b/tests/Functional/Controllers/Widgets/IndexTest.php
@@ -31,7 +31,7 @@ class IndexTest extends Enlight_Components_Test_Controller_TestCase
     /**
      * @ticket SW-8127
      */
-    public function testShopMenu()
+    public function testShopMenu(): void
     {
         $this->dispatch('/Widgets/Index/shopMenu');
         static::assertEquals(200, $this->Response()->getHttpResponseCode());

--- a/tests/Functional/Core/AdminTest.php
+++ b/tests/Functional/Core/AdminTest.php
@@ -2313,6 +2313,8 @@ class AdminTest extends TestCase
 
     public function testsGetPremiumShippingcosts(): void
     {
+        $this->generateBasketSession();
+
         // No basket, return false,
         static::assertFalse($this->module->sGetPremiumShippingcosts());
 
@@ -2325,7 +2327,6 @@ class AdminTest extends TestCase
         }
         static::assertIsArray($germany);
 
-        $this->generateBasketSession();
         $this->basketModule->sAddArticle('SW10010');
 
         // With country data, no dispatch method

--- a/tests/Functional/Core/ExportTest.php
+++ b/tests/Functional/Core/ExportTest.php
@@ -183,7 +183,7 @@ class ExportTest extends TestCase
             'shippingfree' => '0',
             'amount' => '19.99',
             'max_tax' => '19.00',
-            'userID' => null,
+            'userID' => '',
             'has_topseller' => '0',
             'has_comment' => '',
             'has_esd' => '0',
@@ -192,7 +192,7 @@ class ExportTest extends TestCase
             'paymentID' => '5',
             'customergroupID' => '1',
             'multishopID' => '1',
-            'sessionID' => null,
+            'sessionID' => 'testSessionId',
         ];
         $surcharge = $this->export->sGetPremiumDispatchSurcharge($cart);
 
@@ -216,7 +216,7 @@ class ExportTest extends TestCase
             'shippingfree' => '0',
             'amount' => '19.99',
             'max_tax' => '19.00',
-            'userID' => null,
+            'userID' => '',
             'has_topseller' => '0',
             'has_comment' => '',
             'has_esd' => '0',

--- a/tests/Functional/Core/OrderTest.php
+++ b/tests/Functional/Core/OrderTest.php
@@ -91,10 +91,9 @@ class OrderTest extends TestCase
             ]
         );
 
-        // Register the event listener, so that we test the value of "$context"
         Shopware()->Events()->addListener(
-            'Shopware_Modules_Order_SendMail_Create',
-            [$this, 'validatePaymentContextData']
+            'Shopware_Modules_Order_SendMail_FilterContext',
+            [$this, 'extendPaymentContextDataToPreventFailures']
         );
 
         Shopware()->Front()->setRequest(new ShopwareRequest());
@@ -102,19 +101,55 @@ class OrderTest extends TestCase
         $variables = [
             'additional' => [
                 'payment' => Shopware()->Modules()->Admin()->sGetPaymentMeanById(
-                    Shopware()->Db()->fetchRow('SELECT * FROM s_core_paymentmeans WHERE name LIKE "debit"')
+                    (int) Shopware()->Db()->fetchOne('SELECT id FROM s_core_paymentmeans WHERE name LIKE "debit"')
                 ),
+                'country' => [
+                    'countryname' => 'Deutschland',
+                ],
+                'countryShipping' => [
+                    'countryname' => 'Deutschland',
+                ],
+            ],
+            'billingaddress' => [
+                'company' => '',
+                'firstname' => 'Test',
+                'lastname' => 'Foo',
+                'street' => 'Ebbinghoff',
+                'streetnumber' => '10',
+                'zipcode' => '48624',
+                'city' => 'Schöppingen',
+                'ustid' => '',
+            ],
+            'shippingaddress' => [
+                'company' => '',
+                'firstname' => 'Test',
+                'lastname' => 'Foo',
+                'street' => 'Ebbinghoff',
+                'streetnumber' => '10',
+                'zipcode' => '48624',
+                'city' => 'Schöppingen',
+            ],
+            'sDispatch' => [
+                'name' => 'test',
+                'description' => 'foo',
             ],
         ];
 
         $this->module->sendMail($variables);
     }
 
-    public function validatePaymentContextData(Enlight_Event_EventArgs $args): void
+    public function extendPaymentContextDataToPreventFailures(Enlight_Event_EventArgs $args): void
     {
-        $context = $args->get('context');
+        $context = $args->getReturn();
         static::assertIsArray($context['sPaymentTable']);
         static::assertCount(0, $context['sPaymentTable']);
+
+        $context['sPaymentTable']['account'] = null;
+        $context['sPaymentTable']['bankcode'] = null;
+        $context['sPaymentTable']['bankname'] = null;
+        $context['sPaymentTable']['bankholder'] = null;
+
+        $args->setReturn($context);
     }
 
     public function testTransactionExistTrue(): void
@@ -343,12 +378,12 @@ class OrderTest extends TestCase
         $billingAttr = $billing->getAttribute();
 
         if ($billingAttr !== null) {
-            static::assertSame($originalBillingAddress['text1'], $billingAttr->getText1());
-            static::assertSame($originalBillingAddress['text2'], $billingAttr->getText2());
-            static::assertSame($originalBillingAddress['text3'], $billingAttr->getText3());
-            static::assertSame($originalBillingAddress['text4'], $billingAttr->getText4());
-            static::assertSame($originalBillingAddress['text5'], $billingAttr->getText5());
-            static::assertSame($originalBillingAddress['text6'], $billingAttr->getText6());
+            static::assertSame($originalBillingAddress['text1'] ?? null, $billingAttr->getText1());
+            static::assertSame($originalBillingAddress['text2'] ?? null, $billingAttr->getText2());
+            static::assertSame($originalBillingAddress['text3'] ?? null, $billingAttr->getText3());
+            static::assertSame($originalBillingAddress['text4'] ?? null, $billingAttr->getText4());
+            static::assertSame($originalBillingAddress['text5'] ?? null, $billingAttr->getText5());
+            static::assertSame($originalBillingAddress['text6'] ?? null, $billingAttr->getText6());
             Shopware()->Models()->remove($billingAttr);
         }
         Shopware()->Models()->remove($billing);
@@ -377,12 +412,12 @@ class OrderTest extends TestCase
         $shippingAttr = $shipping->getAttribute();
 
         if ($shippingAttr !== null) {
-            static::assertSame($originalBillingAddress['text1'], $shippingAttr->getText1());
-            static::assertSame($originalBillingAddress['text2'], $shippingAttr->getText2());
-            static::assertSame($originalBillingAddress['text3'], $shippingAttr->getText3());
-            static::assertSame($originalBillingAddress['text4'], $shippingAttr->getText4());
-            static::assertSame($originalBillingAddress['text5'], $shippingAttr->getText5());
-            static::assertSame($originalBillingAddress['text6'], $shippingAttr->getText6());
+            static::assertSame($originalBillingAddress['text1'] ?? null, $shippingAttr->getText1());
+            static::assertSame($originalBillingAddress['text2'] ?? null, $shippingAttr->getText2());
+            static::assertSame($originalBillingAddress['text3'] ?? null, $shippingAttr->getText3());
+            static::assertSame($originalBillingAddress['text4'] ?? null, $shippingAttr->getText4());
+            static::assertSame($originalBillingAddress['text5'] ?? null, $shippingAttr->getText5());
+            static::assertSame($originalBillingAddress['text6'] ?? null, $shippingAttr->getText6());
             Shopware()->Models()->remove($shippingAttr);
         }
 
@@ -482,6 +517,9 @@ class OrderTest extends TestCase
                 'getVariantEsd',
                 [$basketRow['ordernumber']]
             );
+            if (!\is_array($esdArticle)) {
+                continue;
+            }
 
             $availableSerials = $this->invokeMethod(
                 $this->module,

--- a/tests/Functional/Library/Zend/ZendDBTest.php
+++ b/tests/Functional/Library/Zend/ZendDBTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -22,16 +24,23 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Tests\Functional\Controllers\Frontend;
+namespace Shopware\Tests\Functional\Library\Zend;
 
-use Enlight_Components_Test_Controller_TestCase;
+use PHPUnit\Framework\TestCase;
+use Shopware\Tests\Functional\Traits\ContainerTrait;
+use Zend_Db_Adapter_Exception;
 
-class SitemapXmlTest extends Enlight_Components_Test_Controller_TestCase
+class ZendDBTest extends TestCase
 {
-    public function testIndex()
-    {
-        $this->dispatch('/SitemapXml');
+    use ContainerTrait;
 
-        static::assertEquals(302, $this->Response()->getHttpResponseCode());
+    public function testAdapterException(): void
+    {
+        $dbConnection = $this->getContainer()->get('db');
+
+        $this->expectException(Zend_Db_Adapter_Exception::class);
+        $this->expectExceptionMessageMatches("/SQLSTATE\[42S02\]: Base table or view not found: 1146 Table '.*\.foobar' doesn't exist/");
+        $this->expectExceptionCode(0);
+        $dbConnection->exec('SELECT * FROM foobar');
     }
 }

--- a/tests/Functional/Library/Zend/ZendLocaleTest.php
+++ b/tests/Functional/Library/Zend/ZendLocaleTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -22,13 +24,16 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\Tests\Functional\Library;
+namespace Shopware\Tests\Functional\Library\Zend;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Tests\Functional\Traits\ContainerTrait;
 
 class ZendLocaleTest extends TestCase
 {
+    use ContainerTrait;
+
     public const KNOWN_FAILURE = [
         'wo_SN',
         'tt_RU',
@@ -64,22 +69,20 @@ class ZendLocaleTest extends TestCase
     ];
 
     /**
-     * @param string $localName
-     *
      * @dataProvider getLocales
      */
-    public function testLocalCreation($localName)
+    public function testLocalCreation(string $localName): void
     {
         static::assertFileExists(sprintf('%s/engine/Library/Zend/Locale/Data/%s.xml', Shopware()->DocPath(), $localName));
     }
 
     /**
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
-    public function getLocales()
+    public function getLocales(): array
     {
-        $con = Shopware()->Container()->get(\Doctrine\DBAL\Connection::class);
+        $sql = 'SELECT locale FROM s_core_locales WHERE locale NOT IN(?)';
 
-        return $con->fetchAll('SELECT locale FROM s_core_locales WHERE locale NOT IN(?)', [self::KNOWN_FAILURE], [Connection::PARAM_STR_ARRAY]);
+        return $this->getContainer()->get(Connection::class)->fetchAllAssociative($sql, [self::KNOWN_FAILURE], [Connection::PARAM_STR_ARRAY]);
     }
 }

--- a/tests/Functional/Models/Article/DetailTest.php
+++ b/tests/Functional/Models/Article/DetailTest.php
@@ -116,15 +116,15 @@ class DetailTest extends Enlight_Components_Test_TestCase
                 'number' => '€SW100066@1',
             ],
             [
-                'regex' => '/^[\w-_.@€]+$/',
+                'regex' => '/^[\w\-_.@€]+$/',
                 'number' => '@SW100066€1',
             ],
             [
-                'regex' => '/^[\w\s-_.@€]+$/',
+                'regex' => '/^[\w\s\-_.@€]+$/',
                 'number' => '€SW1 00 066@1',
             ],
             [
-                'regex' => '/^[\w\u-_.@€]+$/',
+                'regex' => '/^[\p{L}\p{N}\p{P}\p{S}]+$/u',
                 'number' => '€SW100💙066@1',
             ],
         ];

--- a/tests/Functional/Models/Category/BlogCategoryTreeListQueryTest.php
+++ b/tests/Functional/Models/Category/BlogCategoryTreeListQueryTest.php
@@ -45,8 +45,6 @@ class BlogCategoryTreeListQueryTest extends Enlight_Components_Test_TestCase
                 'position' => 0,
                 'blog' => false,
                 'childrenCount' => '1',
-                'emotions' => null,
-                'articles' => null,
             ],
             1 => [
                 'id' => 39,
@@ -54,8 +52,6 @@ class BlogCategoryTreeListQueryTest extends Enlight_Components_Test_TestCase
                 'position' => 1,
                 'blog' => false,
                 'childrenCount' => '1',
-                'emotions' => null,
-                'articles' => null,
             ],
         ],
         3 => [
@@ -65,8 +61,6 @@ class BlogCategoryTreeListQueryTest extends Enlight_Components_Test_TestCase
                 'position' => 5,
                 'blog' => true,
                 'childrenCount' => '0',
-                'emotions' => null,
-                'articles' => null,
             ],
         ],
         39 => [
@@ -76,8 +70,6 @@ class BlogCategoryTreeListQueryTest extends Enlight_Components_Test_TestCase
                 'position' => 0,
                 'blog' => true,
                 'childrenCount' => '0',
-                'emotions' => null,
-                'articles' => null,
             ],
         ],
     ];
@@ -88,7 +80,7 @@ class BlogCategoryTreeListQueryTest extends Enlight_Components_Test_TestCase
             $filter = [['property' => 'c.parentId', 'value' => $id]];
             $query = $this->getRepo()->getBlogCategoryTreeListQuery($filter);
             $data = $this->removeDates($query->getArrayResult());
-            static::assertEquals($data, $expected);
+            static::assertEquals($expected, $data);
         }
     }
 
@@ -110,13 +102,17 @@ class BlogCategoryTreeListQueryTest extends Enlight_Components_Test_TestCase
     {
         foreach ($data as &$subCategory) {
             unset($subCategory['changed'], $subCategory['cmsText'], $subCategory['added']);
-            foreach ($subCategory['emotions'] as &$emotion) {
-                unset($emotion['createDate'], $emotion['modified']);
+            if (isset($subCategory['emotions'])) {
+                foreach ($subCategory['emotions'] as &$emotion) {
+                    unset($emotion['createDate'], $emotion['modified']);
+                }
             }
             unset($emotion);
 
-            foreach ($subCategory['articles'] as &$article) {
-                unset($article['added'], $article['changed'], $article['mainDetail']['releaseDate']);
+            if (isset($subCategory['articles'])) {
+                foreach ($subCategory['articles'] as &$article) {
+                    unset($article['added'], $article['changed'], $article['mainDetail']['releaseDate']);
+                }
             }
         }
 

--- a/tests/Functional/Models/CustomerStream/CustomerStreamRepositoryTest.php
+++ b/tests/Functional/Models/CustomerStream/CustomerStreamRepositoryTest.php
@@ -118,7 +118,7 @@ class CustomerStreamRepositoryTest extends TestCase
     }
 
     /**
-     * @return array{name: 'Teststream', static: false, description: 'Stream created for testing purposes', conditions: '{"Shopware\Bundle\CustomerSearchBundle\Condition\HasOrderCountCondition":{"minimumOrderCount":0}}', indexStream: true}
+     * @return array{name: 'Teststream', static: false, description: 'Stream created for testing purposes', conditions: string, indexStream: true}
      */
     private static function getCustomerStreamData(): array
     {
@@ -126,7 +126,7 @@ class CustomerStreamRepositoryTest extends TestCase
             'name' => 'Teststream',
             'static' => false,
             'description' => 'Stream created for testing purposes',
-            'conditions' => '{"Shopware\\Bundle\\CustomerSearchBundle\\Condition\\HasOrderCountCondition":{"minimumOrderCount":0}}',
+            'conditions' => '{"Shopware\\\\Bundle\\\\CustomerSearchBundle\\\\Condition\\\\HasOrderCountCondition":{"minimumOrderCount":0}}',
             'indexStream' => true,
         ];
     }

--- a/tests/Functional/Models/Order/OrderDocumentDocumentTest.php
+++ b/tests/Functional/Models/Order/OrderDocumentDocumentTest.php
@@ -35,11 +35,13 @@ use Shopware\Models\Attribute\Document as DocumentAttribute;
 use Shopware\Models\Order\Document\Document;
 use Shopware\Models\Shop\Shop;
 use Shopware\Tests\Functional\Traits\ContainerTrait;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 use Shopware_Components_Document;
 
 class OrderDocumentDocumentTest extends Enlight_Components_Test_TestCase
 {
     use ContainerTrait;
+    use DatabaseTransactionBehaviour;
 
     private ModelManager $modelManager;
 
@@ -72,6 +74,7 @@ class OrderDocumentDocumentTest extends Enlight_Components_Test_TestCase
         // Flush changed shop to the database, needed for the Document code
         $this->modelManager->flush($shop);
 
+        $document = null;
         try {
             /*
              * Used to fail with the following error before allowing inactive subshops

--- a/tests/Functional/Modules/Articles/CompareTest.php
+++ b/tests/Functional/Modules/Articles/CompareTest.php
@@ -63,9 +63,9 @@ class CompareTest extends Enlight_Components_Test_TestCase
 
     public function testDeleteComparison(): void
     {
-        $article = $this->getTestProductId();
-        static::assertTrue($this->Module()->sAddComparison($article));
-        $this->Module()->sDeleteComparison($article);
+        $productId = $this->getTestProductId();
+        static::assertTrue($this->Module()->sAddComparison($productId));
+        $this->Module()->sDeleteComparison($productId);
         static::assertEmpty($this->Module()->sGetComparisons());
     }
 
@@ -83,6 +83,14 @@ class CompareTest extends Enlight_Components_Test_TestCase
     {
         static::assertTrue($this->Module()->sAddComparison($this->getTestProductId()));
         static::assertNotEmpty($this->Module()->sGetComparisons());
+    }
+
+    public function testAddComparisonSameProductTwice(): void
+    {
+        $productId = $this->getTestProductId();
+        static::assertTrue($this->Module()->sAddComparison($productId));
+        static::assertTrue($this->Module()->sAddComparison($productId));
+        static::assertCount(1, $this->Module()->sGetComparisons());
     }
 
     public function testGetComparisons(): void

--- a/tests/Functional/Modules/Articles/sGetArticleByIdTest.php
+++ b/tests/Functional/Modules/Articles/sGetArticleByIdTest.php
@@ -3542,7 +3542,7 @@ class sGetArticleByIdTest extends Enlight_Components_Test_Plugin_TestCase
             }
 
             static::assertEquals(
-                $expected[$property],
+                $expected[$property] ?? null,
                 $data[$property],
                 sprintf('Property %s dont match for article : %s - %s', $property, $expected['ordernumber'], $expected['articleName'])
             );

--- a/tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
+++ b/tests/Functional/Plugins/Core/HttpCache/DynamicCacheTimeServiceTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Shopware 5
  * Copyright (c) shopware AG
@@ -34,23 +36,25 @@ use Shopware\Bundle\PluginInstallerBundle\Service\InstallerService;
 use Shopware\Bundle\PluginInstallerBundle\Service\LegacyPluginInstaller;
 use Shopware\Components\HttpCache\CacheTimeServiceInterface;
 use Shopware\Components\HttpCache\DynamicCacheTimeService;
-use Shopware\Models\Article\Article;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Models\Article\Article as Product;
+use Shopware\Models\Article\Detail;
 use Shopware\Models\Blog\Blog;
 use Shopware\Models\Category\Category;
 use Shopware\Models\Emotion\Emotion;
-use Shopware\Models\Plugin\Plugin;
+use Shopware\Tests\Functional\Traits\ContainerTrait;
+use Shopware\Tests\Functional\Traits\DatabaseTransactionBehaviour;
 
 class DynamicCacheTimeServiceTest extends TestCase
 {
-    /**
-     * @var CacheTimeServiceInterface
-     */
-    private $cacheTimeService;
+    use ContainerTrait;
+    use DatabaseTransactionBehaviour;
 
-    /**
-     * @var int
-     */
-    private $defaultTime;
+    private CacheTimeServiceInterface $cacheTimeService;
+
+    private int $defaultTime;
+
+    private ModelManager $modelManager;
 
     /**
      * {@inheritdoc}
@@ -64,7 +68,6 @@ class DynamicCacheTimeServiceTest extends TestCase
 
         $pluginManager = Shopware()->Container()->get(InstallerService::class);
 
-        /** @var Plugin $plugin */
         $plugin = $pluginManager->getPluginByName('HttpCache');
 
         $pluginManager->installPlugin($plugin);
@@ -85,23 +88,23 @@ class DynamicCacheTimeServiceTest extends TestCase
      */
     public function setUp(): void
     {
-        $this->cacheTimeService = Shopware()->Container()->get(CacheTimeServiceInterface::class);
-
+        $this->cacheTimeService = $this->getContainer()->get(CacheTimeServiceInterface::class);
         $this->defaultTime = 3600;
+        $this->modelManager = $this->getContainer()->get(ModelManager::class);
 
         Shopware()->Models()->clear();
     }
 
-    public function testServiceIsAvailable()
+    public function testServiceIsAvailable(): void
     {
         static::assertInstanceOf(DynamicCacheTimeService::class, $this->cacheTimeService);
     }
 
-    public function testProductDetailTimeCalculation()
+    public function testProductDetailTimeCalculation(): void
     {
         $product = $this->createTestProduct();
         $request = $this->getProductRequest($product);
-        Shopware()->Container()->get('front')->setRequest($request);
+        $this->getContainer()->get('front')->setRequest($request);
 
         /**
          * The release date of products only contains information about the day, not minutes or seconds,
@@ -111,14 +114,14 @@ class DynamicCacheTimeServiceTest extends TestCase
         $productCacheTime = $this->cacheTimeService->getCacheTime($request);
         static::assertLessThanOrEqual($this->defaultTime, $productCacheTime);
 
-        Shopware()->Models()->remove($product);
+        $this->modelManager->remove($product);
     }
 
-    public function testCategoryTimeCalculation()
+    public function testCategoryTimeCalculation(): void
     {
         $category = $this->createTestCategory();
-        $request = $this->getcategoryRequest($category);
-        Shopware()->Container()->get('front')->setRequest($request);
+        $request = $this->getCategoryRequest($category);
+        $this->getContainer()->get('front')->setRequest($request);
 
         /*
          * Test if the five minute time difference is correctly recognised by the CacheTimeService.
@@ -129,14 +132,14 @@ class DynamicCacheTimeServiceTest extends TestCase
         $emotionCacheTime = $this->cacheTimeService->getCacheTime($request);
         static::assertLessThan(5, abs(300 - $emotionCacheTime));
 
-        Shopware()->Models()->remove($category);
+        $this->modelManager->remove($category);
     }
 
-    public function testBlogTimeCalculation()
+    public function testBlogTimeCalculation(): void
     {
         $blog = $this->createTestBlog();
         $request = $this->getBlogRequest($blog);
-        Shopware()->Container()->get('front')->setRequest($request);
+        $this->getContainer()->get('front')->setRequest($request);
 
         /*
          * Test if the five minute time difference is correctly recognised by the CacheTimeService.
@@ -147,14 +150,14 @@ class DynamicCacheTimeServiceTest extends TestCase
         $blogCacheTime = $this->cacheTimeService->getCacheTime($request);
         static::assertLessThan(5, abs(300 - $blogCacheTime));
 
-        Shopware()->Models()->remove($blog);
+        $this->modelManager->remove($blog);
     }
 
-    public function testBlogListingTimeCalculation()
+    public function testBlogListingTimeCalculation(): void
     {
         $blog = $this->createTestBlogWithCategory();
         $request = $this->getBlogListingRequest($blog);
-        Shopware()->Container()->get('front')->setRequest($request);
+        $this->getContainer()->get('front')->setRequest($request);
 
         /*
          * Test if the five minute time difference is correctly recognised by the CacheTimeService.
@@ -165,13 +168,10 @@ class DynamicCacheTimeServiceTest extends TestCase
         $blogCacheTime = $this->cacheTimeService->getCacheTime($request);
         static::assertLessThan(5, abs(300 - $blogCacheTime));
 
-        Shopware()->Models()->remove($blog);
+        $this->modelManager->remove($blog);
     }
 
-    /**
-     * @return Enlight_Controller_Request_RequestTestCase
-     */
-    private function getBlogListingRequest(Blog $blog)
+    private function getBlogListingRequest(Blog $blog): Enlight_Controller_Request_RequestTestCase
     {
         $request = new Enlight_Controller_Request_RequestTestCase();
         $request->setParams([
@@ -184,10 +184,7 @@ class DynamicCacheTimeServiceTest extends TestCase
         return $request;
     }
 
-    /**
-     * @return Enlight_Controller_Request_RequestTestCase
-     */
-    private function getBlogRequest(Blog $blog)
+    private function getBlogRequest(Blog $blog): Enlight_Controller_Request_RequestTestCase
     {
         $request = new Enlight_Controller_Request_RequestTestCase();
         $request->setParams([
@@ -200,17 +197,14 @@ class DynamicCacheTimeServiceTest extends TestCase
         return $request;
     }
 
-    /**
-     * @return Blog|null
-     */
-    private function createTestBlog()
+    private function createTestBlog(): Blog
     {
         try {
             $blog = new Blog();
             $blog->fromArray($this->getBlogTestData());
 
-            Shopware()->Models()->persist($blog);
-            Shopware()->Models()->flush();
+            $this->modelManager->persist($blog);
+            $this->modelManager->flush();
 
             return $blog;
         } catch (Exception $e) {
@@ -218,10 +212,7 @@ class DynamicCacheTimeServiceTest extends TestCase
         }
     }
 
-    /**
-     * @return Blog|null
-     */
-    private function createTestBlogWithCategory()
+    private function createTestBlogWithCategory(): Blog
     {
         try {
             $blog = $this->createTestBlog();
@@ -229,8 +220,8 @@ class DynamicCacheTimeServiceTest extends TestCase
 
             $blog->setCategoryId($blogCategory->getId());
 
-            Shopware()->Models()->persist($blog);
-            Shopware()->Models()->flush();
+            $this->modelManager->persist($blog);
+            $this->modelManager->flush();
 
             return $blog;
         } catch (Exception $e) {
@@ -238,10 +229,7 @@ class DynamicCacheTimeServiceTest extends TestCase
         }
     }
 
-    /**
-     * @return Enlight_Controller_Request_RequestTestCase
-     */
-    private function getcategoryRequest(Category $category)
+    private function getCategoryRequest(Category $category): Enlight_Controller_Request_RequestTestCase
     {
         $request = new Enlight_Controller_Request_RequestTestCase();
         $request->setParams([
@@ -254,17 +242,14 @@ class DynamicCacheTimeServiceTest extends TestCase
         return $request;
     }
 
-    /**
-     * @return Emotion|null
-     */
-    private function createTestEmotion()
+    private function createTestEmotion(): Emotion
     {
         try {
             $emotion = new Emotion();
             $emotion->fromArray($this->getEmotionTestData());
 
-            Shopware()->Models()->persist($emotion);
-            Shopware()->Models()->flush();
+            $this->modelManager->persist($emotion);
+            $this->modelManager->flush();
 
             return $emotion;
         } catch (Exception $e) {
@@ -272,16 +257,13 @@ class DynamicCacheTimeServiceTest extends TestCase
         }
     }
 
-    /**
-     * @return Category|null
-     */
-    private function createTestCategory()
+    private function createTestCategory(): Category
     {
         try {
             $category = new Category();
-            $category->setActive(1);
+            $category->setActive(true);
             $category->setName('MyTestCategory');
-            $category->setParent(Shopware()->Models()->getRepository(Category::class)->find(1));
+            $category->setParent($this->modelManager->getRepository(Category::class)->find(1));
 
             $emotion = $this->createTestEmotion();
 
@@ -293,8 +275,8 @@ class DynamicCacheTimeServiceTest extends TestCase
                 new ArrayCollection([$emotion])
             );
 
-            Shopware()->Models()->persist($category);
-            Shopware()->Models()->flush();
+            $this->modelManager->persist($category);
+            $this->modelManager->flush();
 
             return $category;
         } catch (Exception $e) {
@@ -302,11 +284,9 @@ class DynamicCacheTimeServiceTest extends TestCase
         }
     }
 
-    /**
-     * @return Enlight_Controller_Request_RequestTestCase
-     */
-    private function getProductRequest(Article $product)
+    private function getProductRequest(Product $product): Enlight_Controller_Request_RequestTestCase
     {
+        static::assertInstanceOf(Detail::class, $product->getMainDetail());
         $request = new Enlight_Controller_Request_RequestTestCase();
         $request->setParams([
             'module' => 'frontend',
@@ -319,13 +299,10 @@ class DynamicCacheTimeServiceTest extends TestCase
         return $request;
     }
 
-    /**
-     * @return Article|null
-     */
-    private function createTestProduct()
+    private function createTestProduct(): Product
     {
         try {
-            $product = new Article();
+            $product = new Product();
 
             $product->fromArray($this->getProductTestData());
             /*
@@ -333,12 +310,13 @@ class DynamicCacheTimeServiceTest extends TestCase
              * so the timestamp "five minutes from now" will evaluate to the previous midnight.
              * Therefore we need to add another day, so it'll evaluate to the next midnight.
              */
+            static::assertInstanceOf(Detail::class, $product->getMainDetail());
             $product->getMainDetail()->setReleaseDate((new DateTime())->add(
                 new DateInterval('P1D')
             ));
 
-            Shopware()->Models()->persist($product);
-            Shopware()->Models()->flush();
+            $this->modelManager->persist($product);
+            $this->modelManager->flush();
 
             return $product;
         } catch (Exception $e) {
@@ -347,18 +325,18 @@ class DynamicCacheTimeServiceTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
-    private function getProductTestData()
+    private function getProductTestData(): array
     {
         return [
-            'name' => 'Testarticle',
-            'description' => 'testdescription',
+            'name' => 'Test product',
+            'description' => 'test description',
             'descriptionLong' => 'Test descriptionLong',
             'active' => true,
             'pseudoSales' => 999,
             'highlight' => true,
-            'keywords' => 'test, testarticle',
+            'keywords' => 'test, testproduct',
             'taxId' => 1,
             'mainDetail' => [
                 'active' => 1,
@@ -369,9 +347,9 @@ class DynamicCacheTimeServiceTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
-    private function getEmotionTestData()
+    private function getEmotionTestData(): array
     {
         return [
             'active' => 1,
@@ -392,9 +370,9 @@ class DynamicCacheTimeServiceTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
-    private function getBlogTestData()
+    private function getBlogTestData(): array
     {
         return [
             'title' => 'MyTestBlog',
@@ -406,10 +384,7 @@ class DynamicCacheTimeServiceTest extends TestCase
         ];
     }
 
-    /**
-     * @return DateTime
-     */
-    private function getTimestampFiveMinutesFromNow()
+    private function getTimestampFiveMinutesFromNow(): DateTime
     {
         return (new DateTime())->add(new DateInterval('PT5M'));
     }

--- a/tests/Functional/TestKernel.php
+++ b/tests/Functional/TestKernel.php
@@ -46,7 +46,6 @@ class TestKernel extends Kernel
         $kernel->boot();
 
         $container = $kernel->getContainer();
-        $container->get('plugins')->Core()->ErrorHandler()->registerErrorHandler(E_ALL | E_STRICT);
 
         $modelManager = $container->get(ModelManager::class);
         $generator = $modelManager->createModelGenerator();

--- a/tests/Mink/Tests/General/Helpers/FeatureContext.php
+++ b/tests/Mink/Tests/General/Helpers/FeatureContext.php
@@ -172,9 +172,7 @@ class FeatureContext extends SubContext implements SnippetAcceptingContext
      */
     public function saveScreenshot(?string $filename = null, ?string $filepath = null): void
     {
-        // Under Cygwin, uniqid with more_entropy must be set to true.
-        // No effect in other environments.
-        $generatedFilename = sprintf('%s_%s_%s.%s', $this->getMinkParameter('browser_name'), (new DateTime())->format('Y-m-d--H-i-s'), uniqid('', true), 'png');
+        $generatedFilename = sprintf('%s_%s.%s', $this->getMinkParameter('browser_name'), $this->getDateTimeWithRandomString(), 'png');
         $filename = $filename ?: $generatedFilename;
         $filepath = $filepath ?: (ini_get('upload_tmp_dir') ?: sys_get_temp_dir());
         file_put_contents($filepath . '/' . $filename, $this->getSession()->getScreenshot());
@@ -264,8 +262,7 @@ class FeatureContext extends SubContext implements SnippetAcceptingContext
             ];
             $filepath = $this->getService(Kernel::class)->getRootDir() . '/build/logs/mink';
 
-            // No effect in other environments.
-            $filename = sprintf('errors_%s_%s.%s', date('c'), uniqid('', true), 'log');
+            $filename = sprintf('errors_%s.%s', $this->getDateTimeWithRandomString(), 'log');
             $filepath .= '/' . $filename;
             file_put_contents($filepath, $errorNameMap[$errno] . ': ' . $errstr, FILE_APPEND);
 
@@ -382,9 +379,7 @@ EOD;
     {
         $logDir = $this->getService(Kernel::class)->getRootDir() . '/build/logs/mink';
 
-        $currentDateAsString = date('YmdHis');
-
-        $path = sprintf('%s/behat-%s.%s', $logDir, $currentDateAsString, 'log');
+        $path = sprintf('%s/behat-%s.%s', $logDir, $this->getDateTime(), 'log');
         if (!file_put_contents($path, $content)) {
             Helper::throwException(sprintf('Failed while trying to write log in "%s".', $path));
         }
@@ -435,5 +430,15 @@ EOD;
         $cacheManager->clearConfigCache();
         $cacheManager->clearTemplateCache();
         $cacheManager->clearThemeCache();
+    }
+
+    private function getDateTimeWithRandomString(): string
+    {
+        return $this->getDateTime() . '_' . uniqid('', true);
+    }
+
+    private function getDateTime(): string
+    {
+        return (new DateTime())->format('Y-m-d--H-i-s');
     }
 }

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -7,6 +7,7 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutResourceUsageDuringSmallTests="true"
          beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
          verbose="true">
     <coverage includeUncoveredFiles="false">
         <include>

--- a/tests/phpunit_unit.xml.dist
+++ b/tests/phpunit_unit.xml.dist
@@ -8,6 +8,7 @@
          beStrictAboutResourceUsageDuringSmallTests="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
          verbose="true">
     <coverage includeUncoveredFiles="false">
         <include>

--- a/themes/Backend/ExtJs/backend/search/articles.tpl
+++ b/themes/Backend/ExtJs/backend/search/articles.tpl
@@ -14,7 +14,7 @@
         {block name="backend/search/index/result_content"}
             <div class="result-container">
                 {foreach $searchResult.articles as $item}
-                    <a onclick="openSearchResult('articles', {$item.articleId});return false;" href="#"{if $item@iteration is odd by 2} class="odd"{/if}>
+                    <a onclick="openSearchResult('articles', {$item.articleId});return false;" href="#">
                         <span class="name" style="display:inline-block;width: 155px">{$item.name|truncate:60}</span>
 
                         {if $item.description}

--- a/themes/Backend/ExtJs/backend/search/customers.tpl
+++ b/themes/Backend/ExtJs/backend/search/customers.tpl
@@ -14,7 +14,7 @@
         {block name="backend/search/index/result_content"}
             <div class="result-container">
                 {foreach $searchResult.customers as $item}
-                    <a onclick="openSearchResult('customers', {$item.id});return false;" href="#"{if $item@iteration is odd by 2} class="odd"{/if}>
+                    <a onclick="openSearchResult('customers', {$item.id});return false;" href="#">
                         <span class="name">
                             {if $item.company}{$item.company} {/if}{$item.firstname} {$item.lastname}
                         </span>

--- a/themes/Backend/ExtJs/backend/search/orders.tpl
+++ b/themes/Backend/ExtJs/backend/search/orders.tpl
@@ -14,7 +14,7 @@
         {block name="backend/search/index/result_content"}
             <div class="result-container">
                 {foreach $searchResult.orders as $item}
-                    <a onclick="openSearchResult('orders', {$item.id});return false;" href="#"{if $item@iteration is odd by 2} class="odd"{/if}>
+                    <a onclick="openSearchResult('orders', {$item.id});return false;" href="#">
                         <span class="name">{$item.number}: {$item.orderStateName|truncate:30} </span>
                         <span class="desc">{if $item.company}{$item.company} {/if}{$item.firstname} {$item.lastname} {$item.street} {$item.zipcode} {$item.city}</span>
                         <span class="desc">{$item.shopName} / {$item.dispatchName} / {$item.paymentName}</span>

--- a/themes/Frontend/Bare/frontend/address/form.tpl
+++ b/themes/Frontend/Bare/frontend/address/form.tpl
@@ -47,7 +47,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterPlaceholderCompany' namespace="frontend/register/billing_fieldset"}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="register_billing_company"
-                                   value="{$formData.company|escape}"
+                                   value="{$formData.company|escapeHtml}"
                                    class="address--field {if $error_flags.company} has--error{/if} is--required"/>
                         </div>
                     {/block}
@@ -60,7 +60,7 @@
                                    type="text"
                                    placeholder="{s name='RegisterLabelDepartment' namespace="frontend/register/billing_fieldset"}{/s}"
                                    id="register_billing_department"
-                                   value="{$formData.department|escape}"
+                                   value="{$formData.department|escapeHtml}"
                                    class="address--field{if $error_flags.department} has--error{/if}"/>
                         </div>
                     {/block}
@@ -72,7 +72,7 @@
                                    type="text"
                                    placeholder="{s name='RegisterLabelTaxId' namespace="frontend/register/billing_fieldset"}{/s}{if {config name="vatcheckrequired"}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                    id="register_billing_vatid"
-                                   value="{$formData.vatId|escape}"
+                                   value="{$formData.vatId|escapeHtml}"
                                    {if {config name="vatcheckrequired"}} required="required" aria-required="true"{/if}
                                    class="address--field{if $error_flags.vatId} has--error{/if}{if {config name="vatcheckrequired"}} is--required{/if}"/>
                         </div>
@@ -112,7 +112,7 @@
                                    type="text"
                                    placeholder="{s name='RegisterPlaceholderTitle' namespace="frontend/register/personal_fieldset"}{/s}"
                                    id="title"
-                                   value="{$formData.title|escape}"
+                                   value="{$formData.title|escapeHtml}"
                                    class="address--field{if $error_flags.title} has--error{/if}" />
                         </div>
                     {/if}
@@ -128,7 +128,7 @@
                                aria-required="true"
                                placeholder="{s name='RegisterShippingPlaceholderFirstname' namespace="frontend/register/shipping_fieldset"}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                id="firstname2"
-                               value="{$formData.firstname|escape}"
+                               value="{$formData.firstname|escapeHtml}"
                                class="address--field is--required{if $error_flags.firstname} has--error{/if}"/>
                     </div>
                 {/block}
@@ -143,7 +143,7 @@
                                aria-required="true"
                                placeholder="{s name='RegisterShippingPlaceholderLastname' namespace="frontend/register/shipping_fieldset"}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                id="lastname2"
-                               value="{$formData.lastname|escape}"
+                               value="{$formData.lastname|escapeHtml}"
                                class="address--field is--required{if $error_flags.lastname} has--error{/if}"/>
                     </div>
                 {/block}
@@ -158,7 +158,7 @@
                                aria-required="true"
                                placeholder="{s name='RegisterBillingPlaceholderStreet' namespace="frontend/register/billing_fieldset"}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                id="street"
-                               value="{$formData.street|escape}"
+                               value="{$formData.street|escapeHtml}"
                                class="address--field address--field-street is--required{if $error_flags.street} has--error{/if}"/>
                     </div>
                 {/block}
@@ -173,7 +173,7 @@
                                    {if {config name="requireAdditionAddressLine1"}} required="required" aria-required="true"{/if}
                                    placeholder="{s name='RegisterLabelAdditionalAddressLine1'  namespace="frontend/register/shipping_fieldset"}{/s}{if {config name="requireAdditionAddressLine1"}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                    id="additionalAddressLine1"
-                                   value="{$formData.additionalAddressLine1|escape}"
+                                   value="{$formData.additionalAddressLine1|escapeHtml}"
                                    class="address--field{if {config name="requireAdditionAddressLine1"}} is--required{/if}{if $error_flags.additionalAddressLine1 && {config name="requireAdditionAddressLine1"}} has--error{/if}"/>
                         </div>
                     {/if}
@@ -189,7 +189,7 @@
                                    {if {config name="requireAdditionAddressLine2"}} required="required" aria-required="true"{/if}
                                    placeholder="{s name='RegisterLabelAdditionalAddressLine2'  namespace="frontend/register/shipping_fieldset"}{/s}{if {config name="requireAdditionAddressLine2"}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                    id="additionalAddressLine2"
-                                   value="{$formData.additionalAddressLine2|escape}"
+                                   value="{$formData.additionalAddressLine2|escapeHtml}"
                                    class="address--field{if {config name="requireAdditionAddressLine2"}} is--required{/if}{if $error_flags.additionalAddressLine2 && {config name="requireAdditionAddressLine2"}} has--error{/if}"/>
                         </div>
                     {/if}
@@ -206,7 +206,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterBillingPlaceholderZipcode' namespace="frontend/register/billing_fieldset"}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="zipcode"
-                                   value="{$formData.zipcode|escape}"
+                                   value="{$formData.zipcode|escapeHtml}"
                                    class="address--field address--spacer address--field-zipcode is--required{if $error_flags.zipcode} has--error{/if}"/>
                             <input autocomplete="section-billing billing address-level2"
                                    name="{$inputPrefix}[city]"
@@ -215,7 +215,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterBillingPlaceholderCity' namespace="frontend/register/billing_fieldset"}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="city"
-                                   value="{$formData.city|escape}"
+                                   value="{$formData.city|escapeHtml}"
                                    size="25"
                                    class="address--field address--field-city is--required{if $error_flags.city} has--error{/if}"/>
                         {else}
@@ -226,7 +226,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterBillingPlaceholderCity' namespace="frontend/register/billing_fieldset"}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="city"
-                                   value="{$formData.city|escape}"
+                                   value="{$formData.city|escapeHtml}"
                                    size="25"
                                    class="address--field address--spacer address--field-city is--required{if $error_flags.city} has--error{/if}"/>
                             <input autocomplete="section-billing billing postal-code"
@@ -236,7 +236,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterBillingPlaceholderZipcode' namespace="frontend/register/billing_fieldset"}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="zipcode"
-                                   value="{$formData.zipcode|escape}"
+                                   value="{$formData.zipcode|escapeHtml}"
                                    class="address--field address--field-zipcode is--required{if $error_flags.zipcode} has--error{/if}"/>
                         {/if}
                     </div>
@@ -305,7 +305,7 @@
                                    {if {config name="requirePhoneField"}} required="required" aria-required="true"{/if}
                                    placeholder="{s name='RegisterPlaceholderPhone' namespace="frontend/register/personal_fieldset"}{/s}{if {config name="requirePhoneField"}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                    id="phone"
-                                   value="{$formData.phone|escape}"
+                                   value="{$formData.phone|escapeHtml}"
                                    class="address--field{if {config name="requirePhoneField"}} is--required{/if}{if $error_flags.phone && {config name="requirePhoneField"}} has--error{/if}"/>
                         </div>
                     {/if}

--- a/themes/Frontend/Bare/frontend/checkout/confirm.tpl
+++ b/themes/Frontend/Bare/frontend/checkout/confirm.tpl
@@ -92,7 +92,7 @@
                         {/block}
 
                         {* Hidden field for the user comment *}
-                        <textarea class="is--hidden user-comment--hidden" rows="1" cols="1" name="sComment">{$sComment|escape}</textarea>
+                        <textarea class="is--hidden user-comment--hidden" rows="1" cols="1" name="sComment">{$sComment|escapeHtml}</textarea>
 
                         <ul class="list--checkbox list--unstyled">
 

--- a/themes/Frontend/Bare/frontend/detail/comment/form.tpl
+++ b/themes/Frontend/Bare/frontend/detail/comment/form.tpl
@@ -21,19 +21,19 @@
 
         {* Review author name *}
         {block name='frontend_detail_comment_input_name'}
-            <input name="sVoteName" type="text" value="{$sFormData.sVoteName|escape}" class="review--field{if $sErrorFlag.sVoteName} has--error{/if}" aria-label="{s name="DetailCommentLabelName"}{/s}" placeholder="{s name="DetailCommentLabelName"}{/s}" />
+            <input name="sVoteName" type="text" value="{$sFormData.sVoteName|escapeHtml}" class="review--field{if $sErrorFlag.sVoteName} has--error{/if}" aria-label="{s name="DetailCommentLabelName"}{/s}" placeholder="{s name="DetailCommentLabelName"}{/s}" />
         {/block}
 
         {* Reviewer email address *}
         {block name='frontend_detail_comment_input_mail'}
             {if {config name="OptinVote"} == true}
-                <input name="sVoteMail" type="email" value="{$sFormData.sVoteMail|escape}" class="review--field{if $sErrorFlag.sVoteMail} has--error{/if}" aria-label="{s name="DetailCommentLabelMail"}{/s}" placeholder="{s name="DetailCommentLabelMail"}{/s}*" required="required" aria-required="true" />
+                <input name="sVoteMail" type="email" value="{$sFormData.sVoteMail|escapeHtml}" class="review--field{if $sErrorFlag.sVoteMail} has--error{/if}" aria-label="{s name="DetailCommentLabelMail"}{/s}" placeholder="{s name="DetailCommentLabelMail"}{/s}*" required="required" aria-required="true" />
             {/if}
         {/block}
 
         {* Review summary *}
         {block name='frontend_detail_comment_input_summary'}
-            <input name="sVoteSummary" type="text" value="{$sFormData.sVoteSummary|escape}" id="sVoteSummary" class="review--field{if $sErrorFlag.sVoteSummary} has--error{/if}" aria-label="{s name="DetailCommentLabelSummary"}{/s}" placeholder="{s name="DetailCommentLabelSummary"}{/s}*" required="required" aria-required="true" />
+            <input name="sVoteSummary" type="text" value="{$sFormData.sVoteSummary|escapeHtml}" id="sVoteSummary" class="review--field{if $sErrorFlag.sVoteSummary} has--error{/if}" aria-label="{s name="DetailCommentLabelSummary"}{/s}" placeholder="{s name="DetailCommentLabelSummary"}{/s}*" required="required" aria-required="true" />
         {/block}
 
         {* Review Rating *}
@@ -56,7 +56,7 @@
 
         {* Review text *}
         {block name='frontend_detail_comment_input_text'}
-            <textarea name="sVoteComment" placeholder="{s name="DetailCommentPlaceholderText"}{/s}" cols="3" rows="2" class="review--field{if $sErrorFlag.sVoteComment} has--error{/if}" aria-label="{s name="DetailCommentPlaceholderText"}{/s}">{$sFormData.sVoteComment|escape}</textarea>
+            <textarea name="sVoteComment" placeholder="{s name="DetailCommentPlaceholderText"}{/s}" cols="3" rows="2" class="review--field{if $sErrorFlag.sVoteComment} has--error{/if}" aria-label="{s name="DetailCommentPlaceholderText"}{/s}">{$sFormData.sVoteComment|escapeHtml}</textarea>
         {/block}
 
         {* Captcha *}

--- a/themes/Frontend/Bare/frontend/detail/product_quick_view.tpl
+++ b/themes/Frontend/Bare/frontend/detail/product_quick_view.tpl
@@ -3,13 +3,13 @@
         {block name='frontend_detail_product_quick_view_inner'}
 
             {block name='frontend_detail_product_quick_view_image_link'}
-                <a class="quick-view--image-link" href="{$sArticle.linkDetails}" title="{if $sArticle.image.res.description}{$sArticle.image.res.description|escape}{else}{$sArticle.articlename|escape}{/if}">
+                <a class="quick-view--image-link" href="{$sArticle.linkDetails}" title="{if $sArticle.image.res.description}{$sArticle.image.res.description|escapeHtml}{else}{$sArticle.articlename|escapeHtml}{/if}">
                     {block name='frontend_detail_product_quick_view_image'}
 
-                        {$alt = $sArticle.articlename|escape}
+                        {$alt = $sArticle.articlename|escapeHtml}
 
                         {if $sArticle.image.description}
-                            {$alt = $sArticle.image.description|escape}
+                            {$alt = $sArticle.image.description|escapeHtml}
                         {/if}
 
                         <span class="quick-view--image">
@@ -31,9 +31,9 @@
                 <div class="quick-view--header">
                     {block name='frontend_detail_product_quick_view_header_inner'}
                         {block name='frontend_detail_product_quick_view_title'}
-                            <a href="{$sArticle.linkDetails}" class="quick-view--title" title="{$sArticle.articleName|escape}">
+                            <a href="{$sArticle.linkDetails}" class="quick-view--title" title="{$sArticle.articleName|escapeHtml}">
                                 {block name='frontend_detail_product_quick_view_title_inner'}
-                                    {$sArticle.articleName|escape}
+                                    {$sArticle.articleName|escapeHtml}
                                 {/block}
                             </a>
                         {/block}
@@ -41,7 +41,7 @@
                         {block name='frontend_detail_product_quick_view_supplier'}
                             <div class="quick-view--supplier">
                                 {block name='frontend_detail_product_quick_view_supplier_inner'}
-                                    {$sArticle.supplierName|escape}
+                                    {$sArticle.supplierName|escapeHtml}
                                 {/block}
                             </div>
                         {/block}

--- a/themes/Frontend/Bare/frontend/listing/actions/action-filter-panel.tpl
+++ b/themes/Frontend/Bare/frontend/listing/actions/action-filter-panel.tpl
@@ -35,25 +35,25 @@
 
                         {block name="frontend_listing_actions_filter_form_search"}
                             {if $term !== null}
-                                <input type="hidden" name="{$shortParameters['sSearch']}" value="{$term|escape}"/>
+                                <input type="hidden" name="{$shortParameters['sSearch']}" value="{$term|escapeHtml}"/>
                             {/if}
                         {/block}
 
                         {block name="frontend_listing_actions_filter_form_sort"}
                             {if $sSort}
-                                <input type="hidden" name="{$shortParameters['sSort']}" value="{$sSort|escape}"/>
+                                <input type="hidden" name="{$shortParameters['sSort']}" value="{$sSort|escapeHtml}"/>
                             {/if}
                         {/block}
 
                         {block name="frontend_listing_actions_filter_form_perpage"}
                             {if $criteria && $criteria->getLimit()}
-                                <input type="hidden" name="{$shortParameters['sPerPage']}" value="{$criteria->getLimit()|escape}"/>
+                                <input type="hidden" name="{$shortParameters['sPerPage']}" value="{$criteria->getLimit()|escapeHtml}"/>
                             {/if}
                         {/block}
 
                             {block name="frontend_listing_actions_filter_form_category"}
                                 {if !$sCategoryContent && $sCategoryCurrent != $sCategoryStart && {controllerName} != 'search'}
-                                    <input type="hidden" name="{$shortParameters['sCategory']}" value="{$sCategoryCurrent|escape}" />
+                                    <input type="hidden" name="{$shortParameters['sCategory']}" value="{$sCategoryCurrent|escapeHtml}" />
                                 {/if}
                             {/block}
 

--- a/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
+++ b/themes/Frontend/Bare/frontend/listing/actions/action-pagination.tpl
@@ -11,7 +11,7 @@
         {block name="frontend_listing_actions_paging_first"}
             {if $sPage > 1}
                 {s name="ListingLinkFirst" assign="snippetListingLinkFirst"}{/s}
-                <a href="{$baseUrl}?{$shortParameters.sPage}=1" title="{$snippetListingLinkFirst|escape}" aria-label="{$snippetListingLinkFirst|escape}" class="paging--link paging--prev" data-action-link="true">
+                <a href="{$baseUrl}?{$shortParameters.sPage}=1" title="{$snippetListingLinkFirst|escapeHtml}" aria-label="{$snippetListingLinkFirst|escapeHtml}" class="paging--link paging--prev" data-action-link="true">
                     <i class="icon--arrow-left"></i>
                     <i class="icon--arrow-left"></i>
                 </a>
@@ -22,7 +22,7 @@
         {block name='frontend_listing_actions_paging_previous'}
             {if $sPage > 1}
                 {s name="ListingLinkPrevious" assign="snippetListingLinkPrevious"}{/s}
-                <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage-1}" title="{$snippetListingLinkPrevious|escape}" aria-label="{$snippetListingLinkPrevious|escape}" class="paging--link paging--prev" data-action-link="true">
+                <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage-1}" title="{$snippetListingLinkPrevious|escapeHtml}" aria-label="{$snippetListingLinkPrevious|escapeHtml}" class="paging--link paging--prev" data-action-link="true">
                     <i class="icon--arrow-left"></i>
                 </a>
             {/if}
@@ -31,7 +31,7 @@
         {* Pagination - current page *}
         {block name='frontend_listing_actions_paging_numbers'}
             {if $pages > 1}
-                <a title="{$sCategoryContent.name|escape}" aria-label="{$sCategoryContent.name|escape}" class="paging--link is--active">{$sPage}</a>
+                <a title="{$sCategoryContent.name|escapeHtml}" aria-label="{$sCategoryContent.name|escapeHtml}" class="paging--link is--active">{$sPage}</a>
             {/if}
         {/block}
 
@@ -39,7 +39,7 @@
         {block name='frontend_listing_actions_paging_next'}
             {if $sPage < $pages}
                 {s name="ListingLinkNext" assign="snippetListingLinkNext"}{/s}
-                <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage+1}" title="{$snippetListingLinkNext|escape}" aria-label="{$snippetListingLinkNext|escape}" class="paging--link paging--next" data-action-link="true">
+                <a href="{$baseUrl}?{$shortParameters.sPage}={$sPage+1}" title="{$snippetListingLinkNext|escapeHtml}" aria-label="{$snippetListingLinkNext|escapeHtml}" class="paging--link paging--next" data-action-link="true">
                     <i class="icon--arrow-right"></i>
                 </a>
             {/if}
@@ -49,7 +49,7 @@
         {block name="frontend_listing_actions_paging_last"}
             {if $sPage < $pages}
                 {s name="ListingLinkLast" assign="snippetListingLinkLast"}{/s}
-                <a href="{$baseUrl}?{$shortParameters.sPage}={$pages}" title="{$snippetListingLinkLast|escape}" aria-label="{$snippetListingLinkLast|escape}" class="paging--link paging--next" data-action-link="true">
+                <a href="{$baseUrl}?{$shortParameters.sPage}={$pages}" title="{$snippetListingLinkLast|escapeHtml}" aria-label="{$snippetListingLinkLast|escapeHtml}" class="paging--link paging--next" data-action-link="true">
                     <i class="icon--arrow-right"></i>
                     <i class="icon--arrow-right"></i>
                 </a>

--- a/themes/Frontend/Bare/frontend/listing/atom.tpl
+++ b/themes/Frontend/Bare/frontend/listing/atom.tpl
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="{encoding}" ?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-<link href="{$sCategoryContent.atomFeed|escape}" rel="self" type="application/atom+xml" />
+<link href="{$sCategoryContent.atomFeed|escapeHtml}" rel="self" type="application/atom+xml" />
 <author>
     <name>{$sShopname|escapeHtml}</name>
 </author>
-<title>{block name='frontend_listing_atom_title'}{$sCategoryContent.description|escape:'hexentity'}{/block}</title>
-<id>{$sCategoryContent.rssFeed|escape:'hexentity'}</id>
+<title>{block name='frontend_listing_atom_title'}{$sCategoryContent.description|escapeHtml:'hexentity'}{/block}</title>
+<id>{$sCategoryContent.rssFeed|escapeHtml:'hexentity'}</id>
 <updated>{time()|date:atom}</updated>
 {foreach $sArticles as $sArticle}
     {block name='frontend_listing_atom_entry'}
         <entry>
-            <title type="text">{block name='frontend_listing_atom_article_title'}{$sArticle.articleName|strip_tags|strip|truncate:80:"...":true|escape}{/block}</title>
-            <id>{block name='frontend_listing_atom_article_name'}{$sArticle.linkDetails|escape}{/block}</id>
-            <link href="{block name='frontend_listing_atom_link'}{$sArticle.linkDetails|escape}{/block}"/>
+            <title type="text">{block name='frontend_listing_atom_article_title'}{$sArticle.articleName|strip_tags|strip|truncate:80:"...":true|escapeHtml}{/block}</title>
+            <id>{block name='frontend_listing_atom_article_name'}{$sArticle.linkDetails|escapeHtml}{/block}</id>
+            <link href="{block name='frontend_listing_atom_link'}{$sArticle.linkDetails|escapeHtml}{/block}"/>
             <summary type="html">
             <![CDATA[
                 {block name='frontend_listing_atom_short_description'}
                 {if $sArticle.description}
-                    {$sArticle.description|strip_tags|strip|truncate:280:"...":true|escape}
+                    {$sArticle.description|strip_tags|strip|truncate:280:"...":true|escapeHtml}
                 {else}
-                    {$sArticle.description_long|strip_tags|strip|truncate:280:"...":true|escape}
+                    {$sArticle.description_long|strip_tags|strip|truncate:280:"...":true|escapeHtml}
                 {/if}{/block}
             ]]>
             </summary>
             <content type="html">
             <![CDATA[
-                {$sArticle.description_long|strip_tags|escape}
+                {$sArticle.description_long|strip_tags|escapeHtml}
             ]]>
             </content>
             <updated>{if $sArticle.changetime}{$sArticle.changetime|date:atom}{else}{$sArticle.datum|date:atom}{/if}</updated>

--- a/themes/Frontend/Bare/frontend/listing/banner.tpl
+++ b/themes/Frontend/Bare/frontend/listing/banner.tpl
@@ -10,18 +10,18 @@
                         <picture>
                             <source srcset="{$sBanner.media.thumbnails[1].sourceSet}" media="(min-width: 48em)">
 
-                            <img srcset="{$sBanner.media.thumbnails[0].sourceSet}" alt="{$sBanner.description|escape}" class="banner--img" />
+                            <img srcset="{$sBanner.media.thumbnails[0].sourceSet}" alt="{$sBanner.description|escapeHtml}" class="banner--img" />
                         </picture>
                     {/block}
                 {else}
 
                     {* Normal banner *}
                     {block name='frontend_listing_normal_banner'}
-                        <a href="{$sBanner.link}" class="banner--link" {if $sBanner.link_target}target="{$sBanner.link_target}"{/if} title="{$sBanner.description|escape}">
+                        <a href="{$sBanner.link}" class="banner--link" {if $sBanner.link_target}target="{$sBanner.link_target}"{/if} title="{$sBanner.description|escapeHtml}">
                             <picture>
                                 <source srcset="{$sBanner.media.thumbnails[1].sourceSet}" media="(min-width: 48em)">
 
-                                <img srcset="{$sBanner.media.thumbnails[0].sourceSet}" alt="{$sBanner.description|escape}" class="banner--img" />
+                                <img srcset="{$sBanner.media.thumbnails[0].sourceSet}" alt="{$sBanner.description|escapeHtml}" class="banner--img" />
                             </picture>
                         </a>
                     {/block}

--- a/themes/Frontend/Bare/frontend/listing/customer_stream/layout.tpl
+++ b/themes/Frontend/Bare/frontend/listing/customer_stream/layout.tpl
@@ -56,7 +56,7 @@
 
                             {if $showListingButton}
                                 <div class="{$showListingCls}{if $fullscreen} is--align-center{/if}">
-                                    <a href="{url controller='cat' sPage=1 sCategory=$sCategoryContent.id}" title="{$sCategoryContent.name|escape}" class="link--show-listing{if $fullscreen} btn is--primary{/if}">
+                                    <a href="{url controller='cat' sPage=1 sCategory=$sCategoryContent.id}" title="{$sCategoryContent.name|escapeHtml}" class="link--show-listing{if $fullscreen} btn is--primary{/if}">
                                         {s name="ListingActionsOffersLink"}Weitere Artikel in dieser Kategorie &raquo;{/s}
                                     </a>
                                 </div>

--- a/themes/Frontend/Bare/frontend/listing/filter/_includes/filter-multi-media-selection.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/_includes/filter-multi-media-selection.tpl
@@ -1,15 +1,15 @@
 {extends file="parent:frontend/listing/filter/_includes/filter-multi-selection.tpl"}
 
 {block name="frontend_listing_filter_facet_multi_selection_input"}
-    {$name = "__{$facet->getFieldName()|escape:'htmlall'}__{$option->getId()|escape:'htmlall'}"}
+    {$name = "__{$facet->getFieldName()|escapeHtmlAttr}__{$option->getId()|escapeHtmlAttr}"}
     {if $singleSelection}
-        {$name = {$facet->getFieldName()|escape:'htmlall'} }
+        {$name = {$facet->getFieldName()|escapeHtmlAttr} }
     {/if}
 
     <input type="{$inputType}"
-       id="__{$facet->getFieldName()|escape:'htmlall'}__{$option->getId()|escape:'htmlall'}"
+       id="__{$facet->getFieldName()|escapeHtmlAttr}__{$option->getId()|escapeHtmlAttr}"
        name="{$name}"
-       title="{$option->getLabel()|escape:'htmlall'}"
-       value="{$option->getId()|escape:'htmlall'}"
+       title="{$option->getLabel()|escapeHtmlAttr}"
+       value="{$option->getId()|escapeHtmlAttr}"
        {if $option->isActive()}checked="checked" {/if}/>
 {/block}

--- a/themes/Frontend/Bare/frontend/listing/filter/_includes/filter-multi-selection.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/_includes/filter-multi-selection.tpl
@@ -1,17 +1,17 @@
 {namespace name="frontend/listing/listing_actions"}
 
 {block name="frontend_listing_filter_facet_multi_selection"}
-    <div class="filter-panel filter--multi-selection filter-facet--{$filterType} facet--{$facet->getFacetName()|escape:'htmlall'}"
+    <div class="filter-panel filter--multi-selection filter-facet--{$filterType} facet--{$facet->getFacetName()|escapeHtmlAttr}"
          data-filter-type="{$filterType}"
-         data-facet-name="{$facet->getFacetName()}"
-         data-field-name="{$facet->getFieldName()|escape:'htmlall'}">
+         data-facet-name="{$facet->getFacetName()|escapeHtmlAttr}"
+         data-field-name="{$facet->getFieldName()|escapeHtmlAttr}">
 
         {block name="frontend_listing_filter_facet_multi_selection_flyout"}
             <div class="filter-panel--flyout">
 
                 {block name="frontend_listing_filter_facet_multi_selection_title"}
-                    <label class="filter-panel--title" for="{$facet->getFieldName()|escape:'htmlall'}" title="{$facet->getLabel()|escape:'htmlall'}">
-                        {$facet->getLabel()|escape}
+                    <label class="filter-panel--title" for="{$facet->getFieldName()|escapeHtmlAttr}" title="{$facet->getLabel()|escapeHtmlAttr}">
+                        {$facet->getLabel()|escapeHtml}
                     </label>
                 {/block}
 
@@ -50,15 +50,15 @@
 
                                                     {block name="frontend_listing_filter_facet_multi_selection_input"}
                                                         <span class="filter-panel--input filter-panel--{$inputType}">
-                                                            {$name = "__{$facet->getFieldName()|escape:'htmlall'}__{$option->getId()|escape:'htmlall'}"}
+                                                            {$name = "__{$facet->getFieldName()|escapeHtmlAttr}__{$option->getId()|escapeHtmlAttr}"}
                                                             {if $filterType == 'radio'}
-                                                                {$name = {$facet->getFieldName()|escape:'htmlall'} }
+                                                                {$name = {$facet->getFieldName()|escapeHtmlAttr} }
                                                             {/if}
 
                                                             <input type="{$inputType}"
-                                                                   id="__{$facet->getFieldName()|escape:'htmlall'}__{$option->getId()|escape:'htmlall'}"
+                                                                   id="__{$facet->getFieldName()|escapeHtmlAttr}__{$option->getId()|escapeHtmlAttr}"
                                                                    name="{$name}"
-                                                                   value="{$option->getId()|escape:'htmlall'}"
+                                                                   value="{$option->getId()|escapeHtmlAttr}"
                                                                    {if $option->isActive()}checked="checked" {/if}/>
 
                                                             <span class="input--state {$inputType}--state">&nbsp;</span>
@@ -67,7 +67,7 @@
 
                                                     {block name="frontend_listing_filter_facet_multi_selection_label"}
                                                         <label class="filter-panel--label"
-                                                               for="__{$facet->getFieldName()|escape:'htmlall'}__{$option->getId()|escape:'htmlall'}">
+                                                               for="__{$facet->getFieldName()|escapeHtmlAttr}__{$option->getId()|escapeHtmlAttr}">
 
                                                             {if $facet|is_a:'\Shopware\Bundle\SearchBundle\FacetResult\MediaListFacetResult'}
                                                                 {$mediaFile = {link file='frontend/_public/src/img/no-picture.jpg'}}
@@ -75,9 +75,9 @@
                                                                     {$mediaFile = $option->getMedia()->getFile()}
                                                                 {/if}
 
-                                                                <img class="filter-panel--media-image" src="{$mediaFile}" alt="{$option->getLabel()|escape:'htmlall'}" />
+                                                                <img class="filter-panel--media-image" src="{$mediaFile}" alt="{$option->getLabel()|escapeHtmlAttr}" />
                                                             {else}
-                                                                {$option->getLabel()|escape}
+                                                                {$option->getLabel()|escapeHtml}
                                                             {/if}
                                                         </label>
                                                     {/block}

--- a/themes/Frontend/Bare/frontend/listing/filter/facet-boolean.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/facet-boolean.tpl
@@ -1,25 +1,25 @@
 {namespace name="frontend/listing/listing_actions"}
 
 {block name="frontend_listing_filter_facet_boolean"}
-    <div class="filter-panel filter--value facet--{$facet->getFacetName()|escape:'htmlall'}"
+    <div class="filter-panel filter--value facet--{$facet->getFacetName()|escapeHtmlAttr}"
          data-filter-type="value"
-         data-facet-name="{$facet->getFacetName()}"
-         data-field-name="{$facet->getFieldName()|escape:'htmlall'}">
+         data-facet-name="{$facet->getFacetName()|escapeHtmlAttr}"
+         data-field-name="{$facet->getFieldName()|escapeHtmlAttr}">
 
         {block name="frontend_listing_filter_facet_boolean_flyout"}
             <div class="filter-panel--flyout">
 
                 {block name="frontend_listing_filter_facet_boolean_title"}
-                    <label class="filter-panel--title" for="{$facet->getFieldName()|escape:'htmlall'}" title="{$facet->getLabel()|escape:'htmlall'}">
-                        {$facet->getLabel()|escape}
+                    <label class="filter-panel--title" for="{$facet->getFieldName()|escapeHtmlAttr}" title="{$facet->getLabel()|escapeHtmlAttr}">
+                        {$facet->getLabel()|escapeHtml}
                     </label>
                 {/block}
 
                 {block name="frontend_listing_filter_facet_boolean_checkbox"}
                     <span class="filter-panel--input filter-panel--checkbox">
                         <input type="checkbox"
-                               id="{$facet->getFieldName()|escape:'htmlall'}"
-                               name="{$facet->getFieldName()|escape:'htmlall'}"
+                               id="{$facet->getFieldName()|escapeHtmlAttr}"
+                               name="{$facet->getFieldName()|escapeHtmlAttr}"
                                value="1"
                                {if $facet->isActive()}checked="checked" {/if}/>
 

--- a/themes/Frontend/Bare/frontend/listing/filter/facet-date-multi.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/facet-date-multi.tpl
@@ -23,8 +23,8 @@
         {block name="frontend_listing_filter_facet_date_multi_input"}
             <input type="text"
                    class="filter-panel--input"
-                   name="{$facet->getFieldName()|escape:'htmlall'}"
-                   id="{$facet->getFieldName()|escape:'htmlall'}"
+                   name="{$facet->getFieldName()|escapeHtmlAttr}"
+                   id="{$facet->getFieldName()|escapeHtmlAttr}"
                    placeholder="{s name="datePickerInputPlaceholder" namespace="frontend/index/datepicker"}{/s}"
                    data-datepicker="true"
                    data-mode="{$mode}"

--- a/themes/Frontend/Bare/frontend/listing/filter/facet-date-range.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/facet-date-range.tpl
@@ -3,8 +3,8 @@
 {namespace name="frontend/listing/listing_actions"}
 
 {block name="frontend_listing_filter_facet_date_title"}
-    <label class="filter-panel--title" for="{$facet->getFacetName()|escape:'htmlall'}" title="{$facet->getLabel()|escape:'htmlall'}">
-        {$facet->getLabel()|escape}
+    <label class="filter-panel--title" for="{$facet->getFacetName()|escapeHtmlAttr}" title="{$facet->getLabel()|escapeHtmlAttr}">
+        {$facet->getLabel()|escapeHtml}
     </label>
 {/block}
 
@@ -20,21 +20,21 @@
             {s name="datePickerInputPlaceholder" namespace="frontend/index/datepicker" assign="snippetDatePickerInputPlaceholder"}{/s}
             <input type="text"
                    class="filter-panel--input"
-                   id="{$facet->getFacetName()|escape:'htmlall'}"
-                   placeholder="{$snippetDatePickerInputPlaceholder|escape:'htmlall'}"
+                   id="{$facet->getFacetName()|escapeHtmlAttr}"
+                   placeholder="{$snippetDatePickerInputPlaceholder|escapeHtmlAttr}"
                    data-datepicker="true"
                    data-mode="range"
                    data-enableTime="{$enableTime}"
                    data-minDate="{$rangeMin}"
                    data-maxDate="{$rangeMax}"
-                   data-rangeStartInput="{$facet->getMinFieldName()|escape:'htmlall'}"
-                   data-rangeEndInput="{$facet->getMaxFieldName()|escape:'htmlall'}"
+                   data-rangeStartInput="{$facet->getMinFieldName()|escapeHtmlAttr}"
+                   data-rangeEndInput="{$facet->getMaxFieldName()|escapeHtmlAttr}"
                    data-static="true"
                    readonly="readonly" />
         {/block}
 
         {block name="frontend_listing_filter_facet_date_range_min_label"}
-            <label for="{$facet->getMinFieldName()|escape:'htmlall'}"
+            <label for="{$facet->getMinFieldName()|escapeHtmlAttr}"
                    data-date-range-label="min"
                    class="is--hidden">{s name="ListingFilterRangeFrom"}{/s}</label>
         {/block}
@@ -42,13 +42,13 @@
         {block name="frontend_listing_filter_facet_date_range_min_input"}
             <input type="hidden"
                    data-date-range-input="min"
-                   id="{$facet->getMinFieldName()|escape:'htmlall'}"
-                   name="{$facet->getMinFieldName()|escape:'htmlall'}"
+                   id="{$facet->getMinFieldName()|escapeHtmlAttr}"
+                   name="{$facet->getMinFieldName()|escapeHtmlAttr}"
                    value="{if $facet->isActive()}{$startMin}{/if}" />
         {/block}
 
         {block name="frontend_listing_filter_facet_date_range_max_label"}
-            <label for="{$facet->getMaxFieldName()|escape:'htmlall'}"
+            <label for="{$facet->getMaxFieldName()|escapeHtmlAttr}"
                    data-date-range-label="max"
                    class="is--hidden">{s name="ListingFilterRangeTo"}{/s}</label>
         {/block}
@@ -56,8 +56,8 @@
         {block name="frontend_listing_filter_facet_date_range_max_input"}
             <input type="hidden"
                    data-date-range-input="max"
-                   id="{$facet->getMaxFieldName()|escape:'htmlall'}"
-                   name="{$facet->getMaxFieldName()|escape:'htmlall'}"
+                   id="{$facet->getMaxFieldName()|escapeHtmlAttr}"
+                   name="{$facet->getMaxFieldName()|escapeHtmlAttr}"
                    value="{if $facet->isActive()}{$startMax}{/if}" />
         {/block}
     </div>

--- a/themes/Frontend/Bare/frontend/listing/filter/facet-date.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/facet-date.tpl
@@ -5,17 +5,17 @@
 {/block}
 
 {block name="frontend_listing_filter_facet_date"}
-    <div class="filter-panel filter--date filter-facet--date facet--{$facet->getFacetName()|escape:'htmlall'}"
+    <div class="filter-panel filter--date filter-facet--date facet--{$facet->getFacetName()|escapeHtmlAttr}"
          data-filter-type="date"
-         data-facet-name="{$facet->getFacetName()}"
-         data-field-name="{$facet->getFacetName()|escape:'htmlall'}">
+         data-facet-name="{$facet->getFacetName()|escapeHtmlAttr}"
+         data-field-name="{$facet->getFacetName()|escapeHtmlAttr}">
 
         {block name="frontend_listing_filter_facet_date_flyout"}
             <div class="filter-panel--flyout">
 
                 {block name="frontend_listing_filter_facet_date_title"}
-                    <label class="filter-panel--title" for="{$facet->getFieldName()|escape:'htmlall'}" title="{$facet->getLabel()|escape:'htmlall'}">
-                        {$facet->getLabel()|escape}
+                    <label class="filter-panel--title" for="{$facet->getFieldName()|escapeHtmlAttr}" title="{$facet->getLabel()|escapeHtmlAttr}">
+                        {$facet->getLabel()|escapeHtml}
                     </label>
                 {/block}
 
@@ -39,8 +39,8 @@
                         {block name="frontend_listing_filter_facet_date_input"}
                             <input type="text"
                                    class="filter-panel--input"
-                                   name="{$facet->getFieldName()|escape:'htmlall'}"
-                                   id="{$facet->getFieldName()|escape:'htmlall'}"
+                                   name="{$facet->getFieldName()|escapeHtmlAttr}"
+                                   id="{$facet->getFieldName()|escapeHtmlAttr}"
                                    placeholder="{s name="datePickerInputPlaceholder" namespace="frontend/index/datepicker"}{/s}"
                                    data-datepicker="true"
                                    data-mode="single"

--- a/themes/Frontend/Bare/frontend/listing/filter/facet-group.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/facet-group.tpl
@@ -1,4 +1,4 @@
 {if $facet->getLabel()}
-    <h3 class="filter--set-title">{$facet->getLabel()|escape}</h3>
+    <h3 class="filter--set-title">{$facet->getLabel()|escapeHtml}</h3>
 {/if}
 {include file="frontend/listing/actions/action-filter-facets.tpl" facets=$facet->getFacetResults()}

--- a/themes/Frontend/Bare/frontend/listing/filter/facet-range.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/facet-range.tpl
@@ -1,17 +1,17 @@
 {namespace name="frontend/listing/listing_actions"}
 
 {block name="frontend_listing_filter_facet_range"}
-    <div class="filter-panel filter--range facet--{$facet->getFacetName()|escape:'htmlall'}"
+    <div class="filter-panel filter--range facet--{$facet->getFacetName()|escapeHtmlAttr}"
          data-filter-type="range"
-         data-facet-name="{$facet->getFacetName()}"
-         data-field-name="{$facet->getFacetName()|escape:'htmlall'}">
+         data-facet-name="{$facet->getFacetName()|escapeHtmlAttr}"
+         data-field-name="{$facet->getFacetName()|escapeHtmlAttr}">
 
         {block name="frontend_listing_filter_facet_range_flyout"}
             <div class="filter-panel--flyout">
 
                 {block name="frontend_listing_filter_facet_range_title"}
-                    <label class="filter-panel--title" title="{$facet->getLabel()|escape:'htmlall'}">
-                        {$facet->getLabel()|escape}
+                    <label class="filter-panel--title" title="{$facet->getLabel()|escapeHtmlAttr}">
+                        {$facet->getLabel()|escapeHtml}
                     </label>
                 {/block}
 
@@ -54,16 +54,16 @@
 
                                 {block name="frontend_listing_filter_facet_range_input_min"}
                                     <input type="hidden"
-                                           id="{$facet->getMinFieldName()|escape:'htmlall'}"
-                                           name="{$facet->getMinFieldName()|escape:'htmlall'}"
+                                           id="{$facet->getMinFieldName()|escapeHtmlAttr}"
+                                           name="{$facet->getMinFieldName()|escapeHtmlAttr}"
                                            data-range-input="min"
                                            value="{$startMin}" {if !$facet->isActive() || $startMin == 0}disabled="disabled" {/if}/>
                                 {/block}
 
                                 {block name="frontend_listing_filter_facet_range_input_max"}
                                     <input type="hidden"
-                                           id="{$facet->getMaxFieldName()|escape:'htmlall'}"
-                                           name="{$facet->getMaxFieldName()|escape:'htmlall'}"
+                                           id="{$facet->getMaxFieldName()|escapeHtmlAttr}"
+                                           name="{$facet->getMaxFieldName()|escapeHtmlAttr}"
                                            data-range-input="max"
                                            value="{$startMax}" {if !$facet->isActive() || $startMax == 0}disabled="disabled" {/if}/>
                                 {/block}
@@ -79,7 +79,7 @@
 
                                         {block name="frontend_listing_filter_facet_range_label_min"}
                                             <label class="range-info--label"
-                                                   for="{$facet->getMinFieldName()|escape:'htmlall'}"
+                                                   for="{$facet->getMinFieldName()|escapeHtmlAttr}"
                                                    data-range-label="min">
                                                 {$startMin}
                                             </label>
@@ -93,7 +93,7 @@
 
                                         {block name="frontend_listing_filter_facet_range_label_max"}
                                             <label class="range-info--label"
-                                                   for="{$facet->getMaxFieldName()|escape:'htmlall'}"
+                                                   for="{$facet->getMaxFieldName()|escapeHtmlAttr}"
                                                    data-range-label="max">
                                                 {$startMax}
                                             </label>

--- a/themes/Frontend/Bare/frontend/listing/filter/facet-rating.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/facet-rating.tpl
@@ -1,17 +1,17 @@
 {namespace name="frontend/listing/listing_actions"}
 
 {block name="frontend_listing_filter_facet_rating"}
-    <div class="filter-panel filter--rating facet--{$facet->getFacetName()|escape:'htmlall'}"
+    <div class="filter-panel filter--rating facet--{$facet->getFacetName()|escapeHtmlAttr}"
          data-filter-type="rating"
-         data-facet-name="{$facet->getFacetName()}"
-         data-field-name="{$facet->getFieldName()|escape:'htmlall'}">
+         data-facet-name="{$facet->getFacetName()|escapeHtmlAttr}"
+         data-field-name="{$facet->getFieldName()|escapeHtmlAttr}">
 
         {block name="frontend_listing_filter_facet_rating_flyout"}
             <div class="filter-panel--flyout">
 
                 {block name="frontend_listing_filter_facet_rating_title"}
-                    <label class="filter-panel--title" title="{$facet->getLabel()|escape:'htmlall'}">
-                        {$facet->getLabel()|escape}
+                    <label class="filter-panel--title" title="{$facet->getLabel()|escapeHtmlAttr}">
+                        {$facet->getLabel()|escapeHtml}
                     </label>
                 {/block}
 

--- a/themes/Frontend/Bare/frontend/listing/filter/facet-value-tree.tpl
+++ b/themes/Frontend/Bare/frontend/listing/filter/facet-value-tree.tpl
@@ -7,17 +7,17 @@
         {$type = 'value-tree-single'}
     {/if}
 
-    <div class="filter-panel filter--value-tree facet--{$facet->getFacetName()|escape:'htmlall'}"
+    <div class="filter-panel filter--value-tree facet--{$facet->getFacetName()|escapeHtmlAttr}"
          data-filter-type="{$type}"
-         data-facet-name="{$facet->getFacetName()}"
-         data-field-name="{$facet->getFieldName()|escape:'htmlall'}">
+         data-facet-name="{$facet->getFacetName()|escapeHtmlAttr}"
+         data-field-name="{$facet->getFieldName()|escapeHtmlAttr}">
 
         {block name="frontend_listing_filter_facet_value_tree_flyout"}
             <div class="filter-panel--flyout">
 
                 {block name="frontend_listing_filter_facet_value_tree_title"}
-                    <label class="filter-panel--title" title="{$facet->getLabel()|escape:'htmlall'}">
-                        {$facet->getLabel()|escape}
+                    <label class="filter-panel--title" title="{$facet->getLabel()|escapeHtmlAttr}">
+                        {$facet->getLabel()|escapeHtml}
                     </label>
                 {/block}
 
@@ -45,9 +45,9 @@
                                                             <span class="filter-panel--input filter-panel--checkbox{if $disabled} is--disabled{/if}">
                                                                 <input type="checkbox"
                                                                        data-parent-id="{$parent}"
-                                                                       id="__{$facet->getFieldName()|escape:'htmlall'}__{$option->getId()|escape:'htmlall'}"
-                                                                       name="__{$facet->getFieldName()|escape:'htmlall'}__{$option->getId()|escape:'htmlall'}"
-                                                                       value="{$option->getId()|escape:'htmlall'}"
+                                                                       id="__{$facet->getFieldName()|escapeHtmlAttr}__{$option->getId()|escapeHtmlAttr}"
+                                                                       name="__{$facet->getFieldName()|escapeHtmlAttr}__{$option->getId()|escapeHtmlAttr}"
+                                                                       value="{$option->getId()|escapeHtmlAttr}"
                                                                        {if $option->isActive()}checked="checked"{elseif $disabled}disabled="disabled"{/if}/>
 
                                                                 <span class="input--state checkbox--state">&nbsp;</span>
@@ -56,8 +56,8 @@
 
                                                         {block name="frontend_listing_filter_facet_value_tree_label"}
                                                             <label class="filter-panel--label value-tree--label"
-                                                                   for="__{$facet->getFieldName()|escape:'htmlall'}__{$option->getId()|escape:'htmlall'}">
-                                                                {$option->getLabel()|escape}
+                                                                   for="__{$facet->getFieldName()|escapeHtmlAttr}__{$option->getId()|escapeHtmlAttr}">
+                                                                {$option->getLabel()|escapeHtml}
                                                             </label>
                                                         {/block}
                                                     </div>

--- a/themes/Frontend/Bare/frontend/listing/header.tpl
+++ b/themes/Frontend/Bare/frontend/listing/header.tpl
@@ -36,7 +36,7 @@
 {/block}
 
 {* Description *}
-{block name="frontend_index_header_meta_description"}{if $sCategoryContent.metaDescription}{$sCategoryContent.metaDescription|strip_tags|escape}{else}{s name="IndexMetaDescriptionStandard"}{/s}{/if}{/block}
+{block name="frontend_index_header_meta_description"}{if $sCategoryContent.metaDescription}{$sCategoryContent.metaDescription|strip_tags|escapeHtml}{else}{s name="IndexMetaDescriptionStandard"}{/s}{/if}{/block}
 
 {* Canonical link *}
 {block name='frontend_index_header_canonical'}
@@ -47,7 +47,7 @@
         {$pages = ceil($sNumberArticles / $criteria->getLimit())}
     {/if}
 
-    {if $SeoMetaRobots|strpos:'noindex' === false}
+    {if !$SeoMetaRobots || $SeoMetaRobots|strpos:'noindex' === false}
         <link rel="canonical" href="{url params = $sCategoryContent.canonicalParams}"/>
     {/if}
 

--- a/themes/Frontend/Bare/frontend/listing/listing.tpl
+++ b/themes/Frontend/Bare/frontend/listing/listing.tpl
@@ -26,7 +26,7 @@
 
                     {if $showListingButton}
                         <div class="{$showListingCls}{if $fullscreen} is--align-center{/if}">
-                            <a href="{url controller='cat' sPage=1 sCategory=$sCategoryContent.id}" title="{$sCategoryContent.name|escape}" class="link--show-listing{if $fullscreen} btn is--primary{/if}">
+                            <a href="{url controller='cat' sPage=1 sCategory=$sCategoryContent.id}" title="{$sCategoryContent.name|escapeHtml}" class="link--show-listing{if $fullscreen} btn is--primary{/if}">
                                 {s name="ListingActionsOffersLink"}Weitere Artikel in dieser Kategorie &raquo;{/s}
                             </a>
                         </div>

--- a/themes/Frontend/Bare/frontend/listing/manufacturer.tpl
+++ b/themes/Frontend/Bare/frontend/listing/manufacturer.tpl
@@ -74,7 +74,7 @@
                     {/if}
                     {if $thumbnail}
                         <div class="vendor--image-wrapper">
-                            <img class="vendor--image" src="{$thumbnail}" alt="{$manufacturer->getName()|escape}">
+                            <img class="vendor--image" src="{$thumbnail}" alt="{$manufacturer->getName()|escapeHtml}">
                         </div>
                     {/if}
                 {/if}

--- a/themes/Frontend/Bare/frontend/listing/product-box/box-big-image.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/box-big-image.tpl
@@ -6,19 +6,19 @@
 
 {block name='frontend_listing_box_article_picture'}
     <a href="{$sArticle.linkDetails}"
-       title="{$sArticle.articleName|escape}"
+       title="{$sArticle.articleName|escapeHtml}"
        class="product--image">
         {block name='frontend_listing_box_article_image_element'}
             <span class="image--element">
             {block name='frontend_listing_box_article_image_media'}
                 <span class="image--media">
 
-                    {$desc = $sArticle.articleName|escape}
+                    {$desc = $sArticle.articleName|escapeHtml}
 
                     {if isset($sArticle.image.thumbnails)}
 
                         {if $sArticle.image.description}
-                            {$desc = $sArticle.image.description|escape}
+                            {$desc = $sArticle.image.description|escapeHtml}
                         {/if}
 
                         {block name='frontend_listing_box_article_image_picture_element'}

--- a/themes/Frontend/Bare/frontend/listing/product-box/box-emotion.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/box-emotion.tpl
@@ -26,7 +26,7 @@
                         {* Product image *}
                         {block name='frontend_listing_box_article_picture'}
                             <a href="{$sArticle.linkDetails}"
-                               title="{$productName|escape}"
+                               title="{$productName|escapeHtml}"
                                class="product--image{if $imageOnly} is--large{/if}">
 
                                 {block name='frontend_listing_box_article_image_element'}
@@ -37,10 +37,10 @@
 
                                                 {block name='frontend_listing_box_article_image_picture'}
 
-                                                    {$desc = $productName|escape}
+                                                    {$desc = $productName|escapeHtml}
 
                                                     {if $sArticle.image.description}
-                                                        {$desc = $sArticle.image.description|escape}
+                                                        {$desc = $sArticle.image.description|escapeHtml}
                                                     {/if}
 
                                                     {if $sArticle.image.thumbnails}

--- a/themes/Frontend/Bare/frontend/listing/product-box/product-actions.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/product-actions.tpl
@@ -24,8 +24,8 @@
             <form action="{url controller='note' action='add' ordernumber=$sArticle.ordernumber _seo=false}" method="post">
                 {s name="DetailLinkNotepad" namespace="frontend/detail/actions" assign="snippetDetailLinkNotepad"}{/s}
                 <button type="submit"
-                   title="{$snippetDetailLinkNotepad|escape}"
-                   aria-label="{$snippetDetailLinkNotepad|escape}"
+                   title="{$snippetDetailLinkNotepad|escapeHtml}"
+                   aria-label="{$snippetDetailLinkNotepad|escapeHtml}"
                    class="product--action action--note"
                    data-ajaxUrl="{url controller='note' action='ajaxAdd' ordernumber=$sArticle.ordernumber _seo=false}"
                    data-text="{s name="DetailNotepadMarked"}{/s}">

--- a/themes/Frontend/Bare/frontend/listing/product-box/product-image.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/product-image.tpl
@@ -1,6 +1,6 @@
 {* Product image - uses the picture element for responsive retina images. *}
 <a href="{$sArticle.linkDetails}"
-   title="{$sArticle.articleName|escape}"
+   title="{$sArticle.articleName|escapeHtml}"
    class="product--image"
    {block name='frontend_listing_box_article_image_attributes'}{/block}
    >
@@ -9,12 +9,12 @@
             {block name='frontend_listing_box_article_image_media'}
                 <span class="image--media">
 
-                    {$desc = $sArticle.articleName|escape}
+                    {$desc = $sArticle.articleName|escapeHtml}
 
                     {if isset($sArticle.image.thumbnails)}
 
                         {if $sArticle.image.description}
-                            {$desc = $sArticle.image.description|escape}
+                            {$desc = $sArticle.image.description|escapeHtml}
                         {/if}
 
                         {block name='frontend_listing_box_article_image_picture_element'}

--- a/themes/Frontend/Bare/frontend/listing/product-box/product-price-unit.tpl
+++ b/themes/Frontend/Bare/frontend/listing/product-box/product-price-unit.tpl
@@ -1,18 +1,18 @@
 {namespace name="frontend/listing/box_article"}
 
-{$tooltip = "{s name='ListingBoxArticleContent'}{/s}"|escape:'html'}
+{$tooltip = "{s name='ListingBoxArticleContent'}{/s}"|escapeHtml:'html'}
 {$hasPurchaseUnit = $sArticle.purchaseunit && $sArticle.purchaseunit != 0}
 {$hasReferenceUnit = $sArticle.purchaseunit && $sArticle.referenceunit && $sArticle.purchaseunit != $sArticle.referenceunit}
 
 {if $hasPurchaseUnit}
     {$purchaseUnit = "{$sArticle.purchaseunit} {$sArticle.sUnit.description}"}
-    {$tooltip = "{$tooltip} {$purchaseUnit|escape:'html'}"}
+    {$tooltip = "{$tooltip} {$purchaseUnit|escapeHtml:'html'}"}
 {/if}
 
 {if $hasReferenceUnit}
     {$price = "{$sArticle.referenceprice|currency}"}
     {$unit = "{s name='Star'}{/s} / {$sArticle.referenceunit} {$sArticle.sUnit.description}"}
-    {$referenceUnit = "({$price} {$unit|escape:'html'})"}
+    {$referenceUnit = "({$price} {$unit|escapeHtml:'html'})"}
     {$tooltip = "{$tooltip} {$referenceUnit}"}
 {/if}
 

--- a/themes/Frontend/Bare/frontend/listing/rss.tpl
+++ b/themes/Frontend/Bare/frontend/listing/rss.tpl
@@ -2,19 +2,19 @@
 {s name='IndexXmlLang' namespace='frontend/index/index' assign='rssChannelLanguage'}{/s}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
-        <atom:link href="{$sCategoryContent.rssFeed|escape}" rel="self" type="application/rss+xml"/>
-        <title>{block name='frontend_atom_title'}{$sCategoryContent.description|escape:'hexentity'}{/block}</title>
+        <atom:link href="{$sCategoryContent.rssFeed|escapeHtml}" rel="self" type="application/rss+xml"/>
+        <title>{block name='frontend_atom_title'}{$sCategoryContent.description|escapeHtml:'hexentity'}{/block}</title>
         <link>{url controller='index'}</link>
-        <description>{$sShopname|escapeHtml} - {$sCategoryContent.description|escape:'hexentity'}</description>
+        <description>{$sShopname|escapeHtml} - {$sCategoryContent.description|escapeHtml:'hexentity'}</description>
         <language>{$rssChannelLanguage|strtolower}</language>
         <lastBuildDate>{time()|date:rss}</lastBuildDate>
         {foreach from=$sArticles item=sArticle key=key name="counter"}
             <item>
-                <title>{block name='frontend_listing_rss_article_name'}{$sArticle.articleName|escape}{/block}</title>
-                <guid>{block name='frontend_listing_rss_guid'}{$sArticle.linkDetails|escape}{/block}</guid>
-                <link>{block name='frontend_listing_rss_link'}{$sArticle.linkDetails|escape}{/block}</link>
-                <description>{block name='frontend_listing_rss_description'}{$sArticle.description_long|strip_tags|strip|truncate:280:"...":true|escape}{/block}</description>
-                <category>{block name='frontend_listing_rss_category'}{$sArticle.supplierName|escape}{/block}</category>
+                <title>{block name='frontend_listing_rss_article_name'}{$sArticle.articleName|escapeHtml}{/block}</title>
+                <guid>{block name='frontend_listing_rss_guid'}{$sArticle.linkDetails|escapeHtml}{/block}</guid>
+                <link>{block name='frontend_listing_rss_link'}{$sArticle.linkDetails|escapeHtml}{/block}</link>
+                <description>{block name='frontend_listing_rss_description'}{$sArticle.description_long|strip_tags|strip|truncate:280:"...":true|escapeHtml}{/block}</description>
+                <category>{block name='frontend_listing_rss_category'}{$sArticle.supplierName|escapeHtml}{/block}</category>
                 {if $sArticle.changetime}
                     <pubDate>{block name='frontend_listing_rss_date'}{$sArticle.changetime|date:rss}{/block}</pubDate>
                 {/if}

--- a/themes/Frontend/Bare/frontend/listing/text.tpl
+++ b/themes/Frontend/Bare/frontend/listing/text.tpl
@@ -29,7 +29,7 @@
                             <div class="teaser--text-short is--hidden">
                                 {$sCategoryContent.cmstext|strip_tags|truncate:200}
                                 {s namespace="frontend/listing/listing" name="ListingActionsOpenOffCanvas" assign="snippetListingActionsOpenOffCanvas"}{/s}
-                                <a href="#" title="{$snippetListingActionsOpenOffCanvas|escape}" class="text--offcanvas-link">
+                                <a href="#" title="{$snippetListingActionsOpenOffCanvas|escapeHtml}" class="text--offcanvas-link">
                                     {s namespace="frontend/listing/listing" name="ListingActionsOpenOffCanvas"}{/s} &raquo;
                                 </a>
                             </div>
@@ -42,7 +42,7 @@
                                 {* Close Button *}
                                 {block name="frontend_listing_text_content_offcanvas_close"}
                                     {s namespace="frontend/listing/listing" name="ListingActionsCloseOffCanvas" assign="snippetListingActionsCloseOffCanvas"}{/s}
-                                    <a href="#" title="{$snippetListingActionsCloseOffCanvas|escape}" class="close--off-canvas">
+                                    <a href="#" title="{$snippetListingActionsCloseOffCanvas|escapeHtml}" class="close--off-canvas">
                                         <i class="icon--arrow-left"></i> {s namespace="frontend/listing/listing" name="ListingActionsCloseOffCanvas"}{/s}
                                     </a>
                                 {/block}

--- a/themes/Frontend/Bare/frontend/register/billing_fieldset.tpl
+++ b/themes/Frontend/Bare/frontend/register/billing_fieldset.tpl
@@ -19,7 +19,7 @@
                                aria-required="true"
                                placeholder="{s name='RegisterPlaceholderCompany'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                id="register_billing_company"
-                               value="{$form_data.company|escape}"
+                               value="{$form_data.company|escapeHtml}"
                                class="register--field is--required{if isset($error_flags.company)} has--error{/if}" />
                     </div>
                 {/block}
@@ -32,7 +32,7 @@
                                type="text"
                                placeholder="{s name='RegisterLabelDepartment'}{/s}"
                                id="register_billing_department"
-                               value="{$form_data.department|escape}"
+                               value="{$form_data.department|escapeHtml}"
                                class="register--field{if isset($error_flags.department)} has--error{/if}" />
                     </div>
                 {/block}
@@ -44,7 +44,7 @@
                                type="text" {if {config name="vatCheckRequired"}} required="required" aria-required="true"{/if}
                                placeholder="{s name='RegisterLabelTaxId'}{/s}{if {config name="vatcheckrequired"}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                id="register_billing_vatid"
-                               value="{$form_data.vatId|escape}"
+                               value="{$form_data.vatId|escapeHtml}"
                                 {if {config name="vatcheckrequired"}} required="required" aria-required="true"{/if}
                                class="register--field{if isset($error_flags.vatId)} has--error{/if}{if {config name="vatcheckrequired"}} is--required{/if}"/>
                     </div>
@@ -75,7 +75,7 @@
                                aria-required="true"
                                placeholder="{s name='RegisterBillingPlaceholderStreet'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                id="street"
-                               value="{$form_data.street|escape}"
+                               value="{$form_data.street|escapeHtml}"
                                class="register--field register--field-street is--required{if isset($error_flags.street)} has--error{/if}" />
                     </div>
                 {/block}
@@ -89,7 +89,7 @@
                                    type="text"{if {config name="requireAdditionAddressLine1"}} required="required" aria-required="true"{/if}
                                    placeholder="{s name='RegisterLabelAdditionalAddressLine1'}{/s}{if {config name="requireAdditionAddressLine1"}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                    id="additionalAddressLine1"
-                                   value="{$form_data.additionalAddressLine1|escape}"
+                                   value="{$form_data.additionalAddressLine1|escapeHtml}"
                                    class="register--field{if {config name="requireAdditionAddressLine1"}} is--required{/if}{if isset($error_flags.additionalAddressLine1) && {config name="requireAdditionAddressLine1"}} has--error{/if}" />
                         </div>
                     {/if}
@@ -104,7 +104,7 @@
                                    type="text"{if {config name="requireAdditionAddressLine2"}} required="required" aria-required="true"{/if}
                                    placeholder="{s name='RegisterLabelAdditionalAddressLine2'}{/s}{if {config name="requireAdditionAddressLine2"}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                    id="additionalAddressLine2"
-                                   value="{$form_data.additionalAddressLine2|escape}"
+                                   value="{$form_data.additionalAddressLine2|escapeHtml}"
                                    class="register--field{if {config name="requireAdditionAddressLine2"}} is--required{/if}{if isset($error_flags.additionalAddressLine2) && {config name="requireAdditionAddressLine2"}} has--error{/if}" />
                         </div>
                     {/if}
@@ -121,7 +121,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterBillingPlaceholderZipcode'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="zipcode"
-                                   value="{$form_data.zipcode|escape}"
+                                   value="{$form_data.zipcode|escapeHtml}"
                                    class="register--field register--spacer register--field-zipcode is--required{if isset($error_flags.zipcode)} has--error{/if}" />
 
                             <input autocomplete="section-billing billing address-level2"
@@ -131,7 +131,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterBillingPlaceholderCity'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="city"
-                                   value="{$form_data.city|escape}"
+                                   value="{$form_data.city|escapeHtml}"
                                    size="25"
                                    class="register--field register--field-city is--required{if isset($error_flags.city)} has--error{/if}" />
                         {else}
@@ -142,7 +142,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterBillingPlaceholderCity'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="city"
-                                   value="{$form_data.city|escape}"
+                                   value="{$form_data.city|escapeHtml}"
                                    size="25"
                                    class="register--field register--spacer register--field-city is--required{if isset($error_flags.city)} has--error{/if}" />
 
@@ -153,7 +153,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterBillingPlaceholderZipcode'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="zipcode"
-                                   value="{$form_data.zipcode|escape}"
+                                   value="{$form_data.zipcode|escapeHtml}"
                                    class="register--field register--field-zipcode is--required{if isset($error_flags.zipcode)} has--error{/if}" />
                         {/if}
                     </div>

--- a/themes/Frontend/Bare/frontend/register/index.tpl
+++ b/themes/Frontend/Bare/frontend/register/index.tpl
@@ -18,7 +18,7 @@
             {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish" assign="snippetFinishButtonBackToShop"}{/s}
             <a href="{url controller='index'}"
                class="btn is--small btn--back-top-shop is--icon-left"
-               title="{$snippetFinishButtonBackToShop|escape}">
+               title="{$snippetFinishButtonBackToShop|escapeHtml}">
                 <i class="icon--arrow-left"></i>
                 {s name="FinishButtonBackToShop" namespace="frontend/checkout/finish"}{/s}
             </a>

--- a/themes/Frontend/Bare/frontend/register/login.tpl
+++ b/themes/Frontend/Bare/frontend/register/login.tpl
@@ -40,7 +40,7 @@
 
                     <form name="sLogin" method="post" action="{$url}" id="login--form">
                         {block name='frontend_register_login_form_additional_inputs'}
-                            {if $sTarget}<input name="sTarget" type="hidden" value="{$sTarget|escape}" />{/if}
+                            {if $sTarget}<input name="sTarget" type="hidden" value="{$sTarget|escapeHtml}" />{/if}
                             {if $showNoAccount}<input name="showNoAccount" type="hidden" value="true"/>{/if}
                         {/block}
 
@@ -55,7 +55,7 @@
                                        type="email"
                                        autocomplete="email"
                                        tabindex="1"
-                                       value="{$sFormData.email|escape}"
+                                       value="{$sFormData.email|escapeHtml}"
                                        id="email"
                                        class="register--login-field{if $sErrorFlag.email} has--error{/if}"
                                 />
@@ -78,7 +78,7 @@
                             <div class="register--login-lostpassword">
                                 {s name="LoginLinkLostPassword" assign="snippetLoginLinkLostPassword"}{/s}
                                 <a href="{url controller=account action=password}"
-                                   title="{$snippetLoginLinkLostPassword|escape}"
+                                   title="{$snippetLoginLinkLostPassword|escapeHtml}"
                                 >
                                     {s name="LoginLinkLostPassword"}{/s}
                                 </a>

--- a/themes/Frontend/Bare/frontend/register/personal_fieldset.tpl
+++ b/themes/Frontend/Bare/frontend/register/personal_fieldset.tpl
@@ -15,7 +15,7 @@
                 {* Customer type *}
                 {block name='frontend_register_personal_fieldset_customer_type'}
                     {if $form_data.sValidation}
-                        <input type="hidden" name="register[personal][sValidation]" value="{$form_data.sValidation|escape}" />
+                        <input type="hidden" name="register[personal][sValidation]" value="{$form_data.sValidation|escapeHtml}" />
                     {else}
                         <div class="register--customertype">
                             {if {config name="showCompanySelectField"} == 0}
@@ -93,7 +93,7 @@
                                    type="text"
                                    placeholder="{s name='RegisterPlaceholderTitle'}{/s}"
                                    id="title"
-                                   value="{$form_data.title|escape}"
+                                   value="{$form_data.title|escapeHtml}"
                                    class="register--field{if isset($error_flags.title)} has--error{/if}" />
                         </div>
                     {/if}
@@ -109,7 +109,7 @@
                                aria-required="true"
                                placeholder="{s name='RegisterPlaceholderFirstname'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                id="firstname"
-                               value="{$form_data.firstname|escape}"
+                               value="{$form_data.firstname|escapeHtml}"
                                class="register--field is--required{if isset($error_flags.firstname)} has--error{/if}" />
                     </div>
                 {/block}
@@ -123,7 +123,7 @@
                                required="required"
                                aria-required="true"
                                placeholder="{s name='RegisterPlaceholderLastname'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
-                               id="lastname" value="{$form_data.lastname|escape}"
+                               id="lastname" value="{$form_data.lastname|escapeHtml}"
                                class="register--field is--required{if isset($error_flags.lastname)} has--error{/if}" />
                     </div>
                 {/block}
@@ -162,7 +162,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterPlaceholderMail'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="register_personal_email"
-                                   value="{$form_data.email|escape}"
+                                   value="{$form_data.email|escapeHtml}"
                                    class="register--field email is--required{if isset($error_flags.email)} has--error{/if}" />
                         </div>
 
@@ -175,7 +175,7 @@
                                        aria-required="true"
                                        placeholder="{s name='RegisterPlaceholderMailConfirmation'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                        id="register_personal_emailConfirmation"
-                                       value="{$form_data.emailConfirmation|escape}"
+                                       value="{$form_data.emailConfirmation|escapeHtml}"
                                        class="register--field emailConfirmation is--required{if isset($error_flags.emailConfirmation)} has--error{/if}" />
                             </div>
                         {/if}
@@ -231,7 +231,7 @@
                                    type="tel"{if {config name="requirePhoneField"}} required="required" aria-required="true"{/if}
                                    placeholder="{s name='RegisterPlaceholderPhone'}{/s}{if {config name="requirePhoneField"}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                    id="phone"
-                                   value="{$form_data.phone|escape}"
+                                   value="{$form_data.phone|escapeHtml}"
                                    class="register--field{if {config name="requirePhoneField"}} is--required{/if}{if isset($error_flags.phone) && {config name="requirePhoneField"}} has--error{/if}" />
                         </div>
                     {/if}

--- a/themes/Frontend/Bare/frontend/register/shipping_fieldset.tpl
+++ b/themes/Frontend/Bare/frontend/register/shipping_fieldset.tpl
@@ -32,7 +32,7 @@
                                name="register[shipping][company]"
                                type="text"
                                placeholder="{s name='RegisterShippingPlaceholderCompany'}{/s}"
-                               id="company2" value="{$form_data.company|escape}"
+                               id="company2" value="{$form_data.company|escapeHtml}"
                                class="register--field{if isset($error_flags.company)} has--error{/if}" />
                     </div>
                 {/block}
@@ -44,7 +44,7 @@
                                name="register[shipping][department]"
                                type="text"
                                placeholder="{s name='RegisterShippingPlaceholderDepartment'}{/s}"
-                               id="department2" value="{$form_data.department|escape}"
+                               id="department2" value="{$form_data.department|escapeHtml}"
                                class="register--field {if isset($error_flags.department)} has--error{/if}" />
                     </div>
                 {/block}
@@ -59,7 +59,7 @@
                                aria-required="true"
                                placeholder="{s name='RegisterShippingPlaceholderFirstname'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                id="firstname2"
-                               value="{$form_data.firstname|escape}"
+                               value="{$form_data.firstname|escapeHtml}"
                                class="register--field is--required{if isset($error_flags.firstname)} has--error{/if}" />
                     </div>
                 {/block}
@@ -74,7 +74,7 @@
                                aria-required="true"
                                placeholder="{s name='RegisterShippingPlaceholderLastname'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                id="lastname2"
-                               value="{$form_data.lastname|escape}"
+                               value="{$form_data.lastname|escapeHtml}"
                                class="register--field is--required{if isset($error_flags.lastname)} has--error{/if}" />
                     </div>
                 {/block}
@@ -89,7 +89,7 @@
                                aria-required="true"
                                placeholder="{s name='RegisterShippingPlaceholderStreet'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                id="street2"
-                               value="{$form_data.street|escape}"
+                               value="{$form_data.street|escapeHtml}"
                                class="register--field register--field-street is--required{if isset($error_flags.street)} has--error{/if}" />
                     </div>
                 {/block}
@@ -103,7 +103,7 @@
                                    type="text"{if {config name="requireAdditionAddressLine1"}} required="required" aria-required="true"{/if}
                                    placeholder="{s name='RegisterLabelAdditionalAddressLine1'}{/s}{if {config name="requireAdditionAddressLine1"}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                    id="additionalAddressLine21"
-                                   value="{$form_data.additionalAddressLine1|escape}"
+                                   value="{$form_data.additionalAddressLine1|escapeHtml}"
                                    class="register--field{if {config name="requireAdditionAddressLine1"}} is--required{/if}{if isset($error_flags.additionalAddressLine1) && {config name="requireAdditionAddressLine1"}} has--error{/if}" />
                         </div>
                     {/if}
@@ -118,7 +118,7 @@
                                    type="text"{if {config name="requireAdditionAddressLine2"}} required="required" aria-required="true"{/if}
                                    placeholder="{s name='RegisterLabelAdditionalAddressLine2'}{/s}{if {config name="requireAdditionAddressLine2"}}{s name="RequiredField" namespace="frontend/register/index"}{/s}{/if}"
                                    id="additionalAddressLine22"
-                                   value="{$form_data.additionalAddressLine2|escape}"
+                                   value="{$form_data.additionalAddressLine2|escapeHtml}"
                                    class="register--field{if {config name="requireAdditionAddressLine2"}} is--required{/if}{if isset($error_flags.additionalAddressLine2) && {config name="requireAdditionAddressLine2"}} has--error{/if}" />
                         </div>
                     {/if}
@@ -135,7 +135,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterShippingPlaceholderZipcode'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="zipcode2"
-                                   value="{$form_data.zipcode|escape}"
+                                   value="{$form_data.zipcode|escapeHtml}"
                                    class="register--field register--spacer register--field-zipcode is--required{if isset($error_flags.zipcode)} has--error{/if}" />
 
                             <input autocomplete="section-shipping shipping address-level2"
@@ -145,7 +145,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterShippingPlaceholderCity'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="city2"
-                                   value="{$form_data.city|escape}"
+                                   value="{$form_data.city|escapeHtml}"
                                    size="25"
                                    class="register--field register--field-city is--required{if isset($error_flags.city)} has--error{/if}" />
                         {else}
@@ -156,7 +156,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterShippingPlaceholderCity'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="city2"
-                                   value="{$form_data.city|escape}"
+                                   value="{$form_data.city|escapeHtml}"
                                    size="25"
                                    class="register--field register--spacer register--field-city is--required{if isset($error_flags.city)} has--error{/if}" />
 
@@ -167,7 +167,7 @@
                                    aria-required="true"
                                    placeholder="{s name='RegisterShippingPlaceholderZipcode'}{/s}{s name="RequiredField" namespace="frontend/register/index"}{/s}"
                                    id="zipcode2"
-                                   value="{$form_data.zipcode|escape}"
+                                   value="{$form_data.zipcode|escapeHtml}"
                                    class="register--field register--field-zipcode is--required{if isset($error_flags.zipcode)} has--error{/if}" />
                         {/if}
                     </div>


### PR DESCRIPTION
### 1. Why is this change necessary?

PHP notices and warnings are omitted in Shopware. 

### 2. What does this change do, exactly?

For tests those notices and warnings are no longer omitted. It improve the overall code quality. 

### 3. Describe each step to reproduce the issue or behaviour.

/

### 4. Please link to the relevant issues (if any).

https://shopware.atlassian.net/browse/SW-27005

### 5. Which documentation changes (if any) need to be made because of this PR?

/

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.