### PR TITLE
Fix paged listing with emotion

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -495,10 +495,6 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
      */
     private function getDevicesWithListing(array $emotions): array
     {
-        if ($this->Request()->getParam('sPage')) {
-            return [];
-        }
-
         $visibleDevices = [0, 1, 2, 3, 4];
         $permanentVisibleDevices = [];
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Because the product listing is not shown if the page parameter is defined and an emotion is shown.

### 2. What does this change do, exactly?
Remove the sPage parameter check when collecting devices with listing.

### 3. Describe each step to reproduce the issue or behaviour.
Create an emotion > assign it to a category with products > activate product listing > select "Category start page and listing" as visibility > go to the second page of the product listing > emotion is shown, product listing is not

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.