### PR TITLE
fix: Do not yield an error in registration when the customer group does not exist

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Register.php
+++ b/engine/Shopware/Controllers/Frontend/Register.php
@@ -469,7 +469,7 @@ class Shopware_Controllers_Frontend_Register extends Enlight_Controller_Action
         );
 
         if ($customerGroupKey && !$customerGroupId) {
-            throw new Enlight_Exception('Invalid customergroup');
+            return $this->get(Shopware_Components_Config::class)->get('defaultCustomerGroup', 'EK');
         }
 
         $event = Shopware()->Events()->notifyUntil(

--- a/themes/Frontend/Bare/frontend/register/index.tpl
+++ b/themes/Frontend/Bare/frontend/register/index.tpl
@@ -110,8 +110,7 @@
             {/block}
 
             {block name='frontend_register_index_cgroup_header'}
-                {if $register.personal.sValidation}
-                    {* Include information related to registration for other customergroups then guest, this block get overridden by b2b essentials plugin *}
+                {if $register.personal.sValidation && $register.personal.sValidation|lower != 'ek'}
                     <div class="panel register--supplier">
                         {block name='frontend_register_index_cgroup_header_title'}
                             <h2 class="panel--title is--underline">{$sShopname|escapeHtml} {s name='RegisterHeadlineSupplier' namespace='frontend/register/index'}{/s}</h2>

--- a/themes/Frontend/Bare/frontend/register/login.tpl
+++ b/themes/Frontend/Bare/frontend/register/login.tpl
@@ -32,7 +32,7 @@
 
             <div class="panel--body is--wide">
                 {block name='frontend_register_login_form'}
-                    {if $register.personal.sValidation}
+                    {if $register.personal.sValidation && $register.personal.sValidation|lower != 'ek'}
                         {$url = {url controller=account action=login sTarget=$sTarget sTargetAction=$sTargetAction sValidation=$register.personal.sValidation} }
                     {else}
                         {$url = {url controller=account action=login sTarget=$sTarget sTargetAction=$sTargetAction} }

--- a/themes/Frontend/Bare/frontend/register/personal_fieldset.tpl
+++ b/themes/Frontend/Bare/frontend/register/personal_fieldset.tpl
@@ -14,7 +14,7 @@
             <div class="panel--body is--wide">
                 {* Customer type *}
                 {block name='frontend_register_personal_fieldset_customer_type'}
-                    {if $form_data.sValidation}
+                    {if $form_data.sValidation && $form_data.sValidation|lower != 'ek'}
                         <input type="hidden" name="register[personal][sValidation]" value="{$form_data.sValidation|escapeHtml}" />
                     {else}
                         <div class="register--customertype">


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix #2579

### 2. What does this change do, exactly?
Do not throw an error if the customer group is not existent and use the default customer group instead.

### 3. Describe each step to reproduce the issue or behaviour.
See #2579 (or open http://your.shop.com/registerFC/index/sValidation/G)

### 4. Please link to the relevant issues (if any).
#2579

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.