### PR TITLE
fix: backend voucher individual code search

### DIFF
--- a/themes/Backend/ExtJs/backend/voucher/controller/code.js
+++ b/themes/Backend/ExtJs/backend/voucher/controller/code.js
@@ -264,8 +264,15 @@ Ext.define('Shopware.apps.Voucher.controller.Code', {
         var me = this,
             searchString = Ext.String.trim(value),
             store = me.subApplication.getStore('Code');
-        store.filter('filter', searchString);
+
         store.filters.clear();
+
+        if (searchString.length <= 0) {
+            store.load();
+            return;
+        }
+
+        store.filter('filter', searchString);
     },
 
     /**

--- a/themes/Backend/ExtJs/backend/voucher/controller/voucher.js
+++ b/themes/Backend/ExtJs/backend/voucher/controller/voucher.js
@@ -169,6 +169,7 @@ Ext.define('Shopware.apps.Voucher.controller.Voucher', {
                     mode = record.data.modus,
                     codeStore = me.getStore('Code');
 
+                codeStore.filters.clear();
                 codeStore.clearData();
                 codeStore.currentPage = 1;
 


### PR DESCRIPTION
Hi,

### 1. Why is this change necessary?
the individual voucher code search is broken, after a reload the store lose its filter

### 2. What does this change do, exactly?
the last filter get cleared bevor and not after the search method.

### 3. Describe each step to reproduce the issue or behaviour.
open a individual voucher and search for a code, after a list reload the filter gets cleared.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.