### PR TITLE
fix: Update devenv configuration for current devenv versions in 2025

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,10 +1,16 @@
 { pkgs, lib, inputs, config, ... }:
-
+let
+  # Use an older nixpkgs-version, containing Node 18.
+  oldPkgs = import (fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/nixos-23.11.tar.gz";
+    sha256 = "1f5d2g1p6nfwycpmrnnmc2xmcszp804adp16knjvdkj8nz36y1fg";
+  }) {
+  system = pkgs.system;
+  };
+in
 {
-  imports = [ inputs.nur.nixosModules.nur ];
-
   languages.javascript.enable = true;
-  languages.javascript.package = lib.mkDefault pkgs.nodejs-18_x;
+  languages.javascript.package = lib.mkDefault oldPkgs.nodejs-18_x;
 
     languages.php = {
         enable = lib.mkDefault true;
@@ -47,6 +53,13 @@
   services.caddy.virtualHosts."http://localhost:8000" = {
     extraConfig = ''
       root * .
+
+      handle /recovery/* {
+        php_fastcgi unix/${config.languages.php.fpm.pools.web.socket} {
+          index {path}/index.php
+        }
+      }
+
       php_fastcgi unix/${config.languages.php.fpm.pools.web.socket} {
         index shopware.php
       }


### PR DESCRIPTION
Remember to run `devenv update` once before running `devenv up`!

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The current devenv.nix will not work in updated Nix/devenv environment or a new install of devenv.

### 2. What does this change do, exactly?
It pins the Nix versions to the last version that includes NodeJS v18.

### 3. Describe each step to reproduce the issue or behaviour.
just checkout and run `devenv up`

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.