### PR TITLE
fix: backend article preview 'shop' cookie

### DIFF
--- a/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
+++ b/engine/Shopware/Plugins/Default/Core/Router/Bootstrap.php
@@ -29,6 +29,7 @@ use Shopware\Models\Customer\Group as CustomerGroup;
 use Shopware\Models\Shop\Shop;
 use Shopware\Models\Shop\Template;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Response;
 
 class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_Bootstrap
 {
@@ -53,6 +54,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
     public function onRouteStartup(Enlight_Controller_EventArgs $args)
     {
         $request = $args->getRequest();
+        $response = $args->getResponse();
 
         if (str_starts_with($request->getPathInfo(), '/backend')
             || str_starts_with($request->getPathInfo(), '/api/')
@@ -60,7 +62,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
             return;
         }
 
-        $shop = $this->getShopByRequest($request);
+        $shop = $this->getShopByRequest($request, $response);
 
         if (!$shop->getHost()) {
             $shop->setHost($request->getHttpHost());
@@ -306,7 +308,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
      *
      * @return Shop
      */
-    protected function getShopByRequest(Request $request)
+    protected function getShopByRequest(Request $request, Response $response)
     {
         $repository = $this->get(ModelManager::class)->getRepository(Shop::class);
 
@@ -317,6 +319,7 @@ class Shopware_Plugins_Core_Router_Bootstrap extends Shopware_Components_Plugin_
 
         if ($shop === null && $request->getCookie('shop') !== null) {
             $shop = $repository->getActiveById($request->getCookie('shop'));
+            $response->headers->clearCookie('shop');
         }
 
         if ($shop && $request->getCookie('shop') !== null && $request->getPost('__shop') === null) {


### PR DESCRIPTION
### 1. Why is this change necessary?
If you have a subshop with a different domain and click on the preview button in the backend, you are no longer able to visit the main shop on the main domain. You get redirected to the subshop all the time.

### 2. What does this change do, exactly?
The `shop` cookie get a ttl from 30 seconds. after this time you can visit the main shop again.

### 3. Describe each step to reproduce the issue or behaviour.
Setup a subshop with a different domain and show the preview of an article in this subshop. you are no longer able to visit the main shop.

This bug works only over https!

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.