### PR TITLE
refactor: Remove dead code

### DIFF
--- a/engine/Shopware/Components/Modules.php
+++ b/engine/Shopware/Components/Modules.php
@@ -225,17 +225,11 @@ class Shopware_Components_Modules extends Enlight_Class implements ArrayAccess
     /**
      * Load a module defined by $name
      * Possible values for $name - sBasket, sAdmin etc.
+     *
+     * @param class-string $name
      */
     private function loadModule(string $name): void
     {
-        if (isset($this->modules_container[$name])) {
-            return;
-        }
-
-        $this->modules_container[$name] = null;
-        /** @var class-string $name */
-        $name = basename($name);
-
         if ($name === 'sSystem') {
             $this->modules_container[$name] = $this->system;
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Cleanup dead code. 

The code which is removed, is not needed, since on the one hand `loadModule` is a private method, which is only called if `this->modules_container[$name]` is `null`. On the other hand, `$name` [will never be a valid `path`](https://www.php.net/%20basename), since the `getModule` method always appends an `s` in front of the `$name`.

### 2. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.