### PR TITLE
Refactor/tell a friend

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -24646,31 +24646,6 @@ parameters:
 			path: engine/Shopware/Controllers/Frontend/Sitemap.php
 
 		-
-			message: "#^Access to an undefined property Enlight_Controller_Request_RequestHttp\\:\\:\\$sArticle\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Frontend/Tellafriend.php
-
-		-
-			message: "#^Method Shopware_Controllers_Frontend_Tellafriend\\:\\:indexAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Frontend/Tellafriend.php
-
-		-
-			message: "#^Method Shopware_Controllers_Frontend_Tellafriend\\:\\:init\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Frontend/Tellafriend.php
-
-		-
-			message: "#^Method Shopware_Controllers_Frontend_Tellafriend\\:\\:successAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Frontend/Tellafriend.php
-
-		-
-			message: "#^Property Shopware_Controllers_Frontend_Tellafriend\\:\\:\\$sSYSTEM has no type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Frontend/Tellafriend.php
-
-		-
 			message: "#^Property Shopware_Controllers_Frontend_Tracking\\:\\:\\$testRepository has no type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Controllers/Frontend/Tracking.php

--- a/engine/Shopware/Components/TemplateMail.php
+++ b/engine/Shopware/Components/TemplateMail.php
@@ -161,6 +161,8 @@ class Shopware_Components_TemplateMail
     }
 
     /**
+     * @deprecated The $overrideConfig parameter will be removed with Shopware 5.8, directly apply the changes to the returned mail component
+     *
      * @param string|Mail $mailModel
      * @param array       $context
      * @param Shop        $shop
@@ -255,6 +257,8 @@ class Shopware_Components_TemplateMail
 
     /**
      * Loads values from MailModel into Mail
+     *
+     * @deprecated The $overrideConfig parameter will be removed with Shopware 5.8, directly apply the changes to the returned mail component
      *
      * @param array $overrideConfig
      *


### PR DESCRIPTION
### 1. Why is this change necessary?
I wanted to remove occurrences where `\sSystem` is used, and found the `Tellafriend` controller. I refactored a bit and thereby removed the usage of `\sSystem`. 

While at it, I noticed that there is an unused parameter in `\sArticles::sGetPromotionById`, which I therefore deprecated. I was not sure where I should document this deprecation.

Furthermore I am not sure, if the `Tellafriend` functionality should be removed (and therefore deprecated) altogether. As the mails probably will be categorized as spam anyways.
Before adding a test for this controller, I would rather remove it :-)

### 2. What does this change do, exactly?
See above.

### 3. Describe each step to reproduce the issue or behaviour.
See above.

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.