### PR TITLE
fix: Ensure that the update version is formatted correctly during the update check

### DIFF
--- a/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/UpdateCheck.php
+++ b/engine/Shopware/Plugins/Default/Backend/SwagUpdate/Components/UpdateCheck.php
@@ -130,7 +130,8 @@ class UpdateCheck
     private function getRelease(string $shopwareVersion, array $releaseInformation): array
     {
         foreach ($releaseInformation as $release) {
-            if (version_compare($shopwareVersion, ltrim($release['tag_name'], 'v'), '>=')) {
+            $release['tag_name'] = ltrim($release['tag_name'], 'v');
+            if (version_compare($shopwareVersion, $release['tag_name'], '>=')) {
                 continue;
             }
 

--- a/tests/Unit/Plugin/Backend/SwagUpdate/Components/UpdateCheckTest.php
+++ b/tests/Unit/Plugin/Backend/SwagUpdate/Components/UpdateCheckTest.php
@@ -134,7 +134,7 @@ class UpdateCheckTest extends TestCase
 
         $version = $updateChecker->checkUpdate('5.7.13');
         static::assertInstanceOf(Version::class, $version);
-        static::assertSame('v5.7.14', $version->version);
+        static::assertSame('5.7.14', $version->version);
     }
 
     public function testCheckUpdateReturnsVersionWithNewPreRelease(): void
@@ -151,7 +151,7 @@ class UpdateCheckTest extends TestCase
 
         $version = $updateChecker->checkUpdate('5.7.13');
         static::assertInstanceOf(Version::class, $version);
-        static::assertSame('v5.7.14', $version->version);
+        static::assertSame('5.7.14', $version->version);
     }
 
     public function testCheckUpdateReturnsVersionOfPreReleaseWithPreRelease(): void
@@ -168,7 +168,7 @@ class UpdateCheckTest extends TestCase
 
         $version = $updateChecker->checkUpdate('5.7.13');
         static::assertInstanceOf(Version::class, $version);
-        static::assertSame('v5.7.15', $version->version);
+        static::assertSame('5.7.15', $version->version);
     }
 
     public function testCheckUpdateReturnsVersionOfNormalReleaseWithoutPreRelease(): void
@@ -185,7 +185,7 @@ class UpdateCheckTest extends TestCase
 
         $version = $updateChecker->checkUpdate('5.7.13');
         static::assertInstanceOf(Version::class, $version);
-        static::assertSame('v5.7.14', $version->version);
+        static::assertSame('5.7.14', $version->version);
     }
 
     private function getSingleVersionJson(string $version, bool $prerelease = false): string


### PR DESCRIPTION
### 1. Why is this change necessary?

Without the change, a leading "v" would be on the update version, which leads to errors, if this version is used for calls against the SBP

### 2. What does this change do, exactly?

Remove the leading "v" from the version altogether
