### PR TITLE
fix: change z-index of element for compatibility with iOS 18

### DIFF
--- a/themes/Frontend/Bare/frontend/detail/content.tpl
+++ b/themes/Frontend/Bare/frontend/detail/content.tpl
@@ -32,7 +32,7 @@
                     data-image-gallery="true"
                     data-maxZoom="{$theme.lightboxZoomFactor}"
                     data-thumbnails=".image--thumbnails"
-                    {/if}>
+                    {/if} style="z-index: unset;">
                     {block name="frontend_detail_index_image"}
                         {include file="frontend/detail/image.tpl"}
                     {/block}


### PR DESCRIPTION
Changed z-index to unset to avoid overlapping of blocks on mobile displays in iOS 18

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Compatibility with iOS 18. Without the change overlapping of blocks can occur on Safari, so the cart button is not clickable anymore.

### 2. What does this change do, exactly?
The z-index of the div with class "product--image-container" is before set to 1000. This change unsets the z-index.

### 3. Describe each step to reproduce the issue or behaviour.
Occurs after the update to iOS 18 on Safari and Chrome (and maybe more browsers). The image container overlaps the cart button.

### 4. Please link to the relevant issues (if any).
https://forum.shopware.com/t/ios-safari-oder-chrome-detailseite-buttons-ohne-funktion/105237/

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.