### PR TITLE
fix: PHP 8 error if plugin bootstrap class is missing

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -2801,11 +2801,6 @@ parameters:
 			path: engine/Library/Enlight/Event/Handler/Default.php
 
 		-
-			message: "#^Method Enlight_Event_Handler_Plugin\\:\\:Plugin\\(\\) should return Enlight_Plugin_Bootstrap but returns Enlight_Plugin_Bootstrap\\|Enlight_Plugin_Namespace\\|null\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler/Plugin.php
-
-		-
 			message: "#^Method Enlight_Event_Handler_Plugin\\:\\:execute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Event/Handler/Plugin.php
@@ -2822,11 +2817,6 @@ parameters:
 
 		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler/Plugin.php
-
-		-
-			message: "#^Variable \\$plugin might not be defined\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Event/Handler/Plugin.php
 

--- a/engine/Library/Enlight/Event/Handler/Plugin.php
+++ b/engine/Library/Enlight/Event/Handler/Plugin.php
@@ -42,6 +42,8 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
     protected $namespace;
 
     /**
+     * @deprecated Will be only `string` starting from Shopware 5.8
+     *
      * @var Enlight_Plugin_Bootstrap|string contains an instance
      *                                      of the Enlight_Plugin_Bootstrap or the plugin name
      */
@@ -51,11 +53,13 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
      * The Enlight_Event_Handler_Plugin class constructor expects the event name.
      * All parameters are set in the internal properties.
      *
-     * @param string                   $event
-     * @param Enlight_Plugin_Namespace $namespace
-     * @param Enlight_Plugin_Bootstrap $plugin
-     * @param string                   $listener
-     * @param int                      $position
+     * @deprecated The parameter $plugin will only accept `string` starting from Shopware 5.8
+     *
+     * @param string                          $event
+     * @param Enlight_Plugin_Namespace        $namespace
+     * @param Enlight_Plugin_Bootstrap|string $plugin
+     * @param string                          $listener
+     * @param int                             $position
      *
      * @throws Enlight_Event_Exception
      */
@@ -92,12 +96,19 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
      * Getter method for the internal plugin property. If the plugin property is a string,
      * enlight determines the plugin object over the namespace.
      *
-     * @return Enlight_Plugin_Bootstrap
+     * @return ?Enlight_Plugin_Bootstrap
      */
     public function Plugin()
     {
-        if (!$this->plugin instanceof Enlight_Plugin_Bootstrap) {
-            $plugin = $this->namespace->get($this->plugin);
+        // In the past always `null` was returned if $this->plugin was of instance `Enlight_Plugin_Bootstrap`
+        // therefore this bug is replicated here, can be removed once the type has been fixed to `string`
+        if ($this->plugin instanceof Enlight_Plugin_Bootstrap) {
+            return null;
+        }
+
+        $plugin = $this->namespace->get($this->plugin);
+        if (!$plugin instanceof Enlight_Plugin_Bootstrap) {
+            return null;
         }
 
         return $plugin;
@@ -145,7 +156,7 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
     public function execute(Enlight_Event_EventArgs $args)
     {
         $plugin = $this->Plugin();
-        if (!method_exists($plugin, $this->listener)) {
+        if ($plugin === null || !method_exists($plugin, $this->listener)) {
             $name = $this->plugin instanceof Enlight_Plugin_Bootstrap ? $this->plugin->getName() : $this->plugin;
             trigger_error('Listener "' . $this->listener . '" in "' . $name . '" is not callable.', E_USER_ERROR);
             // throw new Enlight_Exception('Listener "' . $this->listener . '" in "' . $name . '" is not callable.');


### PR DESCRIPTION
### 1. Why is this change necessary?
If the plugin bootstrap class was used as a subscriber, but the plugin has been deleted on the filesystem but is still present in the plugin database table, and if it has a subscriber, starting from PHP8.0 this will yield an error, since the `$plugin` variable is `null` but `method_exists` does not accept `null`.

### 2. What does this change do, exactly?
Fixes the typehint, and the `if` condition. Furthermore I noticed that at least currently if the `plugin` was an instance of `Enlight_Plugin_Bootstrap` also `null` was returned. I replicated this behavior such that it can be more easily removed for Shopware 5.8.

There currently exist no tests, as far as I can tell for this area. But in general it might also be more favorable to refactor this area completely, hence I am not sure if I should add a test case for this.

### 3. Describe each step to reproduce the issue or behaviour.
See above.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.