### PR TITLE
refactor: Prepare Enlight\Event for Shopware 5.8 and fix the phpstan issues

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -2661,36 +2661,6 @@ parameters:
 			path: engine/Library/Enlight/Controller/Router.php
 
 		-
-			message: "#^Method Enlight_Event_EventArgs\\:\\:__construct\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventArgs.php
-
-		-
-			message: "#^Method Enlight_Event_EventArgs\\:\\:getReturn\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventArgs.php
-
-		-
-			message: "#^Method Enlight_Event_EventArgs\\:\\:setName\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventArgs.php
-
-		-
-			message: "#^Method Enlight_Event_EventArgs\\:\\:setName\\(\\) should return string but return statement is missing\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventArgs.php
-
-		-
-			message: "#^Method Enlight_Event_EventArgs\\:\\:setReturn\\(\\) has parameter \\$return with no type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventArgs.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$args with type array\\|null is not subtype of native type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventArgs.php
-
-		-
 			message: "#^Method Enlight_Event_EventHandler\\:\\:__construct\\(\\) has parameter \\$plugin with no type specified\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Event/EventHandler.php
@@ -2721,109 +2691,9 @@ parameters:
 			path: engine/Library/Enlight/Event/EventHandler.php
 
 		-
-			message: "#^Method Enlight_Event_EventManager\\:\\:buildEventArgs\\(\\) has parameter \\$eventArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventManager.php
-
-		-
-			message: "#^Method Enlight_Event_EventManager\\:\\:collect\\(\\) has parameter \\$collection with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection but does not specify its types\\: TKey, T$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventManager.php
-
-		-
-			message: "#^Method Enlight_Event_EventManager\\:\\:collect\\(\\) has parameter \\$eventArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventManager.php
-
-		-
-			message: "#^Method Enlight_Event_EventManager\\:\\:collect\\(\\) return type with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventManager.php
-
-		-
-			message: "#^Method Enlight_Event_EventManager\\:\\:filter\\(\\) has parameter \\$eventArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventManager.php
-
-		-
-			message: "#^Method Enlight_Event_EventManager\\:\\:getEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventManager.php
-
-		-
-			message: "#^Method Enlight_Event_EventManager\\:\\:getListeners\\(\\) has parameter \\$event with no type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventManager.php
-
-		-
-			message: "#^Method Enlight_Event_EventManager\\:\\:notify\\(\\) has parameter \\$eventArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventManager.php
-
-		-
-			message: "#^Method Enlight_Event_EventManager\\:\\:notifyUntil\\(\\) has parameter \\$eventArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventManager.php
-
-		-
-			message: "#^Method Enlight_Event_EventManager\\:\\:registerSubscriber\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/EventManager.php
-
-		-
-			message: "#^Method Enlight_Event_Handler\\:\\:__construct\\(\\) has parameter \\$event with no type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler.php
-
-		-
-			message: "#^Method Enlight_Event_Handler\\:\\:execute\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler.php
-
-		-
-			message: "#^Method Enlight_Event_Handler_Default\\:\\:execute\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler/Default.php
-
-		-
-			message: "#^Method Enlight_Event_Handler_Default\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler/Default.php
-
-		-
-			message: "#^Parameter \\#1 \\$listener of method Enlight_Event_Handler_Default\\:\\:setListener\\(\\) expects array\\<int, object\\|string\\>\\|\\(callable\\(\\)\\: mixed\\), array\\<int, \\(callable\\(\\)\\: mixed\\)\\|object\\|string\\>\\|\\(callable\\(\\)\\: mixed\\) given\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler/Default.php
-
-		-
-			message: "#^Parameter \\#1 \\$position of method Enlight_Event_Handler\\:\\:setPosition\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler/Default.php
-
-		-
-			message: "#^Method Enlight_Event_Handler_Plugin\\:\\:execute\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler/Plugin.php
-
-		-
-			message: "#^Method Enlight_Event_Handler_Plugin\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler/Plugin.php
-
-		-
-			message: "#^Parameter \\#1 \\$position of method Enlight_Event_Handler\\:\\:setPosition\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Handler/Plugin.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Event/Handler/Plugin.php
-
-		-
-			message: "#^Method Enlight_Event_Subscriber\\:\\:getListeners\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Subscriber.php
 
 		-
 			message: "#^Method Enlight_Event_Subscriber_Array\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
