### PR TITLE
fix: backend statistics notification pagination

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -22861,36 +22861,6 @@ parameters:
 			path: engine/Shopware/Controllers/Backend/NewsletterManager.php
 
 		-
-			message: "#^Access to an undefined property Enlight_Controller_Request_RequestHttp\\:\\:\\$limit\\.$#"
-			count: 2
-			path: engine/Shopware/Controllers/Backend/Notification.php
-
-		-
-			message: "#^Access to an undefined property Enlight_Controller_Request_RequestHttp\\:\\:\\$orderNumber\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Notification.php
-
-		-
-			message: "#^Access to an undefined property Enlight_Controller_Request_RequestHttp\\:\\:\\$start\\.$#"
-			count: 2
-			path: engine/Shopware/Controllers/Backend/Notification.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_Notification\\:\\:getArticleListAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Notification.php
-
-		-
-			message: "#^Method Shopware_Controllers_Backend_Notification\\:\\:getCustomerListAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: engine/Shopware/Controllers/Backend/Notification.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$filter has no value type specified in iterable type array\\.$#"
-			count: 2
-			path: engine/Shopware/Controllers/Backend/Notification.php
-
-		-
 			message: "#^Method Shopware_Controllers_Backend_Overview\\:\\:getOrderSummaryAction\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: engine/Shopware/Controllers/Backend/Overview.php
@@ -37379,26 +37349,6 @@ parameters:
 			message: "#^Property Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\MailTest\\:\\:\\$testData type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Functional/Controllers/Backend/MailTest.php
-
-		-
-			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$data\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/NotificationTest.php
-
-		-
-			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$success\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/NotificationTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\NotificationTest\\:\\:testGetArticleList\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/NotificationTest.php
-
-		-
-			message: "#^Method Shopware\\\\Tests\\\\Functional\\\\Controllers\\\\Backend\\\\NotificationTest\\:\\:testGetCustomerList\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Functional/Controllers/Backend/NotificationTest.php
 
 		-
 			message: "#^Access to an undefined property Enlight_View_Default\\:\\:\\$success\\.$#"

