### PR TITLE
ci(): check for mysql availbality

### DIFF
--- a/.github/workflows/check-js-code.yml
+++ b/.github/workflows/check-js-code.yml
@@ -33,17 +33,6 @@ jobs:
             run: nix profile install github:cachix/devenv/v0.5
             shell: sh
 
-          - name: Get Composer Cache Directory
-            id: composer-cache
-            run: |
-                echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-          - uses: actions/cache@v3
-            with:
-                path: ${{ steps.composer-cache.outputs.dir }}
-                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                restore-keys: |
-                    ${{ runner.os }}-composer-
-
           - run: devenv up &
           - run: devenv shell check-js-code
           - run: devenv shell test-jest

--- a/.github/workflows/check-php-code.yml
+++ b/.github/workflows/check-php-code.yml
@@ -46,5 +46,6 @@ jobs:
                       ${{ runner.os }}-composer-
 
             - run: devenv up &
+            - run: devenv shell ./.github/check-mysql.sh
             - run: devenv shell init-shopware
             - run: devenv shell check-code


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The CI pipeline sometimes fails because MySQL is not yet started.

### 2. What does this change do, exactly?
Wait for MySQL.