### PR TITLE
fix: backend notification customer list stuck on last seen page

### DIFF
--- a/themes/Backend/ExtJs/backend/notification/controller/notification.js
+++ b/themes/Backend/ExtJs/backend/notification/controller/notification.js
@@ -79,6 +79,7 @@ Ext.define('Shopware.apps.Notification.controller.Notification', {
         customerStore.getProxy().extraParams = {
             orderNumber: record.get("number")
         };
+        customerStore.currentPage = 1;
         customerStore.load();
     },
 


### PR DESCRIPTION
Hi,

### 1. Why is this change necessary?
The backend voucher customer list stay on last page by switching to another product.
The result is an empty page if the new product has less subscriber.

### 2. What does this change do, exactly?
Every-time switching a product, the subscriber list will set to page 1

### 3. Describe each step to reproduce the issue or behaviour.
1. open a product with more than 21 subscriber
2. switch to the next customer page
3. switch to another product with less subscriber

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.