### PR TITLE
Fix/version compare deprecation

### DIFF
--- a/engine/Shopware/Commands/PluginInstallCommand.php
+++ b/engine/Shopware/Commands/PluginInstallCommand.php
@@ -83,7 +83,7 @@ class PluginInstallCommand extends PluginCommand implements CompletionAwareInter
                 'activate',
                 null,
                 InputOption::VALUE_NONE,
-                'Activate plugin after intallation.'
+                'Activate plugin after installation.'
             )
             ->addOption(
                 'no-refresh',

--- a/engine/Shopware/Components/Plugin/Bootstrap.php
+++ b/engine/Shopware/Components/Plugin/Bootstrap.php
@@ -98,8 +98,11 @@ abstract class Shopware_Components_Plugin_Bootstrap extends Enlight_Plugin_Boots
     public function hasInfoNewerVersion(Enlight_Config $updatePluginInfo, Enlight_Config $currentPluginInfo)
     {
         $currentVersion = $currentPluginInfo->get('version');
-        $updateVersion = $updatePluginInfo->get('version');
+        if ($currentVersion === null) {
+            return true;
+        }
 
+        $updateVersion = $updatePluginInfo->get('version');
         if (empty($updateVersion)) {
             return false;
         }

--- a/tests/Functional/Components/Plugin/BootstrapTest.php
+++ b/tests/Functional/Components/Plugin/BootstrapTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace Shopware\Tests\Functional\Components\Plugin;
 
+use Enlight_Config;
 use PHPUnit\Framework\TestCase;
 use Shopware\Tests\Functional\Components\Plugin\fixtures\TestPlugin;
 
@@ -36,5 +37,62 @@ class BootstrapTest extends TestCase
         $pluginInstance = new TestPlugin($expectedPluginName);
         $pluginName = $pluginInstance->getName();
         static::assertSame($expectedPluginName, $pluginName);
+    }
+
+    /**
+     * @dataProvider pluginVersionProvider
+     */
+    public function testHasNewerVersion(?string $currentVersion, ?string $updateVersion, bool $isNewer): void
+    {
+        $currentPluginConfig = new Enlight_Config(['version' => $currentVersion]);
+        $updatePluginConfig = new Enlight_Config(['version' => $updateVersion]);
+
+        $pluginBootstrap = new TestPlugin('test');
+
+        static::assertSame($isNewer, $pluginBootstrap->hasInfoNewerVersion($updatePluginConfig, $currentPluginConfig));
+    }
+
+    /**
+     * @return list<array{currentVersion: ?string, updateVersion: ?string, isNewer: bool}>
+     */
+    public function pluginVersionProvider(): array
+    {
+        return [
+            [
+                'currentVersion' => '2.0.0',
+                'updateVersion' => '2.0.0',
+                'isNewer' => false,
+            ],
+            [
+                'currentVersion' => '1.0.0',
+                'updateVersion' => '2.0.0',
+                'isNewer' => true,
+            ],
+            [
+                'currentVersion' => null,
+                'updateVersion' => '2.0.0',
+                'isNewer' => true,
+            ],
+            [
+                'currentVersion' => '2.0.0',
+                'updateVersion' => null,
+                'isNewer' => false,
+            ],
+            [
+                'currentVersion' => '1',
+                'updateVersion' => '1.0.0',
+                'isNewer' => false,
+            ],
+            [
+                'currentVersion' => '0',
+                'updateVersion' => '0.0.1',
+                'isNewer' => true,
+            ],
+            [
+                'currentVersion' => '0',
+                'updateVersion' => '0',
+                'isNewer' => false,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
This PR fixes two minor issues, on the one hand a typo in a command. On the other hand a PHP deprecation:
```
PHP Deprecated:  version_compare(): Passing null to parameter #2 ($version2) of type string is deprecated in .../engine/Shopware/Components/Plugin/Bootstrap.php on line 112
```
which occurs when a plugin from the legacy plugin structure is not present in the `s_core_plugins` table.

### 2. What does this change do, exactly?
Fix those issues.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.