### PR TITLE
fix: backend order detail position, missing Article Detail id on add …

### DIFF
--- a/engine/Shopware/Controllers/Backend/Order.php
+++ b/engine/Shopware/Controllers/Backend/Order.php
@@ -1967,8 +1967,9 @@ class Shopware_Controllers_Backend_Order extends Shopware_Controllers_Backend_Ex
         $variant = $this->getManager()->getRepository(ProductVariant::class)
             ->findOneBy(['number' => $data['articleNumber']]);
 
-        // Load ean, unit and pack unit (translate if needed)
+        // Load articleDetailId, ean, unit and pack unit (translate if needed)
         if ($variant instanceof ProductVariant) {
+            $data['articleDetail'] = $variant;
             $mainVariant = $variant->getArticle()->getMainDetail();
             $data['ean'] = $variant->getEan();
             if (!\is_string($data['ean']) && $mainVariant instanceof ProductVariant) {


### PR DESCRIPTION
…or update position

### 1. Why is this change necessary?
Shopware Backend Order Position Module don't save `articleDetailID` from later added/updated article. 

This cause issues with Doctrine, trying to get the articleDetail from orderPosition.

```
+---+-------+---------+------------------+---------------+
|id |orderID|articleID|articleordernumber|articleDetailID|
+---+-------+---------+------------------+---------------+
|208|59     |78       |SW10079           |141            |
|209|59     |0        |SHIPPINGDISCOUNT  |null           |
|210|59     |215      |SW10213.3         |null           |
|212|59     |113      |SW10114           |null           |
+---+-------+---------+------------------+---------------+
```
Here a query result with the bug from the `s_order_details` table with 'SW10213.3' and 'SW10114' as later added position.

```
+---+-------+---------+------------------+---------------+
|id |orderID|articleID|articleordernumber|articleDetailID|
+---+-------+---------+------------------+---------------+
|208|59     |78       |SW10079           |141            |
|209|59     |0        |SHIPPINGDISCOUNT  |null           |
|210|59     |215      |SW10213.3         |759            |
|212|59     |113      |SW10114           |178            |
+---+-------+---------+------------------+---------------+
```

Here the same query with the fix


### 2. What does this change do, exactly?
Later added/updated Positions get saved with `articleDetailID`

### 3. Describe each step to reproduce the issue or behaviour.
Open a order in Backend and add a position 

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.