@@ -2884,46 +2754,6 @@ parameters:
 			message: "#^Property Enlight_Event_Subscriber_Config\\:\\:\\$listeners type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Event/Subscriber/Config.php
-
-		-
-			message: "#^Access to an undefined property Enlight_Config\\:\\:\\$listener\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Subscriber/Plugin.php
-
-		-
-			message: "#^Access to an undefined property Enlight_Config\\:\\:\\$listeners\\.$#"
-			count: 2
-			path: engine/Library/Enlight/Event/Subscriber/Plugin.php
-
-		-
-			message: "#^Access to an undefined property Enlight_Config\\:\\:\\$name\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Subscriber/Plugin.php
-
-		-
-			message: "#^Access to an undefined property Enlight_Config\\:\\:\\$plugin\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Subscriber/Plugin.php
-
-		-
-			message: "#^Access to an undefined property Enlight_Config\\:\\:\\$position\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Subscriber/Plugin.php
-
-		-
-			message: "#^Method Enlight_Event_Subscriber_Plugin\\:\\:__construct\\(\\) has parameter \\$namespace with no type specified\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Subscriber/Plugin.php
-
-		-
-			message: "#^Method Enlight_Event_Subscriber_Plugin\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Event/Subscriber/Plugin.php
-
-		-
-			message: "#^Method Enlight_Hook_HookArgs\\:\\:__construct\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Hook/HookArgs.php
 
 		-
 			message: "#^Method Enlight_Hook_HookArgs\\:\\:__construct\\(\\) has parameter \\$subject with no type specified\\.$#"
@@ -3162,11 +2992,6 @@ parameters:
 
 		-
 			message: "#^Method Enlight_Plugin_Namespace_Config\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: engine/Library/Enlight/Plugin/Namespace/Config.php
-
-		-
-			message: "#^Parameter \\#2 \\$options of class Enlight_Event_Subscriber_Plugin constructor expects null, Enlight_Config given\\.$#"
 			count: 1
 			path: engine/Library/Enlight/Plugin/Namespace/Config.php
 
@@ -15072,11 +14897,6 @@ parameters:
 
 		-
 			message: "#^Method Shopware\\\\Components\\\\ContainerAwareEventManager\\:\\:addSubscriberService\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Components/ContainerAwareEventManager.php
-
-		-
-			message: "#^Method Shopware\\\\Components\\\\ContainerAwareEventManager\\:\\:getListeners\\(\\) has parameter \\$eventName with no type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Components/ContainerAwareEventManager.php
 

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -152,10 +152,6 @@ parameters:
             message: '#Property Shopware\\Models\\.*::\$.* is never written, only read#'
             path: engine/Shopware/Models
 
-        - # Giving "test" as construct parameter sets up a test storage
-            message: '#Parameter \#1 \$options of class Enlight_Event_Subscriber_Config constructor expects array\|null, string given#'
-            path: tests/Unit/Components/Event/SubscriberConfigTest.php
-
         - # The Symfony extension does not correctly recognize the helper type. see: https://github.com/phpstan/phpstan-symfony/issues/239
             message: '#Call to an undefined method Symfony\\Component\\Console\\Helper\\HelperInterface::ask\(\)#'
             paths:

--- a/engine/Library/Enlight/.php-cs-fixer.php
+++ b/engine/Library/Enlight/.php-cs-fixer.php
@@ -71,7 +71,7 @@ return (new Config())
         'no_alias_functions' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_superfluous_phpdoc_tags' => true,
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
         'nullable_type_declaration_for_default_null_value' => true,
         'operator_linebreak' => ['only_booleans' => true],
         'ordered_class_elements' => true,

