### PR TITLE
ci: Update checkout action

### DIFF
--- a/.github/workflows/check-js-code.yml
+++ b/.github/workflows/check-js-code.yml
@@ -14,7 +14,7 @@ jobs:
   js:
       runs-on: ubuntu-latest
       steps:
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v3
           - uses: cachix/install-nix-action@v22
             with:
                 github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-php-code.yml
+++ b/.github/workflows/check-php-code.yml
@@ -14,7 +14,7 @@ jobs:
     php:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: cachix/install-nix-action@v22
               with:
                   github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -61,7 +61,7 @@ jobs:
                 mysql: ['pkgs.mysql80', 'pkgs.mariadb', 'pkgs.mariadb_104', 'config.nur.repos.pascalthesing.mysql57']
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - uses: cachix/install-nix-action@v22
               with:
@@ -112,7 +112,7 @@ jobs:
         env:
             TESTSUITE: 'all'
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: cachix/install-nix-action@v22
               with:
                   github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 1. Why is this change necessary?

There is a deprecation annotation on some jobs. this should fix them