### PR TITLE
fix: backend voucher codes stuck on last page and shows old entry's

### DIFF
--- a/themes/Backend/ExtJs/backend/voucher/controller/voucher.js
+++ b/themes/Backend/ExtJs/backend/voucher/controller/voucher.js
@@ -166,11 +166,15 @@ Ext.define('Shopware.apps.Voucher.controller.Voucher', {
             scope: this,
             callback: function (records, operation, success) {
                 var record = records[0],
-                    mode = record.data.modus;
+                    mode = record.data.modus,
+                    codeStore = me.getStore('Code');
+
+                codeStore.clearData();
+                codeStore.currentPage = 1;
 
                 me.getView('voucher.Window').create({
                     record: record,
-                    codeStore: me.getStore('Code'),
+                    codeStore: codeStore,
                     taxStore: me.getStore('Tax')
                 });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
the voucher individual code list keep the page of the last voucher. If you open a voucher with less codes, the list will be empty, if you stay on a not longer existing page.

### 2. What does this change do, exactly?
Every time opening a voucher, the page will set to 1.
To not showing outdated results, the store get cleared.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.