--- a/engine/Shopware/Controllers/Backend/Notification.php
+++ b/engine/Shopware/Controllers/Backend/Notification.php
@@ -28,26 +28,24 @@ class Shopware_Controllers_Backend_Notification extends Shopware_Controllers_Bac
 {
     /**
      * returns a JSON string to with all found articles for the backend listing
+     *
+     * @return void
      */
     public function getArticleListAction()
     {
         try {
-            $limit = (int) $this->Request()->limit;
-            $offset = (int) $this->Request()->start;
-
-            /** @var array $filter */
-            $filter = $this->Request()->getParam('filter', []);
+            $limit = (int) $this->Request()->get('limit', 20);
+            $offset = (int) $this->Request()->get('start', 0);
+            $filter = (array) $this->Request()->getParam('filter', []);
 
             // order data
             $order = (array) $this->Request()->getParam('sort', []);
 
             $repository = $this->get('models')->getRepository(Article::class);
             $dataQuery = $repository->getArticlesWithRegisteredNotificationsQuery($filter, $offset, $limit, $order);
-            $data = $dataQuery->getArrayResult();
 
-            // manually calc the totalAmount cause the paginate($this->get('models')->getQueryCount) doesn't work with this query
-            $dataQuery->setFirstResult(0);
-            $totalCount = \count($dataQuery->getArrayResult());
+            $data = $dataQuery->getResult(AbstractQuery::HYDRATE_ARRAY);
+            $totalCount = (int) $repository->getProductsWithNotificationsCountQuery()->getOneOrNullResult(AbstractQuery::HYDRATE_SINGLE_SCALAR);
 
             $summaryQuery = $repository->getArticlesWithRegisteredNotificationsQuery($filter, $offset, $limit, $order, true);
             $summaryData = $summaryQuery->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY);
@@ -68,16 +66,17 @@ class Shopware_Controllers_Backend_Notification extends Shopware_Controllers_Bac
 
     /**
      * returns a JSON string to with all found customers for the backend listing
+     *
+     * @return void
      */
     public function getCustomerListAction()
     {
         try {
-            $limit = (int) $this->Request()->limit;
-            $offset = (int) $this->Request()->start;
-            $productOrderNumber = $this->Request()->orderNumber;
+            $limit = (int) $this->Request()->get('limit', 20);
+            $offset = (int) $this->Request()->get('start', 0);
+            $productOrderNumber = $this->Request()->get('orderNumber');
 
-            /** @var array $filter */
-            $filter = $this->Request()->getParam('filter', []);
+            $filter = (array) $this->Request()->getParam('filter', []);
 
             // order data
             $order = (array) $this->Request()->getParam('sort', []);

--- a/engine/Shopware/Models/Article/Repository.php
+++ b/engine/Shopware/Models/Article/Repository.php
@@ -2086,7 +2086,7 @@ class Repository extends ModelRepository
         $summarize = null
     ) {
         $builder = $this->getArticlesWithRegisteredNotificationsBuilder($filter, $order, $summarize);
-        if (empty($summarize) && !empty($limit) && !empty($offset)) {
+        if (empty($summarize) && !empty($limit) && $offset !== null) {
             $builder->setFirstResult($offset)
                 ->setMaxResults($limit);
         }
@@ -2141,6 +2141,19 @@ class Repository extends ModelRepository
     }
 
     /**
+     * @return Query<Notification>
+     */
+    public function getProductsWithNotificationsCountQuery(): Query
+    {
+        $builder = $this->getEntityManager()->createQueryBuilder();
+        $builder->select('COUNT(DISTINCT notification.articleNumber)');
+
+        $builder->from(Notification::class, 'notification');
+
+        return $builder->getQuery();
+    }
+
+    /**
      * Returns an instance of the \Doctrine\ORM\Query object which selects all notification customers by the given articleOrderNumber
      *
      * @param string $articleOrderNumber
@@ -2156,7 +2169,7 @@ class Repository extends ModelRepository
     public function getNotificationCustomerByArticleQuery($articleOrderNumber, $filter, $offset, $limit, $order)
     {
         $builder = $this->getNotificationCustomerByArticleBuilder($articleOrderNumber, $filter, $order);
-        if (!empty($limit) && !empty($offset)) {
+        if (!empty($limit) && $offset !== null) {
             $builder->setFirstResult($offset)
                     ->setMaxResults($limit);
         }

--- a/tests/Functional/Controllers/Backend/NotificationTest.php
+++ b/tests/Functional/Controllers/Backend/NotificationTest.php
@@ -27,6 +27,20 @@ use Enlight_Components_Test_Controller_TestCase;
 
 class NotificationTest extends Enlight_Components_Test_Controller_TestCase
 {
+    private const TEST_PRODUCT_LIST_LIMIT = 2;
+    private const TEST_PRODUCT_LIST_FIRST_PAGE_OFFSET = 0;
+    private const TEST_PRODUCT_LIST_SECOND_PAGE_OFFSET = 2;
+    private const TEST_PRODUCT_LIST_TOTAL_RESULTS = 3;
+    private const TEST_PRODUCT_LIST_FIRST_PAGE_ITEMS_COUNT = 2;
+    private const TEST_PRODUCT_LIST_SECOND_PAGE_ITEMS_COUNT = 1;
+
+    private const TEST_CUSTOMER_LIST_LIMIT = 2;
+    private const TEST_CUSTOMER_LIST_FIRST_PAGE_OFFSET = 0;
+    private const TEST_CUSTOMER_LIST_SECOND_PAGE_OFFSET = 2;
+    private const TEST_CUSTOMER_LIST_TOTAL_RESULTS = 3;
+    private const TEST_CUSTOMER_LIST_FIRST_PAGE_ITEMS_COUNT = 2;
+    private const TEST_CUSTOMER_LIST_SECOND_PAGE_ITEMS_COUNT = 1;
+
     /**
      * Standard set up for every test - just disable auth
      */
@@ -40,7 +54,10 @@ class NotificationTest extends Enlight_Components_Test_Controller_TestCase
         $sql = "INSERT IGNORE INTO `s_articles_notification` (`id`, `ordernumber`, `date`, `mail`, `send`, `language`, `shopLink`) VALUES
                 (1111111111, 'SW2001', '2010-10-04 10:46:56', 'test@example.de', 0, '1', 'http://example.com/'),
                 (1111111112, 'SW2003', '2010-10-05 10:46:55', 'test@example.com', 1, '1', 'http://example.com/'),
-                (1111111113, 'SW2001', '2010-10-04 10:46:54', 'test@example.org', 1, '1', 'http://example.com/');";
+                (1111111113, 'SW2001', '2010-10-04 10:46:54', 'test@example.org', 1, '1', 'http://example.com/'),
+                (1111111114, 'SW2005', '2024-03-27 10:00:00', 'test@example.org', 1, '1', 'http://example.com/'),
+                (1111111115, 'SW2001', '2024-03-27 10:01:00', 'john@example.org', 1, '1', 'http://example.com/')
+       ;";
         Shopware()->Db()->query($sql);
     }
 
@@ -50,49 +67,90 @@ class NotificationTest extends Enlight_Components_Test_Controller_TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        $sql = 'DELETE FROM s_articles_notification WHERE id IN (1111111111, 1111111112, 1111111113)';
+        $sql = 'DELETE FROM s_articles_notification WHERE id IN (1111111111, 1111111112, 1111111113, 1111111114, 1111111115)';
         Shopware()->Db()->query($sql);
     }
 
     /**
      * test getList controller action
      */
-    public function testGetArticleList()
+    public function testGetArticleListFirstPage(): void
     {
-        $this->dispatch('backend/Notification/getArticleList');
-        static::assertTrue($this->View()->success);
-        $returnData = $this->View()->data;
+        $parameter = [
+            'limit' => self::TEST_PRODUCT_LIST_LIMIT,
+            'start' => self::TEST_PRODUCT_LIST_FIRST_PAGE_OFFSET,
+        ];
+        $getParameter = http_build_query($parameter);
+
+        $this->dispatch('backend/Notification/getArticleList?' . $getParameter);
+        static::assertTrue($this->View()->getAssign('success'));
+        $returnData = $this->View()->getAssign('data');
         static::assertNotEmpty($returnData);
-        static::assertCount(2, $returnData);
+
+        static::assertCount(self::TEST_PRODUCT_LIST_FIRST_PAGE_ITEMS_COUNT, $returnData);
+        static::assertSame(self::TEST_PRODUCT_LIST_TOTAL_RESULTS, $this->View()->getAssign('totalCount'));
         $listingFirstEntry = $returnData[0];
 
         // cause of the DataSet you can assert fix values
-        static::assertEquals(2, $listingFirstEntry['registered']);
-        static::assertEquals('SW2001', $listingFirstEntry['number']);
-        static::assertEquals(1, $listingFirstEntry['notNotified']);
+        static::assertSame(3, $listingFirstEntry['registered']);
+        static::assertSame('SW2001', $listingFirstEntry['number']);
+        static::assertSame('1', $listingFirstEntry['notNotified']);
+    }
+
+    /**
+     * test getList controller action
+     */
+    public function testGetArticleListSecondPage(): void
+    {
+        $parameter = [
+            'limit' => self::TEST_PRODUCT_LIST_LIMIT,
+            'start' => self::TEST_PRODUCT_LIST_SECOND_PAGE_OFFSET,
+        ];
+        $getParameter = http_build_query($parameter);
+
+        $this->dispatch('backend/Notification/getArticleList?' . $getParameter);
+        static::assertTrue($this->View()->getAssign('success'));
+        $returnData = $this->View()->getAssign('data');
+        static::assertNotEmpty($returnData);
+
+        static::assertCount(self::TEST_PRODUCT_LIST_SECOND_PAGE_ITEMS_COUNT, $returnData);
+        static::assertSame(self::TEST_PRODUCT_LIST_TOTAL_RESULTS, $this->View()->getAssign('totalCount'));
+        $listingFirstEntry = $returnData[0];
+
+        static::assertSame(1, $listingFirstEntry['registered']);
+        static::assertSame('SW2005', $listingFirstEntry['number']);
+        static::assertSame('0', $listingFirstEntry['notNotified']);
     }
 
     /**
      * test getCustomerList controller action
      */
-    public function testGetCustomerList()
+    public function testGetCustomerList(): void
     {
-        $params['orderNumber'] = 'SW2001';
+        $params = [
+            'orderNumber' => 'SW2001',
+            'limit' => self::TEST_CUSTOMER_LIST_LIMIT,
+            'start' => self::TEST_CUSTOMER_LIST_FIRST_PAGE_OFFSET,
+        ];
+
         $this->Request()->setParams($params);
         $this->dispatch('backend/Notification/getCustomerList');
         static::assertTrue($this->View()->getAssign('success'));
 
+        $totalCount = $this->View()->getAssign('totalCount');
+        static::assertSame(self::TEST_CUSTOMER_LIST_TOTAL_RESULTS, $totalCount);
+
         $returnData = $this->View()->getAssign('data');
-        static::assertCount(2, $returnData);
+        static::assertCount(self::TEST_CUSTOMER_LIST_FIRST_PAGE_ITEMS_COUNT, $returnData);
         $listingFirstEntry = $returnData[0];
         $listingSecondEntry = $returnData[1];
 
         // cause of the DataSet you can assert fix values
-        static::assertEquals('test@example.de', $listingFirstEntry['mail']);
-        static::assertEquals(0, $listingFirstEntry['notified']);
+        static::assertSame('test@example.de', $listingFirstEntry['mail']);
+        static::assertSame(0, $listingFirstEntry['notified']);
 
-        static::assertEquals('test@example.org', $listingSecondEntry['mail']);
-        static::assertEquals(1, $listingSecondEntry['notified']);
+        static::assertSame('test@example.org', $listingSecondEntry['mail']);
+        static::assertSame(1, $listingSecondEntry['notified']);
 
         $params['orderNumber'] = 'SW2003';
         $this->Request()->setParams($params);
@@ -102,8 +160,31 @@ class NotificationTest extends Enlight_Components_Test_Controller_TestCase
         $returnData = $this->View()->getAssign('data');
 
         static::assertCount(1, $returnData);
-        static::assertEquals('test@example.com', $returnData[0]['mail']);
+        static::assertSame('test@example.com', $returnData[0]['mail']);
         static::assertNotEmpty($returnData[0]['name']);
         static::assertNotEmpty($returnData[0]['customerId']);
+    }
+
+    public function testGetCustomerListSecondPage(): void
+    {
+        $params = [
+            'orderNumber' => 'SW2001',
+            'limit' => self::TEST_CUSTOMER_LIST_LIMIT,
+            'start' => self::TEST_CUSTOMER_LIST_SECOND_PAGE_OFFSET,
+        ];
+
+        $this->Request()->setParams($params);
+        $this->dispatch('backend/Notification/getCustomerList');
+        static::assertTrue($this->View()->getAssign('success'));
+
+        $totalCount = $this->View()->getAssign('totalCount');
+        static::assertSame(self::TEST_CUSTOMER_LIST_TOTAL_RESULTS, $totalCount);
+
+        $returnData = $this->View()->getAssign('data');
+        static::assertCount(self::TEST_CUSTOMER_LIST_SECOND_PAGE_ITEMS_COUNT, $returnData);
+        $listingFirstEntry = $returnData[0];
+
+        static::assertSame('john@example.org', $listingFirstEntry['mail']);
+        static::assertSame(1, $listingFirstEntry['notified']);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The pagination of the notification module is broken. The first page has no limit and the second page shows wrong total results.

### 2. What does this change do, exactly?
The `start` property can now be 0.

The total results get now count from SQL Server and not in php code.


### 3. Describe each step to reproduce the issue or behaviour.
signup for over 21 article notification and the pagination will not work


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.