### PR TITLE
fix: doc path for moved repository

### DIFF
--- a/engine/Shopware/Components/ReflectionHelper.php
+++ b/engine/Shopware/Components/ReflectionHelper.php
@@ -63,7 +63,7 @@ class ReflectionHelper
         $folders = Shopware()->Container()->getParameter('shopware.plugin_directories');
 
         $folders[] = Shopware()->DocPath('engine_Shopware');
-        $folders[] = Shopware()->DocPath('vendor_shopware_shopware');
+        $folders[] = Shopware()->DocPath('vendor_shopware5_shopware');
 
         foreach ($folders as $folder) {
             $directories[] = substr($folder, \strlen($docPath));


### PR DESCRIPTION
Wrong DocPath means that the path or class cannot be downloaded.
![Bildschirmfoto 2023-11-16 um 10 36 22](https://github.com/shopware5/shopware/assets/23236518/f43c102e-a67e-4e0c-bb92-2cd209690a44)
![Bildschirmfoto 2023-11-16 um 10 37 08](https://github.com/shopware5/shopware/assets/23236518/cfad5a86-2c27-479a-8c12-a357f6f3fdfd)

