### PR TITLE
fix: Change links to GitHub to new organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,14 @@
-# Shopware 6
-
-<a href="https://github.com/shopware/platform"><img src="https://s3.eu-central-1.amazonaws.com/shopware-platform-assets/github-platform/readme/discover_sw6.png" align="right" height="39" /></a>
-
-<p align="center">
-<img src="https://www.shopware.com/media/image/8a/cf/98/open-commerce-platform.png" width=500>
-</p>
-
-
-The completely newly developed successor "Shopware 6" is based entirely on the Symfony Framework and VueJS and is available under MIT licence at https://github.com/shopware/platform
-
 # Shopware 5
 
-![Build Status](https://github.com/shopware/shopware/workflows/PHPUnit/badge.svg)
+![Build Status](https://github.com/shopware5/shopware/workflows/PHPUnit/badge.svg)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/shopware/localized.svg)](https://crowdin.com/project/shopware)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/shopware/shopware/badges/quality-score.png?b=5.5)](https://scrutinizer-ci.com/g/shopware/shopware/?branch=5.5)
 [![Latest Stable Version](https://poser.pugx.org/shopware/shopware/v/stable)](https://packagist.org/packages/shopware/shopware)
 [![Total Downloads](https://poser.pugx.org/shopware/shopware/downloads)](https://packagist.org/packages/shopware/shopware)
 [![Slack](https://img.shields.io/badge/chat-on%20slack-%23ECB22E)](http://slack.shopware.com?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 - **License**: Dual license AGPL v3 / Proprietary
-- **GitHub Repository**: <https://github.com/shopware/shopware>
-- **Issue Tracker**: <https://issues.shopware.com>
+- **GitHub Repository**: <https://github.com/shopware5/shopware>
+- **Issues**: <https://github.com/shopware5/shopware/issues>
 
 ## Overview
 
@@ -67,7 +55,7 @@ Follow the instruction below if you want to install Shopware 5 using Git.
 
 1.) Clone the git repository to the desired location using:
 
-    git clone https://github.com/shopware/shopware.git
+    git clone https://github.com/shopware5/shopware.git
 
 In case you wish to contribute to Shopware, fork the `5.7` branch rather than cloning it, and create a pull request via GitHub.
 For further information please read the section "Get involved" of this document.
@@ -152,7 +140,7 @@ Shopware is distributed under a dual license (AGPL v3 and proprietary license). 
 
 # Changelog
 
-The changelog and all available commits are located under <https://github.com/shopware/shopware>.
+The changelog and all available commits are located under <https://github.com/shopware5/shopware>.
 
 ## Further reading
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -4,14 +4,14 @@ This changelog references changes done in Shopware 5.0 patch versions.
 
 ## 5.0.4 (2015-09-16)
 
-[View all changes from v5.0.3...v5.0.4](https://github.com/shopware/shopware/compare/v5.0.3...v5.0.4)
+[View all changes from v5.0.3...v5.0.4](https://github.com/shopware5/shopware/compare/v5.0.3...v5.0.4)
 
 * Change file extension of `Shopware_Components_Convert_Excel::generateXML` to .xls
 * Fixed jsonrenderer for backend order batchprocessing
     
 ## 5.0.3 (2015-08-24)
 
-[View all changes from v5.0.2...v5.0.3](https://github.com/shopware/shopware/compare/v5.0.2...v5.0.3)
+[View all changes from v5.0.2...v5.0.3](https://github.com/shopware5/shopware/compare/v5.0.2...v5.0.3)
 
 * The variant API resource now supports the getList method. It will return all variants with prices and attributes. You can optionally calculate the gross price by using the "considerTaxInput" parameter.
 * The getList method of the articles API resource now returns additionally the attributes of an article.
@@ -22,7 +22,7 @@ This changelog references changes done in Shopware 5.0 patch versions.
 
 ## 5.0.2 (2015-07-20)
 
-[View all changes from v5.0.1...v5.0.2](https://github.com/shopware/shopware/compare/v5.0.1...v5.0.2)
+[View all changes from v5.0.1...v5.0.2](https://github.com/shopware5/shopware/compare/v5.0.1...v5.0.2)
 
 * Method `createMenuItem` in plugin bootstrap now results in an duplicate error when passing an existing label with the same parent
 * Removed `Shopware_Controllers_Backend_Order::getStatisticAction` and statistics in the order backend module.
@@ -100,7 +100,7 @@ This changelog references changes done in Shopware 5.0 patch versions.
 
 ## 5.0.1 (2015-05-26)
 
-[View all changes from v5.0.0...v5.0.1](https://github.com/shopware/shopware/compare/v5.0.0...v5.0.1)
+[View all changes from v5.0.0...v5.0.1](https://github.com/shopware5/shopware/compare/v5.0.0...v5.0.1)
 
 * Create `sw:theme:dump:configuration` command to generate watch files for theme compiling
 * Rename \Shopware\Components\Theme\Compiler::preCompile to \Shopware\Components\Theme\Compiler::compile

--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -4,20 +4,20 @@ This changelog references changes done in Shopware 5.1 patch versions.
 
 ## 5.1.6 (2016-05-23)
 
-[View all changes from v5.1.5...v5.1.6](https://github.com/shopware/shopware/compare/v5.1.5...v5.1.6)
+[View all changes from v5.1.5...v5.1.6](https://github.com/shopware5/shopware/compare/v5.1.5...v5.1.6)
 
 * The interface `Enlight_Components_Cron_Adapter` in `engine/Library/Enlight/Components/Cron/Adapter.php` got a new method `getJobByAction`. For default implementation see `engine/Library/Enlight/Components/Cron/Adapter/DBAL.php`.
 * Fix a unserialize regression with PHP 5.6.21 and PHP 7.0.6.
     
 ## 5.1.5 (2016-04-11)
 
-[View all changes from v5.1.4...v5.1.5](https://github.com/shopware/shopware/compare/v5.1.4...v5.1.5)
+[View all changes from v5.1.4...v5.1.5](https://github.com/shopware5/shopware/compare/v5.1.4...v5.1.5)
 
 * The smarty variable `sCategoryInfo` in Listing and Blog controllers is now deprecated and will be removed soon. Use `sCategoryContent` instead, it's a drop in replacement.
 
 ## 5.1.4 (2016-03-22)
 
-[View all changes from v5.1.3...v5.1.4](https://github.com/shopware/shopware/compare/v5.1.3...v5.1.4)
+[View all changes from v5.1.3...v5.1.4](https://github.com/shopware5/shopware/compare/v5.1.3...v5.1.4)
 
 * Customer logout will now regenerate the session id and clear the customers basket.
 * Added `IsNew` condition for product streams
@@ -40,7 +40,7 @@ This changelog references changes done in Shopware 5.1 patch versions.
     
 ## 5.1.3 (2016-02-15)
 
-[View all changes from v5.1.2...v5.1.3](https://github.com/shopware/shopware/compare/v5.1.2...v5.1.3)
+[View all changes from v5.1.2...v5.1.3](https://github.com/shopware5/shopware/compare/v5.1.2...v5.1.3)
 
 * Switch Grunt to relativeUrls to unify the paths to less.php
 * Deprecated `Enlight_Application::getOption()` and `Enlight_Application::getOptions`
@@ -56,7 +56,7 @@ This changelog references changes done in Shopware 5.1 patch versions.
 
 ## 5.1.2 (2016-01-12)
 
-[View all changes from v5.1.1...v5.1.2](https://github.com/shopware/shopware/compare/v5.1.1...v5.1.2)
+[View all changes from v5.1.1...v5.1.2](https://github.com/shopware5/shopware/compare/v5.1.1...v5.1.2)
 
 * Out-of-stock variants on the detail page are now selectable
 * `ProductNumberService::getAvailableNumber()` now returns the provided product variant to allow deep linking of out-of-stock variants
@@ -99,14 +99,14 @@ This changelog references changes done in Shopware 5.1 patch versions.
     
 ## 5.1.1 (2015-10-26)
 
-[View all changes from v5.1.0...v5.1.1](https://github.com/shopware/shopware/compare/v5.1.0...v5.1.1)
+[View all changes from v5.1.0...v5.1.1](https://github.com/shopware5/shopware/compare/v5.1.0...v5.1.1)
 
 * Added new smarty block `frontend_detail_index_tabs_cross_selling` in the detail/ajax.tpl to prevent problems with custom themes
 * Renamed block `backend/order/view/detail/communication` in `backend/order/view/detail/configuration.js` to `backend/order/view/detail/configuration`. The name was duplicated in another file and was renamed to match the correct file.
 
 ## 5.1.0 (2015-10-19)
 
-[View all changes from v5.0.4...v5.1.0](https://github.com/shopware/shopware/compare/v5.0.4...v5.1.0)
+[View all changes from v5.0.4...v5.1.0](https://github.com/shopware5/shopware/compare/v5.0.4...v5.1.0)
 
 * Added event `Shopware_Plugin_Collect_MediaXTypes` to collect media related x_type fields for which the value needs to be normalized
 * Updated Behat to v3.0 and other related libraries

--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -4,7 +4,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 # 5.2.27
 
-[View all changes from v5.2.26...v5.2.27](https://github.com/shopware/shopware/compare/v5.2.26...v5.2.27)
+[View all changes from v5.2.26...v5.2.27](https://github.com/shopware5/shopware/compare/v5.2.26...v5.2.27)
 
 * Added config check to disable the `Tell a friend` page if it is disabled via config.
 * Fixed id collision in `themes/Backend/ExtJs/backend/base/component/Shopware.ModuleManager.js`
@@ -18,11 +18,11 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 # 5.2.26
 
-[View all changes from v5.2.25...v5.2.26](https://github.com/shopware/shopware/compare/v5.2.25...v5.2.26)
+[View all changes from v5.2.25...v5.2.26](https://github.com/shopware5/shopware/compare/v5.2.25...v5.2.26)
 
 ## 5.2.25
 
-[View all changes from v5.2.24...v5.2.25](https://github.com/shopware/shopware/compare/v5.2.24...v5.2.25)
+[View all changes from v5.2.24...v5.2.25](https://github.com/shopware5/shopware/compare/v5.2.24...v5.2.25)
 
 * Added notify event `Shopware_Modules_Basket_AddArticle_Added` in `engine/Shopware/Core/sBasket.php`
 * The event `Shopware_Modules_Export_ExportResult_Filter_Fixed` was added and now filters the processed export result. Previously with `Shopware_Modules_Export_ExportResult_Filter`, an instance of `Zend_Db_Statement_Pdo` was supplied, which could not be used to filter the actual result.
@@ -30,14 +30,14 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 # 5.2.24
 
-[View all changes from v5.2.23...v5.2.24](https://github.com/shopware/shopware/compare/v5.2.23...v5.2.24)
+[View all changes from v5.2.23...v5.2.24](https://github.com/shopware5/shopware/compare/v5.2.23...v5.2.24)
 
 * Fixed custom datefield format for articles
 * Fixed styling of image slider on tablet landscape view
 
 ## 5.2.23
 
-[View all changes from v5.2.22...v5.2.23](https://github.com/shopware/shopware/compare/v5.2.22...v5.2.23)
+[View all changes from v5.2.22...v5.2.23](https://github.com/shopware5/shopware/compare/v5.2.22...v5.2.23)
 
 * Added conditional statement in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.product-slider.js` to prevent the jquery plugin from sending ajax requests indefinitely
 * Added `limit` parameter to `createQuery` and `createOptionQuery` in `engine/Shopware/Bundle/ESIndexingBundle/Property/PropertyQueryFactory`
@@ -46,7 +46,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.22
 
-[View all changes from v5.2.21...v5.2.22](https://github.com/shopware/shopware/compare/v5.2.21...v5.2.22)
+[View all changes from v5.2.21...v5.2.22](https://github.com/shopware5/shopware/compare/v5.2.21...v5.2.22)
 
 * Fixed the picture implementation of the `box-emotion.tpl` to load the correct image sizes
 * Added new event `plugin/swAutoSubmit/onChangeSelection` in `themes/Frontend/Responsive/frontend/_public/src/js/jquery.auto-submit.js`
@@ -56,7 +56,7 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.21
 
-[View all changes from v5.2.20...v5.2.21](https://github.com/shopware/shopware/compare/v5.2.20...v5.2.21)
+[View all changes from v5.2.20...v5.2.21](https://github.com/shopware5/shopware/compare/v5.2.20...v5.2.21)
 
 * Updated Symfony to version 2.8.17
 * Added paymentID as event property in `Shopware_Modules_Admin_Execute_Risk_Rule_RuleName`
@@ -73,13 +73,13 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.20
 
-[View all changes from v5.2.19...v5.2.20](https://github.com/shopware/shopware/compare/v5.2.19...v5.2.20)
+[View all changes from v5.2.19...v5.2.20](https://github.com/shopware5/shopware/compare/v5.2.19...v5.2.20)
 
-* Reverted shopware/shopware#821 which added left joins for basket attributes in `sAdmin::sGetDispatchBasket()` and `sExport::sGetDispatchBasket()`
+* Reverted [shopware5/shopware#821](https://github.com/shopware5/shopware/pull/821) which added left joins for basket attributes in `sAdmin::sGetDispatchBasket()` and `sExport::sGetDispatchBasket()`
 
 ## 5.2.19
 
-[View all changes from v5.2.18...v5.2.19](https://github.com/shopware/shopware/compare/v5.2.18...v5.2.19)
+[View all changes from v5.2.18...v5.2.19](https://github.com/shopware5/shopware/compare/v5.2.18...v5.2.19)
 
 * Changed the loading of backend widgets to disable widgets of deactivated plugins
 * Added new Event `Shopware_Modules_Admin_regenerateSessionId_Start` in sAdmin::regenerateSessionId
@@ -98,14 +98,14 @@ This changelog references changes done in Shopware 5.2 patch versions.
 
 ## 5.2.18
 
-[View all changes from v5.2.17...v5.2.18](https://github.com/shopware/shopware/compare/v5.2.17...v5.2.18)
+[View all changes from v5.2.17...v5.2.18](https://github.com/shopware5/shopware/compare/v5.2.17...v5.2.18)
 
 * Fixed invalid permissions after running media optimizer on some hosting systems
 * Fixed session error in exports
 
 ## 5.2.17
 
-[View all changes from v5.2.16...v5.2.17](https://github.com/shopware/shopware/compare/v5.2.16...v5.2.17)
+[View all changes from v5.2.16...v5.2.17](https://github.com/shopware5/shopware/compare/v5.2.16...v5.2.17)
 
 * Deprecated Smarty modifier `rewrite`. Modifier will be removed in 5.3.0.
 * Changed default `session.gc_divisor` to `200`. To decrease session garbage collection probability.
@@ -150,13 +150,13 @@ The api resources are now available in the dependency injection container using 
 
 ## 5.2.16
 
-[View all changes from v5.2.15...v5.2.16](https://github.com/shopware/shopware/compare/v5.2.15...v5.2.16)
+[View all changes from v5.2.15...v5.2.16](https://github.com/shopware5/shopware/compare/v5.2.15...v5.2.16)
 
 * Improved form input filtering
 
 ## 5.2.15
 
-[View all changes from v5.2.14...v5.2.15](https://github.com/shopware/shopware/compare/v5.2.14...v5.2.15)
+[View all changes from v5.2.14...v5.2.15](https://github.com/shopware5/shopware/compare/v5.2.14...v5.2.15)
 
 * Fixed article api resource when creating a new article with new configurator options and an image mapping for this new options
 * Added cronjob registration via `Resources/cronjob.xml` file
@@ -165,7 +165,7 @@ The api resources are now available in the dependency injection container using 
 
 ## 5.2.14
 
-[View all changes from v5.2.13...v5.2.14](https://github.com/shopware/shopware/compare/v5.2.13...v5.2.14)
+[View all changes from v5.2.13...v5.2.14](https://github.com/shopware5/shopware/compare/v5.2.13...v5.2.14)
 
 ### Add property "valueField" to the media field.
 * The shopping world element "Media field" supports now to change the value field. All possible properties you can find in the file: `themes/Backend/ExtJs/backend/media_manager/model/media.js`
@@ -182,7 +182,7 @@ The api resources are now available in the dependency injection container using 
 
 ## 5.2.13
 
-[View all changes from v5.2.12...v5.2.13](https://github.com/shopware/shopware/compare/v5.2.12...v5.2.13)
+[View all changes from v5.2.12...v5.2.13](https://github.com/shopware5/shopware/compare/v5.2.12...v5.2.13)
 
 * Changed duplicate smarty block from `frontend_checkout_confirm_information_addresses_equal_panel_shipping_select_address` to `frontend_checkout_confirm_information_addresses_equal_panel_shipping_add_address` in `frontend/checkout/confirm.tpl`
 * Added interface `\Shopware\Bundle\ESIndexingBundle\TextMappingInterface` which handles text field mappings for different elastic search versions
@@ -209,11 +209,11 @@ Example:
 
 ## 5.2.12
 
-[View all changes from v5.2.11...v5.2.12](https://github.com/shopware/shopware/compare/v5.2.11...v5.2.12)
+[View all changes from v5.2.11...v5.2.12](https://github.com/shopware5/shopware/compare/v5.2.11...v5.2.12)
 
 ## 5.2.11
 
-[View all changes from v5.2.10...v5.2.11](https://github.com/shopware/shopware/compare/v5.2.10...v5.2.11)
+[View all changes from v5.2.10...v5.2.11](https://github.com/shopware5/shopware/compare/v5.2.10...v5.2.11)
 
 * Added new Smarty block `frontend_robots_txt_allows` to `frontend/robots_txt/index.tpl`
 * Added new Smarty block `frontend_account_order_item_availability` to `frontend/account/order_item_details.tpl`
@@ -261,7 +261,7 @@ There must be at least one option tag and inside each option tag where must be a
 
 ## 5.2.10
 
-[View all changes from v5.2.9...v5.2.10](https://github.com/shopware/shopware/compare/v5.2.9...v5.2.10)
+[View all changes from v5.2.9...v5.2.10](https://github.com/shopware5/shopware/compare/v5.2.9...v5.2.10)
 
 * Added optional `filter` option to `Shopware.apps.Base.view.element.Select`
 * Set `remoteFilter` to `true` in several *base* stores:
@@ -287,13 +287,13 @@ There must be at least one option tag and inside each option tag where must be a
 
 ## 5.2.9
 
-[View all changes from v5.2.8...v5.2.9](https://github.com/shopware/shopware/compare/v5.2.8...v5.2.9)
+[View all changes from v5.2.8...v5.2.9](https://github.com/shopware5/shopware/compare/v5.2.8...v5.2.9)
 
 * `filtergroupID` column will be set to `null` in the `s_articles` table when deleting a property set 
 
 ## 5.2.8
 
-[View all changes from v5.2.7...v5.2.8](https://github.com/shopware/shopware/compare/v5.2.7...v5.2.8)
+[View all changes from v5.2.7...v5.2.8](https://github.com/shopware5/shopware/compare/v5.2.7...v5.2.8)
 
 * Fixed a PHP 7 fatal error in the SVG rendering of mPDF
 * Added missing update of the order details' order number, when converting a cancelled order to a *normal* order in `Shopware_Controllers_Backend_CanceledOrder::convertOrderAction()`
@@ -302,7 +302,7 @@ There must be at least one option tag and inside each option tag where must be a
 
 ## 5.2.7
 
-[View all changes from v5.2.6...v5.2.7](https://github.com/shopware/shopware/compare/v5.2.6...v5.2.7)
+[View all changes from v5.2.6...v5.2.7](https://github.com/shopware5/shopware/compare/v5.2.6...v5.2.7)
 
 * Add support for third party post messages in the backend
 * getOne function of customer api resource contains now the country and state data for billing and shipping address
@@ -311,7 +311,7 @@ There must be at least one option tag and inside each option tag where must be a
 
 ## 5.2.6
 
-[View all changes from v5.2.5...v5.2.6](https://github.com/shopware/shopware/compare/v5.2.5...v5.2.6)
+[View all changes from v5.2.5...v5.2.6](https://github.com/shopware5/shopware/compare/v5.2.5...v5.2.6)
 
 * Changed visibility of sAdmin::loginUser to protected
 * Added filter events to all convert functions in `LegacyStructConverter`
@@ -340,13 +340,13 @@ There must be at least one option tag and inside each option tag where must be a
 
 ## 5.2.5
 
-[View all changes from v5.2.4...v5.2.5](https://github.com/shopware/shopware/compare/v5.2.4...v5.2.5)
+[View all changes from v5.2.4...v5.2.5](https://github.com/shopware5/shopware/compare/v5.2.4...v5.2.5)
 
 * Fixed SEO URL generation for URLs containing dots and forward slashes
 
 ## 5.2.4
 
-[View all changes from v5.2.3...v5.2.4](https://github.com/shopware/shopware/compare/v5.2.3...v5.2.4)
+[View all changes from v5.2.3...v5.2.4](https://github.com/shopware5/shopware/compare/v5.2.3...v5.2.4)
 
 * Introduced new interface `Shopware\Components\Slug\SlugInterface` to generate URL safe versions of a string
     * Service id `shopware.slug`
@@ -388,7 +388,7 @@ There must be at least one option tag and inside each option tag where must be a
 
 ## 5.2.3
 
-[View all changes from v5.2.2...v5.2.3](https://github.com/shopware/shopware/compare/v5.2.2...v5.2.3)
+[View all changes from v5.2.2...v5.2.3](https://github.com/shopware5/shopware/compare/v5.2.2...v5.2.3)
 
 * Updated `guzzlehttp/guzzle` to version 5.3.1 to mitigate [httproxy](https://httpoxy.org/) vulnerability
 * Set timeouts from install/update/(secure) uninstall operations in plugin manager to 300 seconds
@@ -405,13 +405,13 @@ There must be at least one option tag and inside each option tag where must be a
 
 ## 5.2.2 (2016-07-13)
 
-[View all changes from v5.2.0...v5.2.2](https://github.com/shopware/shopware/compare/v5.2.0...v5.2.2)
+[View all changes from v5.2.0...v5.2.2](https://github.com/shopware5/shopware/compare/v5.2.0...v5.2.2)
 
 * Add support for Symfony `console.command` service tag to register commands directly inside service container
 
 ## 5.2.0 (2016-07-01)
 
-[View all changes from v5.1.6...v5.2.0](https://github.com/shopware/shopware/compare/v5.1.6...v5.2.0)
+[View all changes from v5.1.6...v5.2.0](https://github.com/shopware5/shopware/compare/v5.1.6...v5.2.0)
 
 * Increased minimum required PHP version to PHP >= 5.6.4.
 * Added CSRF protection to frontend and backend which is enabled by default.

--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -4,7 +4,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 
 ## 5.3.7
 
-[View all changes from v5.3.6...v5.3.7](https://github.com/shopware/shopware/compare/v5.3.6...v5.3.7)
+[View all changes from v5.3.6...v5.3.7](https://github.com/shopware5/shopware/compare/v5.3.6...v5.3.7)
 
 ### Changes
 
@@ -17,7 +17,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 
 ## 5.3.6
 
-[View all changes from v5.3.5...v5.3.6](https://github.com/shopware/shopware/compare/v5.3.5...v5.3.6)
+[View all changes from v5.3.5...v5.3.6](https://github.com/shopware5/shopware/compare/v5.3.5...v5.3.6)
 
 ### Changes
 
@@ -29,7 +29,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 
 ## 5.3.5
 
-[View all changes from v5.3.4...v5.3.5](https://github.com/shopware/shopware/compare/v5.3.4...v5.3.5)
+[View all changes from v5.3.4...v5.3.5](https://github.com/shopware5/shopware/compare/v5.3.4...v5.3.5)
 
 ### Additions
 
@@ -62,7 +62,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 
 ## 5.3.4
 
-[View all changes from v5.3.3...v5.3.4](https://github.com/shopware/shopware/compare/v5.3.3...v5.3.4)
+[View all changes from v5.3.3...v5.3.4](https://github.com/shopware5/shopware/compare/v5.3.3...v5.3.4)
 
 ### Additions
 
@@ -92,7 +92,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 
 ## 5.3.3
 
-[View all changes from v5.3.2...v5.3.3](https://github.com/shopware/shopware/compare/v5.3.2...v5.3.3)
+[View all changes from v5.3.2...v5.3.3](https://github.com/shopware5/shopware/compare/v5.3.2...v5.3.3)
 
 ### Additions
 
@@ -111,7 +111,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 
 ## 5.3.2
 
-[View all changes from v5.3.1...v5.3.2](https://github.com/shopware/shopware/compare/v5.3.1...v5.3.2)
+[View all changes from v5.3.1...v5.3.2](https://github.com/shopware5/shopware/compare/v5.3.1...v5.3.2)
 
 ### Additions
 
@@ -125,7 +125,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 
 ## 5.3.0
 
-[View all changes from v5.2.27...v5.3.0](https://github.com/shopware/shopware/compare/v5.2.27...v5.3.0)
+[View all changes from v5.2.27...v5.3.0](https://github.com/shopware5/shopware/compare/v5.2.27...v5.3.0)
 
 ### Additions
 

--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -4,7 +4,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
 
 ## 5.4.6
 
-[View all changes from v5.4.5...v5.4.6](https://github.com/shopware/shopware/compare/v5.4.5...v5.4.6)
+[View all changes from v5.4.5...v5.4.6](https://github.com/shopware5/shopware/compare/v5.4.5...v5.4.6)
 
 ### Additions
 
@@ -42,7 +42,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
 
 ## 5.4.5
 
-[View all changes from v5.4.4...v5.4.5](https://github.com/shopware/shopware/compare/v5.4.4...v5.4.5)
+[View all changes from v5.4.4...v5.4.5](https://github.com/shopware5/shopware/compare/v5.4.4...v5.4.5)
 
 ### Additions
 
@@ -80,7 +80,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
 
 ## 5.4.4
 
-[View all changes from v5.4.3...v5.4.4](https://github.com/shopware/shopware/compare/v5.4.3...v5.4.4)
+[View all changes from v5.4.3...v5.4.4](https://github.com/shopware5/shopware/compare/v5.4.3...v5.4.4)
 
 ### Additions
 
@@ -136,7 +136,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
 
 ## 5.4.3
 
-[View all changes from v5.4.2...v5.4.3](https://github.com/shopware/shopware/compare/v5.4.2...v5.4.3)
+[View all changes from v5.4.2...v5.4.3](https://github.com/shopware5/shopware/compare/v5.4.2...v5.4.3)
 
 ### Additions
 
@@ -167,7 +167,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
 
 ## 5.4.2
 
-[View all changes from v5.4.1...v5.4.2](https://github.com/shopware/shopware/compare/v5.4.1...v5.4.2)
+[View all changes from v5.4.1...v5.4.2](https://github.com/shopware5/shopware/compare/v5.4.1...v5.4.2)
 
 ### Additions
 
@@ -190,7 +190,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
 
 ## 5.4.1
 
-[View all changes from v5.4.0...v5.4.1](https://github.com/shopware/shopware/compare/v5.4.0...v5.4.1)
+[View all changes from v5.4.0...v5.4.1](https://github.com/shopware5/shopware/compare/v5.4.0...v5.4.1)
 
 ### Additions
 
@@ -237,7 +237,7 @@ This changelog references changes done in Shopware 5.4 patch versions.
 
 ## 5.4.0
 
-[View all changes from v5.3.7...v5.4.0](https://github.com/shopware/shopware/compare/v5.3.7...v5.4.0)
+[View all changes from v5.3.7...v5.4.0](https://github.com/shopware5/shopware/compare/v5.3.7...v5.4.0)
 
 ### Additions
 

--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -4,7 +4,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 
 ## 5.5.10
 
-[View all changes from v5.5.9...v5.5.10](https://github.com/shopware/shopware/compare/v5.5.9...v5.5.10)
+[View all changes from v5.5.9...v5.5.10](https://github.com/shopware5/shopware/compare/v5.5.9...v5.5.10)
 
 ### Additions
 
@@ -20,7 +20,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 
 ## 5.5.9
 
-[View all changes from v5.5.8...v5.5.9](https://github.com/shopware/shopware/compare/v5.5.8...v5.5.9)
+[View all changes from v5.5.8...v5.5.9](https://github.com/shopware5/shopware/compare/v5.5.8...v5.5.9)
 
 ### Additions
 
@@ -82,7 +82,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 
 ## 5.5.8
 
-[View all changes from v5.5.7...v5.5.8](https://github.com/shopware/shopware/compare/v5.5.7...v5.5.8)
+[View all changes from v5.5.7...v5.5.8](https://github.com/shopware5/shopware/compare/v5.5.7...v5.5.8)
 
 ### Additions
 
@@ -167,7 +167,7 @@ For security reasons, some extensions like php, cgi, com, exe are not allowed in
 
 ## 5.5.7
 
-[View all changes from v5.5.6...v5.5.7](https://github.com/shopware/shopware/compare/v5.5.6...v5.5.7)
+[View all changes from v5.5.6...v5.5.7](https://github.com/shopware5/shopware/compare/v5.5.6...v5.5.7)
 
 ### Additions
 
@@ -220,7 +220,7 @@ For security reasons, some extensions like php, cgi, com, exe are not allowed in
     * `\Shopware\Components\Plugin\XmlCronjobReader`
     * `\Shopware\Components\Plugin\XmlPluginInfoReader`
     * `\Shopware\Components\Plugin\XmlConfigDefinitionReader`
-    They have been replaced in Shopware 5.6 with new implementations in the namespace [Shopware\Components\Plugin\XmlReader](https://github.com/shopware/shopware/tree/5.6/engine/Shopware/Components/Plugin/XmlReader)
+    They have been replaced in Shopware 5.6 with new implementations in the namespace [Shopware\Components\Plugin\XmlReader](https://github.com/shopware5/shopware/tree/5.6/engine/Shopware/Components/Plugin/XmlReader)
 
 ### Removals
 
@@ -289,7 +289,7 @@ return [
 
 ## 5.5.6
 
-[View all changes from v5.5.5...v5.5.6](https://github.com/shopware/shopware/compare/v5.5.5...v5.5.6)
+[View all changes from v5.5.5...v5.5.6](https://github.com/shopware5/shopware/compare/v5.5.5...v5.5.6)
 
 ### Changes
 
@@ -298,7 +298,7 @@ return [
 
 ## 5.5.5
 
-[View all changes from v5.5.4...v5.5.5](https://github.com/shopware/shopware/compare/v5.5.4...v5.5.5)
+[View all changes from v5.5.4...v5.5.5](https://github.com/shopware5/shopware/compare/v5.5.4...v5.5.5)
 
 ### Additions
 
@@ -387,7 +387,7 @@ return [
 
 ## 5.5.4
 
-[View all changes from v5.5.3...v5.5.4](https://github.com/shopware/shopware/compare/v5.5.3...v5.5.4)
+[View all changes from v5.5.3...v5.5.4](https://github.com/shopware5/shopware/compare/v5.5.3...v5.5.4)
 
 ### Additions
 
@@ -457,7 +457,7 @@ return [
 
 ## 5.5.3
 
-[View all changes from v5.5.2...v5.5.3](https://github.com/shopware/shopware/compare/v5.5.2...v5.5.3)
+[View all changes from v5.5.2...v5.5.3](https://github.com/shopware5/shopware/compare/v5.5.2...v5.5.3)
 
 ### Additions
 
@@ -485,7 +485,7 @@ return [
 
 ## 5.5.2
 
-[View all changes from v5.5.1...v5.5.2](https://github.com/shopware/shopware/compare/v5.5.1...v5.5.2)
+[View all changes from v5.5.1...v5.5.2](https://github.com/shopware5/shopware/compare/v5.5.1...v5.5.2)
 
 ### Additions
 
@@ -567,7 +567,7 @@ return [
 
 ## 5.5.1
 
-[View all changes from v5.5.0...v5.5.1](https://github.com/shopware/shopware/compare/v5.5.0...v5.5.1)
+[View all changes from v5.5.0...v5.5.1](https://github.com/shopware5/shopware/compare/v5.5.0...v5.5.1)
 
 ### Changes
 
@@ -575,7 +575,7 @@ return [
 
 ## 5.5.0
 
-[View all changes from v5.4.6...v5.5.0](https://github.com/shopware/shopware/compare/v5.4.6...v5.5.0)
+[View all changes from v5.4.6...v5.5.0](https://github.com/shopware5/shopware/compare/v5.4.6...v5.5.0)
 
 ### Additions
 

--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -4,11 +4,11 @@ This changelog references changes done in Shopware 5.6 patch versions.
 
 ## 5.6.10
 
-[View all changes from v5.6.9...v5.6.10](https://github.com/shopware/shopware/compare/v5.6.9...v5.6.10)
+[View all changes from v5.6.9...v5.6.10](https://github.com/shopware5/shopware/compare/v5.6.9...v5.6.10)
 
 ## 5.6.9
 
-[View all changes from v5.6.8...v5.6.9](https://github.com/shopware/shopware/compare/v5.6.8...v5.6.9)
+[View all changes from v5.6.8...v5.6.9](https://github.com/shopware5/shopware/compare/v5.6.8...v5.6.9)
 
 ### Changes
 
@@ -16,7 +16,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
 
 ## 5.6.8
 
-[View all changes from v5.6.7...v5.6.8](https://github.com/shopware/shopware/compare/v5.6.7...v5.6.8)
+[View all changes from v5.6.7...v5.6.8](https://github.com/shopware5/shopware/compare/v5.6.7...v5.6.8)
 
 ### Additions
 
@@ -35,7 +35,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
 
 ## 5.6.7
 
-[View all changes from v5.6.6...v5.6.7](https://github.com/shopware/shopware/compare/v5.6.6...v5.6.7)
+[View all changes from v5.6.6...v5.6.7](https://github.com/shopware5/shopware/compare/v5.6.6...v5.6.7)
 
 ### Additions
 
@@ -104,7 +104,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
 
 ## 5.6.6
 
-[View all changes from v5.6.5...v5.6.6](https://github.com/shopware/shopware/compare/v5.6.5...v5.6.6)
+[View all changes from v5.6.5...v5.6.6](https://github.com/shopware5/shopware/compare/v5.6.5...v5.6.6)
 
 ### Changes
 
@@ -112,7 +112,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
 
 ## 5.6.5
 
-[View all changes from v5.6.4...v5.6.5](https://github.com/shopware/shopware/compare/v5.6.4...v5.6.5)
+[View all changes from v5.6.4...v5.6.5](https://github.com/shopware5/shopware/compare/v5.6.4...v5.6.5)
 
 ### Additions
 
@@ -161,7 +161,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
 
 ## 5.6.4
 
-[View all changes from v5.6.3...v5.6.4](https://github.com/shopware/shopware/compare/v5.6.3...v5.6.4)
+[View all changes from v5.6.3...v5.6.4](https://github.com/shopware5/shopware/compare/v5.6.3...v5.6.4)
 
 ### Changes
 
@@ -169,7 +169,7 @@ This changelog references changes done in Shopware 5.6 patch versions.
 
 ## 5.6.3
 
-[View all changes from v5.6.2...v5.6.3](https://github.com/shopware/shopware/compare/v5.6.2...v5.6.3)
+[View all changes from v5.6.2...v5.6.3](https://github.com/shopware5/shopware/compare/v5.6.2...v5.6.3)
 
 ### Additions
 
@@ -232,7 +232,7 @@ to read [this documentation](https://developers.shopware.com/developers-guide/co
 
 ## 5.6.2
 
-[View all changes from v5.6.1...v5.6.2](https://github.com/shopware/shopware/compare/v5.6.1...v5.6.2)
+[View all changes from v5.6.1...v5.6.2](https://github.com/shopware5/shopware/compare/v5.6.1...v5.6.2)
 
 ### Additions
 
@@ -295,7 +295,7 @@ to read [this documentation](https://developers.shopware.com/developers-guide/co
 
 ## 5.6.1
 
-[View all changes from v5.6.0...v5.6.1](https://github.com/shopware/shopware/compare/v5.6.0...v5.6.1)
+[View all changes from v5.6.0...v5.6.1](https://github.com/shopware5/shopware/compare/v5.6.0...v5.6.1)
 
 ### Additions
 
@@ -325,7 +325,7 @@ to read [this documentation](https://developers.shopware.com/developers-guide/co
 
 ## 5.6.0
 
-[View all changes from v5.5.10...v5.6.0](https://github.com/shopware/shopware/compare/v5.5.10...v5.6.0)
+[View all changes from v5.5.10...v5.6.0](https://github.com/shopware5/shopware/compare/v5.5.10...v5.6.0)
 
 ### Additions
 

--- a/UPGRADE-5.7.md
+++ b/UPGRADE-5.7.md
@@ -4,7 +4,7 @@ This changelog references changes done in Shopware 5.7 patch versions.
 
 ## 5.7.19
 
-[View all changes from v5.7.18...v5.7.19](https://github.com/shopware/shopware/compare/v5.7.18...v5.7.19)
+[View all changes from v5.7.18...v5.7.19](https://github.com/shopware5/shopware/compare/v5.7.18...v5.7.19)
 
 ### Changes
 
@@ -22,7 +22,7 @@ This changelog references changes done in Shopware 5.7 patch versions.
 
 ## 5.7.18
 
-[View all changes from v5.7.17...v5.7.18](https://github.com/shopware/shopware/compare/v5.7.17...v5.7.18)
+[View all changes from v5.7.17...v5.7.18](https://github.com/shopware5/shopware/compare/v5.7.17...v5.7.18)
 
 ### Additions
 
@@ -61,7 +61,7 @@ This changelog references changes done in Shopware 5.7 patch versions.
 
 ## 5.7.17
 
-[View all changes from v5.7.16...v5.7.17](https://github.com/shopware/shopware/compare/v5.7.16...v5.7.17)
+[View all changes from v5.7.16...v5.7.17](https://github.com/shopware5/shopware/compare/v5.7.16...v5.7.17)
 
 ### Additions
 
@@ -112,7 +112,7 @@ This changelog references changes done in Shopware 5.7 patch versions.
 
 ## 5.7.16
 
-[View all changes from v5.7.15...v5.7.16](https://github.com/shopware/shopware/compare/v5.7.15...v5.7.16)
+[View all changes from v5.7.15...v5.7.16](https://github.com/shopware5/shopware/compare/v5.7.15...v5.7.16)
 
 ### Additions
 
@@ -208,19 +208,19 @@ This changelog references changes done in Shopware 5.7 patch versions.
 
 ## 5.7.15
 
-[View all changes from v5.7.14...v5.7.15](https://github.com/shopware/shopware/compare/v5.7.14...v5.7.15)
+[View all changes from v5.7.14...v5.7.15](https://github.com/shopware5/shopware/compare/v5.7.14...v5.7.15)
 
 ## 5.7.14
 
-[View all changes from v5.7.13...v5.7.14](https://github.com/shopware/shopware/compare/v5.7.13...v5.7.14)
+[View all changes from v5.7.13...v5.7.14](https://github.com/shopware5/shopware/compare/v5.7.13...v5.7.14)
 
 ## 5.7.13
 
-[View all changes from v5.7.12...v5.7.13](https://github.com/shopware/shopware/compare/v5.7.12...v5.7.13)
+[View all changes from v5.7.12...v5.7.13](https://github.com/shopware5/shopware/compare/v5.7.12...v5.7.13)
 
 ## 5.7.12
 
-[View all changes from v5.7.11...v5.7.12](https://github.com/shopware/shopware/compare/v5.7.11...v5.7.12)
+[View all changes from v5.7.11...v5.7.12](https://github.com/shopware5/shopware/compare/v5.7.11...v5.7.12)
 
 ### Additions
 
@@ -269,15 +269,15 @@ This changelog references changes done in Shopware 5.7 patch versions.
 
 ## 5.7.11
 
-[View all changes from v5.7.10...v5.7.11](https://github.com/shopware/shopware/compare/v5.7.10...v5.7.11)
+[View all changes from v5.7.10...v5.7.11](https://github.com/shopware5/shopware/compare/v5.7.10...v5.7.11)
 
 ## 5.7.10
 
-[View all changes from v5.7.9...v5.7.10](https://github.com/shopware/shopware/compare/v5.7.9...v5.7.10)
+[View all changes from v5.7.9...v5.7.10](https://github.com/shopware5/shopware/compare/v5.7.9...v5.7.10)
 
 ## 5.7.9
 
-[View all changes from v5.7.8...v5.7.9](https://github.com/shopware/shopware/compare/v5.7.8...v5.7.9)
+[View all changes from v5.7.8...v5.7.9](https://github.com/shopware5/shopware/compare/v5.7.8...v5.7.9)
 
 ### Changes
 
@@ -287,7 +287,7 @@ This changelog references changes done in Shopware 5.7 patch versions.
 
 ## 5.7.8
 
-[View all changes from v5.7.7...v5.7.8](https://github.com/shopware/shopware/compare/v5.7.7...v5.7.8)
+[View all changes from v5.7.7...v5.7.8](https://github.com/shopware5/shopware/compare/v5.7.7...v5.7.8)
 
 ### Additions
 
@@ -346,7 +346,7 @@ This changelog references changes done in Shopware 5.7 patch versions.
 
 ## 5.7.7
 
-[View all changes from v5.7.6...v5.7.7](https://github.com/shopware/shopware/compare/v5.7.6...v5.7.7)
+[View all changes from v5.7.6...v5.7.7](https://github.com/shopware5/shopware/compare/v5.7.6...v5.7.7)
 
 ### Deprecations
 
@@ -398,7 +398,7 @@ to log in again.**
 
 ## 5.7.6
 
-[View all changes from v5.7.5...v5.7.6](https://github.com/shopware/shopware/compare/v5.7.5...v5.7.6)
+[View all changes from v5.7.5...v5.7.6](https://github.com/shopware5/shopware/compare/v5.7.5...v5.7.6)
 
 ### Additions
 
@@ -406,11 +406,11 @@ to log in again.**
 
 ## 5.7.5
 
-[View all changes from v5.7.4...v5.7.5](https://github.com/shopware/shopware/compare/v5.7.4...v5.7.5)
+[View all changes from v5.7.4...v5.7.5](https://github.com/shopware5/shopware/compare/v5.7.4...v5.7.5)
 
 ## 5.7.4
 
-[View all changes from v5.7.3...v5.7.4](https://github.com/shopware/shopware/compare/v5.7.3...v5.7.4)
+[View all changes from v5.7.3...v5.7.4](https://github.com/shopware5/shopware/compare/v5.7.3...v5.7.4)
 
 ### Deprecations
 
@@ -474,7 +474,7 @@ please extend the `frontend_listing_actions_filter_include` block from now on in
 
 ## 5.7.3
 
-[View all changes from v5.7.2...v5.7.3](https://github.com/shopware/shopware/compare/v5.7.2...v5.7.3)
+[View all changes from v5.7.2...v5.7.3](https://github.com/shopware5/shopware/compare/v5.7.2...v5.7.3)
 
 ### Changes
 
@@ -487,7 +487,7 @@ please extend the `frontend_listing_actions_filter_include` block from now on in
 
 ## 5.7.2
 
-[View all changes from v5.7.1...v5.7.2](https://github.com/shopware/shopware/compare/v5.7.1...v5.7.2)
+[View all changes from v5.7.1...v5.7.2](https://github.com/shopware5/shopware/compare/v5.7.1...v5.7.2)
 
 ### Changes
 
@@ -495,7 +495,7 @@ please extend the `frontend_listing_actions_filter_include` block from now on in
 
 ## 5.7.1
 
-[View all changes from v5.7.0...v5.7.1](https://github.com/shopware/shopware/compare/v5.7.0...v5.7.1)
+[View all changes from v5.7.0...v5.7.1](https://github.com/shopware5/shopware/compare/v5.7.0...v5.7.1)
 
 ### Additions
 
@@ -512,7 +512,7 @@ please extend the `frontend_listing_actions_filter_include` block from now on in
 
 ## 5.7.0
 
-[View all changes from v5.6.10...v5.7.0](https://github.com/shopware/shopware/compare/v5.6.10...v5.7.0)
+[View all changes from v5.6.10...v5.7.0](https://github.com/shopware5/shopware/compare/v5.6.10...v5.7.0)
 
 ### Breaks
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "forum": "https://forum.shopware.com",
         "chat": "https://slack.shopware.com",
         "wiki": "https://developers.shopware.com/",
-        "source": "https://github.com/shopware/shopware",
+        "source": "https://github.com/shopware5/shopware",
         "issues": "https://issues.shopware.com"
     },
     "require": {

--- a/engine/Library/Enlight/Components/Session/Namespace.php
+++ b/engine/Library/Enlight/Components/Session/Namespace.php
@@ -164,7 +164,7 @@ class Enlight_Components_Session_Namespace extends Session implements ArrayAcces
         // - Shopware\Components\DependencyInjection\Bridge\Session::createSession()
         // In case the session is started somewhere else we need to ensure no other session is active. The same logic as
         // in Shopware's factories is used here.
-        // This behaviour is analogue to Zend: https://github.com/shopware/shopware/blob/cbc212ca4642878cac62193d3a2f41e08f4849a2/engine/Library/Zend/Session.php#L413
+        // This behaviour is analogue to Zend: https://github.com/shopware5/shopware/blob/cbc212ca4642878cac62193d3a2f41e08f4849a2/engine/Library/Zend/Session.php#L413
         $container = Shopware()->Container();
         self::ensureFrontendSessionClosed($container);
         self::ensureBackendSessionClosed($container);

--- a/engine/Shopware/Bundle/AttributeBundle/README.md
+++ b/engine/Shopware/Bundle/AttributeBundle/README.md
@@ -1,9 +1,5 @@
 # AttributeBundle
 
-- **License**: Dual license AGPL v3 / Proprietary
-- **Github Repository**: <https://github.com/shopware/shopware>
-- **Issue-Tracker**: <https://issues.shopware.com>
-
 ## Controllers
 
 There are only two controllers for handle all actions regarding attributes.

--- a/engine/Shopware/Components/Plugin/XmlPluginInfoReader.php
+++ b/engine/Shopware/Components/Plugin/XmlPluginInfoReader.php
@@ -38,7 +38,7 @@ use Symfony\Component\Config\Util\XmlUtils;
  *
  * Use new class Shopware\Components\Plugin\XmlReader\XmlPluginInfoReader (see Shopware 5.6)
  *
- * https://github.com/shopware/shopware/blob/5.6/engine/Shopware/Components/Plugin/XmlReader/XmlPluginInfoReader.php
+ * https://github.com/shopware5/shopware/blob/5.6/engine/Shopware/Components/Plugin/XmlReader/XmlPluginInfoReader.php
  */
 class XmlPluginInfoReader
 {

--- a/recovery/update/src/UpdateHtaccess.php
+++ b/recovery/update/src/UpdateHtaccess.php
@@ -40,44 +40,44 @@ class UpdateHtaccess
      * versions, the file gets replaced with the new .htacces.dist.
      */
     private const OLD_FILES = [
-        'ea1cf343d866211a2cd3fb1cda96c568', // https://github.com/shopware/shopware/blob/2822875087/.htaccess
-        '50201598e7180f7c9165936a9c5f4a53', // https://github.com/shopware/shopware/blob/2822875087/.htaccess + SwagSecurity section
-        'ae5381e3a07011f35a45c066749f76a5', // https://github.com/shopware/shopware/blob/37213e91d5/.htaccess
-        'baeb964cec3d2696e1030a5018b345c6', // https://github.com/shopware/shopware/blob/37213e91d5/.htaccess + SwagSecurity section
-        'e18138d4ef5c4dda6c5a24f796d83109', // https://github.com/shopware/shopware/blob/f307af9286/.htaccess
-        'c0f0bea10c3a8f5b1550d8d537294e32', // https://github.com/shopware/shopware/blob/f307af9286/.htaccess + SwagSecurity section
-        'f45b5cf94584b362960acca19bd79a02', // https://github.com/shopware/shopware/blob/e4b24110b9/.htaccess
-        'fd449fd74ce36aa3f4f01be5b198c42b', // https://github.com/shopware/shopware/blob/e4b24110b9/.htaccess + SwagSecurity section
-        '9d8825b4597f8f46dc40137b7afe2602', // https://github.com/shopware/shopware/blob/dea3a35b71/.htaccess
-        '7dc562c8f584358dae85e335e192c59f', // https://github.com/shopware/shopware/blob/dea3a35b71/.htaccess + SwagSecurity section
-        '657f2a28ce414c1a859f9f104bf16522', // https://github.com/shopware/shopware/blob/649b5a6e0a/.htaccess
-        'a10d145e79029b78c797e58995eb2743', // https://github.com/shopware/shopware/blob/649b5a6e0a/.htaccess + SwagSecurity section
-        'ece5e7d151499f18db260955642bc342', // https://github.com/shopware/shopware/blob/1982fda855/.htaccess
-        'bece28210fc7c53c424999daa2f93303', // https://github.com/shopware/shopware/blob/1982fda855/.htaccess + SwagSecurity section
-        'ebe05d01541cfd3bb4dcb4f46b761c0f', // https://github.com/shopware/shopware/blob/24b7abaa25/.htaccess
-        '16147aac5b54351c55f1cc2403892f40', // https://github.com/shopware/shopware/blob/24b7abaa25/.htaccess + SwagSecurity section
-        '54085d04dbcf32bdc27a464258380240', // https://github.com/shopware/shopware/blob/cf8907c6c5/.htaccess
-        '78f7207131fad361a710991f73620dd6', // https://github.com/shopware/shopware/blob/cf8907c6c5/.htaccess + SwagSecurity section
-        'be8e8ddf9e048dcd127beeb7a1f2b93b', // https://github.com/shopware/shopware/blob/053632e79f/.htaccess
-        'aaa3dae669543f176ec76ef1acb53b1b', // https://github.com/shopware/shopware/blob/053632e79f/.htaccess + SwagSecurity section
-        '33dd62e280adb9809173c3208eb14547', // https://github.com/shopware/shopware/blob/b021d77c8a/.htaccess
-        '7707cd5927b638a258548fd78c31e61a', // https://github.com/shopware/shopware/blob/b021d77c8a/.htaccess + SwagSecurity section
-        '45ef3f6ca5788085a3bb7378a1510c80', // https://github.com/shopware/shopware/blob/4aba9b79ac/.htaccess
-        '79b3663dd1dfa883a6d23b7cc6f56bd0', // https://github.com/shopware/shopware/blob/4aba9b79ac/.htaccess + SwagSecurity section
-        '486f52a32a31b97e11d5a83a0add7541', // https://github.com/shopware/shopware/blob/c0616709fb/.htaccess
-        'ec269ec668c9e64c6e188ee0bdf9c273', // https://github.com/shopware/shopware/blob/c0616709fb/.htaccess + SwagSecurity section
-        '49959e6a8fa61bf38b1c269e97da0d46', // https://github.com/shopware/shopware/blob/2ab66c45c9/.htaccess
-        'afde28bbcdf4f0d437ec44641a6faa3c', // https://github.com/shopware/shopware/blob/2ab66c45c9/.htaccess + SwagSecurity section
-        '1927450e0bcd5a1fbdad879356329f9d', // https://github.com/shopware/shopware/blob/0c0f6ff2e6/.htaccess
-        '7df38ad7aaa2410e363b3945759d9cf4', // https://github.com/shopware/shopware/blob/0c0f6ff2e6/.htaccess + SwagSecurity section
-        '136f3597e8745ae57e7e3139fab84c78', // https://github.com/shopware/shopware/blob/710076a2a2/.htaccess
-        'b3ece266f62b8f7ab75307f2e9734605', // https://github.com/shopware/shopware/blob/710076a2a2/.htaccess + SwagSecurity section
-        'b7f41355e1db0103b48bfe36458e4bb7', // https://github.com/shopware/shopware/blob/bb95afbd01/.htaccess
-        '596eb625c7f2804c10ec7be1ab441c82', // https://github.com/shopware/shopware/blob/bb95afbd01/.htaccess + SwagSecurity section
-        '781a1cdbd51aabf58e4626b3db8fd9c5', // https://github.com/shopware/shopware/blob/08661660a6/.htaccess
-        'aaff6dcc929190c7f65e26fe3ec0538b', // https://github.com/shopware/shopware/blob/08661660a6/.htaccess + SwagSecurity section
-        '5d7e6211ff581e12cbd9769e5b3da4bd', // https://github.com/shopware/shopware/blob/7662e140d2/.htaccess
-        '7ca5b55b89c5a2306307d9b65479791a', // https://github.com/shopware/shopware/blob/7662e140d2/.htaccess + SwagSecurity section
+        'ea1cf343d866211a2cd3fb1cda96c568', // https://github.com/shopware5/shopware/blob/2822875087/.htaccess
+        '50201598e7180f7c9165936a9c5f4a53', // https://github.com/shopware5/shopware/blob/2822875087/.htaccess + SwagSecurity section
+        'ae5381e3a07011f35a45c066749f76a5', // https://github.com/shopware5/shopware/blob/37213e91d5/.htaccess
+        'baeb964cec3d2696e1030a5018b345c6', // https://github.com/shopware5/shopware/blob/37213e91d5/.htaccess + SwagSecurity section
+        'e18138d4ef5c4dda6c5a24f796d83109', // https://github.com/shopware5/shopware/blob/f307af9286/.htaccess
+        'c0f0bea10c3a8f5b1550d8d537294e32', // https://github.com/shopware5/shopware/blob/f307af9286/.htaccess + SwagSecurity section
+        'f45b5cf94584b362960acca19bd79a02', // https://github.com/shopware5/shopware/blob/e4b24110b9/.htaccess
+        'fd449fd74ce36aa3f4f01be5b198c42b', // https://github.com/shopware5/shopware/blob/e4b24110b9/.htaccess + SwagSecurity section
+        '9d8825b4597f8f46dc40137b7afe2602', // https://github.com/shopware5/shopware/blob/dea3a35b71/.htaccess
+        '7dc562c8f584358dae85e335e192c59f', // https://github.com/shopware5/shopware/blob/dea3a35b71/.htaccess + SwagSecurity section
+        '657f2a28ce414c1a859f9f104bf16522', // https://github.com/shopware5/shopware/blob/649b5a6e0a/.htaccess
+        'a10d145e79029b78c797e58995eb2743', // https://github.com/shopware5/shopware/blob/649b5a6e0a/.htaccess + SwagSecurity section
+        'ece5e7d151499f18db260955642bc342', // https://github.com/shopware5/shopware/blob/1982fda855/.htaccess
+        'bece28210fc7c53c424999daa2f93303', // https://github.com/shopware5/shopware/blob/1982fda855/.htaccess + SwagSecurity section
+        'ebe05d01541cfd3bb4dcb4f46b761c0f', // https://github.com/shopware5/shopware/blob/24b7abaa25/.htaccess
+        '16147aac5b54351c55f1cc2403892f40', // https://github.com/shopware5/shopware/blob/24b7abaa25/.htaccess + SwagSecurity section
+        '54085d04dbcf32bdc27a464258380240', // https://github.com/shopware5/shopware/blob/cf8907c6c5/.htaccess
+        '78f7207131fad361a710991f73620dd6', // https://github.com/shopware5/shopware/blob/cf8907c6c5/.htaccess + SwagSecurity section
+        'be8e8ddf9e048dcd127beeb7a1f2b93b', // https://github.com/shopware5/shopware/blob/053632e79f/.htaccess
+        'aaa3dae669543f176ec76ef1acb53b1b', // https://github.com/shopware5/shopware/blob/053632e79f/.htaccess + SwagSecurity section
+        '33dd62e280adb9809173c3208eb14547', // https://github.com/shopware5/shopware/blob/b021d77c8a/.htaccess
+        '7707cd5927b638a258548fd78c31e61a', // https://github.com/shopware5/shopware/blob/b021d77c8a/.htaccess + SwagSecurity section
+        '45ef3f6ca5788085a3bb7378a1510c80', // https://github.com/shopware5/shopware/blob/4aba9b79ac/.htaccess
+        '79b3663dd1dfa883a6d23b7cc6f56bd0', // https://github.com/shopware5/shopware/blob/4aba9b79ac/.htaccess + SwagSecurity section
+        '486f52a32a31b97e11d5a83a0add7541', // https://github.com/shopware5/shopware/blob/c0616709fb/.htaccess
+        'ec269ec668c9e64c6e188ee0bdf9c273', // https://github.com/shopware5/shopware/blob/c0616709fb/.htaccess + SwagSecurity section
+        '49959e6a8fa61bf38b1c269e97da0d46', // https://github.com/shopware5/shopware/blob/2ab66c45c9/.htaccess
+        'afde28bbcdf4f0d437ec44641a6faa3c', // https://github.com/shopware5/shopware/blob/2ab66c45c9/.htaccess + SwagSecurity section
+        '1927450e0bcd5a1fbdad879356329f9d', // https://github.com/shopware5/shopware/blob/0c0f6ff2e6/.htaccess
+        '7df38ad7aaa2410e363b3945759d9cf4', // https://github.com/shopware5/shopware/blob/0c0f6ff2e6/.htaccess + SwagSecurity section
+        '136f3597e8745ae57e7e3139fab84c78', // https://github.com/shopware5/shopware/blob/710076a2a2/.htaccess
+        'b3ece266f62b8f7ab75307f2e9734605', // https://github.com/shopware5/shopware/blob/710076a2a2/.htaccess + SwagSecurity section
+        'b7f41355e1db0103b48bfe36458e4bb7', // https://github.com/shopware5/shopware/blob/bb95afbd01/.htaccess
+        '596eb625c7f2804c10ec7be1ab441c82', // https://github.com/shopware5/shopware/blob/bb95afbd01/.htaccess + SwagSecurity section
+        '781a1cdbd51aabf58e4626b3db8fd9c5', // https://github.com/shopware5/shopware/blob/08661660a6/.htaccess
+        'aaff6dcc929190c7f65e26fe3ec0538b', // https://github.com/shopware5/shopware/blob/08661660a6/.htaccess + SwagSecurity section
+        '5d7e6211ff581e12cbd9769e5b3da4bd', // https://github.com/shopware5/shopware/blob/7662e140d2/.htaccess
+        '7ca5b55b89c5a2306307d9b65479791a', // https://github.com/shopware5/shopware/blob/7662e140d2/.htaccess + SwagSecurity section
     ];
 
     private string $htaccessPath;

--- a/tests/Unit/Bundle/PluginInstallerBundle/Fixtures/TestPlugin/plugin.xml
+++ b/tests/Unit/Bundle/PluginInstallerBundle/Fixtures/TestPlugin/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.3/engine/Shopware/Components/Plugin/schema/plugin.xsd">
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware5/shopware/5.3/engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label>TestPlugin</label>
 
     <version>1.0.0</version>

--- a/tests/Unit/Components/Plugin/XmlReader/examples/menu/paypal.xml
+++ b/tests/Unit/Components/Plugin/XmlReader/examples/menu/paypal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.2/engine/Shopware/Components/Plugin/schema/menu.xsd">
+      xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware5/shopware/5.2/engine/Shopware/Components/Plugin/schema/menu.xsd">
     <entries>
         <entry>
             <name>PayPal</name>

--- a/tests/Unit/Plugin/Backend/SwagUpdate/Components/SwagUpdateTest.php
+++ b/tests/Unit/Plugin/Backend/SwagUpdate/Components/SwagUpdateTest.php
@@ -203,7 +203,7 @@ class SwagUpdateTest extends TestCase
     {
         return json_encode([
                 [
-                    'html_url' => 'https://github.com/shopware/shopware/releases/tag/v5.7.17',
+                    'html_url' => 'https://github.com/shopware5/shopware/releases/tag/v5.7.17',
                     'body' => '',
                     'id' => 97288305,
                     'node_id' => 'RE_kwDOAFa3Gs4FzIBx',
@@ -215,7 +215,7 @@ class SwagUpdateTest extends TestCase
                     'published_at' => '2023-03-29T09:06:24Z',
                     'assets' => [
                                 [
-                                    'url' => 'https://api.github.com/repos/shopware/shopware/releases/assets/102259279',
+                                    'url' => 'https://api.github.com/repos/shopware5/shopware/releases/assets/102259279',
                                     'id' => 102259279,
                                     'node_id' => 'RA_kwDOAFa3Gs4GGFpP',
                                     'name' => 'install_31b8b37fe396c41da6dfe6c5354e968ca82d890c.zip',
@@ -226,10 +226,10 @@ class SwagUpdateTest extends TestCase
                                     'download_count' => 132,
                                     'created_at' => '2023-04-04T12:14:50Z',
                                     'updated_at' => '2023-05-30T07:14:09Z',
-                                    'browser_download_url' => 'https://github.com/shopware/shopware/releases/download/v5.7.17/install_31b8b37fe396c41da6dfe6c5354e968ca82d890c.zip',
+                                    'browser_download_url' => 'https://github.com/shopware5/shopware/releases/download/v5.7.17/install_31b8b37fe396c41da6dfe6c5354e968ca82d890c.zip',
                                 ],
                                 [
-                                    'url' => 'https://api.github.com/repos/shopware/shopware/releases/assets/102259331',
+                                    'url' => 'https://api.github.com/repos/shopware5/shopware/releases/assets/102259331',
                                     'id' => 102259331,
                                     'node_id' => 'RA_kwDOAFa3Gs4GGFqD',
                                     'name' => 'update_e0a7813fcbae9ecf1dd566899b02e820a0c0b3e5.zip',
@@ -240,7 +240,7 @@ class SwagUpdateTest extends TestCase
                                     'download_count' => 12,
                                     'created_at' => '2023-04-04T12:15:18Z',
                                     'updated_at' => '2023-05-30T07:14:37Z',
-                                    'browser_download_url' => 'https://github.com/shopware/shopware/releases/download/v5.7.17/update_e0a7813fcbae9ecf1dd566899b02e820a0c0b3e5.zip',
+                                    'browser_download_url' => 'https://github.com/shopware5/shopware/releases/download/v5.7.17/update_e0a7813fcbae9ecf1dd566899b02e820a0c0b3e5.zip',
                                 ],
                         ],
                 ],
@@ -251,7 +251,7 @@ class SwagUpdateTest extends TestCase
     {
         return json_encode([
             [
-                'html_url' => 'https://github.com/shopware/shopware/releases/tag/v5.7.17',
+                'html_url' => 'https://github.com/shopware5/shopware/releases/tag/v5.7.17',
                 'body' => '',
                 'id' => 97288305,
                 'node_id' => 'RE_kwDOAFa3Gs4FzIBx',
@@ -263,8 +263,8 @@ class SwagUpdateTest extends TestCase
                 'published_at' => '2023-03-29T09:06:24Z',
                 'assets' => [
                     ],
-                'tarball_url' => 'https://api.github.com/repos/shopware/shopware/tarball/v5.7.17',
-                'zipball_url' => 'https://api.github.com/repos/shopware/shopware/zipball/v5.7.17',
+                'tarball_url' => 'https://api.github.com/repos/shopware5/shopware/tarball/v5.7.17',
+                'zipball_url' => 'https://api.github.com/repos/shopware5/shopware/zipball/v5.7.17',
             ],
         ], JSON_THROW_ON_ERROR);
     }
@@ -273,7 +273,7 @@ class SwagUpdateTest extends TestCase
     {
         return json_encode([
             [
-                'html_url' => 'https://github.com/shopware/shopware/releases/tag/v5.7.17',
+                'html_url' => 'https://github.com/shopware5/shopware/releases/tag/v5.7.17',
                 'body' => '',
                 'id' => 97288305,
                 'node_id' => 'RE_kwDOAFa3Gs4FzIBx',
@@ -285,7 +285,7 @@ class SwagUpdateTest extends TestCase
                 'published_at' => '2023-03-29T09:06:24Z',
                 'assets' => [
                         [
-                            'url' => 'https://api.github.com/repos/shopware/shopware/releases/assets/102259279',
+                            'url' => 'https://api.github.com/repos/shopware5/shopware/releases/assets/102259279',
                             'id' => 102259279,
                             'node_id' => 'RA_kwDOAFa3Gs4GGFpP',
                             'name' => 'install_31b8b37fe396c41da6dfe6c5354e968ca82d890c.zip',
@@ -296,10 +296,10 @@ class SwagUpdateTest extends TestCase
                             'download_count' => 132,
                             'created_at' => '2023-04-04T12:14:50Z',
                             'updated_at' => '2023-05-30T07:14:09Z',
-                            'browser_download_url' => 'https://github.com/shopware/shopware/releases/download/v5.7.17/install_31b8b37fe396c41da6dfe6c5354e968ca82d890c.zip',
+                            'browser_download_url' => 'https://github.com/shopware5/shopware/releases/download/v5.7.17/install_31b8b37fe396c41da6dfe6c5354e968ca82d890c.zip',
                         ],
                         [
-                            'url' => 'https://api.github.com/repos/shopware/shopware/releases/assets/102259331',
+                            'url' => 'https://api.github.com/repos/shopware5/shopware/releases/assets/102259331',
                             'id' => 102259331,
                             'node_id' => 'RA_kwDOAFa3Gs4GGFqD',
                             'name' => 'update_e0a7813fcbae9ecf1dd566899b02e820a0c0b3e5.zip',
@@ -310,12 +310,12 @@ class SwagUpdateTest extends TestCase
                             'download_count' => 12,
                             'created_at' => '2023-04-04T12:15:18Z',
                             'updated_at' => '2023-05-30T07:14:37Z',
-                            'browser_download_url' => 'https://github.com/shopware/shopware/releases/download/v5.7.17/update_e0a7813fcbae9ecf1dd566899b02e820a0c0b3e5.zip',
+                            'browser_download_url' => 'https://github.com/shopware5/shopware/releases/download/v5.7.17/update_e0a7813fcbae9ecf1dd566899b02e820a0c0b3e5.zip',
                         ],
                     ],
             ],
             [
-                'html_url' => 'https://github.com/shopware/shopware/releases/tag/v5.7.17',
+                'html_url' => 'https://github.com/shopware5/shopware/releases/tag/v5.7.17',
                 'body' => '',
                 'id' => 97288305,
                 'node_id' => 'RE_kwDOAFa3Gs4FzIBx',
@@ -327,7 +327,7 @@ class SwagUpdateTest extends TestCase
                 'published_at' => '2023-03-29T09:06:24Z',
                 'assets' => [
                         [
-                            'url' => 'https://api.github.com/repos/shopware/shopware/releases/assets/102259279',
+                            'url' => 'https://api.github.com/repos/shopware5/shopware/releases/assets/102259279',
                             'id' => 102259279,
                             'node_id' => 'RA_kwDOAFa3Gs4GGFpP',
                             'name' => 'install_31b8b37fe396c41da6dfe6c5354e968ca82d890c.zip',
@@ -338,10 +338,10 @@ class SwagUpdateTest extends TestCase
                             'download_count' => 132,
                             'created_at' => '2023-04-04T12:14:50Z',
                             'updated_at' => '2023-05-30T07:14:09Z',
-                            'browser_download_url' => 'https://github.com/shopware/shopware/releases/download/v5.7.17/install_31b8b37fe396c41da6dfe6c5354e968ca82d890c.zip',
+                            'browser_download_url' => 'https://github.com/shopware5/shopware/releases/download/v5.7.17/install_31b8b37fe396c41da6dfe6c5354e968ca82d890c.zip',
                         ],
                         [
-                            'url' => 'https://api.github.com/repos/shopware/shopware/releases/assets/102259331',
+                            'url' => 'https://api.github.com/repos/shopware5/shopware/releases/assets/102259331',
                             'id' => 102259331,
                             'node_id' => 'RA_kwDOAFa3Gs4GGFqD',
                             'name' => 'update_e0a7813fcbae9ecf1dd566899b02e820a0c0b3e5.zip',
@@ -352,7 +352,7 @@ class SwagUpdateTest extends TestCase
                             'download_count' => 12,
                             'created_at' => '2023-04-04T12:15:18Z',
                             'updated_at' => '2023-05-30T07:14:37Z',
-                            'browser_download_url' => 'https://github.com/shopware/shopware/releases/download/v5.7.17/update_e0a7813fcbae9ecf1dd566899b02e820a0c0b3e5.zip',
+                            'browser_download_url' => 'https://github.com/shopware5/shopware/releases/download/v5.7.17/update_e0a7813fcbae9ecf1dd566899b02e820a0c0b3e5.zip',
                         ],
                     ],
             ],

--- a/themes/Frontend/Responsive/package.json
+++ b/themes/Frontend/Responsive/package.json
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/shopware/shopware.git"
+        "url": "git+https://github.com/shopware5/shopware.git"
     },
     "keywords": [
         "shopware",
@@ -26,7 +26,7 @@
     "bugs": {
         "url": "https://issues.shopware.com"
     },
-    "homepage": "https://github.com/shopware/shopware#readme",
+    "homepage": "https://github.com/shopware5/shopware#readme",
     "dependencies": {
         "flatpickr": "2.6.3",
         "jquery": "3.6.0",


### PR DESCRIPTION
### 1. Why is this change necessary?

some links still point to original Shopware organistion

### 2. What does this change do, exactly?

Fix the links

