### PR TITLE
ci: Fix artifact upload in e2e tests

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -140,5 +140,5 @@ jobs:
                 if: always()
                 uses: actions/upload-artifact@v4
                 with:
-                    name: build data
+                    name: build-data-${{ matrix.MINK_TAG }}
                     path: build/logs


### PR DESCRIPTION
The upload of the artifacts in the e2e tests is failing since the update of the GitHub action