### PR TITLE
fix NotifyAlreadyRegistered is never set caused by fetchColumn

### DIFF
--- a/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
@@ -109,13 +109,16 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
 
         if (!empty($notificationProducts)) {
             $sql = 'SELECT `ordernumber` FROM `s_articles_details` WHERE `articleID`=?';
-            $ordernumbers = $this->get(Connection::class)->fetchColumn($sql, [$id]);
+            $ordernumbers = $this->get(Connection::class)->fetchAllAssociative($sql, [$id]);
+            $ordernumbers = array_map(function (array $product) {
+                return $product['ordernumber'];
+            }, $ordernumbers);
 
             if (!empty($ordernumbers)) {
                 foreach ($ordernumbers as $ordernumber) {
                     if (\in_array($ordernumber, $notificationProducts)) {
                         $notificationVariants[] = $ordernumber;
-                        if ($ordernumber === $sArticle) {
+                        if ($ordernumber === $sArticle['ordernumber']) {
                             $view->assign('NotifyAlreadyRegistered', true);
                         }
                     }

--- a/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Frontend/Notification/Bootstrap.php
@@ -109,10 +109,7 @@ class Shopware_Plugins_Frontend_Notification_Bootstrap extends Shopware_Componen
 
         if (!empty($notificationProducts)) {
             $sql = 'SELECT `ordernumber` FROM `s_articles_details` WHERE `articleID`=?';
-            $ordernumbers = $this->get(Connection::class)->fetchAllAssociative($sql, [$id]);
-            $ordernumbers = array_map(function (array $product) {
-                return $product['ordernumber'];
-            }, $ordernumbers);
+            $ordernumbers = $this->get(Connection::class)->fetchAssociative($sql, [$id]);
 
             if (!empty($ordernumbers)) {
                 foreach ($ordernumbers as $ordernumber) {

--- a/tests/Functional/Plugins/Frontend/NotificationTest.php
+++ b/tests/Functional/Plugins/Frontend/NotificationTest.php
@@ -48,6 +48,7 @@ class NotificationTest extends Enlight_Components_Test_Plugin_TestCase
     ];
 
     public const NOTIFICATION_ACTION_URL = 'genusswelten/koestlichkeiten/272/spachtelmasse?action=notify&number=SW10239';
+    public const NOTIFICATION_DETAIL_URL = 'genusswelten/koestlichkeiten/272/spachtelmasse?number=SW10239';
 
     /**
      * @throws \Doctrine\DBAL\Exception
@@ -178,6 +179,18 @@ class NotificationTest extends Enlight_Components_Test_Plugin_TestCase
         $viewVariables = $this->View()->getAssign();
 
         static::assertArrayHasKey('NotifyCaptchaError', $viewVariables);
+    }
+
+    public function testDetailPageHasVariableIfAlreadyNotified(): void
+    {
+        $this->getContainer()->get('session')->offsetSet('sNotificatedArticles', [
+            self::NOTIFY_POST_PARAMETERS['notifyOrdernumber']
+        ]);
+
+        $this->dispatch(self::NOTIFICATION_DETAIL_URL);
+        $viewVariables = $this->View()->getAssign();
+        static::assertArrayHasKey('NotifyAlreadyRegistered', $viewVariables);
+        static::assertTrue($viewVariables['NotifyAlreadyRegistered']);
     }
 
     private function saveNotifyCaptcha(string $value): void

--- a/tests/Functional/Plugins/Frontend/NotificationTest.php
+++ b/tests/Functional/Plugins/Frontend/NotificationTest.php
@@ -184,7 +184,7 @@ class NotificationTest extends Enlight_Components_Test_Plugin_TestCase
     public function testDetailPageHasVariableIfAlreadyNotified(): void
     {
         $this->getContainer()->get('session')->offsetSet('sNotificatedArticles', [
-            self::NOTIFY_POST_PARAMETERS['notifyOrdernumber']
+            self::NOTIFY_POST_PARAMETERS['notifyOrdernumber'],
         ]);
 
         $this->dispatch(self::NOTIFICATION_DETAIL_URL);

--- a/tests/Functional/Plugins/Frontend/NotificationTest.php
+++ b/tests/Functional/Plugins/Frontend/NotificationTest.php
@@ -181,6 +181,13 @@ class NotificationTest extends Enlight_Components_Test_Plugin_TestCase
         static::assertArrayHasKey('NotifyCaptchaError', $viewVariables);
     }
 
+    public function testDetailPageHasNoVariableIfNotNotified(): void
+    {
+        $this->dispatch(self::NOTIFICATION_DETAIL_URL);
+        $viewVariables = $this->View()->getAssign();
+        static::assertArrayNotHasKey('NotifyAlreadyRegistered', $viewVariables);
+    }
+
     public function testDetailPageHasVariableIfAlreadyNotified(): void
     {
         $this->getContainer()->get('session')->offsetSet('sNotificatedArticles', [


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
`$NotifyAlreadyRegistered` is never set `fetchColumn` is still used but it is an old method and is deprecated with new library version of doctrine. `$ordernumbers` is currently an string but it should be an array since it is iterated.


### 2. What does this change do, exactly?
Fixes the variable `$NotifyAlreadyRegistered` to be set and available in the storefront.


### 3. Describe each step to reproduce the issue or behaviour.
Choose a product that is out of stock and has notification feature enabled:

- Enter an email address
- Confirm the email address
- Check the product
- You should see "You have already subscribed to notifications on this item!" 


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.