--- a/engine/Library/Enlight/Event/EventArgs.php
+++ b/engine/Library/Enlight/Event/EventArgs.php
@@ -49,7 +49,7 @@ class Enlight_Event_EventArgs extends Enlight_Collection_ArrayCollection
     /**
      * The Enlight_Event_EventArgs class constructor expects the name of the event.
      *
-     * @param array|null $args
+     * @param array<string|int, mixed> $args
      */
     public function __construct(array $args = [])
     {
@@ -95,7 +95,9 @@ class Enlight_Event_EventArgs extends Enlight_Collection_ArrayCollection
     /**
      * Setter method for the event name property.
      *
-     * @return string
+     * @param string $name
+     *
+     * @return void
      */
     public function setName($name)
     {
@@ -115,6 +117,8 @@ class Enlight_Event_EventArgs extends Enlight_Collection_ArrayCollection
     /**
      * Setter method for the return property.
      *
+     * @param mixed $return
+     *
      * @return void
      */
     public function setReturn($return)
@@ -124,6 +128,8 @@ class Enlight_Event_EventArgs extends Enlight_Collection_ArrayCollection
 
     /**
      * Getter method for the return property.
+     *
+     * @return mixed
      */
     public function getReturn()
     {

--- a/engine/Library/Enlight/Event/EventHandler.php
+++ b/engine/Library/Enlight/Event/EventHandler.php
@@ -24,7 +24,7 @@
  * @copyright  Copyright (c) 2011, shopware AG (http://www.shopware.de)
  * @license    http://enlight.de/license     New BSD License
  *
- * @deprecated in Shopware 5.6, will be removed in 5.8. Please use `Enlight_Event_Handler_Default` or `SubscriberInterface::getSubscribedEvents` instead.
+ * @deprecated in Shopware 5.6, will be removed in 5.8. Please use `SubscriberInterface::getSubscribedEvents` instead.
  */
 class Enlight_Event_EventHandler extends Enlight_Event_Handler_Default
 {

--- a/engine/Library/Enlight/Event/EventManager.php
+++ b/engine/Library/Enlight/Event/EventManager.php
@@ -153,23 +153,21 @@ class Enlight_Event_EventManager extends Enlight_Class
     /**
      * Retrieve a list of listeners registered to a given event.
      *
+     * @param string $event
+     *
      * @return Enlight_Event_Handler[]
      */
     public function getListeners($event)
     {
         $event = strtolower($event);
 
-        if (isset($this->listeners[$event])) {
-            return $this->listeners[$event];
-        }
-
-        return [];
+        return $this->listeners[$event] ?? [];
     }
 
     /**
      * Get a list of events for which this collection has listeners.
      *
-     * @return array
+     * @return string[]
      */
     public function getEvents()
     {
@@ -185,8 +183,8 @@ class Enlight_Event_EventManager extends Enlight_Class
      * Before the listener will be executed the the flag "processed" will be set to false in the event arguments.
      * After all event listeners has been executed the "processed" flag will be set to true.
      *
-     * @param string                             $event
-     * @param Enlight_Event_EventArgs|array|null $eventArgs
+     * @param string                                                $event
+     * @param Enlight_Event_EventArgs|array<string|int, mixed>|null $eventArgs
      *
      * @throws Enlight_Event_Exception
      *
@@ -222,8 +220,8 @@ class Enlight_Event_EventManager extends Enlight_Class
      *
      * The event listeners will be executed until one of the listeners return not null.
      *
-     * @param string                             $event
-     * @param Enlight_Event_EventArgs|array|null $eventArgs
+     * @param string                                                $event
+     * @param Enlight_Event_EventArgs|array<string|int, mixed>|null $eventArgs
      *
      * @throws Enlight_Exception
      *
@@ -268,9 +266,9 @@ class Enlight_Event_EventManager extends Enlight_Class
      *
      * @template TValue of mixed
      *
-     * @param string                             $event
-     * @param TValue                             $value
-     * @param Enlight_Event_EventArgs|array|null $eventArgs
+     * @param string                                                $event
+     * @param TValue                                                $value
+     * @param Enlight_Event_EventArgs|array<string|int, mixed>|null $eventArgs
      *
      * @throws Enlight_Event_Exception
      *
@@ -301,12 +299,13 @@ class Enlight_Event_EventManager extends Enlight_Class
      * Event which is fired to collect plugin parameters
      * to register additionally application components or configurations.
      *
-     * @param string     $event
-     * @param array|null $eventArgs
+     * @param string                      $event
+     * @param ArrayCollection<int, mixed> $collection
+     * @param array<string, mixed>|null   $eventArgs
      *
      * @throws Enlight_Event_Exception
      *
-     * @return ArrayCollection<mixed>
+     * @return ArrayCollection<int, mixed>
      */
     public function collect($event, ArrayCollection $collection, $eventArgs = null)
     {
@@ -359,6 +358,8 @@ class Enlight_Event_EventManager extends Enlight_Class
 
     /**
      * Registers all listeners of the given Enlight_Event_Subscriber.
+     *
+     * @return void
      */
     public function registerSubscriber(Enlight_Event_Subscriber $subscriber)
     {
@@ -382,22 +383,22 @@ class Enlight_Event_EventManager extends Enlight_Class
     }
 
     /**
-     * @param Enlight_Event_EventArgs|array|null $eventArgs
+     * @param Enlight_Event_EventArgs|array<string|int, mixed>|null $eventArgs
      *
      * @throws Enlight_Event_Exception
      *
      * @return Enlight_Event_EventArgs
      */
-    private function buildEventArgs($eventArgs = null)
+    private function buildEventArgs($eventArgs)
     {
-        if (isset($eventArgs) && \is_array($eventArgs)) {
-            return new Enlight_Event_EventArgs($eventArgs);
-        } elseif (!isset($eventArgs)) {
-            return new Enlight_Event_EventArgs();
-        } elseif (!$eventArgs instanceof Enlight_Event_EventArgs) {
-            throw new Enlight_Event_Exception('Parameter "eventArgs" must be an instance of "Enlight_Event_EventArgs"');
+        if ($eventArgs instanceof Enlight_Event_EventArgs) {
+            return $eventArgs;
         }
 
-        return $eventArgs;
+        if ($eventArgs === null || \is_array($eventArgs)) {
+            return new Enlight_Event_EventArgs((array) $eventArgs);
+        }
+
+        throw new Enlight_Event_Exception('Parameter "eventArgs" must be an array or instance of "Enlight_Event_EventArgs"');
     }
 }

--- a/engine/Library/Enlight/Event/Handler.php
+++ b/engine/Library/Enlight/Event/Handler.php
@@ -45,6 +45,8 @@ abstract class Enlight_Event_Handler
      * The Enlight_Event_Handler class constructor expects an event name. If no name is given,
      * the constructor throws an Enlight_Event_Exception.
      *
+     * @param string $event
+     *
      * @throws Enlight_Event_Exception
      */
     public function __construct($event)
@@ -98,6 +100,8 @@ abstract class Enlight_Event_Handler
 
     /**
      * Executes the event handler with the Enlight_Event_EventArgs.
+     *
+     * @return mixed|false|null
      */
     abstract public function execute(Enlight_Event_EventArgs $args);
 }

--- a/engine/Library/Enlight/Event/Handler/Default.php
+++ b/engine/Library/Enlight/Event/Handler/Default.php
@@ -41,22 +41,23 @@ class Enlight_Event_Handler_Default extends Enlight_Event_Handler
      *
      * @param string                                      $event
      * @param callable|array<int, object|string|callable> $listener
-     * @param int                                         $position
+     * @param ?int                                        $position
      *
      * @throws Enlight_Exception
      */
     public function __construct($event, $listener, $position = null)
     {
         parent::__construct($event);
+
         $this->setListener($listener);
-        $this->setPosition($position);
+        $this->setPosition((int) $position);
     }
 
     /**
      * Checks if the given listener is callable. If it is callable the listener is set
      * in the internal property and can be accessed by using the getListener() function.
      *
-     * @param callable|array<int, object|string> $listener
+     * @param callable|array<int, object|string|callable> $listener
      *
      * @throws Enlight_Event_Exception
      *
@@ -93,7 +94,7 @@ class Enlight_Event_Handler_Default extends Enlight_Event_Handler
     /**
      * Returns the handler properties as array.
      *
-     * @return array
+     * @return array{name: string, position: int, plugin: string, listener: callable}
      */
     public function toArray()
     {

--- a/engine/Library/Enlight/Event/Handler/Plugin.php
+++ b/engine/Library/Enlight/Event/Handler/Plugin.php
@@ -53,13 +53,13 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
      * The Enlight_Event_Handler_Plugin class constructor expects the event name.
      * All parameters are set in the internal properties.
      *
-     * @deprecated The parameter $plugin will only accept `string` starting from Shopware 5.8
+     * @deprecated The parameter $plugin will only accept `string` starting from Shopware 5.8 and all parameters will be strongly typed will not be nullable anymore
      *
-     * @param string                          $event
-     * @param Enlight_Plugin_Namespace        $namespace
-     * @param Enlight_Plugin_Bootstrap|string $plugin
-     * @param string                          $listener
-     * @param int                             $position
+     * @param string                               $event
+     * @param ?Enlight_Plugin_Namespace            $namespace
+     * @param Enlight_Plugin_Bootstrap|string|null $plugin
+     * @param ?string                              $listener
+     * @param ?int                                 $position
      *
      * @throws Enlight_Event_Exception
      */
@@ -75,7 +75,7 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
             $this->setListener($listener);
         }
         parent::__construct($event);
-        $this->setPosition($position);
+        $this->setPosition((int) $position);
     }
 
     /**
@@ -169,7 +169,7 @@ class Enlight_Event_Handler_Plugin extends Enlight_Event_Handler
     /**
      * Returns the plugin handler properties as an array.
      *
-     * @return array
+     * @return array{name: string, position: int, plugin: ?string, listener: string}
      */
     public function toArray()
     {

--- a/engine/Library/Enlight/Event/Subscriber.php
+++ b/engine/Library/Enlight/Event/Subscriber.php
@@ -28,13 +28,15 @@
  *
  * @copyright  Copyright (c) 2011, shopware AG (http://www.shopware.de)
  * @license    http://enlight.de/license     New BSD License
+ *
+ * @deprecated in Shopware 5.7, will be internal in 5.8. Please use `SubscriberInterface::getSubscribedEvents` instead.
  */
 abstract class Enlight_Event_Subscriber extends Enlight_Class
 {
     /**
      * Retrieves a list of listeners registered to a given event.
      *
-     * @return array
+     * @return list<\Enlight_Event_Handler>
      */
     abstract public function getListeners();
 

--- a/engine/Library/Enlight/Event/Subscriber/Array.php
+++ b/engine/Library/Enlight/Event/Subscriber/Array.php
@@ -28,6 +28,8 @@
  *
  * @copyright  Copyright (c) 2011, shopware AG (http://www.shopware.de)
  * @license    http://enlight.de/license     New BSD License
+ *
+ * @deprecated in Shopware 5.7, will be removed in 5.8. Please use `SubscriberInterface::getSubscribedEvents` instead.
  */
 class Enlight_Event_Subscriber_Array extends Enlight_Event_Subscriber
 {

--- a/engine/Library/Enlight/Event/Subscriber/Config.php
+++ b/engine/Library/Enlight/Event/Subscriber/Config.php
@@ -28,6 +28,8 @@
  *
  * @copyright  Copyright (c) 2011, shopware AG (http://www.shopware.de)
  * @license    http://enlight.de/license     New BSD License
+ *
+ * @deprecated in Shopware 5.7, will be removed in 5.8. Please use `SubscriberInterface::getSubscribedEvents` instead.
  */
 class Enlight_Event_Subscriber_Config extends Enlight_Event_Subscriber
 {
@@ -37,7 +39,7 @@ class Enlight_Event_Subscriber_Config extends Enlight_Event_Subscriber
     protected $listeners;
 
     /**
-     * @var Enlight_Config Contains an instance of the Enlight_Config
+     * @var \Enlight_Config
      */
     protected $storage;
 
@@ -47,7 +49,7 @@ class Enlight_Event_Subscriber_Config extends Enlight_Event_Subscriber
      * The storage can be overwritten by the options parameter which must contain the "storage" element
      * which is an instance of the Enlight_Config.
      *
-     * @param array|null $options
+     * @param array|\Enlight_Config|null $options
      */
     public function __construct($options = null)
     {

--- a/engine/Library/Enlight/Event/Subscriber/Plugin.php
+++ b/engine/Library/Enlight/Event/Subscriber/Plugin.php
@@ -26,6 +26,8 @@
  *
  * @copyright  Copyright (c) 2011, shopware AG (http://www.shopware.de)
  * @license    http://enlight.de/license     New BSD License
+ *
+ * @deprecated in Shopware 5.7, will be @internal in 5.8. Please use `SubscriberInterface::getSubscribedEvents` instead.
  */
 class Enlight_Event_Subscriber_Plugin extends Enlight_Event_Subscriber_Config
 {
@@ -36,9 +38,10 @@ class Enlight_Event_Subscriber_Plugin extends Enlight_Event_Subscriber_Config
     protected $namespace;
 
     /**
-     * The Enlight_Event_Subscriber_Plugin class constructor expects an instance of the Enlight_Plugin_Namespace.
+     * @deprecated in 5.8, the $options parameter will only accept an instance of of \Enlight_Config and all parameters are strongly typed
      *
-     * @param null $options
+     * @param \Enlight_Plugin_Namespace                                                                                                $namespace
+     * @param array{storage: \Enlight_Config|string, section: string|null, adapter: \Enlight_Config_Adapter|null}|\Enlight_Config|null $options
      */
     public function __construct($namespace, $options = null)
     {
@@ -53,7 +56,7 @@ class Enlight_Event_Subscriber_Plugin extends Enlight_Event_Subscriber_Config
      */
     public function write()
     {
-        $this->storage->listeners = $this->toArray();
+        $this->storage->set('listeners', $this->toArray());
         $this->storage->write();
 
         return $this;
@@ -68,17 +71,19 @@ class Enlight_Event_Subscriber_Plugin extends Enlight_Event_Subscriber_Config
     {
         $this->listeners = [];
 
-        if ($this->storage->listeners !== null) {
-            foreach ($this->storage->listeners as $entry) {
+        $listeners = $this->storage->get('listeners');
+        if ($listeners !== null) {
+            foreach ($listeners as $entry) {
                 if (!$entry instanceof Enlight_Config) {
                     continue;
                 }
+
                 $this->listeners[] = new Enlight_Event_Handler_Plugin(
-                    $entry->name,
+                    $entry->get('name'),
                     $this->namespace,
-                    $entry->plugin,
-                    $entry->listener,
-                    $entry->position
+                    $entry->get('plugin'),
+                    $entry->get('listener'),
+                    $entry->get('position')
                 );
             }
         }
@@ -89,7 +94,7 @@ class Enlight_Event_Subscriber_Plugin extends Enlight_Event_Subscriber_Config
     /**
      * Returns all listeners as array.
      *
-     * @return array
+     * @return list<array{name: string, position: int, plugin: ?string, listener: string}>
      */
     public function toArray()
     {

--- a/engine/Library/Enlight/Plugin/Namespace/Config.php
+++ b/engine/Library/Enlight/Plugin/Namespace/Config.php
@@ -143,6 +143,8 @@ class Enlight_Plugin_Namespace_Config extends Enlight_Plugin_Namespace
      * Returns the instance of the Enlight_Event_Subscriber_Plugin. If the subscriber
      * isn't instantiated the function will load it automatically.
      *
+     * @deprecated in Shopware 5.7, will be removed in 5.8. Please use `SubscriberInterface::getSubscribedEvents` instead.
+     *
      * @return Enlight_Event_Subscriber_Plugin
      */
     public function Subscriber()

--- a/engine/Shopware/Components/Plugin/Namespace.php
+++ b/engine/Shopware/Components/Plugin/Namespace.php
@@ -515,10 +515,15 @@ class Shopware_Components_Plugin_Namespace extends Enlight_Plugin_Namespace_Conf
         $subscribes = $this->Subscriber()->toArray();
 
         foreach ($subscribes as $subscribe) {
+            if (!isset($subscribe['plugin'])) {
+                continue;
+            }
+
             $subscribe['pluginID'] = $this->getInfo($subscribe['plugin'], 'id');
             if (!isset($subscribe['pluginID'])) {
                 continue;
             }
+
             $subscribe['listener'] = $this->getInfo($subscribe['plugin'], 'class')
                 . '::' . $subscribe['listener'];
 

--- a/tests/Unit/Components/Event/SubscriberConfigTest.php
+++ b/tests/Unit/Components/Event/SubscriberConfigTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace Shopware\Tests\Unit\Components\Event;
 
+use Enlight_Config;
 use Enlight_Event_EventArgs;
 use Enlight_Event_Handler_Default;
 use Enlight_Event_Subscriber_Config;
@@ -37,8 +38,10 @@ class SubscriberConfigTest extends TestCase
 
     public function setUp(): void
     {
-        // Giving "test" as parameter sets up a test storage. Even if it is not a valid value
-        $this->eventManager = new Enlight_Event_Subscriber_Config('test');
+        $this->eventManager = new Enlight_Event_Subscriber_Config(new Enlight_Config('test', [
+            'allowModifications' => true,
+            'section' => 'production',
+        ]));
     }
 
     public function testAddSubscriber(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
This is a first attempt to cleanup the Enlight event system, on the one hand fixing the types and on the other hand updating the deprecations. The complete Enlight event system probably should be replaced completely by the Symfony Event system, but not sure how the exact migration path should look like.

### 2. What does this change do, exactly?
I updated the deprecations and added some new ones and furthermore fixed the phpstan issues of the non deprecated classes. What do you think of the deprecations and the other changes? Are there any objections?
Locally I have also prepared a branch, where I applied the deprecations and changes for Shopware 5.8 (for the Event system), which I will try to regularly rebase.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
Once everything is in shape I will add the necessary information to the `UPGRADE.md`. 

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.